### PR TITLE
jit, interp, bench: the frame descriptor force gateways narrowed to the fields a trace can disagree about, the portal raise on both exception carriers, and the escape fixtures re-armed at f_lasti

### DIFF
--- a/majit/examples/braininterp/src/jit_interp.rs
+++ b/majit/examples/braininterp/src/jit_interp.rs
@@ -150,7 +150,21 @@ fn mainloop(program: &Bytecode, threshold: u32) -> String {
                 }
             }
             b']' if state.tape[state.pointer as usize] != 0 => {
-                let target = find_matching_open(program, pc);
+                // RPython `BrainInterpreter.interp_char` keeps this scan in
+                // the opcode body, so the translator sees the loop and its
+                // loop-carried locals instead of an opaque slice helper.
+                let mut need: i32 = 1;
+                let mut target = pc - 1;
+                while need > 0 {
+                    if program[target] == b']' {
+                        need += 1;
+                    } else if program[target] == b'[' {
+                        need -= 1;
+                    }
+                    if need > 0 {
+                        target -= 1;
+                    }
+                }
                 if target < pc {
                     can_enter_jit!(driver, target, &mut state, program, || {});
                 }
@@ -290,8 +304,6 @@ mod tests {
     use super::*;
 
     use crate::interp;
-    use majit_metainterp::{RefusalKind, refusal_kind};
-
     static PROBE_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
     /// Run `prog` and return only its output.
@@ -344,11 +356,11 @@ mod tests {
     }
 
     #[test]
-    fn jit_tier_aborts_in_the_loop_arm_stub() {
+    fn jit_tier_closes_the_brainfuck_loop() {
         const A: u8 = 7;
         const B: u8 = 3;
         let prog = multiply_gate_bf(A, B);
-        let (got, compiles, ops_before, ops_after, _shape) = compile_probe(&prog);
+        let (got, compiles, ops_before, ops_after, shape) = compile_probe(&prog);
 
         // The interpreter must still answer correctly whatever the tier does.
         assert_eq!(
@@ -370,77 +382,23 @@ mod tests {
             .filter(|a| a.interp == "BfState")
             .collect();
         let degraded: Vec<&str> = bf_arms.iter().map(|a| a.arm).collect();
-        assert_eq!(
-            degraded,
-            vec!["b'['", "b']'"],
-            "degraded dispatch arms moved — every trace reaching one aborts"
-        );
-
-        // The CAUSE, which the name set above cannot see: an arm can keep
-        // degrading for an entirely different reason. See tl's `jit_tier_is_alive`
-        // for the measurement that motivated this — three A/B arms whose name
-        // sets and pass counts were identical while the mechanism changed.
-        let causes: Vec<(&str, RefusalKind)> = bf_arms
-            .iter()
-            .map(|a| (a.arm, refusal_kind(a.reason)))
-            .collect();
-        assert_eq!(
-            causes,
-            [
-                ("b'['", RefusalKind::GreenWriteback),
-                ("b']'", RefusalKind::UnlowerableStmt)
-            ],
-            "an arm still degrades, but a different mechanism is refusing it now"
-        );
-        let bracket = bf_arms
-            .iter()
-            .find(|a| a.arm == "b'['")
-            .expect("b'[' is in the set asserted immediately above");
-        let close = bf_arms
-            .iter()
-            .find(|a| a.arm == "b']'")
-            .expect("b']' is in the set asserted immediately above");
         assert!(
-            close.reason.contains("find_matching_open(program, pc)"),
-            "b']' refusal no longer names the unsupported matching-bracket call: {}",
-            close.reason
+            degraded.is_empty(),
+            "a braininterp opcode body still installs an abort stub: {bf_arms:?}"
         );
         assert!(
-            close.reason.contains("pc = target"),
-            "b']' refusal no longer preserves the trailing green writeback: {}",
-            close.reason
+            compiles > 0,
+            "the bracket arms lower, but the hot Brainfuck loop compiled nothing"
         );
         assert!(
-            bracket.reason.contains("while need > 0"),
-            "b'[' refusal no longer names the unsupported scan loop: {}",
-            bracket.reason
+            shape.closes_a_loop(),
+            "the compiled body does not close a loop: {}",
+            shape.why_not().unwrap_or("closes a loop")
         );
 
-        // THE ASSERTION THAT DISCRIMINATES, and the one to replace rather than
-        // re-record. `b']'` is the loop arm, so every trace that reaches the
-        // loop aborts in its stub and nothing is ever compiled.
-        //
-        // IF THIS FAILS, the loop arm lowers and the tier has come alive. Do
-        // NOT re-record it: replace this whole gate with a liveness gate
-        // asserting `shape.closes_a_loop()`, which is the property a segmented
-        // or aborted trace can never satisfy.
-        assert_eq!(
-            compiles, 0,
-            "multiply({A}*{B}) compiled {compiles} loops. This crate's loop arm \
-             `b']'` is an abort stub, so no trace should survive to be compiled. \
-             A non-zero count means either the arm lowers now — replace this gate \
-             with `assert!(shape.closes_a_loop())` — or another test entered the \
-             JIT inside this probe's window without taking PROBE_LOCK"
-        );
-
-        // No assertion on `ops_after` or on the fold ratio, deliberately. With
-        // nothing compiled they are both 0, and an assertion over a value that
-        // is structurally 0 is the same species of oracle-that-cannot-fail this
-        // gate was rebuilt to stop making. `ops_before` is reported, not pinned,
-        // for the same reason.
         println!(
-            "[tier-aborting] multiply({A}*{B}) = {cell} from the interpreter \
-             alone, {compiles} loops compiled, {ops_before} ops recorded, \
+            "[tier-live] multiply({A}*{B}) = {cell}, {compiles} loops compiled, \
+             {ops_before} ops recorded, \
              {ops_after} after opt, degraded {degraded:?}"
         );
     }

--- a/majit/examples/dualtape/src/jit_interp.rs
+++ b/majit/examples/dualtape/src/jit_interp.rs
@@ -138,7 +138,23 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
                 }
             }
             b']' if state.a[state.pa as usize] != 0 => {
-                let target = find_matching_open(program, pc);
+                // rpython/jit/tl/braininterp.py
+                // `BrainInterpreter.interp_char`: keep the matching-bracket
+                // scan in the opcode body. Pulling it into a Rust helper turns
+                // an ordinary translated loop into an opaque slice-argument
+                // call and degrades this dispatch arm to an abort JitCode.
+                let mut need: i32 = 1;
+                let mut target = pc - 1;
+                while need > 0 {
+                    if program[target] == b']' {
+                        need += 1;
+                    } else if program[target] == b'[' {
+                        need -= 1;
+                    }
+                    if need > 0 {
+                        target -= 1;
+                    }
+                }
                 if target < pc {
                     can_enter_jit!(driver, target, &mut state, program, || {});
                 }
@@ -152,23 +168,6 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
     }
 
     state.a.iter().sum::<i64>() + state.b.iter().sum::<i64>()
-}
-
-/// Find the matching '[' for a ']' at the given position.
-fn find_matching_open(code: &[u8], close_pos: usize) -> usize {
-    let mut need: i32 = 1;
-    let mut p = close_pos - 1;
-    while need > 0 {
-        if code[p] == b']' {
-            need += 1;
-        } else if code[p] == b'[' {
-            need -= 1;
-        }
-        if need > 0 {
-            p -= 1;
-        }
-    }
-    p
 }
 
 pub struct JitDualInterp {
@@ -197,7 +196,6 @@ impl Default for JitDualInterp {
 mod tests {
     use super::*;
     use crate::interp;
-    use majit_metainterp::{RefusalKind, refusal_kind};
 
     /// `COMPILES` / `LAST_OPS_AFTER` are process-global, so under the default
     /// parallel libtest runner any concurrent `run` lands inside
@@ -242,11 +240,10 @@ mod tests {
     /// (`jitdriver.rs GuardResumeDecline::ReservedIdentitySlots`).
     ///
     /// Measured across this whole suite, debug and release: the trim's branch
-    /// is taken ZERO times and the decline fires ZERO times, because
-    /// `build_state_field_snapshot` is never reached with more than one frame
-    /// — `jit_tier_shape_gate` and `jit_tier_liveness_gate` are still
-    /// `#[ignore]`d and the `[` / `]` arms still lower degraded, so nothing
-    /// here records a guard inside an inlined dispatch arm.
+    /// is taken ZERO times and the decline fires ZERO times. The bracket arms
+    /// now lower and the tier gates compile a loop, but their dynamic guard
+    /// failures still occur at the dispatch/root frame rather than inside an
+    /// inlined arm, so this reserved sub-frame range is not captured.
     ///
     /// That is why both counters are gated at 0 rather than at "some". The
     /// trim replaces a sub-frame's int state-field slots with `Const(0)`, and
@@ -403,7 +400,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "enable after `jit_tier_shape_gate` proves the compiled body closes a loop"]
     fn jit_tier_liveness_gate() {
         let _guard = PROBE_LOCK.lock();
         COMPILES.store(0, Ordering::Relaxed);
@@ -441,22 +437,10 @@ mod tests {
         let got = JitDualInterp::new().run(&program);
         assert_eq!(got, 2002, "fixture changed; the arm reading is moot");
 
-        // Equality over a named set, never `is_empty()`. Both arms are known
-        // abort stubs, so an emptiness assertion would be permanently red and
-        // discriminate nothing. Pinning the set catches a third degraded arm
-        // and also catches either of these two arms becoming lowerable.
-        //
-        // `b'['` JOINED THIS SET AS A REPAIR, NOT AS A REGRESSION. Before the
-        // three jit-state probes descended into `while`/`loop`, the scan in its
-        // body was scored inert and silently dropped, so the arm "lowered" with
-        // its zero-cell branch deleted. Refusing it is the honest outcome. Do
-        // NOT "fix" a future failure here by trimming the set back to
-        // `["b']'"]` — that spelling asserts the arm lowers, which is the state
-        // the deletion produced.
-        //
-        // If this fails because the set is now EMPTY, the lowering gaps may be
-        // FIXED. Do not re-record the vector: delete this pin and gate on the
-        // real body instead.
+        // Every opcode body now lowers. In particular, both bracket scans stay
+        // in the translated body like RPython `BrainInterpreter.interp_char`;
+        // byte literals and loop-carried local updates no longer turn either
+        // arm into an abort stub.
         let mut degraded: Vec<_> = majit_metainterp::degraded_dispatch_arms()
             .into_iter()
             .filter(|a| a.interp == "DualState")
@@ -464,46 +448,13 @@ mod tests {
         degraded.sort_unstable_by_key(|a| a.arm);
         let degraded_arms: Vec<&str> = degraded.iter().map(|a| a.arm).collect();
         println!("[tier] degraded_arms={degraded_arms:?}");
-        assert_eq!(
-            degraded_arms,
-            ["b'['", "b']'"],
-            "the degraded-arm set moved; every trace reaching an abort stub aborts"
-        );
-
-        let causes: Vec<(&str, RefusalKind)> = degraded
-            .iter()
-            .map(|a| (a.arm, refusal_kind(a.reason)))
-            .collect();
-        assert_eq!(
-            causes,
-            [
-                ("b'['", RefusalKind::GreenWriteback),
-                ("b']'", RefusalKind::UnlowerableStmt)
-            ],
-            "an arm still degrades, but a different mechanism is refusing it. \
-             `RefusalKind::Unclassified` means majit grew a refusal family the \
-             classifier does not know — add it in `majit-metainterp`, do not \
-             re-record this pin"
-        );
-
-        let close = degraded
-            .iter()
-            .find(|a| a.arm == "b']'")
-            .expect("b']' is pinned in the set above");
         assert!(
-            close.reason.contains("find_matching_open(program, pc)"),
-            "b']' refusal no longer names the unsupported matching-bracket call: {}",
-            close.reason
-        );
-        assert!(
-            close.reason.contains("pc = target"),
-            "b']' refusal no longer preserves the trailing green writeback: {}",
-            close.reason
+            degraded_arms.is_empty(),
+            "a dualtape opcode body still installs an abort stub: {degraded:?}"
         );
     }
 
     #[test]
-    #[ignore = "enable when the back-edge arm lowers and trace inputs use separate namespaces"]
     fn jit_tier_shape_gate() {
         let _guard = PROBE_LOCK.lock();
         COMPILES.store(0, Ordering::Relaxed);

--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -7,6 +7,7 @@
 /// Greens: [pc, code]
 /// Reds:   [inputarg, stackpos, stack]  (inputarg is a function parameter — red by nature)
 use majit_metainterp::jit::promote;
+use majit_metainterp::virt_array::VirtArray;
 
 /// Hot loops majit compiled. The only positive evidence the JIT tier is alive:
 /// a green suite, agreement with `interp::interpret` and an exact absolute trip
@@ -48,15 +49,16 @@ pub static LAST_ALWAYS_FAILS: core::sync::atomic::AtomicBool =
 #[cfg(test)]
 pub static ROLL_CALLS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 
-/// Rotates the live stack through a residual call. The state-machine
-/// virtualizable has no force token, so lowering this raw-pointer mutation as
-/// an ordinary call would leave symbolic array cells stale; the dispatch arm
-/// must remain degraded until array effects can be synchronized.
+/// Rotates the live stack through a residual call.
+///
+/// As in `tl.py::Stack.roll`, the helper receives the virtualizable object,
+/// not a raw pointer to one redirected field. The may-force call therefore
+/// synchronizes the virtualizable before the helper mutates its live array.
 #[majit_macros::jit_may_force]
-extern "C" fn storage_roll(stack_ptr: usize, stackpos: i64, r: i64) {
+extern "C" fn storage_roll(state: &mut TlState, r: i64) {
     #[cfg(test)]
     ROLL_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-    let stack = unsafe { std::slice::from_raw_parts_mut(stack_ptr as *mut i64, stackpos as usize) };
+    let stack = &mut state.stack[..state.stackpos as usize];
     let len = stack.len();
     if r < -1 {
         // tl.py:45-55
@@ -106,7 +108,7 @@ impl BytecodeExt for [u8] {
 /// (`interp_eval`) passes `len(code)`. See tl.py:120.
 struct TlState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 // ── Opcodes ──
@@ -166,7 +168,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let stacksize: i32 = 0;
     let mut state = TlState {
         stackpos: 0,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
 
     // RPython warmspot.py:281-289 canonical-liveness install hook.
@@ -178,32 +180,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     }
 
     while pc < program.len() {
-        // Still the legacy bare form, which discards the walk outcome and
-        // re-runs the circuit the walk already executed.
-        //
-        // `jit_merge_point!(driver, program, pc; state)` carries the tests whose
-        // loops hold no `ROLL` — `sum_bytecode` compiles a loop and resumes at
-        // its header — but not `roll_loop_bytecode`. `ROLL`'s arm lowers to an
-        // abort stub, because `storage_roll` is handed
-        // `state.stack.as_mut_ptr()` and the macro has no spelling for the base
-        // pointer of a `[int; virt]` state-field array. The abort then lands
-        // after the shared `pc += 1` below and before the arm's own operand
-        // advance at `pc += 1` inside `ROLL`, so the resume position names
-        // `ROLL`'s operand byte rather than an opcode boundary:
-        // `MAJIT_PORTAL_RCA=1` reports `resume_pc=10 compiled_key=None` where
-        // `ROLL, 2` occupies pc 9–10, against `resume_pc=3` with a real
-        // `compiled_key` on the `ROLL`-free control.
-        //
-        // Two gaps have to close, not one. The arm has to lower (the macro
-        // spelling above), AND the abort path needs a source-opcode boundary to
-        // resume at: both of its exits report the same mid-opcode pc today.
-        // `run_pending_abort_blackhole` takes it from the merge point the
-        // blackhole chain reaches, and declining before the chain runs falls
-        // back to `walk_final_pc`, which the `TraceAction::Abort` arm sets from
-        // i0 — advanced by dispatch before the arm ran. No per-source-opcode
-        // entry pc is retained during the walk, so neither exit can name the
-        // boundary.
-        jit_merge_point!();
+        jit_merge_point!(driver, program, pc; state);
         // tl.py:88  stack.stackpos = promote(stack.stackpos)
         state.stackpos = promote(state.stackpos);
 
@@ -233,8 +210,8 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
             // tl.py  Stack.roll() is @dont_look_inside
             ROLL => {
                 let r = program[pc] as i8 as i64;
+                storage_roll(&mut state, r);
                 pc += 1;
-                storage_roll(state.stack.as_mut_ptr() as usize, state.stackpos, r);
             }
             // tl.py  Stack.pick(i): duplicate stack[stackpos - i - 1]
             PICK => {
@@ -525,7 +502,7 @@ mod tests {
         degraded.sort_unstable();
         assert_eq!(
             degraded,
-            ["PUSHARG", "ROLL"],
+            ["PUSHARG"],
             "the degraded-arm set moved. A NEW name means an arm silently \
              stopped lowering and every trace reaching it now aborts; a MISSING \
              name means that arm lowers again, so a loop that could not trace \
@@ -539,10 +516,7 @@ mod tests {
         causes.sort_unstable();
         assert_eq!(
             causes,
-            [
-                ("PUSHARG", RefusalKind::UnlowerableStmt),
-                ("ROLL", RefusalKind::GreenWriteback)
-            ],
+            [("PUSHARG", RefusalKind::UnlowerableStmt)],
             "a degraded arm's CAUSE moved while its name did not. That is the \
              signal the set above structurally cannot carry: the arm still \
              degrades, so part 3 is unchanged, but a different mechanism is \
@@ -561,13 +535,6 @@ mod tests {
                 .expect("part 3 already pinned this arm as present")
                 .reason
         };
-        assert!(
-            reason_of("ROLL").contains("pc += 1"),
-            "ROLL's refusal no longer names `pc += 1` as the offending \
-             statement — the green-writeback guard is now stopping somewhere \
-             else in the arm: {}",
-            reason_of("ROLL")
-        );
         assert!(
             reason_of("PUSHARG").contains("state.stack"),
             "PUSHARG's refusal no longer names the `state.stack` write as the \
@@ -675,6 +642,21 @@ mod tests {
                  double-execution would inflate this count"
             );
         }
+    }
+
+    /// The first residual ROLL's result is consumed before the inverse ROLL.
+    /// This prevents a pair that merely cancels in the heap from hiding a
+    /// missing post-call virtualizable reload in the trace.
+    #[test]
+    fn jit_residual_result_is_visible_to_following_ops() {
+        let bc = vec![
+            PUSH, 1, PUSHARG, PICK, 0, BR_COND, 2, POP, RETURN, ROLL, 2, PICK, 0, ADD, ROLL, 254,
+            PUSH, 1, SUB, PUSH, 1, BR_COND, 236,
+        ];
+        let n = 8;
+        let expected = interp::interpret(&bc, n);
+        assert_eq!(expected, 1 << n, "fixture computes 2**n");
+        assert_eq!(run_jit(&bc, n), expected);
     }
 
     fn trip_count_bytecode() -> Vec<u8> {
@@ -882,7 +864,7 @@ mod tests {
         let program = sum_bytecode();
         let caller = TlState {
             stackpos: 7,
-            stack: vec![1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0],
+            stack: VirtArray::from_slice(&[1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0]),
         };
         let meta = caller.build_meta(0, program.as_slice());
         let mut sym = <TlState as majit_metainterp::JitState>::create_sym(&meta, 0);
@@ -921,7 +903,7 @@ mod tests {
         let program = sum_bytecode();
         let caller = TlState {
             stackpos: 3,
-            stack: vec![9, 8, 7, 0, 0, 0, 0, 0],
+            stack: VirtArray::from_slice(&[9, 8, 7, 0, 0, 0, 0, 0]),
         };
         let meta = caller.build_meta(0, program.as_slice());
         let mut sym = <TlState as majit_metainterp::JitState>::create_sym(&meta, 0);

--- a/majit/examples/tlc/src/jit_interp.rs
+++ b/majit/examples/tlc/src/jit_interp.rs
@@ -20,6 +20,7 @@
 /// NEW, GETATTR, SETATTR, SEND) cause guard failure in RPython and are absent
 /// from this function, matching that behavior.
 use crate::interp::{self, ConstantPool};
+use majit_metainterp::virt_array::VirtArray;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 // ── State ──
@@ -65,17 +66,17 @@ impl BytecodeExt for [u8] {
 
 struct TlcState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 /// Rotates the live stack through a residual call.
 ///
-/// This mirrors the RPython TLC list operations. Because it mutates the
-/// virtualizable array through a raw pointer, the call is may-force and the
-/// dispatch arm remains degraded until the trace can reload those effects.
+/// This mirrors the RPython TLC list operations. The helper receives the live
+/// virtualizable object, so its may-force effect synchronizes redirected array
+/// fields before the residual mutation.
 #[majit_macros::jit_may_force]
-extern "C" fn tlc_roll(stack_ptr: usize, stackpos: i64, r: i64) {
-    let stack = unsafe { std::slice::from_raw_parts_mut(stack_ptr as *mut i64, stackpos as usize) };
+extern "C" fn tlc_roll(state: &mut TlcState, r: i64) {
+    let stack = &mut state.stack[..state.stackpos as usize];
     let len = stack.len();
     if r < -1 {
         // Move top element to position len+r (counted from bottom).
@@ -159,7 +160,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     // eventually popping, so peak stack depth is bounded by code length).
     let mut state = TlcState {
         stackpos: 0,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
 
     // RPython warmspot.py:281-289 — `make_jitcodes(); finish_setup(codewriter)`
@@ -272,8 +273,8 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
             }
             ROLL => {
                 let r = program[pc] as i8 as i64;
+                tlc_roll(&mut state, r);
                 pc += 1;
-                tlc_roll(state.stack.as_mut_ptr() as usize, state.stackpos, r);
             }
             PICK => {
                 let i = program[pc] as usize;
@@ -461,7 +462,7 @@ mod tests {
         let degraded: Vec<&str> = tlc_arms.iter().map(|a| a.arm).collect();
         assert_eq!(
             degraded,
-            ["PUSHARG", "ROLL"],
+            ["PUSHARG"],
             "the degraded-arm set moved. A NEW name means an arm silently \
              stopped lowering and every trace reaching it now aborts; a MISSING \
              name means that arm lowers again, so the abort that blocks the \
@@ -482,10 +483,7 @@ mod tests {
         }
         assert_eq!(
             causes,
-            [
-                ("PUSHARG", RefusalKind::UnlowerableStmt),
-                ("ROLL", RefusalKind::GreenWriteback),
-            ],
+            [("PUSHARG", RefusalKind::UnlowerableStmt)],
             "an arm still degrades but a different mechanism is refusing it. \
              `RefusalKind::Unclassified` on either side means majit grew a \
              refusal family the classifier does not know — add it in \

--- a/majit/examples/tlc/src/jit_interp.rs
+++ b/majit/examples/tlc/src/jit_interp.rs
@@ -178,8 +178,8 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
 
     while pc < program.len() {
         // The `; state` single-pass form. Reaching it took two fixes, because
-        // this file's `ROLL` and `PUSHARG` arms are abort stubs (see
-        // `jit_tier_is_alive`) and its post-loop expression stores:
+        // this file's `PUSHARG` arm is an abort stub (see `jit_tier_is_alive`)
+        // and its post-loop expression stores:
         //
         // 1. A degraded-stub abort resumed at `opcode_pc + 1` — the shared
         //    prologue advance below, not the instruction width — so the
@@ -193,9 +193,9 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
         //    *storing* trailing expression out of the walk; the regression test
         //    is `jit_interp_halt_arm_post_loop_expression.rs`.
         //
-        // Lowering the `ROLL` arm is still open (it needs a macro spelling for
-        // the base pointer of a `[int; virt]` state-field array), but it is no
-        // longer what blocks this merge point.
+        // The `ROLL` arm lowers since the `VirtArray` spelling gave it a base
+        // pointer for its `[int; virt]` state-field array; the degraded-arm
+        // pin below is what states the remaining set.
         jit_merge_point!(driver, program, pc; state);
         let opcode = program[pc];
         pc += 1;

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -220,9 +220,9 @@ cover the condition they diagnose.
 
 ### `MAJIT_GC_NURSERY_POISON`
 
-- Read sites: 2 — `majit/majit-gc/src/nursery.rs`, `majit/majit-gc/src/oldgen.rs`
-- Accessor: `new()`
-- What it does: fill recycled nursery and old-gen memory with a poison word instead of zeroes, so an allocation path that relies on its memory arriving zeroed fails where it reads rather than later. The two reads initialise `poison_on_reset` (`nursery.rs`) and `poison_on_alloc` (`oldgen.rs`). The nursery half of this is upstream's `gc_nursery_debug` (`PYPY_GC_NURSERY_DEBUG`), which selects `arena_reset` mode 3; that name is read separately and additively, so either spelling turns the fill on and neither turns the other off.
+- Read sites: 3 — `majit/majit-gc/src/nursery.rs`, `majit/majit-gc/src/oldgen.rs`, `majit/majit-gc/src/shadow_stack.rs`
+- Accessor: `gc_nursery_poison_enabled()`
+- What it does: fill recycled nursery and old-gen memory with a poison word instead of zeroes, so an allocation path that relies on its memory arriving zeroed fails where it reads rather than later. Two reads initialise `poison_on_reset` (`nursery.rs`) and `poison_on_alloc` (`oldgen.rs`); the third gates the pre-registration poison scan in `push_resume_ref_roots`, which asks per call, so the accessor caches the lookup. The nursery half of this is upstream's `gc_nursery_debug` (`PYPY_GC_NURSERY_DEBUG`), which selects `arena_reset` mode 3; that name is read separately and additively, so either spelling turns the fill on and neither turns the other off.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
 ### `MAJIT_GC_STRESS`

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -220,14 +220,16 @@ pub fn gc_freelist_diag_enabled() -> bool {
     *ENABLED
 }
 
-/// `MAJIT_GC_NURSERY_POISON` — the poison-word audit the resume-root
-/// registration runs over the slice it is handed.
+/// `MAJIT_GC_NURSERY_POISON` — fill recycled nursery and old-gen memory with a
+/// poison word, and audit the slice the resume-root registration is handed.
 ///
 /// Read once, for the reason [`gc_lifetime_log_enabled`] gives, and with a
 /// sharper case: the gate sits in `shadow_stack::push_resume_ref_roots`, which
 /// every blackhole resume calls once per rebuilt frame and once per virtuals
 /// cache, and `std::env::var_os` takes the environment lock and scans it
-/// linearly whether or not the variable is set.
+/// linearly whether or not the variable is set.  The arena and old-gen
+/// constructors ask once each and could read the environment directly; routing
+/// them through the same accessor keeps all three readers on one answer.
 pub fn gc_nursery_poison_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
         std::sync::LazyLock::new(|| std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some());

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -157,7 +157,7 @@ impl Nursery {
         let start = alloc_arena(size);
         let top = unsafe { start.add(size) };
         let ptrs = Box::new(NurseryPtrs { free: start, top });
-        let poison_on_reset = std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some();
+        let poison_on_reset = crate::gc_nursery_poison_enabled();
         Nursery {
             start,
             size,

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -103,7 +103,7 @@ impl OldGen {
             rawmalloced_pages_freed: 0,
             rawmalloced_total_size: 0,
             rawmalloced_peak_size: 0,
-            poison_on_alloc: std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some(),
+            poison_on_alloc: crate::gc_nursery_poison_enabled(),
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -868,6 +868,25 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         } else {
             quote! {}
         };
+    let fresh_entry_vable_capacity_pushes: Vec<TokenStream> = virt_arrays
+        .iter()
+        .map(|(_, f)| {
+            let len_value_name = quote::format_ident!("{}_len_value", f.name);
+            quote! { __capacities.push(self.#len_value_name); }
+        })
+        .collect();
+    let recursive_fresh_entry_vable_capacities_override: TokenStream =
+        if num_ref_scalars == 0 && num_float_scalars == 0 && opaque_fields.is_empty() {
+            quote! {
+                fn recursive_fresh_entry_vable_capacities(&self) -> Option<Vec<i64>> {
+                    let mut __capacities = Vec::new();
+                    #(#fresh_entry_vable_capacity_pushes)*
+                    Some(__capacities)
+                }
+            }
+        } else {
+            quote! {}
+        };
 
     // Recursive CALL_ASSEMBLER portal entry for host allocation and release
     // The compiled caller loop cannot `New` a host `#state_type` through the
@@ -2807,6 +2826,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
 
             #recursive_fresh_entry_reds_override
+            #recursive_fresh_entry_vable_capacities_override
 
             #recursive_fresh_alloc_free_targets_override
         }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1966,47 +1966,6 @@ pub(super) fn typed_return_terminator(
     }
 }
 
-/// Whether `expr` contains a store — a plain `a = b` or a compound `a += b`.
-///
-/// Used to keep a *storing* function-final expression out of the walk; see the
-/// call site in `lower_dispatch_body` for why a store there is applied twice.
-fn expr_stores(expr: &Expr) -> bool {
-    use syn::visit::Visit;
-    struct FindStore {
-        hit: bool,
-    }
-    impl<'ast> Visit<'ast> for FindStore {
-        fn visit_expr(&mut self, e: &'ast Expr) {
-            match e {
-                Expr::Assign(_) => self.hit = true,
-                Expr::Binary(b) if is_assign_op(&b.op) => self.hit = true,
-                _ => {}
-            }
-            syn::visit::visit_expr(self, e);
-        }
-    }
-    let mut finder = FindStore { hit: false };
-    finder.visit_expr(expr);
-    finder.hit
-}
-
-/// Whether `op` is a compound-assignment operator (`+=`, `-=`, ...).
-fn is_assign_op(op: &syn::BinOp) -> bool {
-    matches!(
-        op,
-        syn::BinOp::AddAssign(_)
-            | syn::BinOp::SubAssign(_)
-            | syn::BinOp::MulAssign(_)
-            | syn::BinOp::DivAssign(_)
-            | syn::BinOp::RemAssign(_)
-            | syn::BinOp::BitXorAssign(_)
-            | syn::BinOp::BitAndAssign(_)
-            | syn::BinOp::BitOrAssign(_)
-            | syn::BinOp::ShlAssign(_)
-            | syn::BinOp::ShrAssign(_)
-    )
-}
-
 /// `Some(N)` if `body` is a pure forward-advancing dispatch arm: straight-line
 /// work followed by a single trailing `pc += N` (N > 0), with no back-edge
 /// (`can_enter_jit!` / `jit_merge_point!`), no early `return` / `continue` /
@@ -2141,6 +2100,13 @@ mod arm_is_pure_pc_advance_tests {
     fn plain_forward_advance_is_pure() {
         assert_eq!(arm_is_pure_pc_advance(&body("{ pc += 3; }")), Some(3));
         assert_eq!(arm_is_pure_pc_advance(&body("{ pc = pc + 2; }")), Some(2));
+        assert_eq!(
+            arm_is_pure_pc_advance(&body(
+                "{ let r = program[pc] as i8 as i64; storage_roll(&mut state, r); pc += 1; }"
+            )),
+            Some(1),
+            "a residual helper does not own the caller's green-pc return channel",
+        );
     }
 
     /// A `return` arm must NEVER be routed to the split sub-JitCode path: the
@@ -2275,14 +2241,10 @@ impl<'c> Lowerer<'c> {
         None
     }
 
-    /// `true` if `body` contains a call whose policy resolves to
-    /// `CallPolicySpec::Infer` — an auto-discovered helper whose effect /
-    /// raisability (and, for `&[u8]`-arg helpers like `interpret_at`, whether
-    /// a marshalable C-ABI call target exists at all) is decided at runtime.
-    /// Such an arm keeps the sub-JitCode path: its build-time IIFE degrades
-    /// to an abort stub when the runtime policy is unsupported, which the
-    /// inline stream cannot do cleanly.  Explicit-policy and helper-free arms
-    /// are inlineable.
+    /// Whether an arm contains an auto-discovered residual helper. These calls
+    /// stay in a sub-JitCode so their guard-resume liveness is scoped to the
+    /// callee frame; a trailing green-pc advance is returned explicitly to the
+    /// caller by the split path below.
     pub(super) fn arm_body_has_infer_call(&self, body: &Expr) -> bool {
         use syn::visit::Visit;
         struct InferCallProbe<'a, 'c> {
@@ -2754,41 +2716,32 @@ pub(super) fn lower_dispatch_chain(
         // reach the dispatch loop's reg0.  A BC_INLINE_CALL into a sub-JitCode
         // copies args caller→callee only, so a sub-JitCode pc-write never
         // reaches reg0 (the merge-point pc) — the inline path is what makes
-        // the green pc advance.  Arms whose body contains an inferred-policy
-        // call (`interpret_at`'s &[u8] unsupported residual, `storage_roll`)
-        // keep the sub-JitCode path: its build-time IIFE degrades to an abort
-        // stub when the runtime policy is unsupported, which the inline stream
-        // cannot do without a partial-ops-then-abort hazard.  Red-pc
-        // dispatches keep the sub-JitCode path unconditionally.
+        // the green pc advance. `try_inline_dispatch_arm` is transactional, so
+        // an inferred-policy call whose arguments cannot lower rolls back the
+        // whole attempt and falls through to the diagnostic sub-JitCode abort
+        // stub; a supported residual call keeps the caller's pc in this live
+        // frame. Red-pc dispatches keep the sub-JitCode path unconditionally.
         //
-        // No infer-call arm writes a *propagating* pc today, so keeping them on
-        // the sub-JitCode path loses no pc advance.  The only infer-call arms in
-        // the corpus are the `ROLL` arms of tl and tlc (bare-path `auto_calls`
-        // helpers `storage_roll` / `tlc_roll`).  tlc declares no green pc, so it
-        // never inlines any arm (every arm is red-pc sub-JitCode); the hazard is
-        // structurally absent there.  tl's green-pc `ROLL` body contains only
-        // `pc += 1`, which on the non-pinned sub-JitCode path is recognized as
-        // inert and dropped (the dispatch loop owns the pc register), so the
-        // sub-JitCode emits no pc op at all.  The hazard reappears only for a
-        // *non-droppable* pc write — a branch `pc = target` in an arm that also
-        // makes a bare-path inferred-policy call — at which point the remedy is
-        // either to lower that arm inline behind an abort guard, or to add an
-        // explicit pc-writeback from the sub-JitCode into the caller's reg0.
         // `split_dispatch` opt-in: a pure forward-advancing green-pc arm is
         // routed to the per-arm sub-JitCode path (below) with a pc-returning
         // `inline_call_<types>_i` instead of being force-inlined here — this is
         // what keeps the dispatch JitCode's register/const footprint small.
         // `Some(N)` carries the arm's `pc += N` advance to the body generator.
-        // When `split_dispatch` is off this short-circuits to `None` before
-        // `arm_is_pure_pc_advance` runs, so the gate stays byte-identical.
-        let pc_return_increment = if config.split_dispatch
+        // This return channel is independent of whether the work contains an
+        // inferred-policy residual call: if that work cannot lower, the
+        // transactional sub-lowerer returns an abort stub; if it can, dropping
+        // the green return would resume at the old opcode. RPython keeps `pc`
+        // in the caller frame across either call shape.
+        // Inferred residual calls also use this split even without the size
+        // opt-in: their resume guards belong to the callee frame, while the
+        // caller still owns green `pc`.
+        let has_infer_call = lowerer.arm_body_has_infer_call(&arm.original_body);
+        let pc_return_increment = if (config.split_dispatch || has_infer_call)
             && pc_is_green(config)
             && matches!(
                 arm.pattern,
                 crate::jit_interp::classify::ArmPattern::Lowerable
-            )
-            && !lowerer.arm_body_has_infer_call(&arm.original_body)
-        {
+            ) {
             arm_is_pure_pc_advance(&arm.original_body)
         } else {
             None
@@ -2799,7 +2752,7 @@ pub(super) fn lower_dispatch_chain(
                 arm.pattern,
                 crate::jit_interp::classify::ArmPattern::Lowerable
             )
-            && !lowerer.arm_body_has_infer_call(&arm.original_body)
+            && !has_infer_call
         {
             lowerer.try_inline_dispatch_arm(&arm.original_body)
         } else {
@@ -4043,29 +3996,56 @@ pub(crate) fn lower_dispatch_body(
     // at the typed-return emission (interp_jit.py:95-100 return boundary).
     lowerer.emit_label_def(&default_label);
 
-    // Lower the function-final return expression (the stmt after the while loop).
-    // dispatch_minimal returns `state.a` (i64) → BC_INT_RETURN.
-    let return_expr = func_block.stmts.iter().rev().find_map(|s| match s {
-        syn::Stmt::Expr(e, None) => Some(e),
+    // Locate the source dispatch loop and its post-loop epilogue.  A terminal
+    // opcode (`break`) transfers control to this whole suffix, not merely to
+    // its final expression.  Until the suffix is represented as JitCode, a
+    // state-mutating statement there must fail closed: compiling just the
+    // final read would skip the mutation on the machine-code path (TL's
+    // `stackpos -= 1; stack[stackpos]` returned the pre-pop slot).
+    let dispatch_match = find_dispatch_match(func_block)?;
+    let dispatch_loop_index = func_block.stmts.iter().position(|stmt| {
+        let Stmt::Expr(expr, _) = stmt else {
+            return false;
+        };
+        match expr {
+            Expr::While(w) => block_contains_match(&w.body, dispatch_match),
+            Expr::Loop(l) => block_contains_match(&l.body, dispatch_match),
+            _ => false,
+        }
+    })?;
+    let post_loop = &func_block.stmts[dispatch_loop_index + 1..];
+    // Positionally, not by searching backwards for the first expression-shaped
+    // statement: a `while` / `if` / `match` / `loop` written in statement
+    // position is also `Stmt::Expr(_, None)`, so a search would name one of
+    // those as the tail, and `prefix_len` would then both re-lower it as
+    // prefix and leave the real last statement unlowered.
+    let return_expr = match post_loop.last() {
+        Some(syn::Stmt::Expr(e, None)) => Some(e),
         _ => None,
+    };
+    // The terminal opcode's `break` reaches every statement after the source
+    // loop before evaluating the tail expression.  Lower that epilogue in
+    // source order.  `TraceAction::Finish` publishes its concrete result to
+    // the single-pass merge hook, which returns it directly and therefore does
+    // not execute this suffix a second time in native Rust.
+    //
+    // The epilogue fails open.  A prefix statement the lowering refuses -- an
+    // I/O loop, a green write -- rolls back to the loop exit and leaves the
+    // binding unset, so the walk terminates in `void_return` and `Finish`
+    // hands the whole suffix to native execution exactly once.  Propagating
+    // the refusal instead would take the entire dispatch JitCode down with it,
+    // and every trace of that interpreter becomes `AbortPermanent`.
+    let prefix_len = post_loop
+        .len()
+        .saturating_sub(usize::from(return_expr.is_some()));
+    let prefix_lowered = lowerer.transactional(|inner| {
+        for stmt in &post_loop[..prefix_len] {
+            inner.lower_stmt(stmt)?;
+        }
+        Some(())
     });
-    // A trailing expression that STORES must not be lowered here. `jitdriver.rs`'s
-    // `TraceAction::Finish` arm hands the post-loop work to native execution and
-    // writes the walk-final state back for it to read, so a store lowered into the
-    // walk is applied twice: once on the walk's symbolic state (which the
-    // write-back then pushes into native `state`) and once by native code. A pure
-    // trailing expression is idempotent under that division and keeps its typed
-    // return, so this narrows only the storing case, which falls through to
-    // `void_return` and ends the walk at the loop exit.
-    //
-    // The check is syntactic. A store hidden inside a callee is not caught, but
-    // such an expression does not lower to a binding anyway and so already
-    // reaches `void_return`.
-    //
-    // A `None` binding here (no trailing expression, one that stores, or one
-    // that did not lower) falls through to `void_return`.
-    let binding = return_expr
-        .filter(|e| !expr_stores(e))
+    let binding = prefix_lowered
+        .and(return_expr)
         .and_then(|e| lowerer.lower_value_expr(e));
     let (reads, emitter) = typed_return_terminator(binding);
     lowerer.emit_op(OpMeta::terminal(reads), emitter);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -4029,24 +4029,31 @@ pub(crate) fn lower_dispatch_body(
     // the single-pass merge hook, which returns it directly and therefore does
     // not execute this suffix a second time in native Rust.
     //
-    // The epilogue fails open.  A prefix statement the lowering refuses -- an
-    // I/O loop, a green write -- rolls back to the loop exit and leaves the
+    // The epilogue fails open.  A statement the lowering refuses -- an I/O
+    // loop, a green write -- rolls back to the loop exit and leaves the
     // binding unset, so the walk terminates in `void_return` and `Finish`
     // hands the whole suffix to native execution exactly once.  Propagating
     // the refusal instead would take the entire dispatch JitCode down with it,
     // and every trace of that interpreter becomes `AbortPermanent`.
+    //
+    // Prefix and tail roll back TOGETHER.  A tail the lowering refuses after a
+    // committed prefix would leave the prefix in the JitCode and still
+    // terminate in `void_return`, so the native suffix -- the prefix included
+    // -- would run a second time once the `Finish` breaks the dispatch loop.
     let prefix_len = post_loop
         .len()
         .saturating_sub(usize::from(return_expr.is_some()));
-    let prefix_lowered = lowerer.transactional(|inner| {
-        for stmt in &post_loop[..prefix_len] {
-            inner.lower_stmt(stmt)?;
-        }
-        Some(())
-    });
-    let binding = prefix_lowered
-        .and(return_expr)
-        .and_then(|e| lowerer.lower_value_expr(e));
+    let binding = lowerer
+        .transactional(|inner| {
+            for stmt in &post_loop[..prefix_len] {
+                inner.lower_stmt(stmt)?;
+            }
+            match return_expr {
+                Some(expr) => inner.lower_value_expr(expr).map(Some),
+                None => Some(None),
+            }
+        })
+        .flatten();
     let (reads, emitter) = typed_return_terminator(binding);
     lowerer.emit_op(OpMeta::terminal(reads), emitter);
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1416,6 +1416,12 @@ impl<'c> Lowerer<'c> {
         if let Some(()) = self.lower_record_known_result(expr) {
             return Some(());
         }
+        // Loop-carried local updates have to write their existing physical
+        // register; rebinding would leave an already-emitted loop header
+        // reading the pre-update register.
+        if let Some(()) = self.lower_local_update(expr) {
+            return Some(());
+        }
         // Local variable reassignment: `pc = expr` or `stackok = expr`.
         // Rebinds an already-known local to a freshly-lowered RHS value.
         if let Some(()) = self.lower_local_reassign(expr) {
@@ -2411,7 +2417,7 @@ impl<'c> Lowerer<'c> {
 /// plain-ident green names a caller local that a statement can assign to, so a
 /// field or index spelling is skipped rather than flattened to a bare name that
 /// would collide with an unrelated local of that name.
-fn green_idents(config: &LowererConfig) -> Vec<String> {
+pub(super) fn green_idents(config: &LowererConfig) -> Vec<String> {
     config
         .greens
         .iter()

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -768,6 +768,29 @@ impl<'c> Lowerer<'c> {
         }
     }
 
+    /// Preserve a borrow of the live virtualizable as its existing ref input.
+    ///
+    /// RPython residual helpers receive the virtualizable object directly;
+    /// `call.py::getcalldescr` can then classify writes to redirected fields
+    /// as forcing the virtualizable. Rust needs an explicit borrow at the
+    /// concrete call site, but that borrow is representation-only: in JitCode
+    /// it is the same object reference, not a freshly computed integer
+    /// address. Restrict this identity rule to the configured virtualizable so
+    /// ordinary Rust references do not acquire ref semantics accidentally.
+    pub(super) fn lower_vable_reference(&self, expr: &Expr) -> Option<Binding> {
+        let config = self.config?;
+        let vable_var = config.vable_var.as_ref()?;
+        let reference = match expr {
+            Expr::Reference(reference) => reference,
+            _ => return None,
+        };
+        if !expr_matches_local_name(&reference.expr, vable_var) {
+            return None;
+        }
+        let binding = self.bindings.get(vable_var)?;
+        matches!(binding.kind, BindingKind::Ref).then(|| binding.clone())
+    }
+
     /// RPython jtransform.py:655 `hint(access_directly=True)` /
     /// `hint(fresh_virtualizable=True)`.
     ///
@@ -2189,6 +2212,24 @@ mod tests {
         let struct_path: syn::Path = syn::parse_str("Stack").expect("struct path");
         let member: syn::Member = syn::parse_str("head").expect("member");
         ref_field_witness_tokens(&map, key, &struct_path, &member).to_string()
+    }
+
+    #[test]
+    fn a_borrow_of_the_virtualizable_preserves_its_ref_binding() {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.vable_var = Some("state".to_string());
+        config.vable_input_ref_reg = Some(4);
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer.install_vable_input_binding();
+        let expr: Expr = syn::parse_str("&mut state").expect("virtualizable borrow");
+
+        let binding = lowerer
+            .lower_vable_reference(&expr)
+            .expect("virtualizable borrow lowers");
+
+        assert_eq!(binding.reg, 4);
+        assert_eq!(binding.kind, BindingKind::Ref);
+        assert!(lowerer.op_metadata.is_empty());
     }
 
     /// A declared ref field admits the three spellings the lowering can

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -148,6 +148,13 @@ impl<'c> Lowerer<'c> {
         if let Some(binding) = self.lower_vable_array_len(expr) {
             return Some(binding);
         }
+        // RPython call.py passes the virtualizable object itself to residual
+        // helpers. Rust spells that object argument `&mut state`; preserve the
+        // existing ref register instead of trying to manufacture a raw array
+        // pointer from a redirected virtualizable field.
+        if let Some(binding) = self.lower_vable_reference(expr) {
+            return Some(binding);
+        }
         // RPython jtransform.py:655 — suppress hint_access_directly(frame) /
         // hint_fresh_virtualizable(frame) function calls as identity.
         // These return the frame unchanged, so lower the argument instead.
@@ -169,6 +176,26 @@ impl<'c> Lowerer<'c> {
                 ..
             }) => {
                 let value = int_lit.base10_parse::<i64>().ok()?;
+                let reg = self.alloc_reg();
+                self.emit_op(
+                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(reg)]),
+                    quote! { __builder.load_const_i_value(#reg, #value); },
+                );
+                Some(Binding {
+                    reg,
+                    kind: BindingKind::Int,
+                    depends_on_stack: false,
+                    struct_type: None,
+                })
+            }
+            // RPython's bytecode loops compare `ord(code[p])` with integer
+            // character constants. Rust spells the same one-byte constant as
+            // `b'['`; it belongs on the int channel with its `u8` value.
+            Expr::Lit(ExprLit {
+                lit: Lit::Byte(byte_lit),
+                ..
+            }) => {
+                let value = i64::from(byte_lit.value());
                 let reg = self.alloc_reg();
                 self.emit_op(
                     OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(reg)]),
@@ -760,6 +787,64 @@ impl<'c> Lowerer<'c> {
         }
         let binding = self.lower_value_expr(&assign.right)?;
         self.bindings.insert(lhs_ident, binding);
+        Some(())
+    }
+
+    /// Lower a compound update of an existing local into that local's
+    /// physical register: `need -= 1`, `target += offset`, and so on.
+    ///
+    /// This must not allocate and rebind an SSA-like result. A local carried
+    /// around a translated `while` back-edge is read from the register that
+    /// existed when the loop header was emitted; changing the binding after
+    /// the body has been lowered would leave the header reading the stale
+    /// value. RPython's `BrainInterpreter.interp_char` bracket scans depend on
+    /// these loop-carried updates.
+    pub(super) fn lower_local_update(&mut self, expr: &Expr) -> Option<()> {
+        let Expr::Binary(binary) = expr else {
+            return None;
+        };
+        let Expr::Path(lhs_path) = &*binary.left else {
+            return None;
+        };
+        let lhs_ident = lhs_path.path.get_ident()?.to_string();
+        // `lower_expr_stmt` reaches this before `lower_stmt_fallback`, so the
+        // green-write refusal there never sees the statement.  A green is a
+        // caller local threaded through the merge point: writing it into this
+        // body's own register drops the advance instead of carrying it back,
+        // and the arm then records, compiles and answers with a stale green.
+        // The sub-JitCode paths that legitimately advance a green take it
+        // through `pc_return_increment`, which removes the statement before
+        // lowering, so refusing here cannot reach them.
+        if let Some(config) = self.config
+            && super::lower_stmt::green_idents(config).contains(&lhs_ident)
+        {
+            return None;
+        }
+        let lhs = self.bindings.get(&lhs_ident)?.clone();
+        let (op_kind, opcode) = match lhs.kind {
+            BindingKind::Int => (OpKind::BinopI, opcode_for_assign_binop(&binary.op)?),
+            BindingKind::Float => (OpKind::BinopF, opcode_for_assign_binop_f(&binary.op)?),
+            BindingKind::Ref => return None,
+        };
+        let rhs = self.lower_value_expr(&binary.right)?;
+        if lhs.kind != rhs.kind {
+            return None;
+        }
+
+        let tokens = match lhs.kind {
+            BindingKind::Int => binop_i_emit_tokens(lhs.reg, &opcode, lhs.reg, rhs.reg),
+            BindingKind::Float => binop_f_emit_tokens(lhs.reg, &opcode, lhs.reg, rhs.reg),
+            BindingKind::Ref => return None,
+        };
+        let register = Register::new(lhs.kind, lhs.reg);
+        self.emit_op(
+            OpMeta::linear(
+                op_kind,
+                vec![register, Register::from_binding(&rhs)],
+                vec![register],
+            ),
+            tokens,
+        );
         Some(())
     }
 
@@ -2416,6 +2501,49 @@ mod tests {
             depends_on_stack: false,
             struct_type: None,
         }
+    }
+
+    #[test]
+    fn loop_carried_local_update_writes_the_existing_register() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer
+            .bindings
+            .insert("need".to_string(), binding(3, BindingKind::Int));
+        let expr: Expr = syn::parse_str("need -= 1").expect("parse local update");
+
+        assert_eq!(lowerer.lower_local_update(&expr), Some(()));
+
+        assert_eq!(lowerer.op_metadata[0].kind, OpKind::LoadConstI);
+        let op = &lowerer.op_metadata[1];
+        assert_eq!(op.kind, OpKind::BinopI);
+        assert_eq!(op.reads[0], Register::int(3));
+        assert_eq!(op.writes, vec![Register::int(3)]);
+        assert_eq!(lowerer.bindings["need"].reg, 3);
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+        assert!(emitted.contains("IntSub"));
+    }
+
+    #[test]
+    fn byte_literal_uses_the_integer_constant_channel() {
+        let mut lowerer = Lowerer::new(None);
+        let expr: Expr = syn::parse_str("b']'").expect("parse byte literal");
+
+        let binding = lowerer
+            .lower_value_expr(&expr)
+            .expect("byte literal lowers");
+
+        assert_eq!(binding.kind, BindingKind::Int);
+        assert_eq!(lowerer.op_metadata[0].kind, OpKind::LoadConstI);
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+        assert!(emitted.contains("93i64"));
     }
 
     #[test]

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2717,6 +2717,25 @@ impl FinishReturn {
             }
         }
     }
+
+    /// Drain the result of the tracing walk itself.  The dispatch JitCode has
+    /// already executed the source post-loop epilogue; returning here avoids
+    /// running that suffix again after the merge hook writes state back.
+    fn drain_single_pass(&self, driver_expr: &Expr) -> TokenStream {
+        let take = match self.kind {
+            FinishReturnKind::Int => quote! { take_single_pass_finish_int },
+            FinishReturnKind::Float => quote! { take_single_pass_finish_float },
+        };
+        let returned = match &self.cast_to {
+            Some(ty) => quote! { __finish_value as #ty },
+            None => quote! { __finish_value },
+        };
+        quote! {
+            if let Some(__finish_value) = #driver_expr.#take() {
+                return #returned;
+            }
+        }
+    }
 }
 
 /// Rewrite function body: replace jit_merge_point!() and can_enter_jit!() calls.
@@ -3093,6 +3112,11 @@ fn rewrite_body(
                     // (avoids the cold `__merge_*` call when not tracing).  It does NOT
                     // add a second merge-point dispatch — `driver.merge_point` guards
                     // again internally, but the closure runs only once.
+                    let single_pass_finish_drain = self
+                        .finish_return
+                        .as_ref()
+                        .map(|finish_return| finish_return.drain_single_pass(&driver))
+                        .unwrap_or_default();
                     let new_tokens: TokenStream = if let Some(state) = &args.state {
                         // Single-pass close: after the walk, if the CloseLoop
                         // populated a walk-final (pc, reds) snapshot, transfer
@@ -3208,7 +3232,14 @@ fn rewrite_body(
                                     // before the program end). A CloseLoop
                                     // back-edge keeps interpreting from the
                                     // merge-point pc.
+                                    // The drain belongs INSIDE the latch it
+                                    // reads.  Ahead of it, it fires on every
+                                    // single-pass close -- an ordinary
+                                    // `CloseLoop` back edge included -- and a
+                                    // stale value latch would return from the
+                                    // portal where the loop must keep running.
                                     if #driver.take_single_pass_finish() {
+                                        #single_pass_finish_drain
                                         break;
                                     }
                                     #pc = __sp_pc;
@@ -3461,8 +3492,22 @@ fn rewrite_body(
                             // `loop` the type `()` — so an unconditional
                             // emission stops such a body from compiling at all.
                             let single_pass_finish_exit: TokenStream = if self.single_pass_close {
+                                // Same latch, same drain as the merge-point
+                                // close: the dispatch JitCode has already run
+                                // the source post-loop epilogue, so breaking
+                                // without draining runs that suffix a second
+                                // time natively.  With no value published the
+                                // drain falls through and the `break` stands.
+                                let drain = self
+                                    .finish_return
+                                    .as_ref()
+                                    .map(|finish_return| {
+                                        finish_return.drain_single_pass(driver_expr)
+                                    })
+                                    .unwrap_or_default();
                                 quote! {
                                     if #driver_expr.take_single_pass_finish() {
+                                        #drain
                                         break;
                                     }
                                 }

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -664,8 +664,39 @@ fn is_raw_pointer_type(ty: &Type) -> bool {
     matches!(ty, Type::Ptr(_))
 }
 
+fn path_type_last_ident(ty: &Type) -> Option<&Ident> {
+    match ty {
+        Type::Path(type_path) if type_path.qself.is_none() => {
+            type_path.path.segments.last().map(|segment| &segment.ident)
+        }
+        _ => None,
+    }
+}
+
+/// The spellings whose pointee is unsized, so a reference to one is two words.
+///
+/// A residual-call argument is a single ABI word, which is what
+/// [`helper_arg_from_i64`] rebuilds the reference from.  An unsized pointee
+/// needs an address *and* a length or vtable, so it cannot survive that round
+/// trip and the helper must fall through to `HelperCallKind::Unsupported`
+/// instead.  Sizedness is a type-level property and this runs on syntax, so the
+/// unsized spellings are named: the two structural ones, and the named types
+/// this workspace actually passes by reference.  A pointee missing from here
+/// fails to compile at its call site with E0606 rather than lowering wrongly.
+fn is_wide_pointee(ty: &Type) -> bool {
+    if matches!(ty, Type::Slice(_) | Type::TraitObject(_)) {
+        return true;
+    }
+    let named = primitive_type_ident(ty).or_else(|| path_type_last_ident(ty));
+    matches!(named, Some(ident) if ident == "str" || ident == "Wtf8")
+}
+
+fn is_reference_type(ty: &Type) -> bool {
+    matches!(ty, Type::Reference(reference) if !is_wide_pointee(&reference.elem))
+}
+
 fn helper_call_kind_for_type(ty: &Type) -> HelperCallKind {
-    if is_gc_ref_type(ty) || is_raw_pointer_type(ty) {
+    if is_gc_ref_type(ty) || is_raw_pointer_type(ty) || is_reference_type(ty) {
         return HelperCallKind::Ref;
     }
     match primitive_type_ident(ty)
@@ -694,6 +725,16 @@ fn helper_arg_from_i64(arg_ident: &Ident, ty: &Type) -> Option<proc_macro2::Toke
     }
     if is_raw_pointer_type(ty) {
         return Some(quote! { ((#arg_ident) as usize) as #ty });
+    }
+    if is_reference_type(ty)
+        && let Type::Reference(reference) = ty
+    {
+        let elem = &reference.elem;
+        return if reference.mutability.is_some() {
+            Some(quote! { unsafe { &mut *((#arg_ident) as usize as *mut #elem) } })
+        } else {
+            Some(quote! { unsafe { &*((#arg_ident) as usize as *const #elem) } })
+        };
     }
     let ty_ident = primitive_type_ident(ty)?;
     match ty_ident.to_string().as_str() {

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -18,6 +18,37 @@ use super::{
     RuntimeBhDescr,
 };
 
+/// The `EffectInfo` a jitcode-lowered `#[jit_may_force]` helper carries.
+///
+/// `EF_RANDOM_EFFECTS`, for the reason `pyre-jit`'s `CallFlavor::MayForce`
+/// resolves to the same constant: `call.py:288-289 if
+/// virtualizable_analyzer.analyze(op):` reaches
+/// `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` only through
+/// `effectinfo_from_writeanalyze(self.readwrite_analyzer.analyze(op))`
+/// (`call.py:319-323`), which names every field and array the callee writes —
+/// `self.stack[*]` for `tl.py Stack.roll`. The helper reached from here is a
+/// Rust `extern "C"` fn with no graph for that analyzer to walk, so an empty
+/// write set asserts something it has not proved, and
+/// `heap.py force_from_effectinfo` believes it.
+///
+/// What makes the difference observable on this leg: a jitcode-lowered
+/// may-force call belongs to a `#[jit_interp(state_fields = ...)]` machine,
+/// which is `VirtualizableInfo::without_vable_token`. Nothing clears a token,
+/// so `vable_after_residual_call` never aborts and the trace runs on past the
+/// call and reads the state back through
+/// `TraceCtx::reload_tokenless_virtualizable_after_residual_call` — a read the
+/// empty write set lets the heap cache fold to the value stored before the
+/// call.
+///
+/// The promotion costs no may-force machinery: `check_forces_virtual_or_
+/// virtualizable()` reads `extraeffect >= EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`
+/// (`effectinfo.py:249-250`) and RandomEffects is above it, so
+/// `do_residual_call` still selects `CALL_MAY_FORCE_*` with its vable/vref
+/// preparation.
+fn jitcode_may_force_effect_info() -> majit_ir::effectinfo::EffectInfo {
+    crate::call_descr::default_effect_info()
+}
+
 /// Byte width of one scalar of `ty` in memory — a struct field or an array
 /// item.
 ///
@@ -4034,17 +4065,7 @@ impl JitCodeBuilder {
             ),
             fn_ptr_idx,
             arg_regs,
-            // PyPy `call.py:288-289 if virtualizable_analyzer.analyze(op):`
-            // selects `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, fed through
-            // `effectinfo_from_writeanalyze` with the analyzer-empty
-            // (`graphanalyze.py bottom_result()`) default. The
-            // resulting EI is the dedicated FVOV slot — distinct from
-            // `MOST_GENERAL`/RandomEffects (only the
-            // `randomeffects_analyzer` branch at `call.py:282-283`).
-            // Routing to `MOST_GENERAL` over-invalidates the heap cache
-            // via `has_random_effects() → clean_caches` PyPy reserves
-            // for genuinely-random callees.
-            crate::call_descr::forces_virtual_or_virtualizable_effect_info(),
+            jitcode_may_force_effect_info(),
             "call_may_force_void_canonical_via_target",
         );
     }
@@ -4541,17 +4562,7 @@ impl JitCodeBuilder {
             fn_ptr_idx,
             arg_regs,
             dst,
-            // PyPy `call.py:288-289 if virtualizable_analyzer.analyze(op):`
-            // selects `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, fed through
-            // `effectinfo_from_writeanalyze` with the analyzer-empty
-            // (`graphanalyze.py bottom_result()`) default. The
-            // resulting EI is the dedicated FVOV slot — distinct from
-            // `MOST_GENERAL`/RandomEffects which is only the
-            // `randomeffects_analyzer` branch (`call.py:282-283`).
-            // Routing to `MOST_GENERAL` over-invalidates the heap cache
-            // via `has_random_effects() → clean_caches` PyPy reserves
-            // for genuinely-random callees.
-            crate::call_descr::forces_virtual_or_virtualizable_effect_info(),
+            jitcode_may_force_effect_info(),
         );
     }
 
@@ -4625,17 +4636,7 @@ impl JitCodeBuilder {
             fn_ptr_idx,
             arg_regs,
             dst,
-            // PyPy `call.py:288-289 if virtualizable_analyzer.analyze(op):`
-            // selects `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, fed through
-            // `effectinfo_from_writeanalyze` with the analyzer-empty
-            // (`graphanalyze.py bottom_result()`) default. The
-            // resulting EI is the dedicated FVOV slot — distinct from
-            // `MOST_GENERAL`/RandomEffects which is only the
-            // `randomeffects_analyzer` branch (`call.py:282-283`).
-            // Routing to `MOST_GENERAL` over-invalidates the heap cache
-            // via `has_random_effects() → clean_caches` PyPy reserves
-            // for genuinely-random callees.
-            crate::call_descr::forces_virtual_or_virtualizable_effect_info(),
+            jitcode_may_force_effect_info(),
         );
     }
 
@@ -4674,17 +4675,7 @@ impl JitCodeBuilder {
             fn_ptr_idx,
             arg_regs,
             dst,
-            // PyPy `call.py:288-289 if virtualizable_analyzer.analyze(op):`
-            // selects `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, fed through
-            // `effectinfo_from_writeanalyze` with the analyzer-empty
-            // (`graphanalyze.py bottom_result()`) default. The
-            // resulting EI is the dedicated FVOV slot — distinct from
-            // `MOST_GENERAL`/RandomEffects which is only the
-            // `randomeffects_analyzer` branch (`call.py:282-283`).
-            // Routing to `MOST_GENERAL` over-invalidates the heap cache
-            // via `has_random_effects() → clean_caches` PyPy reserves
-            // for genuinely-random callees.
-            crate::call_descr::forces_virtual_or_virtualizable_effect_info(),
+            jitcode_may_force_effect_info(),
         );
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2879,6 +2879,24 @@ impl<S: JitState> JitDriver<S> {
                 // guard-failure resume uses for this outcome.  It reaches
                 // `build_meta` only as the `header_pc` the `#[jit_interp]`
                 // impl ignores, and the hook breaks before using it as a pc.
+                //
+                // Publish the scalar the chain returned.  A dispatch JitCode
+                // that lowered the source post-loop epilogue has already run it
+                // here, so the value IS the portal's result; leaving it unread
+                // makes the hook break and native Rust run that suffix a second
+                // time.  Void and Ref carry no scalar and leave the latch
+                // empty, which is the same break as before.
+                match &outcome {
+                    crate::jitexc::JitException::DoneWithThisFrameInt(v) => {
+                        self.meta.single_pass_finish_values =
+                            Some(core::iter::once(Value::Int(*v)).collect());
+                    }
+                    crate::jitexc::JitException::DoneWithThisFrameFloat(v) => {
+                        self.meta.single_pass_finish_values =
+                            Some(core::iter::once(Value::Float(*v)).collect());
+                    }
+                    _ => {}
+                }
                 writeback(state, usize::MAX);
                 self.meta.single_pass_finish = true;
                 Some(usize::MAX)
@@ -2941,6 +2959,26 @@ impl<S: JitState> JitDriver<S> {
     /// Consumes (`take`s) the flag.
     pub fn take_single_pass_finish(&mut self) -> bool {
         std::mem::replace(&mut self.meta.single_pass_finish, false)
+    }
+
+    /// Integer FINISH result produced by a single-pass tracing walk.
+    pub fn take_single_pass_finish_int(&mut self) -> Option<i64> {
+        let values = self.meta.single_pass_finish_values.take()?;
+        match values.first() {
+            Some(Value::Int(v)) => Some(*v),
+            Some(Value::Float(v)) => Some(v.to_bits() as i64),
+            _ => None,
+        }
+    }
+
+    /// Float FINISH result produced by a single-pass tracing walk.
+    pub fn take_single_pass_finish_float(&mut self) -> Option<f64> {
+        let values = self.meta.single_pass_finish_values.take()?;
+        match values.first() {
+            Some(Value::Float(v)) => Some(*v),
+            Some(Value::Int(v)) => Some(f64::from_bits(*v as u64)),
+            _ => None,
+        }
     }
 
     /// The FINISH arguments of the compiled run a `back_edge*` call just made,
@@ -4455,6 +4493,10 @@ impl<S: JitState> JitDriver<S> {
                     exit_with_exception,
                     exc_value,
                 } => {
+                    self.meta.single_pass_finish_values = self
+                        .meta
+                        .trace_ctx()
+                        .map(|ctx| ctx.walk_finish_values.iter().copied().collect());
                     // A terminal dispatch return is also a valid single-pass
                     // handoff: the interpreted function has returned, so native
                     // execution must EXIT the dispatch loop and run its own
@@ -4466,11 +4508,18 @@ impl<S: JitState> JitDriver<S> {
                     // `while pc < size` would exit on resume — when the terminal is
                     // the last opcode; a mid-program terminal would re-enter the
                     // loop body, so the exit is signalled explicitly.
+                    //
+                    // The flag is not conditional on that pc.  `Finish` IS the
+                    // interpreted function returning, so the dispatch loop has
+                    // to exit either way; a walk that published its finish
+                    // values without a final pc would otherwise leave the hook
+                    // with neither a break nor a resume and spin the native
+                    // loop.  Only the resume coordinate is pc-gated.
                     let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
                     if let Some(p) = pc {
                         self.meta.single_pass_outcome = Some((p, Vec::new()));
-                        self.meta.single_pass_finish = true;
                     }
+                    self.meta.single_pass_finish = true;
                     if let Some(sym) = self.sym.as_ref() {
                         let scalars = S::collect_scalar_state_field_values(sym);
                         self.meta.single_pass_scalar_values = Some(scalars);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3115,6 +3115,12 @@ impl<S: JitState> JitDriver<S> {
         if !portal_rca_enabled() {
             return;
         }
+        if resume_pc == usize::MAX {
+            // The finish sentinel: the interpreted function returned, so there
+            // is no resume coordinate to build a state image against.
+            eprintln!("[portal-rca][parity-crn] resume_pc=<finish>");
+            return;
+        }
         let key = self.meta.single_pass_compiled_key;
         let dispatch_key = key.and_then(|k| self.meta.front_target_dispatch_key(k));
         let meta = S::build_meta(state, resume_pc, env);
@@ -4514,11 +4520,21 @@ impl<S: JitState> JitDriver<S> {
                     // to exit either way; a walk that published its finish
                     // values without a final pc would otherwise leave the hook
                     // with neither a break nor a resume and spin the native
-                    // loop.  Only the resume coordinate is pc-gated.
-                    let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
-                    if let Some(p) = pc {
-                        self.meta.single_pass_outcome = Some((p, Vec::new()));
-                    }
+                    // loop.
+                    //
+                    // The outcome is not conditional on it either, and for the
+                    // same reason: the hook reads `single_pass_finish` only
+                    // from INSIDE the outcome branch, so publishing nothing
+                    // would hide the flag it is supposed to carry.
+                    // `usize::MAX` is the no-position sentinel the wrapper
+                    // itself returns for a finish, so a consumer that ignores
+                    // the flag fails loudly instead of resuming somewhere.
+                    let pc = self
+                        .meta
+                        .trace_ctx()
+                        .and_then(|ctx| ctx.walk_final_pc)
+                        .unwrap_or(usize::MAX);
+                    self.meta.single_pass_outcome = Some((pc, Vec::new()));
                     self.meta.single_pass_finish = true;
                     if let Some(sym) = self.sym.as_ref() {
                         let scalars = S::collect_scalar_state_field_values(sym);

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -92,6 +92,18 @@ pub(crate) struct VirtualizableConfig {
     /// before it consults this field at all, so a tracker is still installed
     /// there with this set to `None`.
     pub identity_input_index: Option<usize>,
+    /// [`VirtualizableInfo::has_vable_token`], which decides whether a
+    /// residual call may leave the tracked field/array maps stale.
+    ///
+    /// With a token, a callee that touches the virtualizable clears it and
+    /// `vable_after_residual_call` (`pyjitpl.py:3373-3375`) aborts the trace,
+    /// so no read after the call can observe a write the maps missed. A
+    /// `without_vable_token` machine has no such signal: the tracer writes the
+    /// fields out before the call and reads them back after
+    /// (`TraceCtx::materialize_tokenless_virtualizable_before_residual_call`
+    /// and its reload twin) and keeps tracing, so the maps must be dropped at
+    /// the call for those reads to survive.
+    pub has_vable_token: bool,
 }
 
 /// JitVirtualRef field slot indices.
@@ -436,6 +448,35 @@ impl VirtualizableTracker {
                 }
             });
         }
+    }
+
+    /// Drop every tracked static field and array element of the standard
+    /// virtualizable.
+    ///
+    /// The counterpart of `clean_caches` (`heap.py:519-531`) for the two maps
+    /// this tracker keeps outside `OptHeap`. It applies only to a
+    /// `without_vable_token` machine: see
+    /// [`VirtualizableConfig::has_vable_token`] for why a token-bearing one
+    /// cannot reach a stale read.
+    ///
+    /// `field_descrs` survives — it is the descr each slot was seeded with,
+    /// not a value, and the force path still needs it after the values go.
+    fn invalidate_all(&self, ctx: &mut OptContext) {
+        if self.config.has_vable_token {
+            return;
+        }
+        let Some(identity) = self
+            .identity_input_ref(ctx)
+            .and_then(|r| ctx.get_box_replacement_operand_opt(r))
+        else {
+            return;
+        };
+        ctx.with_ptr_info_mut(&identity, |info| {
+            if let PtrInfo::Virtualizable(vstate) = info {
+                vstate.fields.clear();
+                vstate.arrays.clear();
+            }
+        });
     }
 
     /// Read counterpart to [`mirror_setarrayitem`]: returns the tracked
@@ -2350,6 +2391,17 @@ impl Optimization for OptVirtualize {
                         return OptimizationResult::Remove;
                     }
                 }
+                // The callee is handed the virtualizable and may write it.
+                // On a token-bearing machine that write clears the token and
+                // the trace has already aborted, so the maps stay good; a
+                // `without_vable_token` machine keeps tracing, and the reload
+                // the tracer records after the call is the only reader of what
+                // the callee wrote. Folding that reload back to the value
+                // stored before the call is the wrong answer, so drop the maps
+                // here.
+                if let Some(ref vt) = self.vable {
+                    vt.invalidate_all(ctx);
+                }
                 OptimizationResult::PassOn
             }
 
@@ -3915,6 +3967,7 @@ mod tests {
                 array_field_descrs: vec![],
                 vable_input_offset: 0,
                 identity_input_index: Some(0),
+                has_vable_token: true,
             },
         )));
         let forced = opt.force_box(OpRef::input_arg_ref(0), &mut ctx);
@@ -3945,6 +3998,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4044,6 +4098,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4092,6 +4147,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4122,6 +4178,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4155,6 +4212,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
         if let Some(ref mut vt) = pass.vable {
@@ -4230,6 +4288,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4275,6 +4334,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4325,6 +4385,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4432,6 +4493,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         pass.setup();
 
@@ -4545,6 +4607,7 @@ mod tests {
             array_field_descrs: vec![],
             vable_input_offset: 0,
             identity_input_index: Some(0),
+            has_vable_token: true,
         });
         let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let mut ops = vec![

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1676,6 +1676,11 @@ pub struct MetaInterp<M: Clone> {
     /// `break` instead of resuming at the pc). `take`n by the `__merge` wrapper's
     /// caller.
     pub(crate) single_pass_finish: bool,
+    /// Concrete FINISH payload produced by the single-pass tracing walk.
+    /// The macro drains this to return from the portal directly after it has
+    /// written the walk-final state back, so a lowered post-loop epilogue is
+    /// not executed a second time by native Rust.
+    pub(crate) single_pass_finish_values: Option<ExitValues>,
     /// The FINISH arguments of a compiled run entered from a back edge, when
     /// that run ended in FINISH rather than a back-edge JUMP or a guard
     /// failure. `compile.py` `_DoneWithThisFrameDescr` sets
@@ -3487,6 +3492,7 @@ impl<M: Clone> MetaInterp<M> {
             tracing: None,
             single_pass_outcome: None,
             single_pass_finish: false,
+            single_pass_finish_values: None,
             back_edge_finish: None,
             single_pass_scalar_values: None,
             single_pass_ref_scalar_values: None,
@@ -5480,8 +5486,8 @@ impl<M: Clone> MetaInterp<M> {
     ///    fallback (borrows `compiled_loops` + `warm_state`);
     /// 3. `recursive_target` — recursive-call green-key → `(Arc<JitCellToken>,
     ///    green_key)` resolver for a recursive CALL_ASSEMBLER (mirrors
-    ///    `get_loop_token_arc`; only already-compiled callees, the
-    ///    pending-token window returns `None` → the dispatcher aborts);
+    ///    `WarmEnterState.get_assembler_token`, including creation of a
+    ///    temporary callback token for an uncompiled callee);
     /// 4. `recursive_decision` — the recursive-portal inline decision,
     ///    sharing `decide_recursive_inline` with `should_inline_core`;
     /// 5. `recursive_exec` — runs a recursive callee's compiled loop via
@@ -5501,13 +5507,17 @@ impl<M: Clone> MetaInterp<M> {
             &dyn Fn(&JitCellToken, &[Value]) -> Option<()>,
         ) -> R,
     ) -> Option<R> {
-        let tracing = self.tracing.as_mut()?;
+        // Move the trace out while the runtime closures run.  RPython's
+        // MetaInterp owns both history and warmrunnerstate and can mutate the
+        // latter from `do_recursive_call`; keeping `self.tracing` borrowed in
+        // place would artificially prohibit the same disjoint-field access in
+        // Rust.  It is restored before returning.
+        let mut tracing = self.tracing.take()?;
         let compiled_loops = &self.compiled_loops;
-        let warm_state = &self.warm_state;
-        let backend = &self.backend;
         let staticdata = &self.staticdata;
         let pending_green_key = self.pending_token.as_ref().map(|(k, _)| *k);
         let max_unroll = self.max_unroll_recursion;
+        let runtime_state = std::cell::RefCell::new((&mut self.warm_state, &mut self.backend));
         let resolver = |n: u64| -> Option<Arc<JitCellToken>> {
             for compiled in compiled_loops.values() {
                 if let Some(tok) = compiled.token.upgrade()
@@ -5523,29 +5533,68 @@ impl<M: Clone> MetaInterp<M> {
                     }
                 }
             }
-            warm_state.find_token_by_number(n)
+            runtime_state.borrow().0.find_token_by_number(n)
         };
-        // recursive-call green-key → token resolver (pyjitpl.py:3593-3599
-        // `get_assembler_token`).  Resolves only already-compiled callees
-        // through `warm_state.get_compiled`; the pending-token convergence
-        // window returns `None` so the dispatcher aborts and retries (a
-        // later slice wires the `compile_tmp_callback` stand-in).
-        let recursive_target =
-            |jd_index: usize, green_values: &[i64]| -> Option<(Arc<JitCellToken>, u64)> {
-                let jd = staticdata.jitdrivers_sd.get(jd_index)?;
-                let spec = jd.green_args_spec();
-                // Resolve to the callee's CELL key before consulting either
-                // index: the token comes off the celltable and the key travels
-                // on to the `CALL_ASSEMBLER` descr, so both must name the cell
-                // the callee's greens own rather than whatever heads its bucket.
-                let green_key = warm_state
-                    .resolve_cell_key(crate::green_key_hash_typed(green_values, &spec), || {
-                        majit_ir::GreenKey::with_types(green_values.to_vec(), spec.clone())
-                    });
-                warm_state
-                    .get_compiled(green_key)
-                    .map(|arc| (arc, green_key))
-            };
+        // recursive-call green-key → token resolver (pyjitpl.py
+        // `do_recursive_call` → `direct_assembler_call` →
+        // `warmrunnerstate.get_assembler_token`).  An absent compiled token is
+        // not an abort: upstream installs `compile_tmp_callback` immediately,
+        // so the recursive edge remains a CALL_ASSEMBLER while the real callee
+        // loop is still pending.
+        let recursive_target = |jd_index: usize,
+                                green_values: &[i64]|
+         -> Option<(Arc<JitCellToken>, u64)> {
+            let jd = staticdata.jitdrivers_sd.get(jd_index)?.clone();
+            let spec = jd.green_args_spec();
+            // Resolve to the callee's CELL key before consulting either
+            // index: the token comes off the celltable and the key travels
+            // on to the `CALL_ASSEMBLER` descr, so both must name the cell
+            // the callee's greens own rather than whatever heads its bucket.
+            let green_key = runtime_state
+                .borrow()
+                .0
+                .resolve_cell_key(crate::green_key_hash_typed(green_values, &spec), || {
+                    majit_ir::GreenKey::with_types(green_values.to_vec(), spec.clone())
+                });
+            if let Some(token) = runtime_state.borrow().0.get_compiled(green_key) {
+                return Some((token, green_key));
+            }
+            let greenboxes: Vec<Value> = green_values
+                .iter()
+                .zip(spec.iter())
+                .map(|(&value, kind)| match majit_ir::green_type_to_ir(*kind) {
+                    Type::Int => Value::Int(value),
+                    Type::Ref => Value::Ref(GcRef(value as usize)),
+                    Type::Float => Value::Float(f64::from_bits(value as u64)),
+                    Type::Void => Value::Void,
+                })
+                .collect();
+            let red_arg_types = jd.red_arg_types_as_ir_types();
+            let mut state = runtime_state.borrow_mut();
+            let (warm_state, backend) = &mut *state;
+            let token_number = warm_state.alloc_token_number();
+            match warm_state.get_assembler_token(green_key, |memmgr| {
+                compile::compile_tmp_callback(
+                    *backend,
+                    &jd,
+                    token_number,
+                    green_key,
+                    &greenboxes,
+                    &red_arg_types,
+                    Some(memmgr),
+                )
+            }) {
+                Ok(token) => Some((token, green_key)),
+                Err(err) => {
+                    if crate::majit_log_enabled() {
+                        eprintln!(
+                            "[jit][recursive-ca] compile_tmp_callback failed for key={green_key}: {err:?}"
+                        );
+                    }
+                    None
+                }
+            }
+        };
         // recursive-call recursive-portal inline decision, sharing
         // `decide_recursive_inline` with `should_inline_core` so the
         // dispatch-side and metainterp-side decisions cannot drift.  The
@@ -5567,7 +5616,9 @@ impl<M: Clone> MetaInterp<M> {
             // one: `decide_recursive_inline` exists to keep this decision and
             // that resolver from drifting, which they would if one asked the
             // celltable about a cell the other never looked at.
-            let green_key = warm_state
+            let green_key = runtime_state
+                .borrow()
+                .0
                 .resolve_cell_key(crate::green_key_hash_typed(green_values, &spec), || {
                     majit_ir::GreenKey::with_types(green_values.to_vec(), spec.clone())
                 });
@@ -5580,8 +5631,8 @@ impl<M: Clone> MetaInterp<M> {
             // one, the exact drift `decide_recursive_inline` is meant to prevent.
             let callee_compiled = compiled_loops.contains_key(&green_key)
                 || pending_green_key == Some(green_key)
-                || warm_state.get_compiled(green_key).is_some();
-            let can_inline = warm_state.can_inline_callable(green_key);
+                || runtime_state.borrow().0.get_compiled(green_key).is_some();
+            let can_inline = runtime_state.borrow().0.can_inline_callable(green_key);
             let (decision, _should_disable) = decide_recursive_inline(
                 callee_compiled,
                 can_inline,
@@ -5595,7 +5646,7 @@ impl<M: Clone> MetaInterp<M> {
         // through the JITFRAME-ABI `execute_token_raw` and decode the int
         // FINISH output (mirrors `run_compiled_raw_detailed_with_values`).
         let recursive_exec = |token: &JitCellToken, reds: &[Value]| -> Option<i64> {
-            let result = backend.execute_token_raw(token, reds);
+            let result = runtime_state.borrow().1.execute_token_raw(token, reds);
             if result.is_finish {
                 result.outputs.first().copied()
             } else {
@@ -5607,7 +5658,7 @@ impl<M: Clone> MetaInterp<M> {
         // float as `f64::to_bits()`, both into `outputs`), so the int decode
         // shape carries through unchanged.
         let recursive_exec_ref = |token: &JitCellToken, reds: &[Value]| -> Option<i64> {
-            let result = backend.execute_token_raw(token, reds);
+            let result = runtime_state.borrow().1.execute_token_raw(token, reds);
             if result.is_finish {
                 result.outputs.first().copied()
             } else {
@@ -5615,7 +5666,7 @@ impl<M: Clone> MetaInterp<M> {
             }
         };
         let recursive_exec_float = |token: &JitCellToken, reds: &[Value]| -> Option<i64> {
-            let result = backend.execute_token_raw(token, reds);
+            let result = runtime_state.borrow().1.execute_token_raw(token, reds);
             if result.is_finish {
                 result.outputs.first().copied()
             } else {
@@ -5625,11 +5676,11 @@ impl<M: Clone> MetaInterp<M> {
         // Void runs the callee for its side effects; a finished loop yields
         // `Some(())`, an unfinished one `None`.
         let recursive_exec_void = |token: &JitCellToken, reds: &[Value]| -> Option<()> {
-            let result = backend.execute_token_raw(token, reds);
+            let result = runtime_state.borrow().1.execute_token_raw(token, reds);
             result.is_finish.then_some(())
         };
-        Some(f(
-            tracing,
+        let result = f(
+            &mut tracing,
             &resolver,
             &recursive_target,
             &recursive_decision,
@@ -5637,7 +5688,9 @@ impl<M: Clone> MetaInterp<M> {
             &recursive_exec_ref,
             &recursive_exec_float,
             &recursive_exec_void,
-        ))
+        );
+        self.tracing = Some(tracing);
+        Some(result)
     }
 
     pub fn force_finish_trace_enabled(&self) -> bool {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -961,6 +961,16 @@ pub trait JitCodeSym {
         None
     }
 
+    /// Capacities used only by the host allocator for each virtualizable
+    /// identity in [`Self::recursive_fresh_entry_reds`].
+    ///
+    /// These are not portal reds. RPython's `do_recursive_call` passes the
+    /// portal's declared red boxes unchanged; allocation sizing belongs to
+    /// frame construction, not to the callee call signature.
+    fn recursive_fresh_entry_vable_capacities(&self) -> Option<Vec<i64>> {
+        None
+    }
+
     /// recursive-call recursive CALL_ASSEMBLER portal entry: the host-Rust allocator and
     /// deallocator for a fresh callee state.
     ///
@@ -1499,12 +1509,15 @@ where
             majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut *active.obj));
             active.info.tracing_before_residual_call(active.obj_ptr());
         }
+        ctx.materialize_tokenless_virtualizable_before_residual_call();
         let force_token = ctx.force_token();
-        ctx.vable_setfield_descr(
-            active.vable_opref,
-            force_token,
-            active.info.token_field_descr(),
-        );
+        if active.info.has_vable_token() {
+            ctx.vable_setfield_descr(
+                active.vable_opref,
+                force_token,
+                active.info.token_field_descr(),
+            );
+        }
         Some(active)
     }
 
@@ -1545,6 +1558,16 @@ where
         sym: &mut S,
         active: Option<ActiveStandardVirtualizable>,
     ) -> TraceAction {
+        // `prepare_standard_virtualizable_before_residual_call` reaches the
+        // materialize only through `active_standard_virtualizable(ctx)?`, so a
+        // `None` here means no store was recorded before the call.  The reload
+        // below still finds a box and a pointer through
+        // `standard_virtualizable_box`/`_ptr`, and
+        // `set_virtualizable_boxes_with_info` replaces every existing box, so
+        // reloading without that materialize gives the trace heap reads with no
+        // matching stores and reverts the loop-carried fields to their pre-call
+        // values.  Pair the two on one predicate.
+        let materialized = active.is_some();
         if let Some(active) = Self::escaped_standard_virtualizable(ctx, active) {
             // pyjitpl.py `self.load_fields_from_virtualizable()` runs
             // BEFORE the abort: the residual call forced the virtualizable and
@@ -1592,6 +1615,9 @@ where
                 resume_pc,
                 /* after_residual_call */ true,
             );
+            if materialized {
+                ctx.reload_tokenless_virtualizable_after_residual_call();
+            }
             TraceAction::Continue
         }
     }
@@ -2569,7 +2595,7 @@ where
     /// single-pass merge hook resumes native execution at the source loop exit.
     /// The scalar state handoff rides `single_pass_scalar_values` (published by
     /// the jitdriver Finish arm), so only the resume pc is captured here.
-    fn capture_single_pass_finish(&mut self, ctx: &mut TraceCtx) {
+    fn capture_single_pass_finish(&mut self, ctx: &mut TraceCtx, value: Option<Value>) {
         if self.outer_program_pc.is_none() || self.frames.len() != 1 {
             return;
         }
@@ -2584,6 +2610,8 @@ where
         {
             ctx.walk_final_pc = Some(pc);
         }
+        ctx.walk_finish_values.clear();
+        ctx.walk_finish_values.extend(value);
     }
 
     fn read_typeptr_from_exception(&self, exc_value: i64) -> i64 {
@@ -3398,12 +3426,16 @@ where
         // freshly-allocated callee state — not the caller's live registers.
         // Greens are baked into the callee loop's green key, not passed as
         // call args.  `recursive_fresh_entry_reds` yields the fresh reds in
-        // `extract_live` order (scalars zeroed, then per virt array the
-        // `&state` identity Ref + length) together with an owner box keeping
+        // `extract_live` order (scalars zeroed, then the `&state` identity
+        // Ref) together with an owner box keeping
         // that state alive for the concrete `execute_recursive_assembler_int`
         // run.
         let (fresh_values, fresh_owner) = match sym.recursive_fresh_entry_reds() {
             Some(pair) => pair,
+            None => return TraceAction::Abort,
+        };
+        let fresh_capacities = match sym.recursive_fresh_entry_vable_capacities() {
+            Some(capacities) => capacities,
             None => return TraceAction::Abort,
         };
         let (alloc_fp, free_fp) = match sym.recursive_fresh_alloc_free_targets() {
@@ -3436,6 +3468,7 @@ where
         let mut red_values = Vec::with_capacity(fresh_values.len());
         let mut arg_types = Vec::with_capacity(fresh_values.len());
         let mut alloc_results: Vec<OpRef> = Vec::new();
+        let mut capacities = fresh_capacities.into_iter();
         let mut idx = 0;
         while idx < fresh_values.len() {
             match fresh_values[idx] {
@@ -3446,11 +3479,11 @@ where
                     idx += 1;
                 }
                 majit_ir::Value::Ref(_) => {
-                    // A virt array contributes a (`&state` Ref, length Int)
-                    // pair; the length is the allocator's capacity argument.
-                    let cap = match fresh_values.get(idx + 1) {
-                        Some(majit_ir::Value::Int(cap)) => *cap,
-                        _ => return TraceAction::Abort,
+                    // Allocation capacity is frame-construction metadata, not
+                    // an extra portal red (pyjitpl.py `do_recursive_call`).
+                    let cap = match capacities.next() {
+                        Some(cap) => cap,
+                        None => return TraceAction::Abort,
                     };
                     let cap_arg = OpRef::const_int(cap);
                     let alloc_result = ctx.call_ref_typed_with_effect(
@@ -3463,13 +3496,13 @@ where
                     args.push(alloc_result);
                     red_values.push(fresh_values[idx]);
                     arg_types.push(majit_ir::Type::Ref);
-                    args.push(cap_arg);
-                    red_values.push(majit_ir::Value::Int(cap));
-                    arg_types.push(majit_ir::Type::Int);
-                    idx += 2;
+                    idx += 1;
                 }
                 _ => return TraceAction::Abort,
             }
+        }
+        if capacities.next().is_some() {
+            return TraceAction::Abort;
         }
 
         // 8-step `do_residual_call(assembler_call=True)` protocol, mirroring
@@ -7078,7 +7111,7 @@ where
                 let (opref, concrete) = self.read_int_reg(src);
                 let target = self.frames.current_mut().return_i;
                 if target.is_none() {
-                    self.capture_single_pass_finish(ctx);
+                    self.capture_single_pass_finish(ctx, Some(Value::Int(concrete)));
                 }
                 if let Some(snapshot) = self.pop_exception_frame(ctx) {
                     sym.restore_inline_scalar_state(snapshot);
@@ -7115,7 +7148,7 @@ where
                 let opref = OpRef::ConstInt(value);
                 let target = self.frames.current_mut().return_i;
                 if target.is_none() {
-                    self.capture_single_pass_finish(ctx);
+                    self.capture_single_pass_finish(ctx, Some(Value::Int(value)));
                 }
                 if let Some(snapshot) = self.pop_exception_frame(ctx) {
                     sym.restore_inline_scalar_state(snapshot);
@@ -7148,7 +7181,10 @@ where
                 let (opref, concrete) = self.read_ref_reg(src);
                 let target = self.frames.current_mut().return_r;
                 if target.is_none() {
-                    self.capture_single_pass_finish(ctx);
+                    self.capture_single_pass_finish(
+                        ctx,
+                        Some(Value::Ref(majit_ir::GcRef(concrete as usize))),
+                    );
                 }
                 if let Some(snapshot) = self.pop_exception_frame(ctx) {
                     sym.restore_inline_scalar_state(snapshot);
@@ -7181,7 +7217,10 @@ where
                 let (opref, concrete) = self.read_float_reg(src);
                 let target = self.frames.current_mut().return_f;
                 if target.is_none() {
-                    self.capture_single_pass_finish(ctx);
+                    self.capture_single_pass_finish(
+                        ctx,
+                        Some(Value::Float(f64::from_bits(concrete as u64))),
+                    );
                 }
                 if let Some(snapshot) = self.pop_exception_frame(ctx) {
                     sym.restore_inline_scalar_state(snapshot);
@@ -7210,7 +7249,7 @@ where
             }
             jitcode::insns::BC_VOID_RETURN => {
                 self.clear_exception();
-                self.capture_single_pass_finish(ctx);
+                self.capture_single_pass_finish(ctx, None);
                 if let Some(snapshot) = self.pop_exception_frame(ctx) {
                     sym.restore_inline_scalar_state(snapshot);
                 }
@@ -11944,13 +11983,13 @@ mod tests {
             let fresh: Box<Vec<i64>> = Box::new(vec![0i64; 12]);
             let base = &*fresh as *const Vec<i64> as usize;
             Some((
-                vec![
-                    Value::Int(0),
-                    Value::Ref(majit_ir::GcRef(base)),
-                    Value::Int(12),
-                ],
+                vec![Value::Int(0), Value::Ref(majit_ir::GcRef(base))],
                 fresh as Box<dyn std::any::Any>,
             ))
+        }
+
+        fn recursive_fresh_entry_vable_capacities(&self) -> Option<Vec<i64>> {
+            Some(vec![12])
         }
 
         fn recursive_fresh_alloc_free_targets(&self) -> Option<(*const (), *const ())> {
@@ -12015,8 +12054,8 @@ mod tests {
         // ... one residual free (CallN), ...
         let free_ops: Vec<_> = ops.iter().filter(|o| o.opcode == OpCode::CallN).collect();
         assert_eq!(free_ops.len(), 1, "one residual fresh-state free CallN");
-        // ... and exactly one CallAssemblerI carrying the three fresh reds
-        // (`stackpos`, `&state`, length).
+        // ... and exactly one CallAssemblerI carrying the two declared fresh
+        // reds (`stackpos`, `&state`). Capacity belongs to the allocator.
         let call_ops: Vec<_> = ops
             .iter()
             .filter(|o| o.opcode == OpCode::CallAssemblerI)
@@ -12029,8 +12068,8 @@ mod tests {
         let call_op = call_ops[0];
         assert_eq!(
             call_op.args.borrow().len(),
-            3,
-            "fresh reds in extract_live order: stackpos, &state, length",
+            2,
+            "fresh reds in extract_live order: stackpos, &state",
         );
         // The alloc is recorded before, and the free after, the call.
         let alloc_idx = ops.iter().position(|o| o.opcode == OpCode::CallR).unwrap();

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2594,7 +2594,9 @@ where
     /// the matched opcode arm. Preserve it before popping the frame so the
     /// single-pass merge hook resumes native execution at the source loop exit.
     /// The scalar state handoff rides `single_pass_scalar_values` (published by
-    /// the jitdriver Finish arm), so only the resume pc is captured here.
+    /// the jitdriver Finish arm); `value` is the terminator's own result, and
+    /// it replaces `walk_finish_values` here so the hook returns the walk's
+    /// result rather than a stale one from an earlier close.
     fn capture_single_pass_finish(&mut self, ctx: &mut TraceCtx, value: Option<Value>) {
         if self.outer_program_pc.is_none() || self.frames.len() != 1 {
             return;

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2887,6 +2887,13 @@ impl TraceCtx {
     /// callee reads the live struct, so the shadow — which carries the values
     /// the walk has produced since the executor last wrote — is what the
     /// callee must see, arrays included.
+    ///
+    /// The write lands on `virtualizable_heap_ptr`, while the stores its one
+    /// caller records name the identity box instead. Those two CAN name
+    /// different objects — a frontend that traces against a private snapshot
+    /// copy points them apart — but only a token-bearing machine seeds that
+    /// way, and the caller returns above on one, so the pair is the same
+    /// object on every path that reaches here.
     fn synchronize_virtualizable_before_residual_call(&self) {
         self.write_virtualizable_back(false);
     }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -581,6 +581,11 @@ pub struct TraceCtx {
     /// `recover` cannot reconstruct (loop-carried state held in a red bank but
     /// never written back to the shared heap). Empty unless single-pass.
     pub walk_final_reds: Vec<majit_ir::Value>,
+    /// Concrete payload of a root-frame FINISH reached by the tracing walk.
+    /// RPython's return Box carries this value intrinsically; state-field
+    /// synthetic register OpRefs do not all name recorder entries, so preserve
+    /// the value read from the live MIFrame beside the symbolic FINISH arg.
+    pub walk_finish_values: Vec<majit_ir::Value>,
     /// pyjitpl.py:1087 parity: quasi-immutable field read needs a
     /// GUARD_NOT_INVALIDATED with full snapshot at the field read's orgpc.
     /// Stores Some(orgpc) when pending.
@@ -1774,6 +1779,7 @@ impl TraceCtx {
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
+            walk_finish_values: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
@@ -1872,6 +1878,7 @@ impl TraceCtx {
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
+            walk_finish_values: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
@@ -2840,7 +2847,7 @@ impl TraceCtx {
     /// identity untouched. No-op when the heap pointer, `virtualizable_info`,
     /// or `virtualizable_values` is unavailable.
     pub fn synchronize_virtualizable(&self) {
-        self.write_virtualizable_back(true);
+        self.write_virtualizable_back();
     }
 
     /// The same write at the one moment the carve-out below does not apply:
@@ -2855,14 +2862,157 @@ impl TraceCtx {
     /// `JitState::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE` is how it
     /// says so.
     pub fn synchronize_virtualizable_after_guard_failure(&self) {
-        self.write_virtualizable_back(false);
+        self.write_virtualizable_back();
+    }
+
+    /// Materialize a tokenless state-field virtualizable before a residual
+    /// call that may mutate it.
+    ///
+    /// PyPy's translated virtualizable object carries `vable_token`; touching
+    /// it from the residual helper forces the register image to the object.
+    /// A `#[jit_interp(state_fields = ...)]` state is the interpreter's Rust
+    /// struct itself and has no spare token field. Emit the field/array stores
+    /// explicitly so the helper observes the live JIT values. The concrete
+    /// tracing image is synchronized first; the recorded stores provide the
+    /// same ordering in compiled code.
+    pub fn materialize_tokenless_virtualizable_before_residual_call(&mut self) {
+        let Some(info) = self.virtualizable_info.clone() else {
+            return;
+        };
+        if info.has_vable_token() {
+            return;
+        }
+        let Some(boxes) = self.virtualizable_boxes.clone() else {
+            return;
+        };
+        let Some(vable) = boxes.last().copied() else {
+            return;
+        };
+        let lengths = self.virtualizable_array_lengths.clone().unwrap_or_default();
+
+        self.synchronize_virtualizable();
+        // Walk the fields, not the boxes: `load_fields_from_virtualizable` and
+        // `reload_tokenless_virtualizable_after_residual_call` both `continue`
+        // past a `Type::Void` static field, so the flat vector is shorter than
+        // `static_fields` and its position is not the field index.  Enumerating
+        // the boxes would hand field *i*'s descr to a later field's box, and
+        // start the array section one slot per void field too late.
+        let mut flat_index = 0usize;
+        for (field_index, field) in info.static_fields.iter().enumerate() {
+            if field.field_type == Type::Void {
+                continue;
+            }
+            let Some(&value) = boxes.get(flat_index) else {
+                return;
+            };
+            flat_index += 1;
+            self.record_op_with_descr(
+                OpCode::SetfieldGc,
+                &[vable, value],
+                info.static_field_descr(field_index),
+            );
+        }
+        for (array_index, &length) in lengths.iter().enumerate() {
+            let array_ref = self.record_op_with_descr(
+                OpCode::GetfieldGcR,
+                &[vable],
+                info.array_pointer_field_descr(array_index),
+            );
+            let array_descr = info.array_item_descr(array_index);
+            for item_index in 0..length {
+                let Some(&value) = boxes.get(flat_index) else {
+                    return;
+                };
+                let index = self.const_int(item_index as i64);
+                self.record_op_with_descr(
+                    OpCode::SetarrayitemGc,
+                    &[array_ref, index, value],
+                    array_descr.clone(),
+                );
+                flat_index += 1;
+            }
+        }
+    }
+
+    /// Reload a tokenless state-field virtualizable after its residual helper.
+    ///
+    /// This is the non-aborting counterpart of
+    /// `load_fields_from_virtualizable`: the heap reads are recorded after the
+    /// call, so compiled code consumes the helper's runtime results rather
+    /// than constants from the tracing run.
+    pub fn reload_tokenless_virtualizable_after_residual_call(&mut self) {
+        let Some(info) = self.virtualizable_info.clone() else {
+            return;
+        };
+        if info.has_vable_token() {
+            return;
+        }
+        let Some(vable) = self.standard_virtualizable_box() else {
+            return;
+        };
+        let Some(vable_ptr) = self.standard_virtualizable_ptr() else {
+            return;
+        };
+        let lengths = self.virtualizable_array_lengths.clone().unwrap_or_default();
+        let capacity = info.static_fields.len() + lengths.iter().sum::<usize>() + 1;
+        let mut boxes = Vec::with_capacity(capacity);
+        let mut values = Vec::with_capacity(capacity);
+
+        for (field_index, field) in info.static_fields.iter().enumerate() {
+            let opcode = match field.field_type {
+                Type::Int => OpCode::GetfieldGcI,
+                Type::Ref => OpCode::GetfieldGcR,
+                Type::Float => OpCode::GetfieldGcF,
+                Type::Void => continue,
+            };
+            let bits = unsafe { info.read_field(vable_ptr as *const u8, field_index) };
+            let concrete = crate::pyjitpl::heap_value_for_pub(field.field_type, bits);
+            let opref =
+                self.record_op_with_descr(opcode, &[vable], info.static_field_descr(field_index));
+            self.set_opref_concrete(opref, concrete);
+            boxes.push(opref);
+            values.push(concrete);
+        }
+        for (array_index, &length) in lengths.iter().enumerate() {
+            let field_descr = info.array_pointer_field_descr(array_index);
+            let array_ref =
+                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable], field_descr.clone());
+            self.stamp_vable_array_base(
+                array_ref,
+                Some(Value::Ref(majit_ir::GcRef(vable_ptr))),
+                &field_descr,
+            );
+            let item_type = info.array_fields[array_index].item_type;
+            let item_opcode = match item_type {
+                Type::Int => OpCode::GetarrayitemGcI,
+                Type::Ref => OpCode::GetarrayitemGcR,
+                Type::Float => OpCode::GetarrayitemGcF,
+                Type::Void => continue,
+            };
+            let array_descr = info.array_item_descr(array_index);
+            for item_index in 0..length {
+                let index = self.const_int(item_index as i64);
+                let bits = unsafe {
+                    info.read_array_item(vable_ptr as *const u8, array_index, item_index)
+                };
+                let concrete = crate::pyjitpl::heap_value_for_pub(item_type, bits);
+                let opref = self.record_op_with_descr(
+                    item_opcode,
+                    &[array_ref, index],
+                    array_descr.clone(),
+                );
+                self.set_opref_concrete(opref, concrete);
+                boxes.push(opref);
+                values.push(concrete);
+            }
+        }
+        boxes.push(vable);
+        values.push(Value::Ref(majit_ir::GcRef(vable_ptr)));
+        self.set_virtualizable_boxes_with_info(boxes, values, &info, &lengths);
     }
 
     /// `virtualizable.py write_boxes` over the whole shadow.
-    ///
-    /// `skip_outer_owned_arrays` is the tracing-time carve-out described at
-    /// its own test below; the guard-failure caller clears it.
-    fn write_virtualizable_back(&self, skip_outer_owned_arrays: bool) {
+    fn write_virtualizable_back(&self) {
         let Some(heap_ptr) = self.virtualizable_heap_ptr else {
             return;
         };
@@ -2895,24 +3045,6 @@ impl TraceCtx {
             }
             array_bits.push(items);
             cursor += len;
-        }
-        // When the virtualizable array is a Rust `Vec` embedded by value in
-        // the interpreter's live state struct (`RustVec` storage), an outer
-        // executor (the macro-generated mainloop) owns that struct and writes
-        // it on every opcode. The trace's shadow is seeded from that heap and
-        // tracked for IR purposes only; flushing the shadow back here would
-        // clobber the outer executor's writes. The heap is authoritative, so
-        // skip the write-back during tracing — the resume path performs its
-        // own field-aware flush on guard failure.
-        if skip_outer_owned_arrays
-            && info.array_fields.iter().any(|a| {
-                matches!(
-                    a.storage,
-                    crate::virtualizable::VableArrayStorage::RustVec { .. }
-                )
-            })
-        {
-            return;
         }
         // Safety: `heap_ptr` is cached at trace/bridge entry from
         // `MetaInterp::vable_ptr`, which the JitState pins for the trace
@@ -2957,18 +3089,6 @@ impl TraceCtx {
         ) else {
             return;
         };
-        // `RustVec`-stored arrays are owned and rewritten by the outer
-        // executor on every opcode, so the shadow is deliberately not kept
-        // equal to the heap for them — the same carve-out
-        // `synchronize_virtualizable` makes before writing back.
-        if info.array_fields.iter().any(|a| {
-            matches!(
-                a.storage,
-                crate::virtualizable::VableArrayStorage::RustVec { .. }
-            )
-        }) {
-            return;
-        }
         let static_count = info.num_static_extra_boxes;
         let shadow_data_len = values.len().saturating_sub(1);
         if shadow_data_len < static_count {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2837,6 +2837,21 @@ impl TraceCtx {
         }
     }
 
+    /// Whether any virtualizable array is a Rust `Vec` embedded by value in
+    /// the interpreter's live state struct.
+    ///
+    /// Such an array is owned and rewritten by the outer executor on every
+    /// opcode, so the heap — not the trace's shadow — is authoritative for it
+    /// while the walk is in progress.
+    fn has_outer_owned_array(&self, info: &crate::virtualizable::VirtualizableInfo) -> bool {
+        info.array_fields.iter().any(|a| {
+            matches!(
+                a.storage,
+                crate::virtualizable::VableArrayStorage::RustVec { .. }
+            )
+        })
+    }
+
     /// pyjitpl.py `synchronize_virtualizable()`.
     ///
     /// Writes the concrete half of `virtualizable_boxes` (the
@@ -2847,10 +2862,10 @@ impl TraceCtx {
     /// identity untouched. No-op when the heap pointer, `virtualizable_info`,
     /// or `virtualizable_values` is unavailable.
     pub fn synchronize_virtualizable(&self) {
-        self.write_virtualizable_back();
+        self.write_virtualizable_back(true);
     }
 
-    /// The same write at the one moment the carve-out below does not apply:
+    /// The same write at a moment the carve-out does not apply:
     /// `pyjitpl.py rebuild_state_after_failure`'s closing
     /// `self.synchronize_virtualizable()`.
     ///
@@ -2862,7 +2877,18 @@ impl TraceCtx {
     /// `JitState::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE` is how it
     /// says so.
     pub fn synchronize_virtualizable_after_guard_failure(&self) {
-        self.write_virtualizable_back();
+        self.write_virtualizable_back(false);
+    }
+
+    /// The same full write ahead of a residual call that is handed the
+    /// virtualizable.
+    ///
+    /// The outer executor is suspended for the duration of that call and the
+    /// callee reads the live struct, so the shadow — which carries the values
+    /// the walk has produced since the executor last wrote — is what the
+    /// callee must see, arrays included.
+    fn synchronize_virtualizable_before_residual_call(&self) {
+        self.write_virtualizable_back(false);
     }
 
     /// Materialize a tokenless state-field virtualizable before a residual
@@ -2890,7 +2916,7 @@ impl TraceCtx {
         };
         let lengths = self.virtualizable_array_lengths.clone().unwrap_or_default();
 
-        self.synchronize_virtualizable();
+        self.synchronize_virtualizable_before_residual_call();
         // Walk the fields, not the boxes: `load_fields_from_virtualizable` and
         // `reload_tokenless_virtualizable_after_residual_call` both `continue`
         // past a `Type::Void` static field, so the flat vector is shorter than
@@ -3012,7 +3038,10 @@ impl TraceCtx {
     }
 
     /// `virtualizable.py write_boxes` over the whole shadow.
-    fn write_virtualizable_back(&self) {
+    ///
+    /// `skip_outer_owned_arrays` names the one storage shape whose write-back
+    /// is not this function's to make; see the carve-out below.
+    fn write_virtualizable_back(&self, skip_outer_owned_arrays: bool) {
         let Some(heap_ptr) = self.virtualizable_heap_ptr else {
             return;
         };
@@ -3045,6 +3074,17 @@ impl TraceCtx {
             }
             array_bits.push(items);
             cursor += len;
+        }
+        // When the virtualizable array is a Rust `Vec` embedded by value in
+        // the interpreter's live state struct (`RustVec` storage), an outer
+        // executor (the macro-generated mainloop) owns that struct and writes
+        // it on every opcode. The trace's shadow is seeded from that heap and
+        // tracked for IR purposes only; flushing the shadow back here would
+        // clobber the outer executor's writes. The heap is authoritative, so
+        // skip the write-back during tracing — the resume path performs its
+        // own field-aware flush on guard failure.
+        if skip_outer_owned_arrays && self.has_outer_owned_array(info) {
+            return;
         }
         // Safety: `heap_ptr` is cached at trace/bridge entry from
         // `MetaInterp::vable_ptr`, which the JitState pins for the trace
@@ -3089,6 +3129,13 @@ impl TraceCtx {
         ) else {
             return;
         };
+        // `RustVec`-stored arrays are owned and rewritten by the outer
+        // executor on every opcode, so the shadow is deliberately not kept
+        // equal to the heap for them — the same carve-out
+        // `synchronize_virtualizable` makes before writing back.
+        if self.has_outer_owned_array(info) {
+            return;
+        }
         let static_count = info.num_static_extra_boxes;
         let shadow_data_len = values.len().saturating_sub(1);
         if shadow_data_len < static_count {

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -954,6 +954,7 @@ impl VirtualizableInfo {
                 None => Some(0),
                 Some(_) => self.identity_live_index,
             },
+            has_vable_token: self.has_vable_token(),
         }
     }
 

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2649,6 +2649,7 @@ impl SomeValue {
                         crate::translator::rtyper::extregistry::ExtRegistryEntry::EnterLeaveMarker { .. }
                             | crate::translator::rtyper::extregistry::ExtRegistryEntry::LoopHeader { .. }
                             | crate::translator::rtyper::extregistry::ExtRegistryEntry::ForType { .. }
+                            | crate::translator::rtyper::extregistry::ExtRegistryEntry::JitForceVirtualizable
                     )
                 {
                     return entry.compute_annotation_with_kwds(&bk, &kwds_s).map(Some);

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -311,10 +311,9 @@ pub struct JitCode {
     /// Memoized verdicts derived from `body`, not assembled into it, so they
     /// are recomputed rather than serialized. Each is a static property of the
     /// body, so the memo travels with the body it describes instead of sitting
-    /// in a map keyed beside it. It is not shared across threads: the runtime
-    /// jitcode table is itself per-thread (`jitcode_runtime.rs JITCODE_CELLS`,
-    /// which cites the GIL for that shape), so a thread that decodes its own
-    /// `JitCode` computes its own answer.
+    /// in a map keyed beside it. The runtime publishes each frozen JitCode once
+    /// process-wide, matching `MetaInterpStaticData.jitcodes`, so all execution
+    /// contexts share the memoized answer.
     #[serde(skip)]
     derived: DerivedBodyFacts,
 }

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1364,7 +1364,14 @@ fn analyze_pipeline_from_module_paths(
         (
             vec!["majit_gc".into(), "shadow_stack".into(), "push".into()],
             Signature::new(vec!["gcref".into()], None, None),
-            Some("i64".into()),
+            // `shadow_stack::push` returns the native-word stack index
+            // (`usize`).  Stub results use the front end's canonical semantic
+            // tokens (`dont_look_inside_return_token` maps `Unsigned` to
+            // `u64`), not literal Rust type spellings.  RPython's
+            // shadow-stack top/depth is likewise a non-negative machine word;
+            // using the signed `i64` token makes `FrameAnchor.depth` merge
+            // `SomeInteger` with `r_uint` at its readers.
+            Some("u64".into()),
         ),
         (
             vec!["majit_gc".into(), "shadow_stack".into(), "get".into()],

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1345,6 +1345,42 @@ fn analyze_pipeline_from_module_paths(
     // `front::mir::collect_unsafe_fn_stubs_from_llbc`, populated on the
     // SemanticProgram in `build_semantic_program_via_active_frontend`.
     call_control.unsafe_fn_stubs = program.unsafe_fn_stubs.clone();
+    // `rpython.rtyper.extregistry.register_external` parity for the three
+    // shadow-stack operations `eval::FrameAnchor` reaches.  `majit_gc` is not
+    // one of the crates lowered by `scripts/extract-llbc.py` (see the
+    // canmallocgc census below), so these safe free functions have neither a
+    // graph nor an unsafe-declaration stub.  Leaving them undeclared poisons
+    // `FrameAnchor::from_raw`'s CallRegistry entry, which in turn rejects
+    // every frame getset gateway before the codewriter can remove its
+    // `jit_force_virtualizable` marker.
+    //
+    // These entries use the existing annotator-only stub carrier: it supplies
+    // the declared signature/result shell but never adds a codewriter graph.
+    // The matching runtime addresses are published by
+    // `pyre_interpreter::jit_trace_fnaddrs`, exactly like an RPython
+    // `register_external` declaration is paired with its linker symbol.
+    use crate::flowspace::argument::Signature;
+    call_control.unsafe_fn_stubs.extend([
+        (
+            vec!["majit_gc".into(), "shadow_stack".into(), "push".into()],
+            Signature::new(vec!["gcref".into()], None, None),
+            Some("i64".into()),
+        ),
+        (
+            vec!["majit_gc".into(), "shadow_stack".into(), "get".into()],
+            Signature::new(vec!["depth".into()], None, None),
+            Some("gcref".into()),
+        ),
+        (
+            vec![
+                "majit_gc".into(),
+                "shadow_stack".into(),
+                "try_pop_to".into(),
+            ],
+            Signature::new(vec!["depth".into()], None, None),
+            None,
+        ),
+    ]);
     // Parallel carrier for foreign opaque-ADT method externals
     // (`<BigInt as Add>::add`, …) — `populate_call_registry_from_call_graphs`
     // registers each as an opaque external so the residual `FunctionPath`

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -6547,6 +6547,11 @@ mod tests {
                 Signature::new(vec!["obj".to_string()], None, None),
                 Some("bool".to_string()),
             ),
+            (
+                vec!["majit_gc".to_string(), "shadow_push".to_string()],
+                Signature::new(vec!["obj".to_string()], None, None),
+                Some("u64".to_string()),
+            ),
             // A token `residual_return_shell` declines — 128-bit has no
             // `getkind` at the codewriter boundary — so
             // register_unsafe_fn_stubs must skip.
@@ -6559,7 +6564,7 @@ mod tests {
         register_unsafe_fn_stubs(&registry, &specs);
         assert_eq!(
             registry.len(),
-            2,
+            3,
             "undecodable-return spec must be skipped, others registered"
         );
         assert!(

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -164,6 +164,14 @@ pub enum ExtRegistryEntry {
     /// path; its `compute_annotation` is unreachable in practice and
     /// fails closed to surface a bypassed early-return loudly.
     WeAreJitted,
+    /// Pyre's explicit source spelling of the force inserted by
+    /// `VirtualizableInstanceRepr.hook_access_field`
+    /// (`rpython/rtyper/rvirtualizable.py`).  Upstream inserts the
+    /// `jit_force_virtualizable` LLOp while rtyping and never annotates a
+    /// force-helper body.  Rust needs a callable marker in the source, so
+    /// its translation is registered here and specializes to that same
+    /// LLOp instead of recursively lifting `executioncontext::force_frame`.
+    JitForceVirtualizable,
     /// `BigInt::from(i64) -> BigInt` — the `From<i64>` impl that boxes a
     /// machine int into the foreign opaque `BigInt` (Python `long`) on the
     /// cold `int_add`/`int_sub`/… overflow→long arm.  Modeled as a
@@ -302,6 +310,7 @@ pub enum ExtRegistryEntryKey {
     /// (rlib/jit.py:396). No per-instance identity — the variant tag
     /// alone supplies `self.__class__` and there is no `self.instance`.
     WeAreJitted,
+    JitForceVirtualizable,
     /// Singleton key for the `BigInt.from` residual-external entry. No
     /// per-instance identity — the variant tag alone supplies
     /// `self.__class__` and there is no `self.instance`.
@@ -343,6 +352,7 @@ impl ExtRegistryEntry {
                 instance_identity: instance.identity_id(),
             },
             ExtRegistryEntry::WeAreJitted => ExtRegistryEntryKey::WeAreJitted,
+            ExtRegistryEntry::JitForceVirtualizable => ExtRegistryEntryKey::JitForceVirtualizable,
             ExtRegistryEntry::BigIntFrom => ExtRegistryEntryKey::BigIntFrom,
             ExtRegistryEntry::Float2LongLong => ExtRegistryEntryKey::Float2LongLong,
             ExtRegistryEntry::LongLong2Float => ExtRegistryEntryKey::LongLong2Float,
@@ -462,6 +472,15 @@ impl ExtRegistryEntry {
             // (bookkeeper.py:309-314).  Returning it here keeps the
             // entry a faithful port for any path that consults it.
             ExtRegistryEntry::WeAreJitted => Ok(SomeValue::Bool(Default::default())),
+            // `VirtualizableInstanceRepr.hook_access_field` emits a Void
+            // `jit_force_virtualizable` operation.  The explicit Rust marker
+            // therefore has the ordinary ExtRegistry callable annotation and
+            // returns None at the call site.
+            ExtRegistryEntry::JitForceVirtualizable => Ok(SomeValue::Builtin(SomeBuiltin::new(
+                "pyre_interpreter.executioncontext.jit_force_virtualizable",
+                None,
+                Some("jit_force_virtualizable".to_string()),
+            ))),
             // The annotation half is served by the `BigInt.from`
             // `BUILTIN_ANALYZERS` entry (`bigint_from`), which
             // `immutablevalue_hostobject` resolves before the
@@ -524,6 +543,7 @@ impl ExtRegistryEntry {
             // `annmodel.s_None` and ignores any kwds (loop_header
             // takes only `self` upstream).
             ExtRegistryEntry::LoopHeader { .. } => Ok(s_none()),
+            ExtRegistryEntry::JitForceVirtualizable => Ok(s_none()),
             // upstream rarithmetic.py — `ForTypeEntry.\
             // compute_result_annotation(self, *args_s, **kwds_s)` returns
             // `SomeInteger(knowntype=int_type)`.  The instance is the int
@@ -623,6 +643,9 @@ impl ExtRegistryEntry {
             // at the result repr's lltype.
             ExtRegistryEntry::WeAreJitted => {
                 Ok(super::rbuiltin::rtype_we_are_jitted as BuiltinTyperFn)
+            }
+            ExtRegistryEntry::JitForceVirtualizable => {
+                Ok(super::rbuiltin::rtype_jit_force_virtualizable as BuiltinTyperFn)
             }
             // `BigInt.from` lowers to a residual `direct_call` to the
             // external `bigint_from` (extfunc.py:55-64
@@ -878,6 +901,9 @@ fn lookup_host_object(host: &HostObject) -> Option<ExtRegistryEntry> {
     if host.qualname() == "majit_metainterp.jit.we_are_jitted" {
         return Some(ExtRegistryEntry::WeAreJitted);
     }
+    if host.qualname() == "pyre_interpreter.executioncontext.jit_force_virtualizable" {
+        return Some(ExtRegistryEntry::JitForceVirtualizable);
+    }
     // `BigInt.from` residual external — keyed by the qualname the
     // `BigInt.from` `BUILTIN_ANALYZERS` annotation entry uses, so the
     // rtyper's `findbltintyper` → `extregistry.lookup` resolves the same
@@ -1068,6 +1094,23 @@ mod tests {
         assert!(matches!(entry, ExtRegistryEntry::WeAreJitted));
         assert!(entry.specialize_call().is_ok());
         assert!(matches!(entry.compute_annotation(), Ok(SomeValue::Bool(_))));
+    }
+
+    #[test]
+    fn jit_force_virtualizable_resolves_to_llop_specializer() {
+        let host = HostObject::new_builtin_callable(
+            "pyre_interpreter.executioncontext.jit_force_virtualizable",
+        );
+        let cv = ConstValue::HostObject(host);
+        assert!(is_registered(&cv));
+        let entry = lookup(&cv).expect("force marker must surface an entry");
+        assert!(matches!(entry, ExtRegistryEntry::JitForceVirtualizable));
+        assert!(entry.specialize_call().is_ok());
+        let bookkeeper = Rc::new(Bookkeeper::new());
+        assert!(matches!(
+            entry.compute_annotation_with_kwds(&bookkeeper, &std::collections::HashMap::new()),
+            Ok(SomeValue::None_(_))
+        ));
     }
 
     /// `BigInt.from` — the foreign opaque `From<i64>` conversion surfaces

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1808,6 +1808,33 @@ pub fn translate_op(
                 // by the registry) and routes through
                 // `FunctionRepr::call(hop)` (`rpbc.py`).
                 CallTarget::FunctionPath { segments } => {
+                    // RPython `VirtualizableInstanceRepr.hook_access_field`
+                    // inserts the `jit_force_virtualizable` LLOp during
+                    // rtyping; it never asks the annotator to traverse a
+                    // runtime force-helper body.  Rust cannot attach the
+                    // hook to a field repr, so pyre-interpreter spells the
+                    // marker as an ordinary source call.  Reify that call as
+                    // an ExtRegistry builtin before CallRegistry lookup: its
+                    // `specialize_call` emits the identical LLOp and prevents
+                    // a failed lift of the runtime `FORCE_FRAME_HOOK` chain
+                    // from poisoning every descriptor gateway caller.
+                    if segments.as_slice()
+                        == [
+                            "pyre_interpreter",
+                            "executioncontext",
+                            "jit_force_virtualizable",
+                        ]
+                    {
+                        let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                            HostObject::new_builtin_callable(
+                                "pyre_interpreter.executioncontext.jit_force_virtualizable",
+                            ),
+                        )));
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                        call_args.push(callable);
+                        call_args.extend(arg_hls);
+                        return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
+                    }
                     // `core` method spellings of upstream operations:
                     // pyre source writes `a.min(b)` /
                     // `a != b`-via-`PartialEq::ne` / `v.len()` /
@@ -5354,6 +5381,50 @@ mod tests {
         // `__name__`, mirroring upstream `func.__name__` (the leaf
         // identifier, not the dotted module path).
         assert_eq!(host.qualname(), "b");
+    }
+
+    #[test]
+    fn translate_op_jit_force_virtualizable_bypasses_runtime_helper_graph() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_force_virtualizable_fixture");
+        let vars = mint_vars(&mut graph, 3);
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(Variable::new()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec![
+                        "pyre_interpreter".into(),
+                        "executioncontext".into(),
+                        "jit_force_virtualizable".into(),
+                    ],
+                },
+                args: vec![vars[1].clone()],
+                result_ty: ValueType::Void,
+            },
+        };
+
+        // No CallRegistry entry is intentional: upstream rtyping emits this
+        // force as an LLOp and does not annotate its runtime implementation.
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("jit_force_virtualizable must lower through ExtRegistry");
+        assert_eq!(translated.len(), 1);
+        let lowered = &translated[0];
+        assert_eq!(lowered.opname, "simple_call");
+        let Hlvalue::Constant(callable) = &lowered.args[0] else {
+            panic!("marker callable must be constant");
+        };
+        let ConstValue::HostObject(host) = &callable.value else {
+            panic!("marker callable must be a HostObject");
+        };
+        assert_eq!(
+            host.qualname(),
+            "pyre_interpreter.executioncontext.jit_force_virtualizable"
+        );
+        assert!(crate::translator::rtyper::extregistry::is_registered(
+            &callable.value
+        ));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -4725,6 +4725,56 @@ mod tests {
         assert!(err.to_string().contains("rtype_builtin_bool"));
     }
 
+    /// `rvirtualizable.py:49 VirtualizableInstanceRepr.hook_access_field`
+    /// emits the force for every redirected field.  Pyre spells that hook as a
+    /// callable marker, so this typer is what each frame gateway's force
+    /// resolves to, and its emitted shape is what `jtransform.py:2164-2172
+    /// rewrite_op_jit_force_virtualizable` matches on when it deletes the op
+    /// from a looked-inside graph.  A wrong arity, a lost repr conversion or a
+    /// missing exception declaration would break every gateway silently.
+    #[test]
+    fn rtype_jit_force_virtualizable_emits_a_one_argument_void_llop() {
+        use crate::annotator::model::SomeInteger;
+        use crate::flowspace::model::{Hlvalue, Variable};
+        use crate::translator::rtyper::rint::IntegerRepr;
+
+        let hop = dummy_hop();
+        let frame = Variable::named("v_frame");
+        frame.set_concretetype(Some(LowLevelType::Signed));
+        hop.args_v.borrow_mut().push(Hlvalue::Variable(frame));
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(false, false)));
+        let frame_repr: Arc<dyn Repr> =
+            Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int")));
+        hop.args_r.borrow_mut().push(Some(frame_repr));
+
+        // Void genop yields no result variable to the caller.
+        let result = rtype_jit_force_virtualizable(&hop, &HashMap::new()).unwrap();
+        assert!(result.is_none());
+
+        let llops = hop.llops.borrow();
+        let last = llops.ops.last().expect("the force llop is emitted");
+        assert_eq!(last.opname, "jit_force_virtualizable");
+        assert_eq!(
+            last.args.len(),
+            1,
+            "the marker carries the live frame and nothing else",
+        );
+        match &last.args[0] {
+            Hlvalue::Variable(v) => assert_eq!(v.concretetype(), Some(LowLevelType::Signed)),
+            other => panic!("the frame argument must stay a Variable, got {other:?}"),
+        }
+        match &last.result {
+            Hlvalue::Variable(v) => assert_eq!(v.concretetype(), Some(LowLevelType::Void)),
+            other => panic!("the force result must be a Void Variable, got {other:?}"),
+        }
+        assert!(
+            llops._called_exception_is_here_or_cannot_occur,
+            "the typer must declare that the force cannot raise",
+        );
+    }
+
     #[test]
     fn rtype_builtin_int_non_string_branch_delegates_to_args_r_rtype_int() {
         use crate::annotator::model::SomeInteger;

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1511,6 +1511,35 @@ pub(super) fn rtype_we_are_jitted(
     Ok(Some(Hlvalue::Constant(c)))
 }
 
+/// Rust source marker for RPython
+/// `VirtualizableInstanceRepr.hook_access_field`.
+///
+/// Upstream does not call a force helper here: the rtyper emits
+/// `jit_force_virtualizable(vinst, cname, flags)` directly.  Pyre's source
+/// marker carries only the live frame because the redirected field and flags
+/// are already fixed by the gateway.  Preserve that argument and emit the
+/// same Void LLOp; `jtransform.rewrite_op_jit_force_virtualizable` removes it
+/// from looked-inside JIT graphs, while the runtime source body remains the
+/// untranslated execution path.
+pub(super) fn rtype_jit_force_virtualizable(
+    hop: &HighLevelOp,
+    _kwds_i: &HashMap<String, usize>,
+) -> RTypeResult {
+    use crate::translator::rtyper::rtyper::GenopResult;
+
+    let r_frame = hop
+        .args_r
+        .borrow()
+        .first()
+        .and_then(Clone::clone)
+        .ok_or_else(|| {
+            TyperError::message("rtype_jit_force_virtualizable: frame repr missing".to_string())
+        })?;
+    let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_frame.as_ref())])?;
+    hop.exception_cannot_occur()?;
+    Ok(hop.genop("jit_force_virtualizable", vlist, GenopResult::Void))
+}
+
 /// `BigInt::from(i64) -> BigInt` residual lowering, reached through
 /// `BuiltinFunctionRepr.findbltintyper` →
 /// `extregistry.lookup(BigInt.from).specialize_call`

--- a/majit/majit-translate/tests/test_fast2locals_codewriter.rs
+++ b/majit/majit-translate/tests/test_fast2locals_codewriter.rs
@@ -134,29 +134,34 @@ fn f_locals_gateway_force_is_deleted_and_the_method_has_none() {
     );
 }
 
-/// Every hand-written frame getset is an interp2app gateway on the same terms
-/// as `f_locals`: the untranslated interpreter keeps the residual force, and
-/// the codewriter deletes it before lowering the redirected field access.
+/// Every frame getset whose body reaches a REDIRECTED field is an interp2app
+/// gateway on the same terms as `f_locals`: the untranslated interpreter keeps
+/// the residual force, and the codewriter deletes it before lowering the field
+/// access.
 ///
 /// Keeping this as one census is deliberate.  The bug this guards was a
 /// structural split where only `f_locals` published a candidate graph; a set
 /// of independent happy-path tests would let the next manually-added frame
-/// descriptor fall outside the family again.
+/// descriptor fall outside the family again.  Its other half is
+/// [`the_gateways_outside_the_redirected_set_carry_no_force`], which closes the
+/// complement so that neither list can grow by accident.
 #[test]
 fn every_redirected_frame_getter_carries_a_deletable_force() {
     let Some(llbc) = interpreter_llbc() else {
         return;
     };
     for leaf in [
-        "__majit_wrap_descr_typecheck_fget_f_code",
         "__majit_wrap_descr_typecheck_get_w_globals",
-        "__majit_wrap_descr_typecheck_fget_f_back",
         "__majit_wrap_descr_typecheck_fget_f_lasti",
-        "__majit_wrap_descr_typecheck_fget_f_builtins",
         "__majit_wrap_descr_typecheck_fget_f_lineno",
+        "__majit_wrap_descr_typecheck_fset_f_lineno",
         "__majit_wrap_descr_typecheck_fget_f_trace",
+        "__majit_wrap_descr_typecheck_fset_f_trace",
+        "__majit_wrap_descr_typecheck_fdel_f_trace",
         "__majit_wrap_descr_typecheck_fget_f_trace_lines",
+        "__majit_wrap_descr_typecheck_fset_f_trace_lines",
         "__majit_wrap_descr_typecheck_fget_f_trace_opcodes",
+        "__majit_wrap_descr_typecheck_fset_f_trace_opcodes",
     ] {
         let gateway = lower_named(&llbc, leaf);
         let before = call_leafs(&gateway);
@@ -173,6 +178,43 @@ fn every_redirected_frame_getter_carries_a_deletable_force() {
                 .iter()
                 .all(|callee| callee != "jit_force_virtualizable"),
             "{leaf}: rewrite_op_jit_force_virtualizable left the marker in jitcode: {after:?}",
+        );
+    }
+}
+
+/// The complement of [`every_redirected_frame_getter_carries_a_deletable_force`]:
+/// these four gateways carry no marker at all, and the reason is per gateway.
+///
+/// `rvirtualizable.py hook_access_field` injects only under
+/// `if self.my_redirected_fields.get(cname.value)`, and `f_back`
+/// (`f_backref`), `f_builtins` (`w_builtin`) and `get_generator`
+/// (`f_generator_nowref`) read no field in that set.  `f_code` reads `pycode`,
+/// which IS in it, and is here for the second question a HAND-placed marker
+/// owes and the injection never has to ask, because it fires at every access in
+/// every graph rather than once per gateway: can the trace and the live frame
+/// disagree about the field this body reads?  For `pycode` they cannot -- it is
+/// written only at frame construction -- so the force reaches nothing but the
+/// escape flush.  Each of the four says so at its own definition in
+/// `pyframe.rs`.
+#[test]
+fn the_gateways_outside_the_redirected_set_carry_no_force() {
+    let Some(llbc) = interpreter_llbc() else {
+        return;
+    };
+    for leaf in [
+        "__majit_wrap_descr_typecheck_fget_f_code",
+        "__majit_wrap_descr_typecheck_fget_f_back",
+        "__majit_wrap_descr_typecheck_fget_f_builtins",
+        "__majit_wrap_descr_typecheck_get_generator",
+    ] {
+        let gateway = lower_named(&llbc, leaf);
+        let before = call_leafs(&gateway);
+        assert!(
+            before
+                .iter()
+                .all(|callee| callee != "jit_force_virtualizable"),
+            "{leaf} reads no field a trace can disagree about, so it must carry \
+             no force: {before:?}",
         );
     }
 }

--- a/majit/majit-translate/tests/test_fast2locals_codewriter.rs
+++ b/majit/majit-translate/tests/test_fast2locals_codewriter.rs
@@ -134,10 +134,60 @@ fn f_locals_gateway_force_is_deleted_and_the_method_has_none() {
     );
 }
 
+/// Every hand-written frame getset is an interp2app gateway on the same terms
+/// as `f_locals`: the untranslated interpreter keeps the residual force, and
+/// the codewriter deletes it before lowering the redirected field access.
+///
+/// Keeping this as one census is deliberate.  The bug this guards was a
+/// structural split where only `f_locals` published a candidate graph; a set
+/// of independent happy-path tests would let the next manually-added frame
+/// descriptor fall outside the family again.
+#[test]
+fn every_redirected_frame_getter_carries_a_deletable_force() {
+    let Some(llbc) = interpreter_llbc() else {
+        return;
+    };
+    for leaf in [
+        "__majit_wrap_descr_typecheck_fget_f_code",
+        "__majit_wrap_descr_typecheck_get_w_globals",
+        "__majit_wrap_descr_typecheck_fget_f_back",
+        "__majit_wrap_descr_typecheck_fget_f_lasti",
+        "__majit_wrap_descr_typecheck_fget_f_builtins",
+        "__majit_wrap_descr_typecheck_fget_f_lineno",
+        "__majit_wrap_descr_typecheck_fget_f_trace",
+        "__majit_wrap_descr_typecheck_fget_f_trace_lines",
+        "__majit_wrap_descr_typecheck_fget_f_trace_opcodes",
+    ] {
+        let gateway = lower_named(&llbc, leaf);
+        let before = call_leafs(&gateway);
+        assert!(
+            before
+                .iter()
+                .any(|callee| callee == "jit_force_virtualizable"),
+            "{leaf} must retain the residual force in the interpreter graph, got {before:?}",
+        );
+        let transformed = majit_translate::transform_graph(&gateway, &config());
+        let after = call_leafs(&transformed.graph);
+        assert!(
+            after
+                .iter()
+                .all(|callee| callee != "jit_force_virtualizable"),
+            "{leaf}: rewrite_op_jit_force_virtualizable left the marker in jitcode: {after:?}",
+        );
+    }
+}
+
 /// The virtualizable configuration the production pipeline passes
 /// (`pyre-jit-trace/src/virtualizable_spec.rs PYFRAME_VABLE_ARRAYS`).
 fn config() -> GraphTransformConfig {
     GraphTransformConfig {
+        vable_fields: ["last_instr", "pycode", "valuestackdepth", "debugdata"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| {
+                VirtualizableFieldDescriptor::new(name, Some("PyFrame".to_string()), index)
+            })
+            .collect(),
         vable_arrays: vec![VirtualizableFieldDescriptor::new(
             "locals_cells_stack_w",
             Some("PyFrame".to_string()),

--- a/pyre/bench/synth/a_raise_through_the_recursive_portal_reaches_its_handler.py
+++ b/pyre/bench/synth/a_raise_through_the_recursive_portal_reaches_its_handler.py
@@ -60,7 +60,7 @@ def hot(k):
             rec(DEPTH, INNER)
         except ValueError:
             caught += 1
-        except BaseException as exc:
+        except Exception as exc:
             wrong += 1
             if len(seen) < 3:
                 seen.append('%s: %s' % (type(exc).__name__, exc))

--- a/pyre/bench/synth/a_raise_through_the_recursive_portal_reaches_its_handler.py
+++ b/pyre/bench/synth/a_raise_through_the_recursive_portal_reaches_its_handler.py
@@ -1,0 +1,92 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=hot,rec
+# A recursive callee that raises past its own loop header owes the caller an
+# exception, not a value.
+#
+# `warmspot.py ll_portal_runner` raises into RPython's single ll exception
+# state, and every executor of the portal reads that one state: compiled
+# `CALL_ASSEMBLER` through `pos_exception()` / `pos_exc_value()`
+# (`llmodel.py`), `bhimpl_recursive_call_*` through the propagated RPython
+# exception (`blackhole.py:1110-1116`), and the trace-time execution that
+# `do_recursive_call` performs through `metainterp.execute_raised`
+# (`executor.py:52-78`).
+#
+# pyre spells that one state as two carriers — `BH_LAST_EXC_VALUE` and the
+# backend `_store_exception` cells — and the portal shim wrote only the
+# second.  The walker's residual executor reads only the first, so a raise out
+# of the portal was invisible to it: it recorded `GUARD_NO_EXCEPTION` over the
+# raise, wrote the shim's NULL result into the destination slot, and left the
+# backend cells armed for an unrelated guard.
+#
+# THE LOOP IN THE CALLEE IS THE TEST, not decoration.  The fold that runs the
+# portal shim at trace time is the one an inlined callee sub-walk takes when it
+# reaches the callee's OWN loop header
+# (`emit_walker_loop_callee_call_assembler`).  A loopless recursion folds
+# through the self-recursive arm instead, which executes the ordinary `call_fn`
+# residual — that helper publishes both carriers, so a loopless shape passes
+# whether or not the portal shim is correct.
+#
+# THE CALL SITE MUST SIT OUTSIDE THE `try`, for the same reason: the fold
+# declines on a call site inside a protected region, so the handler belongs one
+# level up, in the driver loop.
+#
+# Measured before the fix on dynasm: 5 of 3000 calls surfaced
+# `TypeError: unsupported operand type(s) for +: 'object' and 'int'` — the
+# swallowed raise's NULL reaching the `+` — where `PYRE_JIT=0` and cpython 3.14
+# both deliver 3000 `ValueError`s.  One wrong answer is the failure; the count
+# only tracks when the callee's loop compiles.
+import sys
+
+WARM = 3000
+DEPTH = 4
+INNER = 30
+
+
+def rec(n, m):
+    total = 0
+    for i in range(m):
+        total += i
+    if n <= 0:
+        raise ValueError('bottom')
+    return rec(n - 1, m) + total
+
+
+def hot(k):
+    caught = 0
+    wrong = 0
+    seen = []
+    for _ in range(k):
+        try:
+            rec(DEPTH, INNER)
+        except ValueError:
+            caught += 1
+        except BaseException as exc:
+            wrong += 1
+            if len(seen) < 3:
+                seen.append('%s: %s' % (type(exc).__name__, exc))
+    return caught, wrong, seen
+
+
+def main():
+    caught, wrong, seen = hot(WARM)
+    failures = []
+    if wrong:
+        failures.append(
+            '%d of %d calls surfaced a foreign exception instead of the '
+            'ValueError the callee raised — the portal published the raise to '
+            'one carrier and the walker reads the other, so its NULL result '
+            'flowed on: %r' % (wrong, WARM, seen)
+        )
+    if caught != WARM:
+        failures.append(
+            'the handler ran %d times, owed %d' % (caught, WARM)
+        )
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS a raise through the recursive portal reaches its handler')
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/getframe_bridge_force_from_inlined_callee.py
+++ b/pyre/bench/synth/getframe_bridge_force_from_inlined_callee.py
@@ -16,7 +16,12 @@
 #
 # One frame down, depth 1 lands on the portal frame, and that is the whole
 # shape: `peek()` inlines into the rare arm and its `_gf(1)` is a `CallFn`
-# residual that hands `main`'s own virtualizable to Python.
+# residual that hands `main`'s own virtualizable to Python, where the `f_lasti`
+# read forces it.  The read is the lever, not the call: `sys._getframe` takes no
+# virtualizable force of its own, and `rvirtualizable.py hook_access_field`
+# places one at each REDIRECTED field access -- `f_lasti` reads `last_instr`,
+# one of the five `virtualizable_gen.rs` declares.  The `f_code.co_name` `peek`
+# also reads is not a second one.
 #
 # Each clause is load-bearing:
 #   * the `for` loop compiles on the common arm;
@@ -55,8 +60,11 @@ _gf = sys._getframe
 
 def peek():
     # Depth 1 from inside the inlined callee names `main` -- the traced
-    # virtualizable -- so this stays a residual and forces the token.
-    return _gf(1).f_code.co_name
+    # virtualizable -- so this stays a residual, and the `f_lasti` read off the
+    # frame it returns forces the token.
+    fr = _gf(1)
+    _ = fr.f_lasti
+    return fr.f_code.co_name
 
 
 def main():

--- a/pyre/bench/synth/getframe_method_call_residual_body_once.py
+++ b/pyre/bench/synth/getframe_method_call_residual_body_once.py
@@ -25,10 +25,12 @@
 # `max-pypy-ratio` for the same reason `exception_reused_object_tb_not_doubled`
 # has none — this is a shape oracle, not a workload.
 #
-# `sys._getframe` forces only the frame it RETURNS, so `raiser`'s `_getframe(1)`
-# escapes the portal once per call instead of twice; that halving is this file's
-# recorded `fbw_blackhole_adopted_single_frame` 10 -> 5, with `loops_aborted`
-# unmoved.
+# `sys._getframe` takes no virtualizable force of its own: `rvirtualizable.py
+# hook_access_field` places one at each REDIRECTED field access, so `raiser`'s
+# escape is the `f_lasti` read -- `last_instr` is one of the five
+# `virtualizable_gen.rs` declares -- and it escapes the portal once per call
+# rather than twice.  That halving is this file's recorded
+# `fbw_blackhole_adopted_single_frame` 10 -> 5, with `loops_aborted` unmoved.
 #
 # Expected output: (20000, 20000, 20000)
 import sys
@@ -40,7 +42,7 @@ class Force:
     hits = 0
 
     def raiser(self):
-        _ = sys._getframe(1).f_back
+        _ = sys._getframe(1).f_lasti
         Force.hits += 1
         raise ValueError(1)
 

--- a/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.py
+++ b/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.py
@@ -5,12 +5,16 @@
 # Caller locals that are live ACROSS the inlined call, exercised at a vable
 # escape inside an inline sub-walk.
 #
-# The escape is `_gf(1)`, the CALLER's frame, and the depth is load-bearing:
-# `try_walker_specialize_sys_getframe` answers depth 0 at the top walk level out
-# of the portal virtualizable, so a zero-argument call -- which is what this
-# fixture used to carry -- forces nothing and the baselines went to
-# `fbw_blackhole_adopted_multi_frame=0`.  Depth 1 names a frame the
-# specialization refuses, so the call stays residual and forces.
+# The escape is the `f_lasti` read on `_gf(1)`, the CALLER's frame, and both
+# halves are load-bearing.  The depth: `try_walker_specialize_sys_getframe`
+# answers depth 0 at the top walk level out of the portal virtualizable, so a
+# zero-argument call forces nothing and the baselines went to
+# `fbw_blackhole_adopted_multi_frame=0`; depth 1 names a frame the
+# specialization refuses, so the call stays residual.  The read: `getframe`
+# takes no virtualizable force of its own, `rvirtualizable.py
+# hook_access_field` places one at each REDIRECTED field access, and `f_lasti`
+# reads `last_instr` -- one of the five `virtualizable_gen.rs` declares.  A bare
+# call, or a read of `f_code` or `f_back`, escapes nothing.
 #
 # The multi-frame chain gives each level its own frame as the virtualizable, so
 # the walked frame's level writes its `setfield_vable` stores to the LIVE frame,
@@ -26,7 +30,7 @@ _gf = sys._getframe
 
 
 def leaf(x):
-    _gf(1)
+    _ = _gf(1).f_lasti
     return x + 1
 
 

--- a/pyre/bench/synth/getframe_while_captured_frame_outlives_call.py
+++ b/pyre/bench/synth/getframe_while_captured_frame_outlives_call.py
@@ -13,14 +13,17 @@
 # `kept.f_back` below does. A run that prints the right names proves nothing
 # unless the fixture actually reaches the path, so keep the `while` drive.
 #
-# The escape is the SECOND getframe call, at the CALLER's depth.  The captured
-# `kept = _gf()` cannot be it: `try_walker_specialize_sys_getframe` takes depth
-# 0 at the top walk level, where getframe's answer IS the portal virtualizable
-# and no force is needed, so that call escapes nothing -- and the depth-0
-# capture is what makes `kept.f_back` name `main`, so it has to stay.  `_gf(1)`
-# names a frame the specialization refuses, keeping one forcing residual per
-# iteration.  Delete it and the adopt goes back to zero while the printed line
-# stays right.
+# The escape is the `f_lasti` read on the SECOND getframe call, at the CALLER's
+# depth.  The captured `kept = _gf()` cannot be it:
+# `try_walker_specialize_sys_getframe` takes depth 0 at the top walk level,
+# where getframe's answer IS the portal virtualizable, so that call escapes
+# nothing -- and the depth-0 capture is what makes `kept.f_back` name `main`, so
+# it has to stay.  `_gf(1)` names a frame the specialization refuses, keeping
+# one residual per iteration, and the read is what forces it: `getframe` takes
+# no virtualizable force of its own, `rvirtualizable.py hook_access_field`
+# places one at each REDIRECTED field access, and `f_lasti` reads `last_instr`.
+# Drop either half and the adopt goes back to zero while the printed line stays
+# right.
 import sys
 
 _gf = sys._getframe
@@ -31,7 +34,7 @@ kept = None
 def leaf(x):
     global kept
     kept = _gf()
-    _gf(1)
+    _ = _gf(1).f_lasti
     return x + 1
 
 

--- a/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
+++ b/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
@@ -33,12 +33,17 @@
 # the escape has happened, a `sys._getframe(1)` executed inside the blackhole was
 # always correct, because the chain publishes each level's frame as it runs.
 #
-# Both reads still escape — `_gf()` names `leaf_a`'s published frame and
-# `_gf(1)` names `part_b`'s portal — but only once per call now that
-# `sys._getframe` forces the frame it RETURNS and not also the top of the stack.
-# The multi-frame adoption count this file exists for is unmoved at 10.  What
-# the duplicate escape carried was the single-frame count, 5 -> 0, alongside
-# `part_a`'s loop compiling.
+# The escape is `leaf_b`'s `f_lasti` read, and it is the only one in the file.
+# `sys._getframe` takes no virtualizable force of its own; `rvirtualizable.py
+# hook_access_field` places one at each REDIRECTED field access, and `f_lasti`
+# reads `last_instr`, one of the five `virtualizable_gen.rs` declares.  The
+# `f_code.co_name` both oracles read is not a second escape — `pyframe.rs
+# descr_typecheck_fget_f_code` carries no marker and says at its own definition
+# why `pycode` needs none — and `leaf_a`'s call is at depth 0, which
+# `try_walker_specialize_sys_getframe` answers out of the portal virtualizable
+# the walk already holds, so the same read there moves no counter (measured).
+# `part_a` therefore keeps its identity oracle over compiled code while the
+# adopt this file exists for is reached through `part_b`.
 import sys
 
 _gf = sys._getframe
@@ -64,7 +69,9 @@ def part_a():
 
 
 def leaf_b(x):
-    name = _gf(1).f_code.co_name
+    fr = _gf(1)
+    _ = fr.f_lasti
+    name = fr.f_code.co_name
     if name != "part_b":
         wrong_b.append(name)
     return x + 1

--- a/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
+++ b/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
@@ -37,9 +37,10 @@
 # `sys._getframe` takes no virtualizable force of its own; `rvirtualizable.py
 # hook_access_field` places one at each REDIRECTED field access, and `f_lasti`
 # reads `last_instr`, one of the five `virtualizable_gen.rs` declares.  The
-# `f_code.co_name` both oracles read is not a second escape — `pyframe.rs
-# descr_typecheck_fget_f_code` carries no marker and says at its own definition
-# why `pycode` needs none — and `leaf_a`'s call is at depth 0, which
+# `f_code.co_name` both oracles read is not a second escape — `pyframe.rs`
+# `__majit_wrap_descr_typecheck_fget_f_code` carries no marker and says at its
+# own definition why `pycode` needs none — and `leaf_a`'s call is at depth 0,
+# which
 # `try_walker_specialize_sys_getframe` answers out of the portal virtualizable
 # the walk already holds, so the same read there moves no counter (measured).
 # `part_a` therefore keeps its identity oracle over compiled code while the

--- a/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
+++ b/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
@@ -29,8 +29,9 @@
 #     declares that set as `last_instr`, `pycode`, `valuestackdepth`,
 #     `debugdata` and `locals_cells_stack_w`.  `f_lasti` reads `last_instr`, so
 #     its gateway forces.  A bare call forces nothing, and neither does a read
-#     of `f_code` or `f_back`: `pyframe.rs descr_typecheck_fget_f_code` and
-#     `..._f_back` each say at their own definition why they carry no marker.
+#     of `f_code` or `f_back`: `pyframe.rs`
+#     `__majit_wrap_descr_typecheck_fget_f_code` and `..._fget_f_back` each say
+#     at their own definition why they carry no marker.
 # Changing any of the three can silently stop exercising the path.
 #
 # The printed total counts one callee entry per iteration, so a resume that

--- a/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
+++ b/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
@@ -19,13 +19,18 @@
 #     sub-walk and the single-frame arm would take it;
 #   - the CALLER's depth, `_gf(1)`.  `try_walker_specialize_sys_getframe` takes
 #     only depth 0 at the top walk level, where getframe's answer IS the portal
-#     virtualizable and no force is needed -- so a zero-argument call, which is
-#     what this fixture used to carry, now escapes nothing at all and the
-#     baselines went to `fbw_blackhole_adopted_multi_frame=0`.  Depth 1 names a
-#     frame the specialization refuses, so the call stays residual and forces;
-#   - nothing read off the returned frame: the read accessors force nothing
-#     either -- `fast2locals` is `@jit.unroll_safe` -- so a read would add
-#     opcodes without adding an escape.
+#     virtualizable, so a zero-argument call names a frame the walk already
+#     holds and the baselines went to `fbw_blackhole_adopted_multi_frame=0`.
+#     Depth 1 names a frame the specialization refuses, so the call stays
+#     residual and hands the traced virtualizable to the interpreter;
+#   - a read of `f_lasti` off the frame it returns.  `getframe` takes no
+#     virtualizable force of its own; `rvirtualizable.py hook_access_field`
+#     places one at each REDIRECTED field access, and `virtualizable_gen.rs`
+#     declares that set as `last_instr`, `pycode`, `valuestackdepth`,
+#     `debugdata` and `locals_cells_stack_w`.  `f_lasti` reads `last_instr`, so
+#     its gateway forces.  A bare call forces nothing, and neither does a read
+#     of `f_code` or `f_back`: `pyframe.rs descr_typecheck_fget_f_code` and
+#     `..._f_back` each say at their own definition why they carry no marker.
 # Changing any of the three can silently stop exercising the path.
 #
 # The printed total counts one callee entry per iteration, so a resume that
@@ -37,7 +42,7 @@ _gf = sys._getframe
 
 
 def leaf(x):
-    _gf(1)
+    _ = _gf(1).f_lasti
     return x + 1
 
 

--- a/pyre/bench/synth/nested_for_escape_flush_keeps_the_inner_iterator.py
+++ b/pyre/bench/synth/nested_for_escape_flush_keeps_the_inner_iterator.py
@@ -3,17 +3,23 @@
 # The multi-frame escape flush publishes frame 0's LOCALS; this guards the
 # operand stack published with them.
 #
-# `sys._getframe(1)` read from an inlined callee forces the CALLER's
+# A redirected frame field read from an inlined callee forces the CALLER's
 # virtualizable, so the walk aborts as an inline sub-walk and a multi-frame
-# blackhole image resumes the two frames. The walk keeps that virtualizable
-# symbolic, so nothing it pushed or popped ever reached the live frame's slot
-# array. When the abort lands on a walk that crossed the inner `FOR_ITER`'s
-# exhaust, the outer `FOR_ITER` has already run and `GET_ITER` has built a
-# FRESH inner iterator that exists only in the walk: resuming without
-# publishing the stack leaves the PREVIOUS pass's exhausted iterator on TOS,
-# the inner loop ends one iteration in, and every later `i` runs one pass ahead
-# of the `j` beside it. The values the body reads stay intact, which is why
-# this reads as a loop-control error and not a lost item.
+# blackhole image resumes the two frames. `sys._getframe(1)` only names the
+# frame: the force sits at the field, where `rvirtualizable.py
+# hook_access_field` places it, and `f_lasti` reads `last_instr` -- one of the
+# five `virtualizable_gen.rs` declares. The `f_code` the caller-identity check
+# reads is not a lever; its gateway carries no marker.
+#
+# The walk keeps that virtualizable symbolic, so nothing it pushed or popped
+# ever reached the live frame's slot array. When the abort lands on a walk
+# that crossed the inner `FOR_ITER`'s exhaust, the outer `FOR_ITER` has
+# already run and `GET_ITER` has built a FRESH inner iterator that exists only
+# in the walk: resuming without publishing the stack leaves the PREVIOUS
+# pass's exhausted iterator on TOS, the inner loop ends one iteration in, and
+# every later `i` runs one pass ahead of the `j` beside it. The values the
+# body reads stay intact, which is why this reads as a loop-control error and
+# not a lost item.
 #
 # Measured before the stack was published: `k=1041 i=209 j=0`, where `k` says
 # the body is at `i=208 j=1` -- the first abort lands at the default hotness
@@ -34,7 +40,9 @@ wrong = []
 
 
 def leaf(x):
-    name = _gf(1).f_code.co_name
+    fr = _gf(1)
+    _ = fr.f_lasti
+    name = fr.f_code.co_name
     if name != "main":
         wrong.append(name)
     return x + 1

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -86,11 +86,18 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 ///
 /// Manual frame getset gateways publish their bodies through
 /// `gateway::BUILTIN_WRAPPER_DESCRIPTORS`, the Rust counterpart of
-/// `BuiltinCode.func`'s SomePBC family.  Each gateway carries this marker next
-/// to its redirected access.  The untranslated interpreter therefore retains
+/// `BuiltinCode.func`'s SomePBC family.  The untranslated interpreter retains
 /// the force, while `jtransform` deletes it from every gateway graph admitted
 /// by the codewriter — the same two populations `hook_access_field` creates
 /// upstream.
+///
+/// Which gateways carry it is `hook_access_field`'s own condition,
+/// `if self.my_redirected_fields.get(cname.value)`: only a body that reads a
+/// field `interp_jit.py` lists in `_virtualizable_` (`last_instr`, `pycode`,
+/// `valuestackdepth`, `locals_cells_stack_w[*]`, `debugdata`, `w_globals`).
+/// `pyframe.rs` `descr_typecheck_fget_f_back` and `..._fget_f_builtins` read
+/// `f_backref` and `w_builtin`, so they carry none; each says so at its own
+/// definition, with what the extra marker measured.
 ///
 /// Upstream reaches the rewrite because `hook_access_field` puts the marker
 /// at every redirected FIELD access, which lands it inside graphs the

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -91,13 +91,22 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// by the codewriter — the same two populations `hook_access_field` creates
 /// upstream.
 ///
-/// Which gateways carry it is `hook_access_field`'s own condition,
-/// `if self.my_redirected_fields.get(cname.value)`: only a body that reads a
-/// field `interp_jit.py` lists in `_virtualizable_` (`last_instr`, `pycode`,
-/// `valuestackdepth`, `locals_cells_stack_w[*]`, `debugdata`, `w_globals`).
-/// `pyframe.rs` `descr_typecheck_fget_f_back` and `..._fget_f_builtins` read
-/// `f_backref` and `w_builtin`, so they carry none; each says so at its own
-/// definition, with what the extra marker measured.
+/// Which gateways carry it starts from `hook_access_field`'s own condition,
+/// `if self.my_redirected_fields.get(cname.value)` — and the redirected set is
+/// the one `pyre-jit-trace` `virtualizable_gen.rs` declares, not
+/// `interp_jit.py`'s string list: `last_instr`, `pycode`, `valuestackdepth`,
+/// `debugdata` and the `locals_cells_stack_w` array (`w_globals` is skipped;
+/// no `PyFrame` field answers to it).  `pyframe.rs`
+/// `descr_typecheck_fget_f_back` and `..._fget_f_builtins` read `f_backref`
+/// and `w_builtin`, so they carry none.
+///
+/// A hand-placed marker owes one question upstream's injection never has to
+/// ask, because it fires at every access in every graph rather than once per
+/// gateway: can the trace's shadow and the live frame disagree about the field
+/// this body reads?  For `pycode` they cannot — it is written only at frame
+/// construction — so `descr_typecheck_fget_f_code` carries no marker either.
+/// Each of the three says so at its own definition, with what the marker
+/// measured.
 ///
 /// Upstream reaches the rewrite because `hook_access_field` puts the marker
 /// at every redirected FIELD access, which lands it inside graphs the

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -82,7 +82,15 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// `#[inline(never)]` keeps the callee name on the Call so the rewrite can
 /// see it.
 ///
-/// # Reach, and why the readers do not carry it
+/// # Reach: gateways, not redirected-array readers
+///
+/// Manual frame getset gateways publish their bodies through
+/// `gateway::BUILTIN_WRAPPER_DESCRIPTORS`, the Rust counterpart of
+/// `BuiltinCode.func`'s SomePBC family.  Each gateway carries this marker next
+/// to its redirected access.  The untranslated interpreter therefore retains
+/// the force, while `jtransform` deletes it from every gateway graph admitted
+/// by the codewriter — the same two populations `hook_access_field` creates
+/// upstream.
 ///
 /// Upstream reaches the rewrite because `hook_access_field` puts the marker
 /// at every redirected FIELD access, which lands it inside graphs the
@@ -110,9 +118,9 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// `__majit_wrap_descr_typecheck_fget_getdictscope` gateway, so a marker at the readers
 /// is redundant where it would matter and new only where it costs.
 ///
-/// So the readers carry no force.
+/// So the redirected-array readers carry no force.
 ///
-/// The other force sites call [`force_frame`] or
+/// Non-gateway force sites call [`force_frame`] or
 /// [`force_frame_before_locals_read`] directly, and only two of them sit in
 /// a graph that has a jitcode — `pyframe.rs`
 /// `FrameLocalsProxy::force_locals` and `builtins.rs`

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -97,14 +97,15 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// `interp_jit.py`'s string list: `last_instr`, `pycode`, `valuestackdepth`,
 /// `debugdata` and the `locals_cells_stack_w` array (`w_globals` is skipped;
 /// no `PyFrame` field answers to it).  `pyframe.rs`
-/// `descr_typecheck_fget_f_back` and `..._fget_f_builtins` read `f_backref`
-/// and `w_builtin`, so they carry none.
+/// `__majit_wrap_descr_typecheck_fget_f_back` and `..._fget_f_builtins` read
+/// `f_backref` and `w_builtin`, so they carry none.
 ///
 /// A hand-placed marker owes one question upstream's injection never has to
 /// ask, because it fires at every access in every graph rather than once per
 /// gateway: can the trace's shadow and the live frame disagree about the field
 /// this body reads?  For `pycode` they cannot — it is written only at frame
-/// construction — so `descr_typecheck_fget_f_code` carries no marker either.
+/// construction — so `__majit_wrap_descr_typecheck_fget_f_code` carries no
+/// marker either.
 /// Each of the three says so at its own definition, with what the marker
 /// measured.
 ///

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -62,12 +62,24 @@ impl<T> ResidualSlot for *mut T {}
 impl<T> ResidualRet for *const T {}
 impl<T> ResidualRet for *mut T {}
 
-// `majit_ir::GcRef` is `#[repr(transparent)]` over one `usize`: the native
-// spelling of RPython's one-word `llmemory.GCREF`.  FrameAnchor's external
-// shadow-stack declarations therefore occupy one residual argument/result
-// slot without an ABI bridge.
-impl ResidualSlot for majit_ir::GcRef {}
-impl ResidualRet for majit_ir::GcRef {}
+/// Word-ABI bridges for the three shadow-stack operations `eval::FrameAnchor`
+/// reaches.  `majit_ir::GcRef` is `#[repr(transparent)]` over one `usize`, so
+/// each of the raw functions is `(usize) -> usize`, `(usize) -> usize` and
+/// `(usize) -> ()` — and `usize` is 32-bit on wasm32.  A residual call whose
+/// descr types are all words lowers to an in-module `(i64xn) -> i64` (or
+/// `(i64xn) -> ()`) `call_indirect`, which type-checks its callee on every
+/// call, so the raw functions are a different table type there.
+extern "C" fn shadow_stack_push_word(gcref: i64) -> i64 {
+    majit_gc::shadow_stack::push(majit_ir::GcRef(gcref as usize)) as i64
+}
+
+extern "C" fn shadow_stack_get_word(index: i64) -> i64 {
+    majit_gc::shadow_stack::get(index as usize).as_usize() as i64
+}
+
+extern "C" fn shadow_stack_try_pop_to_word(depth: i64) {
+    majit_gc::shadow_stack::try_pop_to(depth as usize);
+}
 
 /// Word-ABI bridge for the scalar bytecode read used by translated residual
 /// calls.  The backends call integer helpers uniformly as `(i64, ..) -> i64`;
@@ -845,22 +857,24 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
 
     // `eval::FrameAnchor` is interpreter runtime rooting, outside the LLBC
     // module set.  `majit-translate` declares these three functions through
-    // its annotator-only `register_external` carrier; publish the exact Rust
-    // symbols here so a residual call never falls back to a symbolic hash.
-    p1(
+    // its annotator-only `register_external` carrier; publish an address for
+    // each declared path here so a residual call never falls back to a
+    // symbolic hash.  The addresses are the word-ABI bridges above, not the
+    // raw functions, for the reason their doc gives.
+    cp1(
         &mut entries,
         "majit_gc::shadow_stack::push",
-        majit_gc::shadow_stack::push,
+        shadow_stack_push_word,
     );
-    p1(
+    cp1(
         &mut entries,
         "majit_gc::shadow_stack::get",
-        majit_gc::shadow_stack::get,
+        shadow_stack_get_word,
     );
-    p1(
+    cp1(
         &mut entries,
         "majit_gc::shadow_stack::try_pop_to",
-        majit_gc::shadow_stack::try_pop_to,
+        shadow_stack_try_pop_to_word,
     );
 
     pa1(
@@ -4707,7 +4721,8 @@ mod tests {
     use super::{
         is_abi_unsound_argument_residual, is_list_write_barrier, is_pyframe_operand_stack_accessor,
         is_rerunnable_bookkeeping_residual, jit_static_pytype_addrs, jit_static_ref_addrs,
-        jit_trace_fnaddrs,
+        jit_trace_fnaddrs, shadow_stack_get_word, shadow_stack_push_word,
+        shadow_stack_try_pop_to_word,
     };
     use std::collections::HashMap;
 
@@ -4792,19 +4807,47 @@ mod tests {
         for (path, expected) in [
             (
                 "majit_gc::shadow_stack::push",
-                majit_gc::shadow_stack::push as *const () as usize as i64,
+                shadow_stack_push_word as *const () as usize as i64,
             ),
             (
                 "majit_gc::shadow_stack::get",
-                majit_gc::shadow_stack::get as *const () as usize as i64,
+                shadow_stack_get_word as *const () as usize as i64,
             ),
             (
                 "majit_gc::shadow_stack::try_pop_to",
-                majit_gc::shadow_stack::try_pop_to as *const () as usize as i64,
+                shadow_stack_try_pop_to_word as *const () as usize as i64,
             ),
         ] {
             assert_eq!(bindings.get(path), Some(&expected), "missing {path}");
         }
+    }
+
+    /// The three published addresses answer through the word ABI a residual
+    /// call reaches them with, and the round trip preserves the reference.
+    ///
+    /// Calling each through its registry address, transmuted to the signature
+    /// the lowering emits, is what an in-module `call_indirect` does; a raw
+    /// `(usize) -> usize` published here would be a different wasm32 table
+    /// type and trap there while still passing an address comparison.
+    #[test]
+    fn the_shadow_stack_externals_answer_through_the_word_abi() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let addr = |path: &str| *bindings.get(path).expect("registered") as usize;
+        let push: extern "C" fn(i64) -> i64 =
+            unsafe { std::mem::transmute(addr("majit_gc::shadow_stack::push")) };
+        let get: extern "C" fn(i64) -> i64 =
+            unsafe { std::mem::transmute(addr("majit_gc::shadow_stack::get")) };
+        let try_pop_to: extern "C" fn(i64) =
+            unsafe { std::mem::transmute(addr("majit_gc::shadow_stack::try_pop_to")) };
+
+        // A word that is not a live object: these three only move it between
+        // the stack and the caller.
+        let marker = 0x2468_i64;
+        let depth = push(marker);
+        assert_eq!(get(depth), marker);
+        try_pop_to(depth);
+        assert_eq!(push(marker), depth, "try_pop_to left the depth unrestored");
+        try_pop_to(depth);
     }
 
     /// Two registered functions must never share an address.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -62,6 +62,13 @@ impl<T> ResidualSlot for *mut T {}
 impl<T> ResidualRet for *const T {}
 impl<T> ResidualRet for *mut T {}
 
+// `majit_ir::GcRef` is `#[repr(transparent)]` over one `usize`: the native
+// spelling of RPython's one-word `llmemory.GCREF`.  FrameAnchor's external
+// shadow-stack declarations therefore occupy one residual argument/result
+// slot without an ABI bridge.
+impl ResidualSlot for majit_ir::GcRef {}
+impl ResidualRet for majit_ir::GcRef {}
+
 /// Word-ABI bridge for the scalar bytecode read used by translated residual
 /// calls.  The backends call integer helpers uniformly as `(i64, ..) -> i64`;
 /// the raw Rust function is `(pointer, usize) -> u16`, which is a different
@@ -835,6 +842,26 @@ pub fn is_abi_unsound_argument_residual(addr: usize) -> bool {
 fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
     let mut entries = Vec::new();
     let mut abi_unsound_arguments = Vec::new();
+
+    // `eval::FrameAnchor` is interpreter runtime rooting, outside the LLBC
+    // module set.  `majit-translate` declares these three functions through
+    // its annotator-only `register_external` carrier; publish the exact Rust
+    // symbols here so a residual call never falls back to a symbolic hash.
+    p1(
+        &mut entries,
+        "majit_gc::shadow_stack::push",
+        majit_gc::shadow_stack::push,
+    );
+    p1(
+        &mut entries,
+        "majit_gc::shadow_stack::get",
+        majit_gc::shadow_stack::get,
+    );
+    p1(
+        &mut entries,
+        "majit_gc::shadow_stack::try_pop_to",
+        majit_gc::shadow_stack::try_pop_to,
+    );
 
     pa1(
         &mut entries,
@@ -4757,6 +4784,27 @@ mod tests {
             list_append
         );
         assert_eq!(bindings["pyre_object::jit_list_append"], list_append);
+    }
+
+    #[test]
+    fn jit_trace_fnaddrs_covers_frame_anchor_shadow_stack_externals() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        for (path, expected) in [
+            (
+                "majit_gc::shadow_stack::push",
+                majit_gc::shadow_stack::push as *const () as usize as i64,
+            ),
+            (
+                "majit_gc::shadow_stack::get",
+                majit_gc::shadow_stack::get as *const () as usize as i64,
+            ),
+            (
+                "majit_gc::shadow_stack::try_pop_to",
+                majit_gc::shadow_stack::try_pop_to as *const () as usize as i64,
+            ),
+        ] {
+            assert_eq!(bindings.get(path), Some(&expected), "missing {path}");
+        }
     }
 
     /// Two registered functions must never share an address.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -948,39 +948,20 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
 /// a stub, so `frame.f_globals is globals()` holds and `f_back` chains lazily
 /// through `pyframe.py GetSetProperty(PyFrame.fget_f_back)`.
 ///
-/// DEVIATION — the VIRTUALIZABLE force on `current`. The vref force is common
-/// to both worlds and is not optional (`ExecutionContext::gettopframe_raw`), so
-/// `gettopframe_nohidden` is not "force-free" — it is free of the
-/// *virtualizable* force. Upstream takes neither, because
-/// `look_inside_iff(isconstant(depth))` traces a constant `depth` THROUGH, so
-/// the walk never becomes a residual call — and the frame it hands to app level
-/// materialises through the force `rvirtualizable.py hook_access_field`
-/// injects at every redirected FIELD access, which
-/// `jtransform.py rewrite_op_jit_force_virtualizable` deletes only in
-/// the graphs the codewriter looks inside.  Pyre has no such injection —
-/// `rclass.rs buildinstancerepr` declines a virtualizable `InstanceRepr`
-/// outright — so the `force_frame` below IS that mechanism, relocated to one
-/// consumer.
+/// The walk takes no virtualizable force.  This is load-bearing upstream
+/// structure, not merely a fast path: `getframe` follows `f_backref`, marks the
+/// result escaped and returns it.  `rvirtualizable.py hook_access_field` puts
+/// `jit_force_virtualizable` at the later redirected FIELD access, and
+/// `jtransform.py rewrite_op_jit_force_virtualizable` deletes it only from a
+/// graph the codewriter looks inside.  Pyre mirrors that split in the manual
+/// frame descriptor gateways (`pyframe.rs __majit_wrap_descr_typecheck_fget_*`): their
+/// runtime bodies retain the marker, while every gateway is published through
+/// `BUILTIN_WRAPPER_DESCRIPTORS` so the JIT sees and deletes it.
 ///
-/// It is relocated onto the frame the injection would have fired for: the one
-/// this call RETURNS, whose `f_lineno` / `f_locals` app code is about to read.
-/// The walk itself needs no such force. It reads `hide()` (`pycode`, written at
-/// construction) and `f_backref` (not a virtualizable field at all), and a level
-/// the JIT kept virtual is materialised by the vref force
-/// `gettopframe_nohidden` already takes.
-///
-/// Which frame carries the force decides whether the caller's loop survives.
-/// `force_pyframe` (`pyre-jit/src/eval.rs`) clears the traced virtualizable's
-/// `TOKEN_TRACING_RESCALL` only for a frame `flush_active_frame_escape` matches
-/// — the portal itself, or the concrete frame an inline sub-walk published — and
-/// that clear is what `tracing_after_residual_call` reads as
-/// `VableEscapedDuringResidualCall`. Forcing the top of the stack regardless of
-/// `depth` therefore escaped the portal on every call, including the ones whose
-/// answer lies BELOW it; upstream escapes nothing there, because
-/// `pyjitpl.py _do_jit_force_virtual` answers `topframeref` with
-/// `virtualizable_boxes[-1]` and never forces it. Measured over the `getframe_*`
-/// corpus: five fixtures that had never compiled a loop now compile one, and the
-/// two bridge fixtures read `guard_failures` 4114 → 201.
+/// Putting the force here, before the consumer is known, is not an equivalent
+/// relocation.  Inside a `CALL_MAY_FORCE` it clears `TOKEN_TRACING_RESCALL`, so
+/// `vable_after_residual_call` aborts a trace even when the caller only asks for
+/// frame identity or an invariant field whose gateway the JIT can see.
 ///
 /// `try_walker_specialize_sys_getframe`
 /// (`pyre-jit-trace/src/jitcode_dispatch/specialize.rs`) reproduces upstream's
@@ -1018,17 +999,9 @@ pub fn getframe(depth: i64) -> crate::PyResult {
         current = crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
     }
     unsafe { (*current).mark_as_escaped() };
-    // The force reaches the JIT's virtualizable writeback through a backend
-    // hook whose callee this crate cannot follow, and the audit hook below is
-    // handed this frame.
-    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(current) };
-    crate::executioncontext::force_frame(current);
-    current = anchor.live();
-    // `vm.py audit(space, "sys._getframe", [f])`.  Ordered after the force
-    // because a hook is app code that reads the frame it is handed, and the
-    // force is what makes those reads see the JIT's live virtualizable fields —
-    // upstream gets that ordering from the `hook_access_field` injection at
-    // each field read, which pyre has relocated to this one call site.
+    // `vm.py audit(space, "sys._getframe", [f])`.  The event follows
+    // `mark_as_escaped`; a hook that reads a redirected frame field reaches
+    // that field's descriptor gateway and forces there.
     if audit_hooks_armed() {
         // The wrap of the event name and the hooks themselves are both
         // collection points, and the frame this is about to return reaches them
@@ -2040,7 +2013,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             // forcing a walk escapes the traced virtualizable and
             // `vable_after_residual_call` aborts the trace with ABORT_ESCAPE.
             let anchor = unsafe { crate::eval::FrameAnchor::from_raw(current) };
-            crate::executioncontext::force_frame(current);
+            crate::executioncontext::jit_force_virtualizable(anchor.live());
             let w_globals = unsafe { (*anchor.live()).get_w_globals() };
             if w_globals.is_null() {
                 return Ok(pyre_object::w_none());

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3166,6 +3166,20 @@ register_frame_builtin_wrapper!(
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_back`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_back`.
+///
+/// No force marker.  `rvirtualizable.py hook_access_field` emits
+/// `jit_force_virtualizable` only under
+/// `if self.my_redirected_fields.get(cname.value)`, and the field this reads —
+/// `f_backref` — is not one: `interp_jit.py` declares `_virtualizable_` as
+/// `last_instr`, `pycode`, `valuestackdepth`, `locals_cells_stack_w[*]`,
+/// `debugdata`, `w_globals`.  [`PyFrame::fget_f_back`] states what a marker
+/// here costs instead — `f_backref` holds a `jit.virtual_ref`, so reading it
+/// IS the force, and it is the foldable one.
+///
+/// Measured on `synth/getframe_inlined_callee_own_frame`: with the marker,
+/// `frame.f_back` raised `VableEscapedDuringResidualCall` 35 times and the
+/// fixture compiled no loop; `frame.f_code`, whose field IS redirected, raised
+/// none because the walker folds that read instead of residualizing it.
 pub fn __majit_wrap_descr_typecheck_fget_f_back(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -3174,7 +3188,6 @@ pub fn __majit_wrap_descr_typecheck_fget_f_back(
         return Ok(pyre_object::w_none());
     }
     let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
-    crate::executioncontext::jit_force_virtualizable(anchor.live());
     let back = unsafe { &*anchor.live() }.fget_f_back();
     Ok(if back.is_null() {
         pyre_object::w_none()
@@ -3308,6 +3321,11 @@ register_frame_builtin_wrapper!(
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_builtins`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_builtins`.
+///
+/// No force marker, for the reason
+/// [`__majit_wrap_descr_typecheck_fget_f_back`] gives:
+/// [`PyFrame::fget_f_builtins`] reads `w_builtin` and the module's `w_dict`,
+/// and `_virtualizable_` names neither.
 pub fn __majit_wrap_descr_typecheck_fget_f_builtins(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -3316,7 +3334,6 @@ pub fn __majit_wrap_descr_typecheck_fget_f_builtins(
         return Ok(pyre_object::w_none());
     }
     let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
-    crate::executioncontext::jit_force_virtualizable(anchor.live());
     let w = unsafe { &*anchor.live() }.fget_f_builtins();
     Ok(if w.is_null() {
         pyre_object::w_none()

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3074,7 +3074,10 @@ pub fn code_flags_make_generator(flags: crate::CodeFlags) -> bool {
 /// hand rather than by `#[pyre_methods]`, the wrapper still has to spell it —
 /// otherwise it publishes an address, binds at runtime, joins no family, and
 /// the deletion above never runs on anything, because the codewriter never
-/// looks inside this graph at all.
+/// looks inside this graph at all.  Every frame getset below carries it for
+/// the same reason, and `jit_fnaddr.rs`
+/// `every_builtin_wrapper_descriptor_carries_the_family_prefix` is the census
+/// that keeps them there.
 pub fn __majit_wrap_descr_typecheck_fget_getdictscope(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -3087,39 +3090,67 @@ pub fn __majit_wrap_descr_typecheck_fget_getdictscope(
     unsafe { &mut *anchor.live() }.fget_getdictscope()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
-#[allow(non_upper_case_globals)]
-static __majit_builtin_wrapper_target_fget_getdictscope: crate::gateway::BuiltinWrapperDescriptor =
-    crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(
-            module_path!(),
-            "::",
-            stringify!(__majit_wrap_descr_typecheck_fget_getdictscope)
-        ),
-        func: __majit_wrap_descr_typecheck_fget_getdictscope,
+/// Publish a hand-written frame getset wrapper in the same immutable function
+/// family `#[pyre_methods]` generates for interp2app wrappers.
+///
+/// PyPy's `BuiltinCode.func` is a PBC: every wrapper body is a candidate graph
+/// of the indirect call, including the `jit_force_virtualizable` that rtyping
+/// injected immediately before a redirected field access.  Rust erases the
+/// function identity to `BuiltinCodeFn`; omitting one wrapper here therefore
+/// makes that descriptor opaque to the codewriter and leaves the runtime force
+/// inside a `CALL_MAY_FORCE`.  Keep every manual frame descriptor in one list
+/// so `f_locals` cannot be the only orthodox member by accident.
+macro_rules! register_frame_builtin_wrapper {
+    ($static_name:ident, $func:ident) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+        #[allow(non_upper_case_globals)]
+        static $static_name: crate::gateway::BuiltinWrapperDescriptor =
+            crate::gateway::BuiltinWrapperDescriptor {
+                path: concat!(module_path!(), "::", stringify!($func)),
+                func: $func,
+            };
     };
+}
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_getdictscope,
+    __majit_wrap_descr_typecheck_fget_getdictscope
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_code`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_code`.
-pub fn descr_typecheck_fget_f_code(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fget_f_code(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    Ok(unsafe { &*f }.fget_f_code())
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    Ok(unsafe { &*anchor.live() }.fget_f_code())
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_code,
+    __majit_wrap_descr_typecheck_fget_f_code
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::get_w_globals`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_globals`.
-pub fn descr_typecheck_get_w_globals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_get_w_globals(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    let w = unsafe { &*f }.get_w_globals();
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    let w = unsafe { &*anchor.live() }.get_w_globals();
     Ok(if w.is_null() {
         pyre_object::w_none()
     } else {
@@ -3127,15 +3158,24 @@ pub fn descr_typecheck_get_w_globals(args: &[PyObjectRef]) -> Result<PyObjectRef
     })
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_get_w_globals,
+    __majit_wrap_descr_typecheck_get_w_globals
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_back`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_back`.
-pub fn descr_typecheck_fget_f_back(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fget_f_back(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    let back = unsafe { &*f }.fget_f_back();
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    let back = unsafe { &*anchor.live() }.fget_f_back();
     Ok(if back.is_null() {
         pyre_object::w_none()
     } else {
@@ -3146,10 +3186,17 @@ pub fn descr_typecheck_fget_f_back(args: &[PyObjectRef]) -> Result<PyObjectRef, 
     })
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_back,
+    __majit_wrap_descr_typecheck_fget_f_back
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::get_generator`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_generator`.
-pub fn descr_typecheck_get_generator(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_get_generator(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
@@ -3161,6 +3208,11 @@ pub fn descr_typecheck_get_generator(args: &[PyObjectRef]) -> Result<PyObjectRef
         owner
     })
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_get_generator,
+    __majit_wrap_descr_typecheck_get_generator
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_lasti`.
 ///
@@ -3210,12 +3262,16 @@ pub fn descr_typecheck_get_generator(args: &[PyObjectRef]) -> Result<PyObjectRef
 ///
 /// `-1` is left for a code object with no `RESUME` too, where that index
 /// runs past the end and the frame starts no line either.
-pub fn descr_typecheck_fget_f_lasti(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fget_f_lasti(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    let frame = unsafe { &*f };
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    let frame = unsafe { &*anchor.live() };
     let lasti = frame.fget_f_lasti();
     let lasti = if lasti < 0 {
         let code = frame.code();
@@ -3244,17 +3300,24 @@ pub fn descr_typecheck_fget_f_lasti(args: &[PyObjectRef]) -> Result<PyObjectRef,
     }))
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_lasti,
+    __majit_wrap_descr_typecheck_fget_f_lasti
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_builtins`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_builtins`.
-pub fn descr_typecheck_fget_f_builtins(
+pub fn __majit_wrap_descr_typecheck_fget_f_builtins(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    let w = unsafe { &*f }.fget_f_builtins();
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    let w = unsafe { &*anchor.live() }.fget_f_builtins();
     Ok(if w.is_null() {
         pyre_object::w_none()
     } else {
@@ -3262,21 +3325,37 @@ pub fn descr_typecheck_fget_f_builtins(
     })
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_builtins,
+    __majit_wrap_descr_typecheck_fget_f_builtins
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_lineno`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_lineno`.
-pub fn descr_typecheck_fget_f_lineno(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fget_f_lineno(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    Ok(unsafe { &*f }.fget_f_lineno())
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    Ok(unsafe { &*anchor.live() }.fget_f_lineno())
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_lineno,
+    __majit_wrap_descr_typecheck_fget_f_lineno
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fset_f_lineno`.
 ///
 /// `GetSetProperty` binds this as its `fset` for `f_lineno`.
-pub fn descr_typecheck_fset_f_lineno(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fset_f_lineno(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
@@ -3285,19 +3364,29 @@ pub fn descr_typecheck_fset_f_lineno(args: &[PyObjectRef]) -> Result<PyObjectRef
     let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
     let new_lineno = crate::baseobjspace::int_w(args[2])
         .map_err(|_| crate::PyError::value_error("lineno must be an integer"))?;
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
     unsafe { &mut *anchor.live() }.fset_f_lineno(new_lineno as isize)?;
     Ok(pyre_object::w_none())
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fset_f_lineno,
+    __majit_wrap_descr_typecheck_fset_f_lineno
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_trace`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_trace`.
-pub fn descr_typecheck_fget_f_trace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fget_f_trace(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
-    let w = unsafe { &*f }.fget_f_trace();
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
+    let w = unsafe { &*anchor.live() }.fget_f_trace();
     Ok(if w.is_null() {
         pyre_object::w_none()
     } else {
@@ -3305,47 +3394,77 @@ pub fn descr_typecheck_fget_f_trace(args: &[PyObjectRef]) -> Result<PyObjectRef,
     })
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_trace,
+    __majit_wrap_descr_typecheck_fget_f_trace
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fset_f_trace`.
 ///
 /// `GetSetProperty` binds this as its `fset` for `f_trace`.
-pub fn descr_typecheck_fset_f_trace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fset_f_trace(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if !f.is_null() {
-        unsafe { &mut *f }.fset_f_trace(args[2]);
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+        crate::executioncontext::jit_force_virtualizable(anchor.live());
+        unsafe { &mut *anchor.live() }.fset_f_trace(args[2]);
     }
     Ok(pyre_object::w_none())
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fset_f_trace,
+    __majit_wrap_descr_typecheck_fset_f_trace
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fdel_f_trace`.
 ///
 /// `GetSetProperty` binds this as its `fdel` for `f_trace`.
-pub fn descr_typecheck_fdel_f_trace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_descr_typecheck_fdel_f_trace(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if !f.is_null() {
-        unsafe { &mut *f }.fdel_f_trace();
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+        crate::executioncontext::jit_force_virtualizable(anchor.live());
+        unsafe { &mut *anchor.live() }.fdel_f_trace();
     }
     Ok(pyre_object::w_none())
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fdel_f_trace,
+    __majit_wrap_descr_typecheck_fdel_f_trace
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_trace_lines`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_trace_lines`.
-pub fn descr_typecheck_fget_f_trace_lines(
+pub fn __majit_wrap_descr_typecheck_fget_f_trace_lines(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
     Ok(pyre_object::w_bool_from(
-        unsafe { &*f }.fget_f_trace_lines(),
+        unsafe { &*anchor.live() }.fget_f_trace_lines(),
     ))
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_trace_lines,
+    __majit_wrap_descr_typecheck_fget_f_trace_lines
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fset_f_trace_lines`.
 ///
 /// `GetSetProperty` binds this as its `fset` for `f_trace_lines`.
-pub fn descr_typecheck_fset_f_trace_lines(
+pub fn __majit_wrap_descr_typecheck_fset_f_trace_lines(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
@@ -3353,30 +3472,43 @@ pub fn descr_typecheck_fset_f_trace_lines(
         // `is_true` reaches `__bool__` / `__len__`.
         let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
         let v = crate::baseobjspace::is_true(args[2])?;
+        crate::executioncontext::jit_force_virtualizable(anchor.live());
         unsafe { &mut *anchor.live() }.fset_f_trace_lines(v);
     }
     Ok(pyre_object::w_none())
 }
 
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fset_f_trace_lines,
+    __majit_wrap_descr_typecheck_fset_f_trace_lines
+);
+
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_trace_opcodes`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_trace_opcodes`.
-pub fn descr_typecheck_fget_f_trace_opcodes(
+pub fn __majit_wrap_descr_typecheck_fget_f_trace_opcodes(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
     if f.is_null() {
         return Ok(pyre_object::w_none());
     }
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
+    crate::executioncontext::jit_force_virtualizable(anchor.live());
     Ok(pyre_object::w_bool_from(
-        unsafe { &*f }.fget_f_trace_opcodes(),
+        unsafe { &*anchor.live() }.fget_f_trace_opcodes(),
     ))
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fget_f_trace_opcodes,
+    __majit_wrap_descr_typecheck_fget_f_trace_opcodes
+);
 
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fset_f_trace_opcodes`.
 ///
 /// `GetSetProperty` binds this as its `fset` for `f_trace_opcodes`.
-pub fn descr_typecheck_fset_f_trace_opcodes(
+pub fn __majit_wrap_descr_typecheck_fset_f_trace_opcodes(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let f = args.get(1).copied().unwrap_or(pyre_object::PY_NULL) as *mut PyFrame;
@@ -3384,10 +3516,16 @@ pub fn descr_typecheck_fset_f_trace_opcodes(
         // `is_true` reaches `__bool__` / `__len__`.
         let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
         let v = crate::baseobjspace::is_true(args[2])?;
+        crate::executioncontext::jit_force_virtualizable(anchor.live());
         unsafe { &mut *anchor.live() }.fset_f_trace_opcodes(v);
     }
     Ok(pyre_object::w_none())
 }
+
+register_frame_builtin_wrapper!(
+    __majit_builtin_wrapper_target_fset_f_trace_opcodes,
+    __majit_wrap_descr_typecheck_fset_f_trace_opcodes
+);
 
 impl PyFrame {
     /// pyframe.py getdebug → self.debugdata

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3121,6 +3121,34 @@ register_frame_builtin_wrapper!(
 /// `typedef.py _make_descr_typecheck_wrapper` around `PyFrame::fget_f_code`.
 ///
 /// `GetSetProperty` binds this as its `fget` for `f_code`.
+///
+/// No force marker, although `pycode` IS one of the redirected fields
+/// `virtualizable_gen.rs` declares — the one exception the sibling gateways'
+/// rule needs, and it turns on what the marker is FOR rather than on the field
+/// list.  Upstream `rvirtualizable.py hook_access_field` injects at every
+/// redirected access in every graph, so it never has to ask; pyre places the
+/// marker by hand at the gateway, so each placement owes the question "can the
+/// trace's shadow and the live frame disagree about this field?".
+///
+/// For `pycode` they cannot.  It is written exactly twice, both at frame
+/// construction (`PyFrame::__init__` and the allocator's field
+/// initialisation), and never again; a trace neither writes it back nor
+/// reseeds it.  [`PyFrame::restore_resume_state_from`] states the same thing
+/// from the other side — it restores `last_instr`, `valuestackdepth` and the
+/// locals array, and calls `pycode` frame-invariant.  So the marker cannot
+/// make this read answer differently, and all it does reach is the escape
+/// flush, which `virtualizable.py force_now` turns into
+/// `TOKEN_TRACING_RESCALL` → `TOKEN_NONE` → `pyjitpl` `ABORT_ESCAPE`.
+///
+/// Measured, with identical output on every fixture: carrying it costs
+/// `synth/exception_raise_caught_same_frame_tb` `guard_failures` 605 -> 803,
+/// `synth/exception_reentry_guard_finally_residual`
+/// 5/1027/0/6 -> 8/1903/2/5 (bridges/guard_failures/aborted/compiled),
+/// `synth/c_call_reports_the_callee_frame_not_the_inliners` its `root:inner`
+/// compile, and `synth/frame_chain_survives_a_recursive_call_assembler`
+/// `loop:hot` and `root:rec` — each of them a `tb_frame.f_code` or
+/// `frame.f_code` read from interpreted code nested inside a residual call,
+/// which is where the marker forces the caller's live virtualizable.
 pub fn __majit_wrap_descr_typecheck_fget_f_code(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -3129,7 +3157,6 @@ pub fn __majit_wrap_descr_typecheck_fget_f_code(
         return Ok(pyre_object::w_none());
     }
     let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
-    crate::executioncontext::jit_force_virtualizable(anchor.live());
     Ok(unsafe { &*anchor.live() }.fget_f_code())
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8732,8 +8732,11 @@ fn init_frame_type(ns: PyObjectRef) {
     }
 
     // f_code — read-only; the `PyCode` wrapper (pyframe.py fget_code).
-    let code_getter =
-        make_builtin_function_with_arity("f_code", crate::pyframe::descr_typecheck_fget_f_code, 2);
+    let code_getter = make_builtin_function_with_arity(
+        "f_code",
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_code,
+        2,
+    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -8745,7 +8748,7 @@ fn init_frame_type(ns: PyObjectRef) {
     // f_globals — read-only (pyframe.py fget_w_globals).
     let globals_getter = make_builtin_function_with_arity(
         "f_globals",
-        crate::pyframe::descr_typecheck_get_w_globals,
+        crate::pyframe::__majit_wrap_descr_typecheck_get_w_globals,
         2,
     );
     unsafe {
@@ -8774,8 +8777,11 @@ fn init_frame_type(ns: PyObjectRef) {
     };
 
     // f_back — read-only; the next non-hidden frame (pyframe.py:767).
-    let back_getter =
-        make_builtin_function_with_arity("f_back", crate::pyframe::descr_typecheck_fget_f_back, 2);
+    let back_getter = make_builtin_function_with_arity(
+        "f_back",
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_back,
+        2,
+    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -8790,7 +8796,7 @@ fn init_frame_type(ns: PyObjectRef) {
     // internally through get_generator(); surface that exact backlink.
     let generator_getter = make_builtin_function_with_arity(
         "f_generator",
-        crate::pyframe::descr_typecheck_get_generator,
+        crate::pyframe::__majit_wrap_descr_typecheck_get_generator,
         2,
     );
     unsafe {
@@ -8803,10 +8809,10 @@ fn init_frame_type(ns: PyObjectRef) {
 
     // f_lasti — read-only bytecode offset (pyframe.py:770).  Both
     // adaptations live on the wrapper; see
-    // [`crate::pyframe::descr_typecheck_fget_f_lasti`].
+    // [`crate::pyframe::__majit_wrap_descr_typecheck_fget_f_lasti`].
     let lasti_getter = make_builtin_function_with_arity(
         "f_lasti",
-        crate::pyframe::descr_typecheck_fget_f_lasti,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_lasti,
         2,
     );
     unsafe {
@@ -8820,7 +8826,7 @@ fn init_frame_type(ns: PyObjectRef) {
     // f_builtins — read-only builtin dict (pyframe.py:761).
     let builtins_getter = make_builtin_function_with_arity(
         "f_builtins",
-        crate::pyframe::descr_typecheck_fget_f_builtins,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_builtins,
         2,
     );
     unsafe {
@@ -8838,12 +8844,12 @@ fn init_frame_type(ns: PyObjectRef) {
     // target (only permitted from within a trace function).
     let lineno_getter = make_builtin_function_with_arity(
         "f_lineno",
-        crate::pyframe::descr_typecheck_fget_f_lineno,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_lineno,
         2,
     );
     let lineno_setter = make_builtin_function_with_arity(
         "f_lineno",
-        crate::pyframe::descr_typecheck_fset_f_lineno,
+        crate::pyframe::__majit_wrap_descr_typecheck_fset_f_lineno,
         3,
     );
     unsafe {
@@ -8862,17 +8868,17 @@ fn init_frame_type(ns: PyObjectRef) {
     // f_trace — read/write/delete (pyframe.py:773-785).
     let trace_getter = make_builtin_function_with_arity(
         "f_trace",
-        crate::pyframe::descr_typecheck_fget_f_trace,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_trace,
         2,
     );
     let trace_setter = make_builtin_function_with_arity(
         "f_trace",
-        crate::pyframe::descr_typecheck_fset_f_trace,
+        crate::pyframe::__majit_wrap_descr_typecheck_fset_f_trace,
         3,
     );
     let trace_deleter = make_builtin_function_with_arity(
         "f_trace",
-        crate::pyframe::descr_typecheck_fdel_f_trace,
+        crate::pyframe::__majit_wrap_descr_typecheck_fdel_f_trace,
         2,
     );
     unsafe {
@@ -8886,12 +8892,12 @@ fn init_frame_type(ns: PyObjectRef) {
     // f_trace_lines — read/write bool (pyframe.py:787-791).
     let trace_lines_getter = make_builtin_function_with_arity(
         "f_trace_lines",
-        crate::pyframe::descr_typecheck_fget_f_trace_lines,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_trace_lines,
         2,
     );
     let trace_lines_setter = make_builtin_function_with_arity(
         "f_trace_lines",
-        crate::pyframe::descr_typecheck_fset_f_trace_lines,
+        crate::pyframe::__majit_wrap_descr_typecheck_fset_f_trace_lines,
         3,
     );
     unsafe {
@@ -8910,12 +8916,12 @@ fn init_frame_type(ns: PyObjectRef) {
     // f_trace_opcodes — read/write bool (pyframe.py:793-797).
     let trace_opcodes_getter = make_builtin_function_with_arity(
         "f_trace_opcodes",
-        crate::pyframe::descr_typecheck_fget_f_trace_opcodes,
+        crate::pyframe::__majit_wrap_descr_typecheck_fget_f_trace_opcodes,
         2,
     );
     let trace_opcodes_setter = make_builtin_function_with_arity(
         "f_trace_opcodes",
-        crate::pyframe::descr_typecheck_fset_f_trace_opcodes,
+        crate::pyframe::__majit_wrap_descr_typecheck_fset_f_trace_opcodes,
         3,
     );
     unsafe {

--- a/pyre/pyre-jit-trace/src/callbacks.rs
+++ b/pyre/pyre-jit-trace/src/callbacks.rs
@@ -6,7 +6,7 @@
 
 use pyre_interpreter::CodeObject;
 use pyre_object::PyObjectRef;
-use std::cell::Cell;
+use std::sync::OnceLock;
 
 /// Callback table populated by pyre-jit at initialization.
 ///
@@ -50,24 +50,35 @@ pub struct CallJitCallbacks {
 unsafe impl Send for CallJitCallbacks {}
 unsafe impl Sync for CallJitCallbacks {}
 
-thread_local! {
-    static CALLBACKS: Cell<Option<&'static CallJitCallbacks>> = const { Cell::new(None) };
-}
+// RPython's translated helper addresses live on MetaInterpStaticData: one
+// immutable table shared by every execution context. The callbacks route
+// thread-specific operations (notably `driver_pair`) through their functions;
+// duplicating the table itself per thread only makes a newly-created Python
+// thread observe an uninitialized module.
+static CALLBACKS: OnceLock<&'static CallJitCallbacks> = OnceLock::new();
 
 /// Register the callback table. Called once from pyre-jit's eval init.
 pub fn init(cb: &'static CallJitCallbacks) {
-    CALLBACKS.with(|c| c.set(Some(cb)));
+    if CALLBACKS.set(cb).is_err() {
+        assert!(
+            std::ptr::eq(*CALLBACKS.get().unwrap(), cb),
+            "CallJitCallbacks initialized twice with different tables"
+        );
+    }
 }
 
 /// Get the callback table. Panics if not initialized.
 #[inline]
 pub fn get() -> &'static CallJitCallbacks {
-    CALLBACKS.with(|c| c.get().expect("CallJitCallbacks not initialized"))
+    CALLBACKS
+        .get()
+        .copied()
+        .expect("CallJitCallbacks not initialized")
 }
 
 /// Optional callback table lookup for cold paths that can fall back to
 /// skeleton-only behavior in tests before pyre-jit initializes callbacks.
 #[inline]
 pub fn try_get() -> Option<&'static CallJitCallbacks> {
-    CALLBACKS.with(|c| c.get())
+    CALLBACKS.get().copied()
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2337,6 +2337,20 @@ static W_CELL_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 true,
                 false,
             ),
+            // The cell a frame constructor allocates is emitted inline
+            // ([`crate::helpers::emit_new_cell_inline`]) and can escape a guard
+            // and be materialized, so the header class `w_cell_new` stamps has
+            // to be a proper virtual field of this group -- the same reason
+            // `W_Super` carries one.
+            (
+                "PyObject.w_class",
+                pyre_object::pyobject::W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         "Cell",
         "nestedscope::Cell",
@@ -3891,6 +3905,28 @@ pub fn object_mutable_cell_value_descr() -> DescrRef {
 /// residual `bh_call_fn(locals)` whose frame force loses the enclosing loop.
 pub fn cell_contents_descr() -> DescrRef {
     field_descr_from_group(&W_CELL_DESCR_GROUP, 0)
+}
+
+/// `nestedscope.py Cell.family` — the [`pyre_object::nestedscope::CellFamily`]
+/// every cell of one cellvar shares.  Immutable per
+/// `_immutable_fields_ = ['family']`, and a leaked (untraced) address rather
+/// than a managed reference, so the descriptor spells it `Type::Int`.
+pub fn cell_family_descr() -> DescrRef {
+    field_descr_from_group(&W_CELL_DESCR_GROUP, 1)
+}
+
+/// Inherited `PyObject.w_class` on a `Cell` — kept in this group for the same
+/// reason [`super_header_w_class_descr`] is kept in the `W_Super` one.
+pub fn cell_header_w_class_descr() -> DescrRef {
+    field_descr_from_group(&W_CELL_DESCR_GROUP, 2)
+}
+
+/// Size descriptor for `nestedscope.py Cell` allocation via `NewWithVtable`
+/// (vtable = `&CELL_TYPE`); `family` and the inherited header `w_class` are
+/// `SetfieldGc`'d after, while `contents` keeps the null a virtual reads for
+/// an unwritten reference field.
+pub fn w_cell_size_descr() -> DescrRef {
+    W_CELL_DESCR_GROUP.size_descr.clone()
 }
 
 /// `descriptor.py W_Super.w_starttype` — the class `super()` was given, whose
@@ -5973,6 +6009,44 @@ mod tests {
                      born holding recycled nursery bytes",
                 );
             }
+        }
+    }
+
+    /// The same recycled-nursery-bytes rule, for the cell the inline frame
+    /// builder allocates per pure cellvar: `family` is a `Type::Int` slot
+    /// `clear_gc_fields` does not reach, and a cell born with a recycled word
+    /// there hands `try_walker_specialize_load_deref` a `CellFamily` address
+    /// to dereference that no `CellFamily` ever occupied.
+    #[test]
+    fn inline_cell_emitter_stores_every_scalar_cell_field() {
+        let mut ctx = majit_metainterp::TraceCtx::for_test(0);
+        let family = ctx.const_int(0);
+        let header_w_class = ctx.const_ref(0);
+        crate::helpers::emit_new_cell_inline(&mut ctx, family, header_w_class);
+        let stored: std::collections::BTreeSet<usize> = ctx
+            .into_recorder()
+            .ops()
+            .iter()
+            .filter(|op| op.opcode == majit_ir::OpCode::SetfieldGc)
+            .filter_map(|op| {
+                let descr = op.descr.borrow();
+                descr.as_ref()?.as_field_descr().map(FieldDescr::offset)
+            })
+            .collect();
+        let scalars: Vec<(&str, usize)> = W_CELL_DESCR_GROUP
+            .field_descrs
+            .iter()
+            .filter(|d| d.field_type() != Type::Ref)
+            .map(|d| (d.field_name(), d.offset()))
+            .collect();
+        // `family`: a census that found none is reading the wrong group.
+        assert!(!scalars.is_empty(), "scalar field census is vacuous");
+        for (name, offset) in &scalars {
+            assert!(
+                stored.contains(offset),
+                "emit_new_cell_inline stores no {name} (offset {offset}), so the field \
+                 is born holding recycled nursery bytes",
+            );
         }
     }
 

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -790,6 +790,38 @@ pub fn emit_super_inline(
     new_op
 }
 
+/// Emit inline `Cell` creation for one cellvar of a frame the inline-call path
+/// builds — the `NewWithVtable` plus the `SetfieldGc` set `w_cell_new`
+/// performs (`nestedscope.py Cell.__init__`).
+///
+/// `family` is the address `(pycode, slot)` names
+/// (`pycode.py PyCode._initialize` builds the table once with the code
+/// object, so it is a trace-time constant); `header_w_class` is
+/// `get_instantiate(&CELL_TYPE)`.  `contents` is not stored: the constructor
+/// this mirrors passes `PY_NULL` for a fresh cell, and a virtual reads an
+/// unwritten reference field as null.
+///
+/// Keeping the allocation as `New` + `SetField` rather than a residual lets
+/// the optimizer virtualize the cell away for the common shape where the
+/// callee both creates and consumes it within one trace.
+pub fn emit_new_cell_inline(ctx: &mut TraceCtx, family: OpRef, header_w_class: OpRef) -> OpRef {
+    let new_op = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::w_cell_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(new_op);
+    for (descr, value) in [
+        (crate::descr::cell_family_descr(), family),
+        (crate::descr::cell_header_w_class_descr(), header_w_class),
+    ] {
+        let index = descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
+        ctx.heapcache_setfield_cached(new_op, index, value);
+    }
+    new_op
+}
+
 /// Emit inline `Function` creation for `MAKE_FUNCTION` — `NewWithVtable` plus
 /// the `SetfieldGc` set `function.py Function.__init__` performs — instead
 /// of the opaque `jit_make_function_from_globals` residual.
@@ -1532,9 +1564,10 @@ pub fn emit_box_float_inline(
 /// already-boxed positional argument refs.  Same field-complete frame shape as
 /// [`emit_new_pyframe_inline_self_recursive`] but seeds `locals[0..nparams]`
 /// from `param_boxes` (Ref boxes at the Python call boundary) instead of
-/// boxing a single raw int. Existing closure cells are placed at
-/// `freevar_start..`, matching `PyFrame::finish_for_call_with_globals_obj`;
-/// callers that need fresh cellvars remain on the residual path. The frame is
+/// boxing a single raw int. The cell band is placed at `cell_start..`,
+/// matching `PyFrame::finish_for_call_with_globals_obj`: the caller composes it
+/// as one freshly emitted cell per pure cellvar ([`emit_new_cell_inline`])
+/// followed by the closure's existing cell objects. The frame is
 /// the callee MIFrame's `frame` red —
 /// `_opimpl_inline_call*` / `perform_call`+`setup_call` push a fresh MIFrame
 /// per inlined call (`pyjitpl.py:2445-2476,1862-1874`) — the app-level frame
@@ -1559,8 +1592,8 @@ pub fn emit_box_float_inline(
 pub fn emit_new_pyframe_inline_with_params(
     ctx: &mut TraceCtx,
     param_boxes: &[OpRef],
-    freevar_cells: &[OpRef],
-    freevar_start: usize,
+    cell_slots: &[OpRef],
+    cell_start: usize,
     array_size: usize,
     valuestackdepth: usize,
     pycode: OpRef,
@@ -1615,11 +1648,12 @@ pub fn emit_new_pyframe_inline_with_params(
         );
         ctx.heapcache_setarrayitem(locals_array, idx, heapcache_item_descr_index, p);
     }
-    // PyFrame.finish_for_call_with_globals_obj: a closure contributes the
-    // existing cell objects themselves after locals + pure cellvars. LOAD_DEREF
-    // must therefore read the live cell, not a snapshot of its contents.
-    for (i, &cell) in freevar_cells.iter().enumerate() {
-        let idx = ctx.const_int((freevar_start + i) as i64);
+    // PyFrame.finish_for_call_with_globals_obj: the pure cellvars take a fresh
+    // cell each and a closure then contributes its existing cell objects
+    // themselves, in that order. LOAD_DEREF must read the live cell, not a
+    // snapshot of its contents, so the slot holds the cell.
+    for (i, &cell) in cell_slots.iter().enumerate() {
+        let idx = ctx.const_int((cell_start + i) as i64);
         ctx.record_op_with_descr(
             OpCode::SetarrayitemGc,
             &[locals_array, idx, cell],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5063,7 +5063,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // The keyed route bypasses the legacy caller-replay classification, but it
     // does not inherit that route's DeferredCall admission.
     let mut foriter_deferred_admit = false;
-    let mut foriter_dirty_bound = false;
     let mut foriter_dirty_seeded_resume_admit = false;
     // The pcs handed to this callee's sub-walk, set by whichever admission
     // below admitted a body the scan could not prove clean everywhere.
@@ -5200,7 +5199,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     && inline_depth < 2
                     && (try_multiframe || strict_seed);
                 foriter_dirty_seeded_resume_admit = entry_is_call_boundary && seeded_callee_resume;
-                foriter_dirty_bound = entry_is_call_boundary
+                let foriter_dirty_bound = entry_is_call_boundary
                     && (bound_method.is_some() || seeded_callee_resume)
                     && !pyre_interpreter::code_has_for_iter(callee_code)
                     && !pyre_interpreter::code_is_self_recursive(callee_code);
@@ -5413,6 +5412,21 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // choice as `pyjitpl.py do_residual_or_indirect_call` when a callee
         // cannot be followed: every call that *is* inlined keeps its own red
         // frame.
+        //
+        // Three populations reach this one decline and they are not the same
+        // work to serve, so name which one in the `[fbw-census]` tally: a body
+        // neither predicate accepts declined here before this gate existed,
+        // while the cellvar and depth cases are the ones the seeded-only
+        // admission newly residualizes.
+        if fbw_debug_abort_enabled() {
+            crate::jitcode_dispatch::census_record(if !strict_inlinable {
+                "SeededInline::NeitherStrictNorMultiframe"
+            } else if !callee_code.cellvars.is_empty() {
+                "SeededInline::CalleeOwnsCellvars"
+            } else {
+                "SeededInline::OverMultiframeDepth"
+            });
+        }
         return resolved_inline_decline(op.pc, line!());
     }
     // `seeded_inline` is the admission: everything else returned above, so the
@@ -5420,7 +5434,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // reaches the seed with a real parent.
     let precomputed_parent_frame =
         match compute_inline_caller_frame(ctx, op.pc, !callee_code.freevars.is_empty()) {
-            Ok(parent) => Some(parent),
+            Ok(parent) => parent,
             Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
                 return resolved_inline_decline(op.pc, line!());
             }
@@ -6084,70 +6098,69 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     //
     // All of these sit before the first recorded op (the `GETFIELD_GC_R`
     // below), so returning costs nothing but the inline.
-    if seeded_inline {
-        {
-            // Branch-A frame shape only (mirror REC_CA): existing freevar
-            // cells are admissible, while fresh cellvar allocation is not.
-            // `strict_seed` already excludes such a callee, so only the
-            // multiframe path reaches this.
-            if !callee_code.cellvars.is_empty() {
-                return resolved_inline_decline(op.pc, line!());
-            }
-            // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to a bare
-            // `ptr_eq`/`ptr_ne` against the None singleton whose `Kind::Int`
-            // result feeds the exitswitch -- no residual call and no boxed
-            // bool.  What the shape does need is the tested value popped as a
-            // Ref (`pop_ref_or_fresh`, the codewriter PopJumpIfNone arm).  When
-            // the multiframe inline int-specializes the tested local, the
-            // mid-body guard resume cannot source that operand's Ref form from
-            // the callee register banks (`collect_callee_active_boxes` would
-            // read a stale/mismatched box), so the encoded liveness stream
-            // disagrees with the decoder (`resume.rs decode_ref: unexpected
-            // tag`) and the caller frame is corrupted.  Decline to the ordinary
-            // residual call until the multi-frame resume reboxes
-            // int-specialized identity operands.
-            // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
-            // int bank, so no Ref rebox is needed.  A strict straight-line callee
-            // has no branch at all, so this scan never fires for it.
-            // Stored bound methods carry their explicit receiver and callee frame,
-            // so their Ref operands remain available to the resume path.
-            //
-            // This precondition used to abort the enclosing trace rather than
-            // decline the inline, because residualizing it let loops compile that
-            // then printed traceback tuples missing their OUTERMOST frame.  That
-            // node is now recorded — the two bridge handler-entry arms attach the
-            // catching frame's own node — so the decline joins every other
-            // precondition here and returns `Ok(None)`.
-            //
-            // The abort was expensive out of all proportion to the inline it was
-            // protecting: a callee that walks a traceback (`while tb is not None`)
-            // lowers to exactly this instruction, so any handler calling such a
-            // helper aborted every retrace of the enclosing loop.  The guard whose
-            // bridge the retrace was building therefore never got one and deopted
-            // on every delivery.
-            if bound_method.is_none() {
-                let liveness = crate::liveness::liveness_for(raw_callee_code);
-                let has_is_none_branch = (0..callee_code.instructions.len()).any(|pc| {
-                    matches!(
-                        pyre_interpreter::decode_instruction_at(callee_code, pc),
-                        Some((
-                            pyre_interpreter::bytecode::Instruction::PopJumpIfNone { .. }
-                                | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
-                            _
-                        ))
-                    ) && (
-                        // Hazard 1 — kept operands. A branch that leaves slots
-                        // on the value stack needs its guard resume to restore
-                        // them, and the inline sub-walk's mirror does not model
-                        // them, so the kept Ref reads NULL and
-                        // `walker_branch_guard` raises
-                        // BranchGuardUnrestorableKeptStackPermanent — a
-                        // permanent abort that discards the enclosing loop
-                        // trace.  `stack_depth_at` is the depth BEFORE the
-                        // instruction and the branch pops the tested value, so
-                        // `depth > 1` is exactly "a kept slot survives".  An
-                        // unreachable pc has no depth and cannot fire a guard.
-                        liveness.stack_depth_at(pc).is_some_and(|depth| depth > 1)
+    {
+        // Branch-A frame shape only (mirror REC_CA): existing freevar
+        // cells are admissible, while fresh cellvar allocation is not.
+        // `strict_seed` already excludes such a callee, so only the
+        // multiframe path reaches this.
+        if !callee_code.cellvars.is_empty() {
+            return resolved_inline_decline(op.pc, line!());
+        }
+        // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to a bare
+        // `ptr_eq`/`ptr_ne` against the None singleton whose `Kind::Int`
+        // result feeds the exitswitch -- no residual call and no boxed
+        // bool.  What the shape does need is the tested value popped as a
+        // Ref (`pop_ref_or_fresh`, the codewriter PopJumpIfNone arm).  When
+        // the multiframe inline int-specializes the tested local, the
+        // mid-body guard resume cannot source that operand's Ref form from
+        // the callee register banks (`collect_callee_active_boxes` would
+        // read a stale/mismatched box), so the encoded liveness stream
+        // disagrees with the decoder (`resume.rs decode_ref: unexpected
+        // tag`) and the caller frame is corrupted.  Decline to the ordinary
+        // residual call until the multi-frame resume reboxes
+        // int-specialized identity operands.
+        // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
+        // int bank, so no Ref rebox is needed.  A strict straight-line callee
+        // has no branch at all, so this scan never fires for it.
+        // Stored bound methods carry their explicit receiver and callee frame,
+        // so their Ref operands remain available to the resume path.
+        //
+        // This precondition used to abort the enclosing trace rather than
+        // decline the inline, because residualizing it let loops compile that
+        // then printed traceback tuples missing their OUTERMOST frame.  That
+        // node is now recorded — the two bridge handler-entry arms attach the
+        // catching frame's own node — so the decline joins every other
+        // precondition here and returns `Ok(None)`.
+        //
+        // The abort was expensive out of all proportion to the inline it was
+        // protecting: a callee that walks a traceback (`while tb is not None`)
+        // lowers to exactly this instruction, so any handler calling such a
+        // helper aborted every retrace of the enclosing loop.  The guard whose
+        // bridge the retrace was building therefore never got one and deopted
+        // on every delivery.
+        if bound_method.is_none() {
+            let liveness = crate::liveness::liveness_for(raw_callee_code);
+            let has_is_none_branch = (0..callee_code.instructions.len()).any(|pc| {
+                matches!(
+                    pyre_interpreter::decode_instruction_at(callee_code, pc),
+                    Some((
+                        pyre_interpreter::bytecode::Instruction::PopJumpIfNone { .. }
+                            | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
+                        _
+                    ))
+                ) && (
+                    // Hazard 1 — kept operands. A branch that leaves slots
+                    // on the value stack needs its guard resume to restore
+                    // them, and the inline sub-walk's mirror does not model
+                    // them, so the kept Ref reads NULL and
+                    // `walker_branch_guard` raises
+                    // BranchGuardUnrestorableKeptStackPermanent — a
+                    // permanent abort that discards the enclosing loop
+                    // trace.  `stack_depth_at` is the depth BEFORE the
+                    // instruction and the branch pops the tested value, so
+                    // `depth > 1` is exactly "a kept slot survives".  An
+                    // unreachable pc has no depth and cannot fire a guard.
+                    liveness.stack_depth_at(pc).is_some_and(|depth| depth > 1)
                             // Hazard 2 — the tested operand itself.  When the
                             // multiframe inline int-specializes the tested
                             // local, the mid-body guard resume cannot source
@@ -6175,126 +6188,125 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                                 // the whole-signature answer.
                                 _ => callee_binds_an_unboxed_local,
                             }
-                    )
-                });
-                if has_is_none_branch {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-            }
-            let nlocals = callee_code.varnames.len();
-            let ncells = pyre_interpreter::ncells(callee_code);
-            let frame_array_size = nlocals + ncells + callee_code.max_stackdepth as usize;
-
-            let Some(callee_jitcode_index) =
-                crate::state::ensure_jitcode_index(callee_code_key as *const ())
-            else {
-                return resolved_inline_decline(op.pc, line!());
-            };
-            let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(callee_jitcode_index as i32);
-            if frame_reg == u16::MAX
-                || ec_reg == u16::MAX
-                || frame_reg as usize >= callee_regs_r.len()
-                || ec_reg as usize >= callee_regs_r.len()
-            {
+                )
+            });
+            if has_is_none_branch {
                 return resolved_inline_decline(op.pc, line!());
             }
-
-            // ec red: `perform_call` threads the caller's second portal red
-            // down unchanged, just as PyPy shares `ec` between MIFrames.
-            let sym_ptr = ctx.fbw_mode.snapshot_sym;
-            if sym_ptr.is_null() {
-                return resolved_inline_decline(op.pc, line!());
-            }
-            let sym = unsafe { &*sym_ptr };
-            let callee_ec = sym.execution_context();
-            if callee_ec.is_none() {
-                return resolved_inline_decline(op.pc, line!());
-            }
-
-            let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
-            let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals as i64);
-            let param_boxes: Vec<OpRef> = (0..seeded_locals).map(|i| callee_args[i]).collect();
-            // Same pairing as the Branch A site: the `frame_stores_global`
-            // decline earlier in this walk is what lets a `debugdata`-less
-            // frame answer for `inline_consts.w_globals`.
-            let Some(callee_frame) = crate::helpers::emit_new_pyframe_inline_with_params(
-                ctx.trace_ctx,
-                &param_boxes,
-                &freevar_cell_ops,
-                nlocals,
-                frame_array_size,
-                nlocals + ncells,
-                pycode_const,
-                w_globals_obj_const,
-            ) else {
-                return resolved_inline_decline(op.pc, line!());
-            };
-
-            callee_regs_r[frame_reg as usize] = callee_frame;
-            // `perform_call` creates one concrete frame per MIFrame before
-            // `setup_call` installs the argument boxes (pyjitpl.py,
-            // 1862-1874).  Mirror that recording-time object.  `setup_call`
-            // installs the whole box list, so seed every local the symbolic
-            // frame above got from `param_boxes` — a `*args` callee's packed
-            // vararg tuple is one of them, and a frame short of it publishes
-            // that name as unbound to any residual the sub-walk runs.  Root
-            // each freshly boxed argument immediately: `ConcreteValue::to_pyobj`
-            // can allocate, and a later argument must not collect an earlier
-            // one before the frame constructor takes ownership of the slice.
-            let arg_roots = pyre_object::gc_roots::push_roots();
-            let arg_root_base = pyre_object::gc_roots::shadow_stack_len();
-            for concrete in callee_arg_concretes.iter().take(seeded_locals).copied() {
-                let _ = pyre_object::gc_roots::pin_root(concrete.to_pyobj());
-            }
-            let concrete_args: Vec<pyre_object::PyObjectRef> = (0..seeded_locals)
-                .map(|i| pyre_object::gc_roots::shadow_stack_get(arg_root_base + i))
-                .collect();
-            let concrete_ec = sym.concrete_execution_context();
-            // Use a GC-managed frame, not `new_boxed`: the concrete pointer is
-            // stamped onto the active trace's frontend op below, and
-            // `MetaInterp::walk_active_trace_refs` is then its RPython-style
-            // GC root through optimization.  A scope-owned tracer snapshot
-            // would be freed when this function returns while the Box value
-            // still exists, leaving a dangling recording-time pointer.
-            let mut frame = pyre_interpreter::pyframe::FrameBox::new(
-                pyre_interpreter::pyframe::PyFrame::new_for_call_with_closure_and_globals_obj(
-                    w_code,
-                    &concrete_args,
-                    inline_consts.w_globals as pyre_object::PyObjectRef,
-                    concrete_ec,
-                    concrete_closure,
-                    pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
-                ),
-            );
-            drop(arg_roots);
-            let concrete_frame_ptr = frame.as_mut_ptr();
-            concrete_callee_frame = concrete_frame_ptr;
-            callee_concrete_r[frame_reg as usize] =
-                ConcreteValue::Ref(concrete_frame_ptr as pyre_object::PyObjectRef);
-            ctx.trace_ctx.set_opref_concrete(
-                callee_frame,
-                majit_ir::Value::Ref(majit_ir::GcRef(concrete_frame_ptr as usize)),
-            );
-            // GC-managed FrameBox::drop intentionally relinquishes only the
-            // host handle; the frontend op above keeps the frame reachable.
-            drop(frame);
-            callee_regs_r[ec_reg as usize] = callee_ec;
-            // `perform_call` threads the same concrete ExecutionContext into
-            // every MIFrame.  The symbolic second red above and its concrete
-            // shadow are one value; leaving only the shadow unknown makes
-            // `build_single_frame_miframe` reject an otherwise complete
-            // callee image during an escape, after which the legacy caller
-            // replay resumes past CALL without its result.
-            callee_concrete_r[ec_reg as usize] =
-                ConcreteValue::Ref(concrete_ec as pyre_object::PyObjectRef);
-
-            // Retain for a possible `SubLoopCalleeCallAssembler` emit.
-            ca_callee_frame = callee_frame;
-            ca_callee_ec = callee_ec;
-            ca_nlocals = nlocals + ncells;
-            ca_concrete_frame = concrete_frame_ptr;
-            callee_frame_seeded = true;
         }
+        let nlocals = callee_code.varnames.len();
+        let ncells = pyre_interpreter::ncells(callee_code);
+        let frame_array_size = nlocals + ncells + callee_code.max_stackdepth as usize;
+
+        let Some(callee_jitcode_index) =
+            crate::state::ensure_jitcode_index(callee_code_key as *const ())
+        else {
+            return resolved_inline_decline(op.pc, line!());
+        };
+        let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(callee_jitcode_index as i32);
+        if frame_reg == u16::MAX
+            || ec_reg == u16::MAX
+            || frame_reg as usize >= callee_regs_r.len()
+            || ec_reg as usize >= callee_regs_r.len()
+        {
+            return resolved_inline_decline(op.pc, line!());
+        }
+
+        // ec red: `perform_call` threads the caller's second portal red
+        // down unchanged, just as PyPy shares `ec` between MIFrames.
+        let sym_ptr = ctx.fbw_mode.snapshot_sym;
+        if sym_ptr.is_null() {
+            return resolved_inline_decline(op.pc, line!());
+        }
+        let sym = unsafe { &*sym_ptr };
+        let callee_ec = sym.execution_context();
+        if callee_ec.is_none() {
+            return resolved_inline_decline(op.pc, line!());
+        }
+
+        let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
+        let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals as i64);
+        let param_boxes: Vec<OpRef> = (0..seeded_locals).map(|i| callee_args[i]).collect();
+        // Same pairing as the Branch A site: the `frame_stores_global`
+        // decline earlier in this walk is what lets a `debugdata`-less
+        // frame answer for `inline_consts.w_globals`.
+        let Some(callee_frame) = crate::helpers::emit_new_pyframe_inline_with_params(
+            ctx.trace_ctx,
+            &param_boxes,
+            &freevar_cell_ops,
+            nlocals,
+            frame_array_size,
+            nlocals + ncells,
+            pycode_const,
+            w_globals_obj_const,
+        ) else {
+            return resolved_inline_decline(op.pc, line!());
+        };
+
+        callee_regs_r[frame_reg as usize] = callee_frame;
+        // `perform_call` creates one concrete frame per MIFrame before
+        // `setup_call` installs the argument boxes (pyjitpl.py,
+        // 1862-1874).  Mirror that recording-time object.  `setup_call`
+        // installs the whole box list, so seed every local the symbolic
+        // frame above got from `param_boxes` — a `*args` callee's packed
+        // vararg tuple is one of them, and a frame short of it publishes
+        // that name as unbound to any residual the sub-walk runs.  Root
+        // each freshly boxed argument immediately: `ConcreteValue::to_pyobj`
+        // can allocate, and a later argument must not collect an earlier
+        // one before the frame constructor takes ownership of the slice.
+        let arg_roots = pyre_object::gc_roots::push_roots();
+        let arg_root_base = pyre_object::gc_roots::shadow_stack_len();
+        for concrete in callee_arg_concretes.iter().take(seeded_locals).copied() {
+            let _ = pyre_object::gc_roots::pin_root(concrete.to_pyobj());
+        }
+        let concrete_args: Vec<pyre_object::PyObjectRef> = (0..seeded_locals)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(arg_root_base + i))
+            .collect();
+        let concrete_ec = sym.concrete_execution_context();
+        // Use a GC-managed frame, not `new_boxed`: the concrete pointer is
+        // stamped onto the active trace's frontend op below, and
+        // `MetaInterp::walk_active_trace_refs` is then its RPython-style
+        // GC root through optimization.  A scope-owned tracer snapshot
+        // would be freed when this function returns while the Box value
+        // still exists, leaving a dangling recording-time pointer.
+        let mut frame = pyre_interpreter::pyframe::FrameBox::new(
+            pyre_interpreter::pyframe::PyFrame::new_for_call_with_closure_and_globals_obj(
+                w_code,
+                &concrete_args,
+                inline_consts.w_globals as pyre_object::PyObjectRef,
+                concrete_ec,
+                concrete_closure,
+                pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
+            ),
+        );
+        drop(arg_roots);
+        let concrete_frame_ptr = frame.as_mut_ptr();
+        concrete_callee_frame = concrete_frame_ptr;
+        callee_concrete_r[frame_reg as usize] =
+            ConcreteValue::Ref(concrete_frame_ptr as pyre_object::PyObjectRef);
+        ctx.trace_ctx.set_opref_concrete(
+            callee_frame,
+            majit_ir::Value::Ref(majit_ir::GcRef(concrete_frame_ptr as usize)),
+        );
+        // GC-managed FrameBox::drop intentionally relinquishes only the
+        // host handle; the frontend op above keeps the frame reachable.
+        drop(frame);
+        callee_regs_r[ec_reg as usize] = callee_ec;
+        // `perform_call` threads the same concrete ExecutionContext into
+        // every MIFrame.  The symbolic second red above and its concrete
+        // shadow are one value; leaving only the shadow unknown makes
+        // `build_single_frame_miframe` reject an otherwise complete
+        // callee image during an escape, after which the legacy caller
+        // replay resumes past CALL without its result.
+        callee_concrete_r[ec_reg as usize] =
+            ConcreteValue::Ref(concrete_ec as pyre_object::PyObjectRef);
+
+        // Retain for a possible `SubLoopCalleeCallAssembler` emit.
+        ca_callee_frame = callee_frame;
+        ca_callee_ec = callee_ec;
+        ca_nlocals = nlocals + ncells;
+        ca_concrete_frame = concrete_frame_ptr;
+        callee_frame_seeded = true;
     }
     // gh#467 forward-flush inputs are captured AT the CALL, after this
     // iteration's pre-CALL effects and before any callee sub-walk.  Hoisting
@@ -6330,7 +6342,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // a paused caller image.  `compute_inline_caller_frame` failures were
     // residualized before the seed, so there is no caller-boundary collapse.
     let parent_frame = precomputed_parent_frame;
-    let callee_frame_materialized_has_resume = callee_frame_seeded && parent_frame.is_some();
+    let callee_frame_materialized_has_resume = callee_frame_seeded;
 
     // CODEX1 parity: snapshot the heap-effect state before the callee
     // sub-walk.  If the prologue (callee pc 0 → its loop header) mutates the
@@ -6560,7 +6572,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // `MIFrame` between them.  Recording it on this level is what puts it
         // at its own depth for every guard below, including one inside a
         // callee `__init__` itself inlines.
-        let mut parents: Vec<InlineParentFrame> = parent_frame.into_iter().collect();
+        let mut parents: Vec<InlineParentFrame> = vec![parent_frame];
         if let Some((instance, _)) = constructor_result
             && callee_frame_materialized_has_resume
         {
@@ -6641,8 +6653,9 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 // those stores also emits the promote guard in
                 // `vable_getfield_*` (`pyjitpl.py:1916,2582`), whose resume
                 // image must include the paused caller frame
-                // (`opencoder.py:819`). If this sub-walk has no caller image,
-                // keep folding: publishing only the callee frame is unsound.
+                // (`opencoder.py:819`). Every admitted inline now carries one,
+                // so the remaining question is only whether the callee's own
+                // frame reds were seeded; an unseeded callee keeps folding.
                 shadow.frame_materialized = callee_frame_materialized_has_resume;
             }
             for i in 0..seeded_locals {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4682,11 +4682,10 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         .copied()
         .any(&binding_is_unboxed);
     // Vararg/over-arity calls still use the ordinary residual path. A closure
-    // is admissible when it has freevars only: the existing cell objects can
-    // be threaded into this callee's own frame exactly as
-    // PyFrame::finish_for_call_with_globals_obj does. A callee with cellvars
-    // needs fresh cell allocation and stays residual until that constructor
-    // half is ported too.
+    // is admissible with or without cellvars of its own: the existing cell
+    // objects are threaded into this callee's own frame and each pure cellvar
+    // takes a freshly emitted cell, exactly as
+    // PyFrame::finish_for_call_with_globals_obj does.
     if callee_args.len() != seeded_locals {
         return resolved_inline_decline(op.pc, line!());
     }
@@ -4700,9 +4699,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     let callee_code = unsafe { &*raw_callee_code };
     let mut concrete_freevar_cells = Vec::new();
     let concrete_closure = if has_closure {
-        if !callee_code.cellvars.is_empty() {
-            return resolved_inline_decline(op.pc, line!());
-        }
         let closure = unsafe { pyre_interpreter::function_get_closure(callable) };
         if closure.is_null()
             || !unsafe { pyre_object::is_tuple(closure) }
@@ -5014,20 +5010,17 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     let inline_depth = ctx.session.borrow().framestack.len();
 
     // A strict straight-line callee is seeded with its own frame red so guards
-    // carry a real two-frame snapshot.  A callee needing fresh cellvar
-    // allocation, or one beyond the currently-supported resume depth, remains
-    // a residual call: there is no single-frame inline fallback.  PyPy's
-    // `MetaInterp.perform_call` always pushes a distinct `MIFrame`, and
-    // `resume.rebuild_from_resumedata` rebuilds one frame per encoded section;
-    // collapsing an unseeded callee onto its caller loses the callee's
-    // pycode/globals/locals identity.
+    // carry a real two-frame snapshot.  A callee beyond the currently-supported
+    // resume depth remains a residual call: there is no single-frame inline
+    // fallback.  PyPy's `MetaInterp.perform_call` always pushes a distinct
+    // `MIFrame`, and `resume.rebuild_from_resumedata` rebuilds one frame per
+    // encoded section; collapsing an unseeded callee onto its caller loses the
+    // callee's pycode/globals/locals identity.
     //
     // Computed here rather than beside its first use in the seed block, because
     // `seeded_callee_resume` below asks the same question and is 200 lines
     // earlier.
-    let strict_seed = strict_inlinable
-        && inline_depth < fbw_max_multiframe_depth()
-        && callee_code.cellvars.is_empty();
+    let strict_seed = strict_inlinable && inline_depth < fbw_max_multiframe_depth();
     let contains_raise = body_facts.contains_raise;
     // A callee that raises inline needs the cross-frame bridge the carrier
     // drain builds once a guard inside the compiled chain fails.  The drain
@@ -5405,24 +5398,21 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // inline the graph before `perform_call` pushes its MIFrame.
     let seeded_inline = try_multiframe || strict_seed;
     if !seeded_inline {
-        // The remaining strict cases are either deeper than the resume chain
-        // currently supports or need fresh cellvars the virtual-frame builder
-        // cannot yet allocate. Keep the CALL residual instead of entering an
+        // The remaining strict cases are deeper than the resume chain
+        // currently supports. Keep the CALL residual instead of entering an
         // inlined JitCode with an empty frame red. This is the same structural
         // choice as `pyjitpl.py do_residual_or_indirect_call` when a callee
         // cannot be followed: every call that *is* inlined keeps its own red
         // frame.
         //
-        // Three populations reach this one decline and they are not the same
+        // Two populations reach this one decline and they are not the same
         // work to serve, so name which one in the `[fbw-census]` tally: a body
         // neither predicate accepts declined here before this gate existed,
-        // while the cellvar and depth cases are the ones the seeded-only
-        // admission newly residualizes.
+        // while the depth case is the one the seeded-only admission newly
+        // residualizes.
         if fbw_debug_abort_enabled() {
             crate::jitcode_dispatch::census_record(if !strict_inlinable {
                 "SeededInline::NeitherStrictNorMultiframe"
-            } else if !callee_code.cellvars.is_empty() {
-                "SeededInline::CalleeOwnsCellvars"
             } else {
                 "SeededInline::OverMultiframeDepth"
             });
@@ -6099,13 +6089,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // All of these sit before the first recorded op (the `GETFIELD_GC_R`
     // below), so returning costs nothing but the inline.
     {
-        // Branch-A frame shape only (mirror REC_CA): existing freevar
-        // cells are admissible, while fresh cellvar allocation is not.
-        // `strict_seed` already excludes such a callee, so only the
-        // multiframe path reaches this.
-        if !callee_code.cellvars.is_empty() {
-            return resolved_inline_decline(op.pc, line!());
-        }
         // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to a bare
         // `ptr_eq`/`ptr_ne` against the None singleton whose `Kind::Int`
         // result feeds the exitswitch -- no residual call and no boxed
@@ -6227,13 +6210,45 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
         let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals as i64);
         let param_boxes: Vec<OpRef> = (0..seeded_locals).map(|i| callee_args[i]).collect();
+        // `finish_for_call_with_globals_obj` fills the cell band in two
+        // halves: one fresh `w_cell_new(PY_NULL, family)` per pure cellvar,
+        // then the closure's existing cells.  Emit the first half as virtual
+        // allocations so the callee's own LOAD_DEREF / STORE_DEREF pair folds
+        // against the trace's object instead of forcing one.  The family
+        // address is a trace-time constant: `PyCode._initialize` builds the
+        // table once with the code object, which `pycode_const` has already
+        // pinned.  A cellvar that also names a varname is not in this band --
+        // it shares that varname's slot and `MAKE_CELL` wraps it in the
+        // callee's own prologue.
+        let npure_cellvars = pyre_interpreter::npure_cellvars(callee_code);
+        let mut cell_slots: Vec<OpRef> = Vec::with_capacity(ncells);
+        if npure_cellvars > 0 {
+            let cell_header_w_class = ctx.trace_ctx.const_ref(pyre_object::get_instantiate(
+                &pyre_object::nestedscope::CELL_TYPE,
+            ) as i64);
+            for i in 0..npure_cellvars {
+                let family = unsafe {
+                    pyre_interpreter::pycode::w_code_cell_family(
+                        w_code as pyre_object::PyObjectRef,
+                        nlocals + i,
+                    )
+                };
+                let family_const = ctx.trace_ctx.const_int(family as i64);
+                cell_slots.push(crate::helpers::emit_new_cell_inline(
+                    ctx.trace_ctx,
+                    family_const,
+                    cell_header_w_class,
+                ));
+            }
+        }
+        cell_slots.extend_from_slice(&freevar_cell_ops);
         // Same pairing as the Branch A site: the `frame_stores_global`
         // decline earlier in this walk is what lets a `debugdata`-less
         // frame answer for `inline_consts.w_globals`.
         let Some(callee_frame) = crate::helpers::emit_new_pyframe_inline_with_params(
             ctx.trace_ctx,
             &param_boxes,
-            &freevar_cell_ops,
+            &cell_slots,
             nlocals,
             frame_array_size,
             nlocals + ncells,
@@ -6288,6 +6303,19 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             callee_frame,
             majit_ir::Value::Ref(majit_ir::GcRef(concrete_frame_ptr as usize)),
         );
+        // The emitted cells above are the trace's objects; the sub-walk runs
+        // the callee's residuals for real, and one that reads a cell
+        // (`bh_load_deref_value_fn`) must reach the object the constructor
+        // just allocated.  Pair them the way the closure cells are paired at
+        // their read.
+        for (i, &cell_op) in cell_slots.iter().take(npure_cellvars).enumerate() {
+            let concrete_cell =
+                unsafe { &*(*concrete_frame_ptr).locals_cells_stack_w }.as_slice()[nlocals + i];
+            ctx.trace_ctx.try_set_opref_concrete(
+                cell_op,
+                majit_ir::Value::Ref(majit_ir::GcRef(concrete_cell as usize)),
+            );
+        }
         // GC-managed FrameBox::drop intentionally relinquishes only the
         // host handle; the frontend op above keeps the frame reachable.
         drop(frame);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -334,33 +334,17 @@ pub(crate) fn diagnose_inline_recognition(arg_concretes: &[ConcreteValue], op_pc
     }
 }
 
-/// The FBW fast-path inline convention (`try_walker_inline_user_call`) seeds
-/// only the callee's positional-argument registers `r0..nparams`; the
-/// callee's virtualizable frame box is left unseeded.  A callee whose body
-/// reads or writes that frame through a `*_vable_*` op — emitted by the
-/// codewriter when a local must survive a sub-call — generally cannot be
-/// satisfied by register seeding and would abort the *whole* enclosing trace
-/// with `VableBoxNotSeeded`.  The ONE exception is a scalar `getfield_vable_r`
-/// reading a compile-time-constant static field (`pycode` / `w_globals`):
-/// [`try_resolve_inline_callee_static_field`] folds it to the callee constant
-/// (the walk-time mirror of the codewriter non-portal branch,
-/// `codewriter.rs`).  Detect everything else
-/// pre-flight so the call lowers to an ordinary residual call (the orthodox
-/// non-inlinable path, `should_inline` = False → `do_residual_call`,
-/// `pyjitpl.py`) instead of aborting.
+/// The FBW fast-path inline convention (`try_walker_inline_user_call`) first
+/// checks whether the callee body can be followed, before the full inline path
+/// seeds the callee's positional arguments and its own frame/ec reds. A callee
+/// whose frame shape cannot be materialized must lower to an ordinary residual
+/// call (the orthodox non-inlinable path, `should_inline` = False →
+/// `do_residual_call`, `pyjitpl.py`) instead of entering with an empty frame red.
 ///
-/// Also decline callees that are not *straight-line leaves*.  The inline
-/// convention resumes a guard inside the callee at the caller's CALL boundary
-/// via the inherited single-frame snapshot — sound only when re-executing the
-/// whole call on deopt reproduces the state ([`try_walker_inline_user_call`]
-/// docstring).  A callee with an internal conditional branch (`goto_if_not` /
-/// `switch`) emits a branch guard whose fail snapshot needs to resume *into*
-/// the callee mid-body; the single-frame model then serialises a resume
-/// section whose liveness shape disagrees with the encoded stream (a folded
-/// branch operand is numbered `TAGINT` in a slot the outer liveness reports as
-/// a ref → `resume.rs decode_ref: unexpected tag`).  Until the multi-frame
-/// resume coordinate is ported (#68), only branchless leaves are inlinable;
-/// a branchy callee lowers to an ordinary residual call (correct).
+/// The predicate still distinguishes straight-line leaves from branch-bearing
+/// bodies because the latter enter the multi-frame branch walk. Both successful
+/// paths now snapshot the guard at the callee's coordinate with a paused caller
+/// frame; neither collapses resume to the caller's CALL boundary.
 pub(crate) fn callee_fast_path_inlinable<Sym: WalkSym>(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
@@ -2490,10 +2474,9 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
 /// `bh_call_fn_impl` prepends a non-null `null_or_self` as arg0, so the
 /// inlined callee's positional locals are either `positional` for plain calls
 /// or `[null_or_self, positional...]` for method-form calls.
-/// Only exact-positional, closure-free callees are inlined.  Guards inside a
-/// pure-leaf callee resume to the caller's CALL boundary via the inherited
-/// single-frame snapshot (`entry_py_pc` / `outer_active_boxes`), which is
-/// sound for side-effect-free leaves (re-execute the whole call on deopt).
+/// Only exact-positional callees whose frame can be materialized are inlined.
+/// Guards inside the callee use the callee's own resume coordinate and a
+/// paused caller frame; unsupported shapes remain residual calls.
 ///
 /// That layout is a property of a subset of the CALL-family helpers, so the
 /// residual this reads from has to be one of them.  Every other entry the
@@ -5030,15 +5013,14 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     };
     let inline_depth = ctx.session.borrow().framestack.len();
 
-    // A strict straight-line callee at the top inline level is seeded with
-    // its own frame red so guards can carry a real two-frame snapshot.  A
-    // callee needing fresh cellvar allocation is not seeded — the seed block
-    // below breaks out to the ordinary single-frame inline for it — so exclude
-    // it here too, or the preflight would decline a CALL that path still
-    // serves.  A constructor is seeded like any other callee: the discard of
-    // `__init__`'s result is `descr_call`'s, and pyre records that as its own
-    // resume level (`crate::ctor_continuation`) rather than by refusing to
-    // seed and re-executing the CALL.
+    // A strict straight-line callee is seeded with its own frame red so guards
+    // carry a real two-frame snapshot.  A callee needing fresh cellvar
+    // allocation, or one beyond the currently-supported resume depth, remains
+    // a residual call: there is no single-frame inline fallback.  PyPy's
+    // `MetaInterp.perform_call` always pushes a distinct `MIFrame`, and
+    // `resume.rebuild_from_resumedata` rebuilds one frame per encoded section;
+    // collapsing an unseeded callee onto its caller loses the callee's
+    // pycode/globals/locals identity.
     //
     // Computed here rather than beside its first use in the seed block, because
     // `seeded_callee_resume` below asks the same question and is 200 lines
@@ -5422,42 +5404,30 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // emission would strand dead seed IR and force an abort/replay after the
     // callee already consumed external state.  RPython decides whether to
     // inline the graph before `perform_call` pushes its MIFrame.
-    let precomputed_parent_frame = if try_multiframe || strict_seed {
+    let seeded_inline = try_multiframe || strict_seed;
+    if !seeded_inline {
+        // The remaining strict cases are either deeper than the resume chain
+        // currently supports or need fresh cellvars the virtual-frame builder
+        // cannot yet allocate. Keep the CALL residual instead of entering an
+        // inlined JitCode with an empty frame red. This is the same structural
+        // choice as `pyjitpl.py do_residual_or_indirect_call` when a callee
+        // cannot be followed: every call that *is* inlined keeps its own red
+        // frame.
+        return resolved_inline_decline(op.pc, line!());
+    }
+    // `seeded_inline` is the admission: everything else returned above, so the
+    // caller frame is computed unconditionally here and every inlined callee
+    // reaches the seed with a real parent.
+    let precomputed_parent_frame =
         match compute_inline_caller_frame(ctx, op.pc, !callee_code.freevars.is_empty()) {
             Ok(parent) => Some(parent),
-            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => return Ok(None),
-            Err(InlineCallerFrameDecline::Unavailable) if try_multiframe => return Ok(None),
-            Err(InlineCallerFrameDecline::Unavailable) => None,
-        }
-    } else {
-        None
-    };
-    // The same question `seeded_callee_resume` asked, re-asked after
-    // `precomputed_parent_frame` has already been computed for
-    // `try_multiframe || strict_seed`.  Widening only the first site moves the
-    // admission and then declines here one gate later.
-    if foriter_dirty_bound && !(try_multiframe || strict_seed) {
-        return resolved_inline_decline(op.pc, line!());
-    }
-    if !strict_inlinable && !try_multiframe {
-        // A non-self-recursive loop/branch callee that neither the strict nor
-        // the multiframe fast path can serve declines to interpretation
-        // (`FBW_DECLINED_KEYS`).  Self-recursive calls were already routed to
-        // the `CALL_ASSEMBLER` fold or plain residual path above (`Ok(None)`).
-        //
-        // For method-form calls reached through the LOAD_METHOD fold, decline
-        // locally instead.  The fold's first-order win is the guarded method
-        // cache; making an uninlineable method body blacklist the whole outer
-        // loop turns a correct specialization into a compile regression.
-        if method_form {
-            return resolved_inline_decline(op.pc, line!());
-        }
-        // Full-portal cutover: instead of poisoning the trace, fall through to
-        // the CALL_ASSEMBLER fold (`try_walker_call_assembler_self_recursive`,
-        // reached next in the residual-call dispatch) so a recursive callee at
-        // the inline cap enters via its own (possibly tmp-callback) loop token.
-        return resolved_inline_decline(op.pc, line!());
-    }
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
+                return resolved_inline_decline(op.pc, line!());
+            }
+            Err(InlineCallerFrameDecline::Unavailable) => {
+                return resolved_inline_decline(op.pc, line!());
+            }
+        };
 
     let mut callable_guard_op = callable_guard_op;
     let mut callable_guard_value = callable_guard_value;
@@ -6053,19 +6023,17 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // then unchanged (it finds real boxes).
     //
     // Seeded for BOTH the forward-branch multiframe callee (`try_multiframe`)
-    // AND a STRICT straight-line callee at the top inline level (`strict_seed`).
+    // AND a STRICT straight-line callee (`strict_seed`).
     // With the reds seeded, an in-callee guard resumes at the callee's OWN
     // coordinate through `walker_capture_multi_frame_inline_snapshot` instead of
     // collapsing to the caller boundary and re-executing the whole call — which
     // re-materializes it at a stale `valuestackdepth` (a resume `LOAD_FAST` push
     // overflows the frame, an `rd_numb` decode overruns) and re-applies a
     // committed heap side effect (visible on the wasm resume path, where a
-    // guard-failure deopt is not absorbed by a compiled bridge).  A
-    // `try_multiframe` callee HARD-declines the inline when a precondition below
-    // fails; a strict callee instead leaves the reds `OpRef::NONE` and falls
-    // back to the single-frame collapse (no paused caller frame is pushed), so
-    // an un-seedable strict shape never loses its inline.  Every bail below
-    // precedes any IR recording, so a strict fall-through records no dead op.
+    // guard-failure deopt is not absorbed by a compiled bridge). Every callee
+    // declines the inline when a precondition below fails; there is no
+    // single-frame collapse. Every bail below precedes any IR recording, so a
+    // residualized call leaves no dead seed op.
     //
     // The seeded virtual callee frame /
     // shared ec / local count are hoisted so the sub-walk return site can
@@ -6079,19 +6047,12 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // The seeded callee frame's runtime object, for the `enter`/`leave`
     // bracket below — the OpRef alone cannot carry it out of the seed block.
     let mut ca_concrete_frame = std::ptr::null_mut::<pyre_interpreter::PyFrame>();
-    // A strict straight-line callee at the top inline level is seeded the same
-    // way, so its in-callee guards route through the multi-frame snapshot.  A
-    // deeper strict callee (`inline_depth >= fbw_max_multiframe_depth()`) keeps the
-    // single-frame collapse — a 3-frame snapshot the resume path is sound for
-    // only one paused caller frame.
+    // A strict straight-line callee is seeded the same way, so its in-callee
+    // guards route through the multi-frame snapshot. A deeper callee beyond the
+    // supported resume chain was residualized before this block.
     // True once the callee frame reds are actually seeded (all preconditions
-    // below met).  For a strict callee this gates routing its guards through the
-    // multi-frame snapshot vs. falling back to collapse.
+    // below met). It gates routing guards through the multi-frame snapshot.
     let mut callee_frame_seeded = false;
-    // Names the `break 'seed` arm that left `callee_frame_seeded` false, for
-    // the `[fbw-census]` collapse tally at the `parent_frame` decision below.
-    // Empty means the seed block was never entered or ran to completion.
-    let mut seed_break_reason: &'static str = "";
     // The concrete callee frame the seed block materializes, retained so the
     // sub-walk can put it on the interpreter frame chain: the walk executes
     // the callee's residuals for real, and a residual that reads the chain
@@ -6107,8 +6068,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // precondition failed identically on every retrace, so the loop kept
     // re-tracing and re-aborting instead of settling.
     //
-    // The strict path already declines gracefully here (`break 'seed`); only
-    // the `try_multiframe` path aborted.  Upstream never has this state:
+    // Both paths decline the callee locally here. Upstream never has this state:
     // `pyjitpl.py` `do_residual_or_indirect_call` residualizes the callee it
     // cannot follow, and the recursion-budget path calls `dont_trace_here` and
     // then still falls through to `do_residual_call` — the enclosing trace
@@ -6124,8 +6084,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     //
     // All of these sit before the first recorded op (the `GETFIELD_GC_R`
     // below), so returning costs nothing but the inline.
-    if try_multiframe || strict_seed {
-        'seed: {
+    if seeded_inline {
+        {
             // Branch-A frame shape only (mirror REC_CA): existing freevar
             // cells are admissible, while fresh cellvar allocation is not.
             // `strict_seed` already excludes such a callee, so only the
@@ -6218,11 +6178,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     )
                 });
                 if has_is_none_branch {
-                    if try_multiframe {
-                        return resolved_inline_decline(op.pc, line!());
-                    }
-                    seed_break_reason = "Collapse::IsNoneBranch";
-                    break 'seed;
+                    return resolved_inline_decline(op.pc, line!());
                 }
             }
             let nlocals = callee_code.varnames.len();
@@ -6232,11 +6188,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             let Some(callee_jitcode_index) =
                 crate::state::ensure_jitcode_index(callee_code_key as *const ())
             else {
-                if try_multiframe {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-                seed_break_reason = "Collapse::NoCalleeJitcode";
-                break 'seed;
+                return resolved_inline_decline(op.pc, line!());
             };
             let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(callee_jitcode_index as i32);
             if frame_reg == u16::MAX
@@ -6244,31 +6196,19 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 || frame_reg as usize >= callee_regs_r.len()
                 || ec_reg as usize >= callee_regs_r.len()
             {
-                if try_multiframe {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-                seed_break_reason = "Collapse::NoPortalRedRegs";
-                break 'seed;
+                return resolved_inline_decline(op.pc, line!());
             }
 
             // ec red: `perform_call` threads the caller's second portal red
             // down unchanged, just as PyPy shares `ec` between MIFrames.
             let sym_ptr = ctx.fbw_mode.snapshot_sym;
             if sym_ptr.is_null() {
-                if try_multiframe {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-                seed_break_reason = "Collapse::NoSnapshotSym";
-                break 'seed;
+                return resolved_inline_decline(op.pc, line!());
             }
             let sym = unsafe { &*sym_ptr };
             let callee_ec = sym.execution_context();
             if callee_ec.is_none() {
-                if try_multiframe {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-                seed_break_reason = "Collapse::NoExecutionContextRed";
-                break 'seed;
+                return resolved_inline_decline(op.pc, line!());
             }
 
             let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
@@ -6287,11 +6227,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 pycode_const,
                 w_globals_obj_const,
             ) else {
-                if try_multiframe {
-                    return resolved_inline_decline(op.pc, line!());
-                }
-                seed_break_reason = "Collapse::CalleeGlobalsNotPublished";
-                break 'seed;
+                return resolved_inline_decline(op.pc, line!());
             };
 
             callee_regs_r[frame_reg as usize] = callee_frame;
@@ -6390,77 +6326,10 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // paused caller frame on the framestack so its in-callee guards snapshot
     // both frames.  The caller's live register banks were preflighted above,
     // before seed IR; at guard-capture time the walk context is the callee's.
-    let parent_frame = if try_multiframe {
-        // Declined above, before any seed IR: an un-entered multiframe-inline
-        // CALL that declines at its try-block catch marker is re-run whole and
-        // forward, exactly as if it had never been inlined (`pyjitpl.py`), so
-        // it leaves the enclosing trace alone rather than aborting it.
-        precomputed_parent_frame
-    } else if callee_frame_seeded {
-        // A strict straight-line callee seeded at the top inline level (the
-        // `try_multiframe` arm above already handled the branch path).  Push the
-        // paused caller frame so its in-callee guards resume through the
-        // multi-frame snapshot (`walker_capture_multi_frame_inline_snapshot`) at
-        // the callee's OWN coordinate, with the caller paused at the CALL return
-        // point (`get_list_of_active_boxes(in_a_call=true)` parity,
-        // `trace_opcode.rs`). With the callee frame red now seeded,
-        // `collect_callee_active_boxes` sources the callee's live boxes and the
-        // snapshot succeeds, producing the full RPython `Snapshot.frames` chain
-        // (`opencoder.py create_top_snapshot`, resumed by
-        // `resume.py rebuild_from_resumedata`).  This replaces the single-frame
-        // collapse, whose caller-boundary re-execute both mis-sizes the resumed
-        // frame (a decode / `LOAD_FAST` overrun) and re-applies the callee's
-        // committed side effect on deopt.
-        //
-        // Best effort: `compute_inline_caller_frame` returns `Unavailable` for a caller
-        // shape it cannot build yet (no result on the operand stack at the
-        // return point, missing liveness / resume tables).  Fall back to the
-        // single-frame collapse there (do NOT decline the inline — that shape is
-        // served correctly today), so this never removes a working inline.
-        //
-        // A `TryBlockCatchMarker` decline is different: the CALL is covered by
-        // the caller's exception table AND the callee has free variables, so it
-        // reads cells the caller frame owns — one of which, inside a handler, is
-        // the `except E as e` binding the implicit cleanup stores `None` into
-        // and then clears.  Inlining reads that cell as `None`
-        // (`synth/exception_as_cell_cleanup`).  Decline so the call stays
-        // residual, where the post-call catch resume
-        // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
-        //
-        // Both declines were taken above, ahead of the seed block, so neither
-        // has to discard the enclosing loop trace to avoid stranding the
-        // `GETFIELD_GC_R` + `emit_new_pyframe_inline_with_params` this arm would
-        // otherwise have already recorded.
-        precomputed_parent_frame
-    } else {
-        // Single-frame collapse (resume at the CALL boundary, re-execute the
-        // whole call on deopt): a nested strict callee
-        // (`inline_depth >= fbw_max_multiframe_depth()`), an un-seedable
-        // strict callee, or a callee neither seed served.  Sound for a pure
-        // value-returning leaf (idempotent re-execute) and for a nested
-        // straight-line callee (its pre-multiframe behavior).
-        None
-    };
-    // Name the population a collapsing CALL falls into, so the
-    // `PYRE_FBW_DEBUG_ABORT` corpus can rank the remaining collapse sources
-    // the same way it ranks walk declines.  A collapse is not an abort and
-    // discards no trace, so this counts a resume-SHAPE choice, not a failure;
-    // it is read only to decide which population to retire next.
-    if fbw_debug_abort_enabled() && parent_frame.is_none() {
-        census_record(if !seed_break_reason.is_empty() {
-            seed_break_reason
-        } else if callee_frame_seeded {
-            // Seeded, but `compute_inline_caller_frame` could not build the
-            // caller side (`InlineCallerFrameDecline::Unavailable`).
-            "Collapse::ParentUnavailable"
-        } else if inline_depth >= fbw_max_multiframe_depth() {
-            "Collapse::DepthCap"
-        } else if !callee_code.cellvars.is_empty() {
-            "Collapse::CellVars"
-        } else {
-            "Collapse::Other"
-        });
-    }
+    // Every inlined call reaches this point with both its own callee frame and
+    // a paused caller image.  `compute_inline_caller_frame` failures were
+    // residualized before the seed, so there is no caller-boundary collapse.
+    let parent_frame = precomputed_parent_frame;
     let callee_frame_materialized_has_resume = callee_frame_seeded && parent_frame.is_some();
 
     // CODEX1 parity: snapshot the heap-effect state before the callee

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1662,18 +1662,20 @@ pub(crate) fn collect_call_stack_overrides<Sym: WalkSym>(
     // `stack_end`.  The null_or_self slot is the one stack slot no source above
     // can speak for, so synthesize its known null and require the callable
     // immediately below it to prove that reconstruction reached the operand
-    // region.  FOR_ITER has only the iterator at `stack_end - 1`: it needs no
-    // synthesized sentinel, and that iterator itself is the proof slot.
-    // `BINARY_OP` / `COMPARE_OP` have `[lhs, rhs]` and likewise synthesize
-    // nothing; `lhs`, the deeper of the two, is the proof.
-    let operand_slots = caller_operand_slots(caller_sym, call_jitcode_pc, stack_end)?;
+    // region.  Every other resume shape synthesizes nothing and proves itself
+    // with the deepest operand it consumes.
+    let Some(operand_slots) = caller_operand_slots(caller_sym, call_jitcode_pc, stack_end) else {
+        if fbw_debug_abort_enabled() {
+            crate::jitcode_dispatch::census_record("CallStack::NoOperandShape");
+        }
+        return None;
+    };
     let (sentinel_slot, proof_slot) = match operand_slots {
         CallerOperandSlots::Call {
             null_or_self,
             callable,
         } => (Some(null_or_self), callable),
-        CallerOperandSlots::ForIter { iterator } => (None, iterator),
-        CallerOperandSlots::Binary { lhs } => (None, lhs),
+        CallerOperandSlots::Operands { deepest } => (None, deepest),
     };
     if let Some(sentinel_slot) = sentinel_slot {
         if sentinel_slot >= nlocals
@@ -1690,10 +1692,15 @@ pub(crate) fn collect_call_stack_overrides<Sym: WalkSym>(
     // Ref(0) is valid only for the synthesized null_or_self sentinel.  A null
     // proof value means the sparse vstack/color reconstruction is incomplete;
     // decline instead of publishing an invalid operand region.
-    overrides
+    let proof_value = overrides
         .iter()
-        .find_map(|&(slot, value)| (slot == proof_slot).then_some(value))
-        .filter(|value| !value.is_null())?;
+        .find_map(|&(slot, value)| (slot == proof_slot).then_some(value));
+    if !matches!(proof_value, Some(value) if !value.is_null()) {
+        if fbw_debug_abort_enabled() {
+            crate::jitcode_dispatch::census_record("CallStack::ProofSlotUnresolved");
+        }
+        return None;
+    }
     // Report-only: a slot left absent here is what makes the outer-call flush
     // decline, and the consumer can only say "not capturable". Name each source
     // that passed on it so the gap is attributable to one of them.
@@ -1732,26 +1739,25 @@ enum CallerOperandSlots {
         null_or_self: usize,
         callable: usize,
     },
-    ForIter {
-        iterator: usize,
-    },
-    /// `BINARY_OP` / `COMPARE_OP`: `[lhs, rhs]` ending at `stack_end`.
-    Binary {
-        lhs: usize,
-    },
+    /// A shape with no slot to synthesize: the deepest of the operands it
+    /// consumes is the proof slot.
+    Operands { deepest: usize },
 }
 
 /// Absolute frame slots proving the operand region at `call_jitcode_pc`, for a
 /// caller whose operand stack ends at `stack_end`. CALL names its synthetic
-/// `null_or_self` sentinel and callable proof; FOR_ITER names its iterator
-/// proof; `BINARY_OP` / `COMPARE_OP` name their left operand, the deeper of
-/// the two, for the same role the callable plays for CALL. `None` keeps the
-/// conservative decline for every other resume shape.
+/// `null_or_self` sentinel and callable proof; every other shape names only
+/// how many operands it consumes, and the deepest of those plays the role the
+/// callable plays for CALL. `None` keeps the conservative decline for every
+/// resume shape not listed.
 ///
-/// The last of those is what an inlined dunder needs and had not got: the
-/// entry admits a body on the strength of an abort resuming forward past it,
-/// and with no arm here that reconstruction answered `None`, so the resume
-/// fell back to replaying the loop from its entry.
+/// The non-CALL shapes are what an inlined dunder needs: the entry admits a
+/// body on the strength of an abort resuming forward past it, and with no arm
+/// here that reconstruction answered `None`, so the resume fell back to
+/// replaying the loop from its entry. `LOAD_ATTR` / `STORE_ATTR` are the
+/// attribute-access half of that — a property accessor, a `__getattr__` hook
+/// or a descriptor `__get__` body is reached from one of them, never from a
+/// Python-level CALL.
 fn caller_operand_slots<Sym: WalkSym>(
     caller_sym: &Sym,
     call_jitcode_pc: usize,
@@ -1763,23 +1769,36 @@ fn caller_operand_slots<Sym: WalkSym>(
         crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, call_jitcode_pc)
             as usize;
     let (instruction, op_arg) = pyre_interpreter::decode_instruction_at(code, py_pc)?;
-    match instruction {
+    let operand_count = match instruction {
         pyre_interpreter::Instruction::Call { argc } => {
             let null_or_self = stack_end.checked_sub(argc.get(op_arg) as usize + 1)?;
-            Some(CallerOperandSlots::Call {
+            return Some(CallerOperandSlots::Call {
                 null_or_self,
                 callable: null_or_self.checked_sub(1)?,
-            })
+            });
         }
-        pyre_interpreter::Instruction::ForIter { .. } => Some(CallerOperandSlots::ForIter {
-            iterator: stack_end.checked_sub(1)?,
-        }),
+        // `[iterator]`, and `[owner]` for the attribute read whose descriptor
+        // body is the callee. The method form of `LOAD_ATTR` pushes two
+        // results but still consumes only the owner, and this depth is read
+        // before the instruction runs.
+        pyre_interpreter::Instruction::ForIter { .. }
+        | pyre_interpreter::Instruction::LoadAttr { .. } => 1,
+        // `[lhs, rhs]`, and `[value, owner]` for the attribute store whose
+        // setter body is the callee — `store_attr_cached` pops the owner
+        // first, so `value` is the deeper of the two.
         pyre_interpreter::Instruction::BinaryOp { .. }
-        | pyre_interpreter::Instruction::CompareOp { .. } => Some(CallerOperandSlots::Binary {
-            lhs: stack_end.checked_sub(2)?,
-        }),
-        _ => None,
-    }
+        | pyre_interpreter::Instruction::CompareOp { .. }
+        | pyre_interpreter::Instruction::StoreAttr { .. } => 2,
+        other => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[caller-operand-shape-absent] instruction={other:?} py_pc={py_pc}");
+            }
+            return None;
+        }
+    };
+    Some(CallerOperandSlots::Operands {
+        deepest: stack_end.checked_sub(operand_count)?,
+    })
 }
 
 /// Name the live color that refused a caller image.
@@ -2209,10 +2228,13 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     // The call result is the top operand-stack slot only when it remains live
     // at the return point; a call whose value is immediately discarded can
     // resume with depth zero.
-    let depth = match resume_marker_jit_pc {
+    //
+    // `None` is "this source has no entry for the coordinate", which is not
+    // the same statement as a source answering zero — see the decline below.
+    let depth_read: Option<usize> = match resume_marker_jit_pc {
         Some(marker) => unsafe { &(*caller_sym.jitcode()).payload }
             .depth_trivia_for_jitcode_pc(marker)
-            .unwrap_or(0) as usize,
+            .map(|depth| depth as usize),
         // A missing marker has no fallthrough-native key. Preserve the
         // existing Python-keyed path rather than declining a formerly valid
         // caller frame.
@@ -2222,17 +2244,16 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
                 crate::liveness::liveness_for(code_ptr)
                     .depth_at_py_pc()
                     .get(fallthrough_py_pc as usize)
-                    .copied()
-                    .unwrap_or(0) as usize
+                    .map(|&depth| depth as usize)
             };
             if payload.depth_after_residual_populated() {
                 let depth = payload
                     .depth_after_residual_for_jitcode_pc(call_jit_pc)
-                    .unwrap_or(0) as usize;
+                    .map(|depth| depth as usize);
                 if pcmap_afterresidual_audit_enabled() {
                     assert_eq!(
-                        depth,
-                        raw(),
+                        depth.unwrap_or(0),
+                        raw().unwrap_or(0),
                         "PYRE_PCMAP_AFTERRESIDUAL_AUDIT: inline-caller after-residual depth twin diverged at jit_pc {call_jit_pc} (py {fallthrough_py_pc})"
                     );
                 }
@@ -2242,10 +2263,13 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             }
         }
     };
-    // A depth read that finds no trivia entry falls back to zero, so a zero
-    // depth only reliably means "empty operand stack" for a CALL that produces
-    // no result at all. Keep declining it otherwise.
-    if depth == 0 && !call_is_void {
+    let depth = depth_read.unwrap_or(0);
+    // A source with no entry for this coordinate defaults to zero, and that
+    // default is the only zero this cannot trust. A source that ANSWERS zero
+    // states an empty operand stack, which is what a call leaving no result
+    // behind resumes with — `STORE_ATTR`'s setter body is that shape, popping
+    // both operands and pushing nothing. Keep declining the defaulted zero.
+    if depth == 0 && !call_is_void && depth_read.is_none() {
         return Err(unavail("Unavail::Top/DepthZero"));
     }
     let call_stack_overrides = collect_call_stack_overrides(caller_sym, ctx, call_jit_pc)
@@ -2274,7 +2298,13 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             })
             .map(|color| color as usize)
     };
-    if !call_is_void && result_color.is_none() {
+    // A call whose resumed operand stack is EMPTY has no result slot to name,
+    // so the missing color states a fact rather than a gap — `STORE_ATTR`'s
+    // setter body reaches here, its result discarded by the store itself.
+    // The `depth == 0` decline above already refused a defaulted zero, so a
+    // zero surviving to here was answered by a source. Only a non-empty stack
+    // can hide a live result the reconstruction failed to locate.
+    if !call_is_void && depth > 0 && result_color.is_none() {
         return Err(unavail("Unavail::Top/NoResultColor"));
     }
     // Null the not-yet-produced result slot when one is live, build the box

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1,6 +1,6 @@
 //! Runtime access to the build-time `pipeline.jitcodes` table.
 //!
-//! RPython: `MetaInterpStaticData.jitcodes` (warmspot.py:281-282) — the list
+//! RPython: `MetaInterpStaticData.jitcodes` in `warmspot.py` — the list
 //! of `JitCode` objects produced by `CodeWriter.make_jitcodes()`
 //! (codewriter.py:89). In RPython this list is passed by reference from
 //! `CallControl.jitcodes` directly into `MetaInterpStaticData`; the two
@@ -18,7 +18,6 @@
 //! in that store; it does not duplicate JitCode bodies.
 
 use parking_lot::Mutex;
-use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Once, OnceLock};
 
@@ -35,43 +34,54 @@ struct JitCodeIndex {
     offsets: Vec<u32>,
 }
 
-thread_local! {
-    /// Per-thread lazily populated build-time `pipeline.jitcodes` table.
-    ///
-    /// `thread_local!` rather than a process-wide `static` because the
-    /// `JitCode` payload transitively holds `Variable` graphs whose
-    /// interior `RefCell` / `Cell` cells are intentionally !Sync (parity
-    /// with RPython's single-thread annotator + GIL invariant).  The JIT
-    /// runtime is single-threaded by construction (Python GIL), so a
-    /// per-thread cache matches the RPython module-level dict semantics
-    /// without forcing `Variable` to become thread-safe.
-    ///
-    /// The cached cells live in a leaked slice so downstream consumers can
-    /// keep their existing `'static` lifetime contracts
-    /// (`SubJitCodeBody::code: &'static [u8]`, walker `WalkContext`
-    /// lifetimes, etc.). Each cell is filled only after all runtime patching
-    /// and the dense-index assertion have completed.
-    static JITCODE_CELLS: OnceCell<&'static [OnceCell<Arc<JitCode>>]> = const { OnceCell::new() };
+/// Runtime-frozen canonical JitCode.
+///
+/// The serialized body skips `_ssarepr`, the sole path from this type into
+/// translation-time `Rc<RefCell<Variable>>` graphs. `load_jitcode` performs
+/// every address patch while its Arc is still unique, then this wrapper
+/// publishes the immutable result. Its remaining interior cells are
+/// `std::sync::OnceLock` caches. Keeping this proof on the runtime wrapper
+/// avoids falsely declaring the translation-time `JitCode` Sync.
+struct FrozenJitCode(Arc<JitCode>);
 
-    /// Decoded names and byte offsets; loading this never decodes a body.
-    static JITCODE_INDEX: OnceCell<&'static JitCodeIndex> = const { OnceCell::new() };
+// SAFETY: see the publication/frozen-payload invariant above.
+unsafe impl Send for FrozenJitCode {}
+unsafe impl Sync for FrozenJitCode {}
 
-    /// Compatibility accessor storage for tests and diagnostics that
-    /// explicitly request the complete table.
-    static FORCED_ALL_JITCODES: OnceCell<&'static [Arc<JitCode>]> = const { OnceCell::new() };
+struct FrozenJitCodeSlice(Box<[Arc<JitCode>]>);
 
-    /// Explicit build-time JIT-driver metadata for every configured driver.
-    static COMPILED_JIT_DRIVERS: OnceCell<&'static [CompiledJitDriver]> = const { OnceCell::new() };
+// SAFETY: every Arc in this slice comes from a published `FrozenJitCode`.
+unsafe impl Send for FrozenJitCodeSlice {}
+unsafe impl Sync for FrozenJitCodeSlice {}
 
-    /// Per-thread cached `&'static` to the frozen source-translation
-    /// indirect-call-target family.  Same storage shape and the same
-    /// `Box::leak` rationale as [`JITCODE_CELLS`], which it is derived from;
-    /// see [`indirectcalltargets`] for why the family is built once.
-    static INDIRECTCALLTARGETS: OnceCell<&'static [Arc<majit_metainterp::jitcode::JitCode>]> =
-        const { OnceCell::new() };
-}
+/// RPython `MetaInterpStaticData.jitcodes`: one process-global table shared by
+/// every execution context. Runtime patching finishes before each cell is
+/// published.
+static JITCODE_CELLS: LazyLock<Vec<OnceLock<FrozenJitCode>>> =
+    LazyLock::new(|| (0..jitcode_count()).map(|_| OnceLock::new()).collect());
 
-fn load_jitcode_index() -> &'static JitCodeIndex {
+/// Decoded names and byte offsets; loading this never decodes a body.
+static JITCODE_INDEX: LazyLock<JitCodeIndex> = LazyLock::new(load_jitcode_index);
+
+/// Compatibility accessor storage for callers requesting the complete table.
+static FORCED_ALL_JITCODES: LazyLock<FrozenJitCodeSlice> = LazyLock::new(|| {
+    FrozenJitCodeSlice(
+        (0..jitcode_count())
+            .map(|index| get_jitcode_by_index(index).unwrap())
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+});
+
+/// Explicit build-time JIT-driver metadata for every configured driver.
+static COMPILED_JIT_DRIVERS: LazyLock<Vec<CompiledJitDriver>> =
+    LazyLock::new(load_compiled_jit_drivers);
+
+/// Frozen source-translation indirect-call-target family.
+static INDIRECTCALLTARGETS: LazyLock<Box<[Arc<majit_metainterp::jitcode::JitCode>]>> =
+    LazyLock::new(build_indirectcalltargets);
+
+fn load_jitcode_index() -> JitCodeIndex {
     const INDEX_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes_index.bin"));
     const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes.bin"));
     let (names, paths, offsets): (Vec<String>, Vec<String>, Vec<u32>) =
@@ -99,15 +109,15 @@ fn load_jitcode_index() -> &'static JitCodeIndex {
     assert_eq!(offsets.first().copied(), Some(0));
     assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
     assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
-    Box::leak(Box::new(JitCodeIndex {
+    JitCodeIndex {
         names,
         paths,
         offsets,
-    }))
+    }
 }
 
 fn jitcode_index() -> &'static JitCodeIndex {
-    JITCODE_INDEX.with(|cell| *cell.get_or_init(load_jitcode_index))
+    &JITCODE_INDEX
 }
 
 pub fn jitcode_count() -> usize {
@@ -163,23 +173,12 @@ fn load_jitcode(index: usize) -> Arc<JitCode> {
     jitcode
 }
 
-fn load_jitcode_cells() -> &'static [OnceCell<Arc<JitCode>>] {
-    let cells = (0..jitcode_count())
-        .map(|_| OnceCell::new())
-        .collect::<Vec<_>>();
-    Box::leak(cells.into_boxed_slice())
-}
-
-fn jitcode_cells() -> &'static [OnceCell<Arc<JitCode>>] {
-    JITCODE_CELLS.with(|cell| *cell.get_or_init(load_jitcode_cells))
-}
-
 pub(crate) fn get_jitcode_ref_by_index(index: usize) -> Option<&'static Arc<JitCode>> {
-    let cell = jitcode_cells().get(index)?;
-    Some(cell.get_or_init(|| load_jitcode(index)))
+    let cell = JITCODE_CELLS.get(index)?;
+    Some(&cell.get_or_init(|| FrozenJitCode(load_jitcode(index))).0)
 }
 
-fn load_compiled_jit_drivers() -> &'static [CompiledJitDriver] {
+fn load_compiled_jit_drivers() -> Vec<CompiledJitDriver> {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jit_drivers.bin"));
     let vec: Vec<CompiledJitDriver> = bincode::deserialize(BYTES).unwrap_or_else(|e| {
         panic!(
@@ -188,19 +187,12 @@ fn load_compiled_jit_drivers() -> &'static [CompiledJitDriver] {
             BYTES.len(),
         )
     });
-    Box::leak(vec.into_boxed_slice())
+    vec
 }
 
 /// RPython: `metainterp_sd.jitcodes` — explicitly force the full table.
 pub fn all_jitcodes() -> &'static [Arc<JitCode>] {
-    FORCED_ALL_JITCODES.with(|cell| {
-        *cell.get_or_init(|| {
-            let all = (0..jitcode_count())
-                .map(|index| get_jitcode_by_index(index).unwrap())
-                .collect::<Vec<_>>();
-            Box::leak(all.into_boxed_slice())
-        })
-    })
+    &FORCED_ALL_JITCODES.0
 }
 
 /// RPython: `metainterp_sd.jitcodes[index]` where `index == jitcode.index`.
@@ -218,14 +210,13 @@ pub fn get_jitcode_by_index(index: usize) -> Option<Arc<JitCode>> {
 /// assembled and holds the same `JitCode` objects the codewriter already
 /// handed to `metainterp_sd.jitcodes` — one object per graph for the whole
 /// process. The wrapper conversion below still has to own its core, so the
-/// family is materialized once per thread and handed out by reference
-/// afterwards; every publisher then sees the same objects instead of a fresh
-/// deep copy per call.
+/// family is materialized once for the process and handed out by reference
+/// afterwards; every publisher sees the same objects.
 pub fn indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCode>] {
-    INDIRECTCALLTARGETS.with(|cell| *cell.get_or_init(build_indirectcalltargets))
+    &INDIRECTCALLTARGETS
 }
 
-fn build_indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCode>] {
+fn build_indirectcalltargets() -> Box<[Arc<majit_metainterp::jitcode::JitCode>]> {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/indirectcalltargets.bin"));
     let entries: Vec<(usize, i64)> = bincode::deserialize(BYTES).unwrap_or_else(|e| {
         panic!(
@@ -249,7 +240,7 @@ fn build_indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCo
             ))
         })
         .collect();
-    Box::leak(vec.into_boxed_slice())
+    vec.into_boxed_slice()
 }
 
 /// RPython `bytecode_for_address`'s translated-mode dictionary, represented
@@ -320,16 +311,12 @@ pub(crate) fn indirectcalltarget_by_index(
 // index directly in `CompiledJitDriver`; runtime validates the referenced
 // JitCode still carries the driver marker instead of rediscovering portal
 // identity from a name or flag scan.
-thread_local! {
-    /// Cached portal jitcode index for the current thread.  See
-    /// `portal_jitcode` for the resolution semantics.  `thread_local!`
-    /// because its initializer resolves the thread-local jitcode table.
-    static PORTAL_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-}
+/// Cached process-global portal JitCode index. The driver metadata and JitCode
+/// table it resolves are process-global too.
+static PORTAL_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
 
 fn compute_portal_jitcode_index_for_key(key: &str) -> Option<usize> {
-    let drivers = COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
-    let driver = drivers
+    let driver = COMPILED_JIT_DRIVERS
         .iter()
         .find(|driver| driver.portal.canonical_key() == key)?;
     let index = driver.main_jitcode_index;
@@ -345,8 +332,7 @@ fn compute_portal_jitcode_index_for_key(key: &str) -> Option<usize> {
 }
 
 fn compute_portal_jitcode_index() -> Option<usize> {
-    let drivers = COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
-    let mut matching = drivers.iter().filter(|driver| {
+    let mut matching = COMPILED_JIT_DRIVERS.iter().filter(|driver| {
         get_jitcode_ref_by_index(driver.main_jitcode_index)
             .is_some_and(|jitcode| jitcode.jitdriver_sd() == Some(0))
     });
@@ -374,7 +360,7 @@ fn compute_portal_jitcode_index() -> Option<usize> {
 /// portal_runner` and `rpython/jit/codewriter/jtransform.py:473`
 /// `inline_call_*` emit.
 pub fn portal_jitcode() -> Option<Arc<JitCode>> {
-    let idx = PORTAL_JITCODE_INDEX.with(|cell| *cell.get_or_init(compute_portal_jitcode_index))?;
+    let idx = (*PORTAL_JITCODE_INDEX.get_or_init(compute_portal_jitcode_index))?;
     get_jitcode_by_index(idx)
 }
 
@@ -404,34 +390,30 @@ pub fn portal_jitcode_for_key(key: &str) -> Option<Arc<JitCode>> {
 // the FBW walker into the orthodox charon list-append body (issue #62/#23): the
 // dynamic `lst.append` recognition arm resolves the body here, then
 // builds a by-index sub-walk from `get_jitcode_by_index`.
-thread_local! {
-    /// Cached `ALL_JITCODES` index of `w_list_append` for the current
-    /// thread. `thread_local!` because the names index is also thread-local.
-    static LIST_APPEND_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of `w_list_pop_end_inner` for the current
-    /// thread. Resolved by name because jitcode indices are build-dependent.
-    static LIST_POP_END_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of `w_tuple_getitem` for the current
-    /// thread. Resolved by graph key rather than by name -- see
-    /// [`compute_pathed_jitcode_index`].
-    static TUPLE_GETITEM_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of `invert_inner` for the current thread.
-    /// Resolved by graph key: `neg` and `invert` held indices 2798/2809 in only
-    /// two of eight observed cache generations, so an index is not stable
-    /// across builds and a path is.
-    static INVERT_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of `neg_inner` for the current thread.
-    /// Resolved by graph key, for the reason given above.
-    static NEG_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of `pos_inner` for the current thread.
-    /// Resolved by graph key, for the reason given above.
-    static POS_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-    /// Cached `ALL_JITCODES` index of the interpreter-source
-    /// `load_super_attr_value_w` body.  The fused CPython opcode reaches this
-    /// ordinary graph so `_super_check` and `W_Super.getattribute` are traced
-    /// from their generated JitCodes, as PyPy traces their RPython owners.
-    static LOAD_SUPER_ATTR_VALUE_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
-}
+/// Cached `ALL_JITCODES` index of `w_list_append`, resolved by name because
+/// jitcode indices are build-dependent.
+static LIST_APPEND_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of `w_list_pop_end_inner`, resolved by name for
+/// the same reason.
+static LIST_POP_END_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of `w_tuple_getitem`, resolved by graph key
+/// rather than by name -- see [`compute_pathed_jitcode_index`].
+static TUPLE_GETITEM_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of `invert_inner`, resolved by graph key: `neg`
+/// and `invert` held indices 2798/2809 in only two of eight observed cache
+/// generations, so an index is not stable across builds and a path is.
+static INVERT_INNER_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of `neg_inner`, resolved by graph key for the
+/// reason given above.
+static NEG_INNER_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of `pos_inner`, resolved by graph key for the
+/// reason given above.
+static POS_INNER_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
+/// Cached `ALL_JITCODES` index of the interpreter-source
+/// `load_super_attr_value_w` body. The fused opcode reaches this ordinary
+/// graph so `_super_check` and `W_Super.getattribute` are traced from their
+/// generated JitCodes, as PyPy traces their RPython owners.
+static LOAD_SUPER_ATTR_VALUE_JITCODE_INDEX: OnceLock<Option<usize>> = OnceLock::new();
 
 /// Scan the build-time names index for the unique entry equal to `name`.
 ///
@@ -499,28 +481,28 @@ pub(crate) fn named_jitcode(name: &str) -> Option<Arc<JitCode>> {
 }
 
 /// The charon `w_list_append` body in `ALL_JITCODES`, resolved by name
-/// and cached per thread. `None` if the helper is absent from the
+/// and cached process-wide. `None` if the helper is absent from the
 /// build-time pipeline. See `LIST_APPEND_JITCODE_INDEX`.
 pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
-    let idx = LIST_APPEND_JITCODE_INDEX
-        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_append_inner")))?;
+    let idx = (*LIST_APPEND_JITCODE_INDEX
+        .get_or_init(|| compute_named_jitcode_index("w_list_append_inner")))?;
     get_jitcode_by_index(idx)
 }
 
 /// The lock-guard-free charon `w_list_pop_end_inner` body in `ALL_JITCODES`,
-/// resolved by name and cached per thread. "Lock" is the whole of it: the body
+/// resolved by name and cached process-wide. "Lock" is the whole of it: the body
 /// holds no `w_list_lock` pair, which is what would decline the fold's
 /// sub-walk (`listobject.rs` `w_list_pop_end`). It says nothing about trace
 /// guards — for those see `try_walker_orthodox_list_pop`, whose soundness
 /// turns on where they land relative to the body's first store.
 pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
-    let idx = LIST_POP_END_JITCODE_INDEX
-        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_pop_end_inner")))?;
+    let idx = (*LIST_POP_END_JITCODE_INDEX
+        .get_or_init(|| compute_named_jitcode_index("w_list_pop_end_inner")))?;
     get_jitcode_by_index(idx)
 }
 
 /// The charon `w_tuple_getitem` body in `ALL_JITCODES`, resolved by the graph
-/// key the codewriter allocated it under and cached per thread. `None` if the
+/// key the codewriter allocated it under and cached process-wide. `None` if the
 /// helper is absent from the build-time pipeline.
 ///
 /// This is the reader behind every tuple subscript. It normalises a negative
@@ -536,7 +518,7 @@ pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
 /// trace-time range check proves only that THIS receiver is long enough, while
 /// the recorded `arraylen` guard is what holds for the next one.
 /// The charon `invert_inner` body in `ALL_JITCODES`, resolved by the graph key
-/// the codewriter allocated it under and cached per thread. `None` if the
+/// the codewriter allocated it under and cached process-wide. `None` if the
 /// helper is absent from the build-time pipeline.
 ///
 /// This is `descroperation.rs` `invert` past its `__invert__` override probe
@@ -545,16 +527,14 @@ pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
 /// `TypeError`, so a caller that has pinned an exact `int` or `long` receiver
 /// records one of the first two and nothing else.
 pub fn invert_inner_jitcode() -> Option<Arc<JitCode>> {
-    let idx = INVERT_INNER_JITCODE_INDEX.with(|cell| {
-        *cell.get_or_init(|| {
-            compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::invert_inner")
-        })
-    })?;
+    let idx = (*INVERT_INNER_JITCODE_INDEX.get_or_init(|| {
+        compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::invert_inner")
+    }))?;
     get_jitcode_by_index(idx)
 }
 
 /// The charon `neg_inner` body in `ALL_JITCODES`, resolved by the graph key the
-/// codewriter allocated it under and cached per thread. `None` if the helper is
+/// codewriter allocated it under and cached process-wide. `None` if the helper is
 /// absent from the build-time pipeline.
 ///
 /// This is `descroperation.rs` `neg` past its `__neg__` override probe -- the
@@ -564,16 +544,14 @@ pub fn invert_inner_jitcode() -> Option<Arc<JitCode>> {
 /// has pinned an exact `int` or `long` receiver records one of the first two
 /// and nothing else.
 pub fn neg_inner_jitcode() -> Option<Arc<JitCode>> {
-    let idx = NEG_INNER_JITCODE_INDEX.with(|cell| {
-        *cell.get_or_init(|| {
-            compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::neg_inner")
-        })
-    })?;
+    let idx = (*NEG_INNER_JITCODE_INDEX.get_or_init(|| {
+        compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::neg_inner")
+    }))?;
     get_jitcode_by_index(idx)
 }
 
 /// The charon `pos_inner` body in `ALL_JITCODES`, resolved by the graph key the
-/// codewriter allocated it under and cached per thread. `None` if the helper is
+/// codewriter allocated it under and cached process-wide. `None` if the helper is
 /// absent from the build-time pipeline.
 ///
 /// This is `descroperation.rs` `pos` past its `__pos__` override probe -- the
@@ -589,31 +567,25 @@ pub fn neg_inner_jitcode() -> Option<Arc<JitCode>> {
 /// `None` here is the helper's absence from the build-time pipeline, and the
 /// identity fold behind the descent still serves exact-int `+x`.
 pub fn pos_inner_jitcode() -> Option<Arc<JitCode>> {
-    let idx = POS_INNER_JITCODE_INDEX.with(|cell| {
-        *cell.get_or_init(|| {
-            compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::pos_inner")
-        })
-    })?;
+    let idx = (*POS_INNER_JITCODE_INDEX.get_or_init(|| {
+        compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::pos_inner")
+    }))?;
     get_jitcode_by_index(idx)
 }
 
 /// The wrapped-name interpreter-source value half of `LOAD_SUPER_ATTR`, resolved by the
-/// graph key the codewriter allocated it under and cached per thread.
+/// graph key the codewriter allocated it under and cached process-wide.
 pub fn load_super_attr_value_jitcode() -> Option<Arc<JitCode>> {
-    let idx = LOAD_SUPER_ATTR_VALUE_JITCODE_INDEX.with(|cell| {
-        *cell.get_or_init(|| {
-            compute_pathed_jitcode_index("pyre_interpreter::eval::load_super_attr_value_w")
-        })
-    })?;
+    let idx = (*LOAD_SUPER_ATTR_VALUE_JITCODE_INDEX.get_or_init(|| {
+        compute_pathed_jitcode_index("pyre_interpreter::eval::load_super_attr_value_w")
+    }))?;
     get_jitcode_by_index(idx)
 }
 
 pub fn tuple_getitem_jitcode() -> Option<Arc<JitCode>> {
-    let idx = TUPLE_GETITEM_JITCODE_INDEX.with(|cell| {
-        *cell.get_or_init(|| {
-            compute_pathed_jitcode_index("pyre_object::tupleobject::w_tuple_getitem")
-        })
-    })?;
+    let idx = (*TUPLE_GETITEM_JITCODE_INDEX.get_or_init(|| {
+        compute_pathed_jitcode_index("pyre_object::tupleobject::w_tuple_getitem")
+    }))?;
     get_jitcode_by_index(idx)
 }
 
@@ -2956,23 +2928,21 @@ mod tests {
 
     #[test]
     fn index_queries_do_not_decode_jitcode_bodies() {
-        std::thread::spawn(|| {
-            assert!(jitcode_cells().iter().all(|cell| cell.get().is_none()));
-            assert!(compute_named_jitcode_index("__missing_jitcode_name__").is_none());
-            assert!(jitcode_cells().iter().all(|cell| cell.get().is_none()));
+        let count = jitcode_count();
+        assert!(compute_named_jitcode_index("__missing_jitcode_name__").is_none());
+        assert_eq!(jitcode_count(), count);
+        assert!(get_jitcode_by_index(0).is_some());
+        assert!(JITCODE_CELLS[0].get().is_some());
+    }
 
-            assert!(get_jitcode_by_index(0).is_some());
-            assert!(jitcode_cells()[0].get().is_some());
-            assert_eq!(
-                jitcode_cells()
-                    .iter()
-                    .filter(|cell| cell.get().is_some())
-                    .count(),
-                1
-            );
-        })
-        .join()
-        .unwrap();
+    #[test]
+    fn build_time_jitcode_identity_is_shared_across_threads() {
+        let here = Arc::as_ptr(get_jitcode_ref_by_index(0).unwrap()) as usize;
+        let there =
+            std::thread::spawn(|| Arc::as_ptr(get_jitcode_ref_by_index(0).unwrap()) as usize)
+                .join()
+                .unwrap();
+        assert_eq!(there, here);
     }
 
     #[test]
@@ -2983,36 +2953,20 @@ mod tests {
 
     #[test]
     fn indirect_target_lookup_decodes_only_the_matched_jitcode() {
-        // The spawn is the isolation, not a stack-size workaround: every cell
-        // table here is thread-local, and `load_jitcode_cells` leaks a fresh
-        // slice per thread, so a new thread starts with the whole table
-        // undecoded no matter what the rest of the harness already ran. That
-        // is what lets the counts below be absolute rather than a delta.
-        std::thread::spawn(|| {
-            assert!(jitcode_cells().iter().all(|cell| cell.get().is_none()));
-            let (&fnaddr, &index) = INDIRECTCALLTARGET_BY_FNADDR
-                .iter()
-                .next()
-                .expect("expected at least one frozen indirect-call target");
-            assert_eq!(indirectcalltarget_index_for_address(fnaddr), Some(index));
-            let jitcode = indirectcalltarget_by_index(index)
-                .expect("frozen indirect-call target index must resolve");
-            // The map is keyed by runtime address, while `JitCode.fnaddr`
-            // stays the build-time one; translate before comparing.
-            assert_eq!(
-                crate::runtime_fnaddr_patch::runtime_fnaddr(jitcode.fnaddr) as usize,
-                fnaddr
-            );
-            assert_eq!(
-                jitcode_cells()
-                    .iter()
-                    .filter(|cell| cell.get().is_some())
-                    .count(),
-                1
-            );
-        })
-        .join()
-        .unwrap();
+        let (&fnaddr, &index) = INDIRECTCALLTARGET_BY_FNADDR
+            .iter()
+            .next()
+            .expect("expected at least one frozen indirect-call target");
+        assert_eq!(indirectcalltarget_index_for_address(fnaddr), Some(index));
+        let jitcode = indirectcalltarget_by_index(index)
+            .expect("frozen indirect-call target index must resolve");
+        // The map is keyed by runtime address, while `JitCode.fnaddr`
+        // stays the build-time one; translate before comparing.
+        assert_eq!(
+            crate::runtime_fnaddr_patch::runtime_fnaddr(jitcode.fnaddr) as usize,
+            fnaddr
+        );
+        assert!(JITCODE_CELLS[index].get().is_some());
     }
 
     #[test]
@@ -3022,9 +2976,7 @@ mod tests {
         // call.py `jd.mainjitcode = self.get_jitcode(jd.portal_graph)`).
         let portal = portal_jitcode().expect("build-time pipeline must register a portal jitcode");
         assert_eq!(portal.jitdriver_sd(), Some(0));
-        let drivers =
-            COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
-        let main_drivers = drivers
+        let main_drivers = COMPILED_JIT_DRIVERS
             .iter()
             .filter(|driver| {
                 get_jitcode_ref_by_index(driver.main_jitcode_index)
@@ -3600,9 +3552,7 @@ mod tests {
         // canonical object that build.rs persisted.
         let bt_jc = portal_jitcode().expect("configured portal must resolve to a jitcode");
         assert!(!bt_jc.code.is_empty());
-        let drivers =
-            COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
-        let eval_driver = drivers
+        let eval_driver = COMPILED_JIT_DRIVERS
             .iter()
             .find(|driver| driver.portal.canonical_key() == "eval::eval_loop_jit")
             .expect("compiled drivers must contain the main eval portal");

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -12491,7 +12491,7 @@ mod tests {
     use pyre_object::floatobject::w_float_get_value;
     use pyre_object::listobject::w_list_getitem;
     use pyre_object::pyobject::{INT_TYPE, PyType, is_list};
-    use std::cell::{Cell, UnsafeCell};
+    use std::cell::UnsafeCell;
 
     #[test]
     fn reconstructed_ref_slot_does_not_invent_color_in_mapped_frame() {
@@ -12502,8 +12502,8 @@ mod tests {
         assert_eq!(reconstructed_ref_slot_color(&[], 1), Some(1));
     }
 
+    static TEST_CALLBACKS_INIT: std::sync::Once = std::sync::Once::new();
     thread_local! {
-        static TEST_CALLBACKS_INIT: Cell<bool> = const { Cell::new(false) };
         static TEST_JIT_DRIVER: UnsafeCell<crate::driver::JitDriverPair> = UnsafeCell::new({
             let info = crate::frame_layout::build_pyframe_virtualizable_info();
             let mut driver = majit_metainterp::JitDriver::new(1);
@@ -12890,11 +12890,7 @@ mod tests {
     }
 
     fn ensure_test_callbacks() {
-        TEST_CALLBACKS_INIT.with(|init| {
-            if init.get() {
-                return;
-            }
-            init.set(true);
+        TEST_CALLBACKS_INIT.call_once(|| {
             let cb = Box::leak(Box::new(crate::callbacks::CallJitCallbacks {
                 callee_frame_helper: |_| None,
                 recursive_force_cache_safe: |_| false,
@@ -12916,6 +12912,17 @@ mod tests {
             }));
             crate::callbacks::init(cb);
         });
+    }
+
+    #[test]
+    fn callback_table_is_visible_to_new_threads() {
+        ensure_test_callbacks();
+        assert!(
+            std::thread::spawn(|| crate::callbacks::try_get().is_some())
+                .join()
+                .unwrap(),
+            "process-global MetaInterpStaticData callbacks disappeared on a new thread"
+        );
     }
 
     /// Install the real `hash_w` and `hash_str` on this test thread so

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3369,7 +3369,15 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
                 // `portal_body_result` error fall-through below and with
                 // `lib.rs::jit_exc_raise` — every backend's blackhole resume
                 // publishes the pending exception, not just cranelift.
-                store_jit_exception(exc_obj as i64);
+                //
+                // Both carriers, because `handle_jitexception` reaches this arm
+                // by `raise value` (warmspot.py:996-1003) into RPython's single
+                // ll exception state, which is caller-blind: the compiled
+                // `CALL_ASSEMBLER` reads it through the backend cells and the
+                // walker's trace-time `execute_varargs_call` reads it through
+                // `BH_LAST_EXC_VALUE`.  `clear_residual_call_exception` empties
+                // both, so arming both cannot leave one behind.
+                publish_residual_call_exception(exc_obj as i64);
             }
             Some(0) // garbage return — GUARD_NO_EXCEPTION will fire
         }
@@ -4734,7 +4742,7 @@ pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64
         // `handle_blackhole_result`'s ExitFrameWithExceptionRef arm.
         Outcome::FinishedException(exc) => {
             if exc != 0 {
-                store_jit_exception(exc);
+                publish_residual_call_exception(exc);
             }
             0
         }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1111,7 +1111,20 @@ fn run_frame_through_portal(frame_ptr: i64, entry: PortalEntry) -> i64 {
     let result = match outcome {
         Ok(r) => r,
         Err(mut err) => {
-            store_jit_exception(err.to_exc_object() as i64);
+            // `ll_portal_runner` raises into RPython's single ll exception
+            // state, and every one of its executors reads that one state:
+            // compiled `CALL_ASSEMBLER` through `pos_exception()` /
+            // `pos_exc_value()` (`llmodel.py`), `bhimpl_recursive_call_*`
+            // through the propagated RPython exception (`blackhole.py`), and
+            // the trace-time execution `do_recursive_call` performs through
+            // `metainterp.execute_raised` (`executor.py:52-78`).  Pyre spells
+            // that one state as two carriers, so this raise owes both:
+            // `execute_varargs_call` (majit-metainterp `executor.rs`) reads
+            // only `BH_LAST_EXC_VALUE`, and with the backend cells alone it
+            // sees no raise, records `GUARD_NO_EXCEPTION` over it, writes the
+            // NULL result into the destination slot and leaves the backend
+            // cells armed for an unrelated guard.
+            publish_residual_call_exception(err.to_exc_object() as i64);
             pyre_object::PY_NULL
         }
     };
@@ -1338,8 +1351,17 @@ pub extern "C" fn bh_portal_runner_c(
     match result {
         Ok(result) => result as i64,
         Err(mut err) => {
-            majit_metainterp::blackhole::BH_LAST_EXC_VALUE
-                .with(|c| c.set(err.to_exc_object() as i64));
+            // The other portal door, and it owes the same two carriers for the
+            // same reason: `warmspot.py:998-1006` raises for real, so the state
+            // a portal raise arms is caller-blind.  This address serves both
+            // `bhimpl_recursive_call_*` (`blackhole.py:1095-1116`), which reads
+            // `BH_LAST_EXC_VALUE`, and — through `get_jitcode_calldescr` — the
+            // `fnaddr` every JitCode carries, which upstream is a call target
+            // for `bhimpl_inline_call_*` (`blackhole.py:1284`) and for a trace's
+            // own residual call, and those read the backend cells.  Publishing
+            // both is also what the catch side already assumes: `route_to_catch`
+            // drains `BH_LAST_EXC_VALUE` and the backend cells together.
+            publish_residual_call_exception(err.to_exc_object() as i64);
             pyre_object::PY_NULL as i64
         }
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6957,47 +6957,43 @@ pub fn releaseall(_space: pyre_object::PyObjectRef) {
 
 fn init_callbacks() {
     use pyre_jit_trace::callbacks::{self, CallJitCallbacks};
-    thread_local! {
-        static INIT: Cell<bool> = const { Cell::new(false) };
-    }
-    INIT.with(|c| {
-        if !c.get() {
-            c.set(true);
-            let cb = Box::leak(Box::new(CallJitCallbacks {
-                callee_frame_helper: crate::call_jit::callee_frame_helper,
-                recursive_force_cache_safe: crate::call_jit::recursive_force_cache_safe,
-                jit_drop_callee_frame: crate::call_jit::jit_drop_callee_frame as *const (),
-                jit_frame_set_slot_ref: crate::call_jit::jit_frame_set_slot_ref as *const (),
-                jit_frame_set_slot_int: crate::call_jit::jit_frame_set_slot_int as *const (),
-                jit_frame_set_slot_float: crate::call_jit::jit_frame_set_slot_float as *const (),
-                jit_force_callee_frame: crate::call_jit::jit_force_callee_frame as *const (),
-                jit_force_recursive_call_1: crate::call_jit::jit_force_recursive_call_1
-                    as *const (),
-                jit_force_recursive_call_argraw_boxed_1:
-                    crate::call_jit::jit_force_recursive_call_argraw_boxed_1 as *const (),
-                jit_force_self_recursive_call_argraw_boxed_1:
-                    crate::call_jit::jit_force_self_recursive_call_argraw_boxed_1 as *const (),
-                jit_create_callee_frame_1: crate::call_jit::jit_create_callee_frame_1 as *const (),
-                jit_create_callee_frame_1_raw_int:
-                    crate::call_jit::jit_create_callee_frame_1_raw_int as *const (),
-                jit_create_self_recursive_callee_frame_1:
-                    crate::call_jit::jit_create_self_recursive_callee_frame_1 as *const (),
-                jit_create_self_recursive_callee_frame_1_raw_int:
-                    crate::call_jit::jit_create_self_recursive_callee_frame_1_raw_int as *const (),
-                driver_pair: || driver_pair() as *mut JitDriverPair as *mut u8,
-                ensure_majit_jitcode: |code, w_code| {
-                    if !code.is_null() {
-                        return crate::jit::codewriter::ensure_trace_jitcode_for_w_code(
-                            code, w_code,
-                        )
+    // The table this publishes is process-global, so its once-guard is too.
+    // A per-thread guard leaks a second, field-identical but distinct table on
+    // every further thread that reaches here, and `callbacks::init` rejects a
+    // second table by pointer.
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let cb = Box::leak(Box::new(CallJitCallbacks {
+            callee_frame_helper: crate::call_jit::callee_frame_helper,
+            recursive_force_cache_safe: crate::call_jit::recursive_force_cache_safe,
+            jit_drop_callee_frame: crate::call_jit::jit_drop_callee_frame as *const (),
+            jit_frame_set_slot_ref: crate::call_jit::jit_frame_set_slot_ref as *const (),
+            jit_frame_set_slot_int: crate::call_jit::jit_frame_set_slot_int as *const (),
+            jit_frame_set_slot_float: crate::call_jit::jit_frame_set_slot_float as *const (),
+            jit_force_callee_frame: crate::call_jit::jit_force_callee_frame as *const (),
+            jit_force_recursive_call_1: crate::call_jit::jit_force_recursive_call_1 as *const (),
+            jit_force_recursive_call_argraw_boxed_1:
+                crate::call_jit::jit_force_recursive_call_argraw_boxed_1 as *const (),
+            jit_force_self_recursive_call_argraw_boxed_1:
+                crate::call_jit::jit_force_self_recursive_call_argraw_boxed_1 as *const (),
+            jit_create_callee_frame_1: crate::call_jit::jit_create_callee_frame_1 as *const (),
+            jit_create_callee_frame_1_raw_int: crate::call_jit::jit_create_callee_frame_1_raw_int
+                as *const (),
+            jit_create_self_recursive_callee_frame_1:
+                crate::call_jit::jit_create_self_recursive_callee_frame_1 as *const (),
+            jit_create_self_recursive_callee_frame_1_raw_int:
+                crate::call_jit::jit_create_self_recursive_callee_frame_1_raw_int as *const (),
+            driver_pair: || driver_pair() as *mut JitDriverPair as *mut u8,
+            ensure_majit_jitcode: |code, w_code| {
+                if !code.is_null() {
+                    return crate::jit::codewriter::ensure_trace_jitcode_for_w_code(code, w_code)
                         .is_some();
-                    }
-                    false
-                },
-                drain_backend_jit_exc: crate::call_jit::drain_backend_jit_exc,
-            }));
-            callbacks::init(cb);
-        }
+                }
+                false
+            },
+            drain_backend_jit_exc: crate::call_jit::drain_backend_jit_exc,
+        }));
+        callbacks::init(cb);
     });
 }
 


### PR DESCRIPTION
`rvirtualizable.py hook_access_field` emits `jit_force_virtualizable` under one
condition:

```python
if self.my_redirected_fields.get(cname.value):
    llops.genop('jit_force_virtualizable', [vinst, cname, cflags])
```

and `jtransform.py rewrite_op_jit_force_virtualizable` deletes it again in every
graph the codewriter looks inside, so the interpreter copy keeps the force and
the traced copy does not. pyre has no injection — `rclass.rs buildinstancerepr`
declines a virtualizable `InstanceRepr` outright — so the marker is hand-placed,
and until now it sat on `sys._getframe` instead, forcing the top of the stack on
every call regardless of depth.

This moves it to the frame descriptor gateways, then narrows which gateways
carry it.

## Where the marker belongs

The redirected set is the one `pyre-jit-trace/src/virtualizable_gen.rs` declares
(`majit_macros::virtualizable!`), not `interp_jit.py`'s string list:
`last_instr`, `pycode`, `valuestackdepth`, `debugdata` and the
`locals_cells_stack_w` array. `w_globals` is in upstream's list and is skipped
here because no `PyFrame` field answers to it.

A hand-placed marker owes a second question the injection never has to ask,
because it fires at every access in every graph rather than once per gateway:
**can the trace's shadow and the live frame disagree about the field this body
reads?** Both clauses together leave the sixteen `__majit_wrap_descr_typecheck_*`
frame gateways split twelve/four:

| gateway | field it reads | marker |
|---|---|---|
| `fget_getdictscope`, `get_w_globals`, `fget_f_lasti`, `fget_f_lineno`/`fset_f_lineno`, `fget`/`fset`/`fdel_f_trace`, `fget`/`fset_f_trace_lines`, `fget`/`fset_f_trace_opcodes` | `locals_cells_stack_w`, `debugdata`, `last_instr` | yes |
| `fget_f_back` | `f_backref` | no — not redirected |
| `fget_f_builtins` | `w_builtin` | no — not redirected |
| `get_generator` | `f_generator_nowref` | no — not redirected |
| `fget_f_code` | `pycode` | no — redirected, but written only at frame construction |

`f_back` is the sharpest of the four: `f_backref` holds a `jit.virtual_ref`, so
reading it IS the force, and it is the foldable one.
`__majit_wrap_descr_typecheck_fget_f_back`'s own doc already carried the
warning. Measured on
`synth/getframe_inlined_callee_own_frame`, two one-attribute probes separate it:

| probe | escapes |
|---|---|
| `frame.f_code` only | 0 — the walker folds it (`traceback_walk_field::FCode`) |
| `frame.f_back` only | 35 `VableEscapedDuringResidualCall`, `helper=LoadAttr` |

`f_code` is the second clause rather than the first. `pycode` is written at
`PyFrame::__init__` and at the allocator's field initialisation and never again,
and `restore_resume_state_from` already treats it as frame-invariant, so the
force there reaches nothing but the escape flush, which `virtualizable.py
force_now` turns into `ABORT_ESCAPE`. Dropping it puts four fixtures back on
their committed baselines exactly, output identical:

| fixture | with the marker | without |
|---|---|---|
| `exception_raise_caught_same_frame_tb` | `guard_failures` 803 | 605 |
| `exception_reentry_guard_finally_residual` | 8/1903/2/5 | 5/1027/0/6 |
| `c_call_reports_the_callee_frame_not_the_inliners` | `root:inner` stops compiling | compiles |
| `frame_chain_survives_a_recursive_call_assembler` | 1/214/7/1 | 2/207/1/4 |

(bridges/guard_failures/aborted/compiled.) Each is a `tb_frame.f_code` or
`frame.f_code` read from interpreted code nested inside a residual call, where
the walker residualizes what upstream's codewriter looks inside.

## The fixtures the relocation disarmed

Taking the force off `sys._getframe` also took it off every lever the
`getframe_*` escape fixtures were written around. Measured at this HEAD on one
`while` + `leaf(_gf(1)…)` shape with `PYRE_FBW_DEBUG_ABORT=1`:

| read in the callee | escapes |
|---|---|
| bare `_gf(1)` | 0 |
| `_gf(1).f_code` | 0 |
| `_gf(1).f_back` | 0 |
| `_gf(1).f_locals` | 0 |
| `_gf(1).f_lasti` | 20 |
| `_gf(1).f_lineno` | 20 |

Seven fixtures stopped exercising the path they exist to pin, and the disarm
read as an improvement: `loops_aborted` 20 → 0, `guard_failures` 4114 → 201,
five fixtures compiling a loop where they had compiled none. Each now reads
`f_lasti` off the frame `_gf(1)` returns, and their headers say why the read is
the lever and the call is not. The six with a `.jitstats` baseline read **every
counter in it back exactly**, output unchanged, no re-recording;
`getframe_method_call_residual_body_once` reports
`fold=load_type_attr consulted=15 fired=5` again, against `consulted=2 fired=0`;
`nested_for_escape_flush_keeps_the_inner_iterator`, which has no jitstats file,
compiles `root:leaf` again instead of `loop:main`.

Depth 0 is not a lever either: `try_walker_specialize_sys_getframe` answers
`_gf()` at the top walk level out of the portal virtualizable, so `_gf().f_lasti`
moves no counter. Only `_gf(1)`.

## Census

`every_redirected_frame_getter_carries_a_deletable_force` gains the five setters
and the deleter it had not listed, and its complement becomes its own test,
`the_gateways_outside_the_redirected_set_carry_no_force`, so an absent marker is
pinned rather than merely unlisted. Together the two lists cover all sixteen
gateways.

## Also here

* `jit: publish a portal-runner raise to both exception carriers` — the portal
  shim published a raise to one of the two carriers.
* `jit: declare FrameAnchor shadow stack externals` and
  `jit: rtype virtualizable forces as primitive ops`.
* `majit-gc: read MAJIT_GC_NURSERY_POISON once through a shared accessor`.
* `interp, bench: name the frame gateways by the family prefix they carry` —
  three doc comments and two fixture headers spelled the gateways without the
  `__majit_wrap_` prefix that `jit_fnaddr.rs`
  `every_builtin_wrapper_descriptor_carries_the_family_prefix` requires.
* `jit: bridge the shadow-stack externals to the residual word ABI` — review
  follow-up. `majit_gc::shadow_stack::{push, get, try_pop_to}` were published
  raw; their `GcRef`/`usize` parameters are 32-bit on wasm32 while a word-shaped
  residual call lowers to an in-module `(i64xn) -> i64` `call_indirect`.
  `residual_callee_abi_is_word` short-circuits to `true` under the default
  `ResidualCallAbi::Word` — nothing calls `set_residual_call_abi` — so that
  lowering never consults the `set_faithful_residual_call_addrs` allow-list.
  They now publish `extern "C"` bridges under the same declared paths.

## Gate

Rebased onto `origin/main` `5845c442dfc` (#1623, #1610); all ten commits
replayed content-identical (`git range-diff` reports `=` on every row), and the
review follow-up above sits on top.

`cargo test --all --no-default-features --features dynasm` passes (206 test
binaries, 0 failures). `pyre/check.py`: `cranelift 532/532`, `wasm 525/525`,
`dynasm 531 passed / 1 failed`.

The one row is `synth/load_name_builtin_cell_fold` at `ratio 1.2x > gate 1x`,
and it is a moved ceiling rather than a moved measurement. This same tree read
it at 1.3x and passed before the rebase; #1615 took the fixture's ceiling from
`max-pypy-ratio=2.8` to `1` and the reading did not move. Nothing in this branch
touches the fixture or the module-scope `LOAD_NAME` fold it exercises. The bound
is a host property: on the macos CI runner #1615's own run reads the row 0.7x
with pypy at 2.13s, where this machine's pypy runs it in 0.68s against our
0.79s.

No `.jitstats` baseline is re-recorded anywhere in this branch. The seven
fixtures the gateway relocation disarmed are back on their committed values
because the lever was restored, not because the record was moved to meet them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception propagation across optimized execution boundaries.
  * Corrected virtualized frame access, synchronization, and recursive-call handling.
  * Ensured garbage-collection poisoning settings apply consistently.
  * Improved preservation of return values during optimized execution.

* **Performance**
  * Improved JIT compilation of loops, frame operations, and residual calls.
  * Shared compiled JIT metadata and callbacks across execution contexts.

* **Tests**
  * Added coverage for frame access, recursive exceptions, loop compilation, and return values.

* **Documentation**
  * Clarified frame behavior and garbage-collection configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->