### PR TITLE
majit: gate checked-arith fusion on the operand width, and stop modelling an unspellable enum tag as i64

### DIFF
--- a/majit/majit-charon-reader/src/ullbc.rs
+++ b/majit/majit-charon-reader/src/ullbc.rs
@@ -311,6 +311,20 @@ impl TypeLayout {
             _ => None,
         }
     }
+
+    /// `true` iff a `Branch` discriminator is recorded, whatever its width.
+    ///
+    /// The question [`Self::discriminant_int_type`] cannot answer on its own:
+    /// it returns `None` both for a layout that records no discriminator at
+    /// all — a single-variant enum, or a `Known` discriminator — and for one
+    /// whose width has no field-type spelling. A consumer that falls back to a
+    /// default tag model owes those two cases different answers.
+    pub fn has_branch_discriminant(&self) -> bool {
+        self.discriminator
+            .as_ref()
+            .and_then(|discriminator| discriminator.get("Branch"))
+            .is_some()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -930,7 +944,14 @@ mod tests {
             );
             let layout: TypeLayout = serde_json::from_str(&json).unwrap();
             assert_eq!(layout.discriminant_int_type(), expected);
+            // A declined width is still a recorded tag: the two `None`s a
+            // consumer sees from `discriminant_int_type` are distinguishable.
+            assert!(layout.has_branch_discriminant());
         }
+        let no_discriminator: TypeLayout =
+            serde_json::from_str(r#"{"variant_layouts": [{"field_offsets": []}]}"#).unwrap();
+        assert!(!no_discriminator.has_branch_discriminant());
+        assert_eq!(no_discriminator.discriminant_int_type(), None);
     }
 
     /// Target selection: exact-match wins; a sole entry is chosen even

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -93,6 +93,22 @@ pub(crate) fn is_checked_arith_target(target: &CallTarget) -> bool {
         && checked_arith_ovf_opname(leaf).is_some()
 }
 
+/// `true` for the signed width atoms (`{"Literal": {"Int": _}}`) whose
+/// overflow bound is the one `add_ovf` / `sub_ovf` / `mul_ovf` test.
+///
+/// Charon spells every inherent integer impl as `<Impl>`, so
+/// [`is_checked_arith_target`] cannot tell `i8::checked_add` from
+/// `i64::checked_add` by path, and `tyref_to_value_type` colors every signed
+/// width `Int`.  Fusing a narrower width answers a different question than
+/// the source asked: `127i8.checked_add(1)` overflows `i8` but not the
+/// machine word, so the rewrite would take the success continuation carrying
+/// `128` where the residual call returns `None`.  `Isize` is the machine word
+/// by definition and shares the equivalence `get_type_flag` already makes for
+/// it; `I128` is wider than the int bank.
+pub(crate) fn is_ovf_width_int_atom(atom: &str) -> bool {
+    matches!(atom, "I64" | "Isize")
+}
+
 /// The `Option::ok_or_else` continuation paired with a signed checked-arith
 /// result.  The MIR collector resolves the type-owned names while the Rust
 /// types are still in hand; the post-pass validates that the call immediately
@@ -685,6 +701,18 @@ mod tests {
     }
 
     #[test]
+    /// The rewrite emits a machine-word `*_ovf`, so only the atoms whose
+    /// overflow bound IS that word may reach it.
+    #[test]
+    fn only_machine_word_signed_atoms_reach_the_ovf_rewrite() {
+        for atom in ["I64", "Isize"] {
+            assert!(is_ovf_width_int_atom(atom), "{atom} should fuse");
+        }
+        for atom in ["I8", "I16", "I32", "I128", "U64", "Usize"] {
+            assert!(!is_ovf_width_int_atom(atom), "{atom} should decline");
+        }
+    }
+
     fn rewrite_lifts_checked_add_to_add_ovf_with_overflow_edge() {
         let mut g = FunctionGraph::new("test_checked_add");
         let a = g.startblock;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1742,17 +1742,25 @@ fn derive_program_metadata(
                 let fieldless = type_decl_is_fieldless_enum(td, llbc);
                 let enum_layout = td.layout_for_target(&target);
                 let base_sid = majit_ir::descr::StructId::from_canonical(&canon_base);
-                if !fieldless {
-                    // The tag is an int-bank value, but its physical width is
-                    // not necessarily a machine word. Charon records the
-                    // exact `Branch.int_ty`; using `i64` for a u8/u16/u32 tag
-                    // reads adjacent payload bytes and can select an
-                    // unreachable switch arm.
-                    let discr_ty = enum_layout
+                // The tag is an int-bank value, but its physical width is
+                // not necessarily a machine word. Charon records the exact
+                // `Branch.int_ty`; using `i64` for a u8/u16/u32 tag reads
+                // adjacent payload bytes and can select an unreachable switch
+                // arm.  `i64` remains the model only where NO tag width was
+                // recorded at all.  A tag that was recorded and declined is a
+                // width no field type spells (`I128`/`U128`), and modelling it
+                // as `i64` would name half of it: register no base at all
+                // there, so a discriminant read declines instead of resolving
+                // to a descriptor that reads eight of sixteen bytes.
+                let discr_ty = enum_layout
+                    .as_ref()
+                    .and_then(|layout| layout.discriminant_int_type());
+                let tag_recorded_but_unspellable = discr_ty.is_none()
+                    && enum_layout
                         .as_ref()
-                        .and_then(|layout| layout.discriminant_int_type())
-                        .unwrap_or("i64")
-                        .to_string();
+                        .is_some_and(|layout| layout.has_branch_discriminant());
+                if !fieldless && !tag_recorded_but_unspellable {
+                    let discr_ty = discr_ty.unwrap_or("i64").to_string();
                     let rows: Vec<(String, String)> =
                         vec![("__discriminant".to_string(), discr_ty)];
                     struct_fields.fields.insert(name.clone(), rows.clone());
@@ -11459,14 +11467,26 @@ impl<'a> Lowering<'a> {
         // Capture `i64::checked_{add,sub,mul}()` results (`Option<i64>`-
         // typed) for the checked-arith rewiring pass
         // (`front::checked_arith`), which rewrites each into the native
-        // `*_ovf` op + OverflowError edge.  Recognition is liberal — any
-        // `core::num::<Impl>::checked_*` call returning `Option` — because
-        // the rewrite itself validates the surrounding overflow-fallback
-        // match and declines (leaving the residual call) on any other
-        // shape.
+        // `*_ovf` op + OverflowError edge.  Recognition is liberal about the
+        // SHAPE — any `core::num::<Impl>::checked_*` call returning `Option`
+        // — because the rewrite itself validates the surrounding
+        // overflow-fallback match and declines (leaving the residual call) on
+        // any other shape.  It is not liberal about the WIDTH: the operand
+        // atoms are only in hand here (Charon renders every inherent integer
+        // impl as `<Impl>`, and `tyref_to_value_type` colors every signed
+        // width `Int`), and the emitted `*_ovf` tests the machine-word bound,
+        // so a narrower operand would answer the wrong question.  Same
+        // placement rationale as the unsigned pass's signedness gate below.
         if let OpKind::Call { target, .. } = &op_kind
             && crate::front::checked_arith::is_checked_arith_target(target)
             && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
+            && [first_arg_ty.as_ref(), second_arg_ty.as_ref()]
+                .into_iter()
+                .all(|operand| {
+                    operand
+                        .and_then(|ty| self.tyref_literal_int_atom(ty))
+                        .is_some_and(crate::front::checked_arith::is_ovf_width_int_atom)
+                })
         {
             self.checked_arith_call_results.push(result_var.clone());
         }


### PR DESCRIPTION
Two review findings from #1614, both about a width this layer cannot represent being modelled at the wrong one instead of declining.

## `checked_{add,sub,mul}` fusion accepted narrower-than-word operands

`front::checked_arith` rewrites `core::num::<Impl>::checked_{add,sub,mul}` into the native `add_ovf` / `sub_ovf` / `mul_ovf`, which test the **machine-word** overflow bound. Nothing in the recognizer constrained the source width:

- Charon renders every inherent integer impl as `<Impl>`, so the call path cannot tell `i8::checked_add` from `i64::checked_add`.
- `tyref_to_value_type` colors every signed width `Int`, so the only downstream gate (`ok_payload_ty != ValueType::Int`) admits all of them.

So `127i8.checked_add(1)` fused into a machine-word `add_ovf`, which does not overflow, and the rewrite took the success continuation carrying `128` where the residual call returns `None`.

The gate goes at the recording site, where the operand types are still in hand — the same placement, for the same reason, as the unsigned pass's existing signedness gate directly below it. Both operand width atoms must be `I64` / `Isize`. That one gate also covers the `ok_or_else` continuation shape, which draws its producer from the same recorded list.

## A declined tag width fell back to an `i64` tag descriptor

`TypeLayout::discriminant_int_type` returns `None` for two different situations: a layout that records no `Branch` discriminator (a single-variant enum, a `Known` discriminator), and one whose width has no field-type spelling (`I128` / `U128` — `get_type_flag` has no 128-bit arm, so those reach its unknown-type fallback and come back as an eight-byte GC reference). The enum registration turned both into an `i64` tag, which for the second case names eight of sixteen bytes.

`has_branch_discriminant` separates them. `i64` stays the model where no tag width was recorded at all; a tag that was recorded and declined now registers no base, so a discriminant read declines rather than resolving to a half-width descriptor.

## Verification

- `cargo test --all --no-default-features --features dynasm` — green, 206 suites
- `pyre/check.py` — cranelift 529/529, wasm 522/522; the one `dynasm synth/load_name_builtin_cell_fold` red is **not from this branch**: a same-binary A/B reverting only these three files to `origin/main` measures the control at **1.5x / 1.5x / 1.5x** against this branch's **1.2x / 1.3x / 1.2x**, both over the `1x` gate. main is already red there and this change makes that fixture faster.