### PR TITLE
_ssl, _cffi_backend, _sqlite3, cpyext: the six review findings left open on #1594

### DIFF
--- a/lib_pypy/_sqlite3.py
+++ b/lib_pypy/_sqlite3.py
@@ -246,6 +246,23 @@ _INT_DBCONFIGS = {
     if symbol in globals()
 }
 
+_C_INT_MIN = -2 ** 31
+_C_INT_MAX = 2 ** 31 - 1
+
+
+def _dbconfig_op(op):
+    # `setconfig` and `getconfig` declare `op: int`, so the argument goes
+    # through `__index__` and is narrowed to a C int before the body tests it
+    # against the supported set: a float or a list is a TypeError from the
+    # conversion, and an out-of-range int an OverflowError, not the membership
+    # test's ValueError.
+    op = operator.index(op)
+    if not _C_INT_MIN <= op <= _C_INT_MAX:
+        raise OverflowError("Python int too large to convert to C int")
+    if op not in _INT_DBCONFIGS:
+        raise ValueError("unknown config 'op': %d" % op)
+    return op
+
 _SQLITE_TRANSIENT = _lib.SQLITE_TRANSIENT
 
 # error codes
@@ -1261,8 +1278,7 @@ class Connection(object):
     @_check_thread_wrap
     @_check_closed_wrap
     def setconfig(self, op, enable=True, /):
-        if op not in _INT_DBCONFIGS:
-            raise ValueError("unknown config 'op': %d" % op)
+        op = _dbconfig_op(op)
         current = _ffi.new('int *')
         rc = _lib.pypy_sqlite3_db_config_int(
             self._db, op, bool(enable), current)
@@ -1274,8 +1290,7 @@ class Connection(object):
     @_check_thread_wrap
     @_check_closed_wrap
     def getconfig(self, op, /):
-        if op not in _INT_DBCONFIGS:
-            raise ValueError("unknown config 'op': %d" % op)
+        op = _dbconfig_op(op)
         current = _ffi.new('int *')
         rc = _lib.pypy_sqlite3_db_config_int(self._db, op, -1, current)
         if rc != _lib.SQLITE_OK:

--- a/lib_pypy/_sqlite3.py
+++ b/lib_pypy/_sqlite3.py
@@ -310,11 +310,13 @@ LEGACY_TRANSACTION_CONTROL = -1
 
 def _check_autocommit(value):
     # `autocommit_converter` takes True and False by identity, then requires an
-    # int equal to the sentinel.  A float -1.0, or an object whose `__eq__`
-    # answers True, is rejected: the type test is part of the contract.
+    # int whose *value* is the sentinel: it reads the value with
+    # `PyLong_AsLong`.  So a float -1.0, an object whose `__eq__` answers True,
+    # and an int subclass that overrides `__eq__` to spoof -1 are all rejected
+    # -- hence `int.__eq__` rather than `==`.
     if (value is not True and value is not False and
             not (isinstance(value, int) and
-                 value == LEGACY_TRANSACTION_CONTROL)):
+                 int.__eq__(value, LEGACY_TRANSACTION_CONTROL) is True)):
         raise ValueError(
             "autocommit must be True, False, or "
             "sqlite3.LEGACY_TRANSACTION_CONTROL")

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -2286,6 +2286,34 @@ pub(super) fn finish_interpreter_type(mirror: *mut CPyTypeObject, w_type: PyObje
     fill_interpreter_slots(mirror, w_type);
 }
 
+/// Hand the vectorcall protocol down from `base` to `tp`.
+///
+/// The offset always travels, so that `PyVectorcall_Call` -- which reads it
+/// without consulting the flag -- keeps working for a subclass; the flag
+/// travels only to a subclass that leaves `tp_call` alone, and decides whether
+/// the offset is read of its own accord.  A class derived in Python from a C
+/// type that lends its instances a function keeps lending it: the instance is
+/// sized by the base's `tp_basicsize`, which the caller copies for exactly that
+/// reason, and filled by the base's `tp_new`.
+///
+/// Both have to run before `tp_call` is filled in.  A subclass that does
+/// declare its own `tp_call` means it, and it is `tp_call` -- not the function
+/// its base lends instances -- that has to answer for it.
+fn inherit_vectorcall(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
+    unsafe {
+        if (*tp).tp_vectorcall_offset == 0 {
+            (*tp).tp_vectorcall_offset = (*base).tp_vectorcall_offset;
+        }
+        if (*tp).tp_call.is_null()
+            && (*base)
+                .tp_flags
+                .contains(TpFlags::PY_TPFLAGS_HAVE_VECTORCALL)
+        {
+            (*tp).tp_flags |= TpFlags::PY_TPFLAGS_HAVE_VECTORCALL;
+        }
+    }
+}
+
 /// `typeobject.py:945-996 inherit_slots` — what a mirror takes from its base.
 ///
 /// Narrower than the [`inherit_slots`] `PyType_Ready` runs: the slots left out
@@ -2385,24 +2413,9 @@ fn inherit_mirror_slots(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
         sq_inplace_repeat,
     );
     suite!(tp_as_mapping, mp_length, mp_subscript, mp_ass_subscript);
-    unsafe {
-        if (*tp).tp_vectorcall_offset == 0 {
-            (*tp).tp_vectorcall_offset = (*base).tp_vectorcall_offset;
-        }
-        // A class derived in Python from a C type that lends its instances a
-        // function keeps lending it: the instance is sized by the base's
-        // `tp_basicsize`, which the caller copies for exactly that reason, and
-        // filled by the base's `tp_new`.  `fill_interpreter_slots` runs after
-        // this and installs the trampoline in `tp_call`, so the test for a
-        // `tp_call` of the subclass's own has to happen here.
-        if (*tp).tp_call.is_null()
-            && (*base)
-                .tp_flags
-                .contains(TpFlags::PY_TPFLAGS_HAVE_VECTORCALL)
-        {
-            (*tp).tp_flags |= TpFlags::PY_TPFLAGS_HAVE_VECTORCALL;
-        }
-    }
+    // `fill_interpreter_slots` runs after this and installs the trampoline in
+    // `tp_call`, so the vectorcall inheritance has to happen here.
+    inherit_vectorcall(tp, base);
 }
 
 /// `true` when `tp` is a type whose storage is the mirror layer's to release —
@@ -4605,27 +4618,9 @@ fn inherit_slots(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
     if base.is_null() {
         return;
     }
-    // The offset always travels, so that `PyVectorcall_Call` -- which reads it
-    // without consulting the flag -- keeps working for a subclass; the flag
-    // travels only to a subclass that leaves `tp_call` alone, and decides
-    // whether the offset is read of its own accord.
-    //
-    // Both have to happen before the copy below fills `tp_call` in, because
-    // afterwards every subclass reads as having declared one.  A subclass that
-    // does declare its own `tp_call` means it, and it is `tp_call` -- not the
-    // function its base lends instances -- that has to answer for it.
-    unsafe {
-        if (*tp).tp_vectorcall_offset == 0 {
-            (*tp).tp_vectorcall_offset = (*base).tp_vectorcall_offset;
-        }
-        if (*tp).tp_call.is_null()
-            && (*base)
-                .tp_flags
-                .contains(TpFlags::PY_TPFLAGS_HAVE_VECTORCALL)
-        {
-            (*tp).tp_flags |= TpFlags::PY_TPFLAGS_HAVE_VECTORCALL;
-        }
-    }
+    // Before the copy below fills `tp_call` in, because afterwards every
+    // subclass reads as having declared one.
+    inherit_vectorcall(tp, base);
     macro_rules! inherit {
         ($($field:ident),* $(,)?) => {
             $(

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cffi1_module.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cffi1_module.rs
@@ -83,14 +83,15 @@ pub fn load_cffi1_module(
 
     let module_slot = lib_slot + 1;
     let _ = roots.pin_root(pyre_object::w_module_new_managed(name));
-    let dict = unsafe { pyre_object::w_module_get_w_dict(roots.get(module_slot)) };
-    crate::module_ns_store(
-        dict,
-        "__file__",
-        crate::gateway::fsdecode_os_str(path.as_os_str()),
-    );
-    crate::module_ns_store(dict, "ffi", roots.get(ffi_slot));
-    crate::module_ns_store(dict, "lib", roots.get(lib_slot));
+    let file_slot = module_slot + 1;
+    let _ = roots.pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
+    // `module_ns_store` allocates, so neither the decoded pathname nor the
+    // dictionary read off the module survives one as a native local: publish
+    // the pathname, and take the dictionary off the rooted module each time.
+    let dict = || unsafe { pyre_object::w_module_get_w_dict(roots.get(module_slot)) };
+    crate::module_ns_store(dict(), "__file__", roots.get(file_slot));
+    crate::module_ns_store(dict(), "ffi", roots.get(ffi_slot));
+    crate::module_ns_store(dict(), "lib", roots.get(lib_slot));
     crate::importing::set_sys_module(name, roots.get(module_slot));
     crate::importing::set_sys_module(&format!("{name}.lib"), roots.get(lib_slot));
     Ok(roots.get(module_slot))

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -72,6 +72,53 @@ pub struct W_SSLSession {
     pub backend: *mut pyre_native::ssl::NativeSession,
 }
 
+/// A TLS record's header: the content type, the two protocol version bytes,
+/// and the two that hold the body's length.
+const TLS_RECORD_HEADER_LEN: usize = 5;
+
+/// Where the shutdown exchange stands inside the record it is reading.
+///
+/// OpenSSL's record layer reads a header and then the body its length names,
+/// which is what keeps a socket-backed `SSL_shutdown` from lifting the
+/// plaintext that follows the peer's close_notify out of the kernel.  A
+/// transport that returns short -- a non-blocking socket, a timed one, an
+/// interrupted read -- unwinds back to the caller, which asks again, so this
+/// belongs to the connection and not to one call.
+#[derive(Default)]
+pub struct ShutdownRecord {
+    header: [u8; TLS_RECORD_HEADER_LEN],
+    header_read: usize,
+    body_left: usize,
+}
+
+impl ShutdownRecord {
+    /// The bytes still owed before the next record boundary.
+    fn want(&self) -> usize {
+        if self.body_left > 0 {
+            self.body_left
+        } else {
+            TLS_RECORD_HEADER_LEN - self.header_read
+        }
+    }
+
+    /// Account for `data`, which must be no longer than [`want`].
+    ///
+    /// [`want`]: ShutdownRecord::want
+    fn consume(&mut self, data: &[u8]) {
+        if self.body_left > 0 {
+            self.body_left -= data.len();
+            return;
+        }
+        self.header[self.header_read..self.header_read + data.len()].copy_from_slice(data);
+        self.header_read += data.len();
+        if self.header_read == TLS_RECORD_HEADER_LEN {
+            // The record's length is the header's last two bytes, big-endian.
+            self.body_left = u16::from_be_bytes([self.header[3], self.header[4]]) as usize;
+            self.header_read = 0;
+        }
+    }
+}
+
 /// One TLS state machine plus its Python-owned transport endpoints.  Rustls
 /// remains opaque in `pyre-native`; these references preserve the same
 /// per-object ownership shape as PyPy's `W_SSLObject`.
@@ -88,6 +135,7 @@ pub struct W_SSLSocket {
     pub server_hostname: PyObjectRef,
     pub server_side: bool,
     pub shutdown_started: bool,
+    pub shutdown_record: ShutdownRecord,
     pub requested_session: *mut pyre_native::ssl::NativeSession,
 }
 
@@ -501,6 +549,7 @@ fn allocate_ssl_socket(
         },
         server_side,
         shutdown_started: false,
+        shutdown_record: ShutdownRecord::default(),
         requested_session,
     })
 }
@@ -1648,6 +1697,17 @@ mod ssl_socket_methods {
         Rejected((i32, String)),
     }
 
+    /// [`pump_record_bounded`] for the goals that read whatever the transport
+    /// has, rather than one TLS record at a time.
+    fn pump(
+        backend: *mut pyre_native::ssl::TlsConnection,
+        fd: crate::module::_socket::rsocket_rffi::Socket,
+        buf: &mut [u8],
+        goal: PumpGoal,
+    ) -> PumpExit {
+        pump_record_bounded(backend, fd, buf, goal, &mut ShutdownRecord::default())
+    }
+
     /// The `PySSL_BEGIN_ALLOW_THREADS` bracket that `SSL_do_handshake`,
     /// `SSL_read` and `SSL_write` each put around their whole exchange: the
     /// peer's records are read, answered and parsed without the interpreter,
@@ -1659,15 +1719,16 @@ mod ssl_socket_methods {
     /// Nothing here may touch a Python object.  The states that need one - a
     /// server context to choose, a signal to deliver, an error to raise - end
     /// the run and are answered by the caller.
-    /// A TLS record's header: the content type, the two protocol version
-    /// bytes, and the two that hold the body's length.
-    const TLS_RECORD_HEADER_LEN: usize = 5;
-
-    fn pump(
+    ///
+    /// `record` carries where a [`PumpGoal::Shutdown`] run stands inside the
+    /// record it is reading, so it has to outlive the call: a transport that
+    /// returns short unwinds to the caller, which re-enters here.
+    fn pump_record_bounded(
         backend: *mut pyre_native::ssl::TlsConnection,
         fd: crate::module::_socket::rsocket_rffi::Socket,
         buf: &mut [u8],
         goal: PumpGoal,
+        record: &mut ShutdownRecord,
     ) -> PumpExit {
         use crate::module::_socket::interp_socket::{socket_recv_raw, socket_send_raw};
         use crate::module::_socket::rsocket_rffi::error_is_interrupted;
@@ -1681,10 +1742,8 @@ mod ssl_socket_methods {
         // body its length names, which is why a socket-backed `SSL_shutdown`
         // leaves the caller's bytes alone; track the same two-step here.  A
         // short read is fed on as it arrives -- the receiver buffers a partial
-        // record -- and only the byte count is carried across.
-        let mut header = [0u8; TLS_RECORD_HEADER_LEN];
-        let mut header_read = 0usize;
-        let mut body_left = 0usize;
+        // record -- and only the byte count is carried across.  `record` is the
+        // connection's, because a transport retry re-enters this function.
         loop {
             loop {
                 let data = match unsafe { pyre_native::ssl::connection_peek_tls(backend) } {
@@ -1732,26 +1791,14 @@ mod ssl_socket_methods {
                 }
             }
             let want = match goal {
-                PumpGoal::Shutdown if body_left > 0 => body_left.min(buf.len()),
-                PumpGoal::Shutdown => TLS_RECORD_HEADER_LEN - header_read,
+                PumpGoal::Shutdown => record.want().min(buf.len()),
                 _ => buf.len(),
             };
             match socket_recv_raw(fd, &mut buf[..want], 0) {
                 Ok(0) => return PumpExit::Eof,
                 Ok(read) => {
                     if matches!(goal, PumpGoal::Shutdown) {
-                        if body_left > 0 {
-                            body_left -= read;
-                        } else {
-                            header[header_read..header_read + read].copy_from_slice(&buf[..read]);
-                            header_read += read;
-                            if header_read == TLS_RECORD_HEADER_LEN {
-                                // The record's length is the header's last two
-                                // bytes, big-endian.
-                                body_left = u16::from_be_bytes([header[3], header[4]]) as usize;
-                                header_read = 0;
-                            }
-                        }
+                        record.consume(&buf[..read]);
                     }
                     if let Err(error) =
                         unsafe { pyre_native::ssl::connection_receive_tls(backend, &buf[..read]) }
@@ -2485,7 +2532,13 @@ mod ssl_socket_methods {
             if let Some((transport, fd)) = pump_transport(self)? {
                 let mut buf = vec![0u8; 32 * 1024];
                 loop {
-                    match pump(self.backend, fd, &mut buf, PumpGoal::Shutdown) {
+                    match pump_record_bounded(
+                        self.backend,
+                        fd,
+                        &mut buf,
+                        PumpGoal::Shutdown,
+                        &mut self.shutdown_record,
+                    ) {
                         PumpExit::Done(_) => {
                             settle_received_tls(self)?;
                             break;

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -1891,6 +1891,19 @@ mod ssl_socket_methods {
     }
 
     fn receive_transport(socket: &mut W_SSLSocket) -> Result<(), crate::PyError> {
+        receive_transport_bounded(socket, false)
+    }
+
+    /// `track_record` stops the socket read at the boundary the connection's
+    /// `shutdown_record` is tracking, and accounts what it read against it.
+    /// The shutdown exchange needs that: what follows the peer's close_notify
+    /// is the plaintext `unwrap()` hands back with the socket, and a read that
+    /// crossed the boundary would feed those bytes to the TLS stream, where
+    /// nothing can return them.
+    fn receive_transport_bounded(
+        socket: &mut W_SSLSocket,
+        track_record: bool,
+    ) -> Result<(), crate::PyError> {
         ensure_connection(socket)?;
         if !unsafe { is_none(socket.incoming) } {
             let incoming = W_MemoryBIO::from_obj(socket.incoming)
@@ -1918,8 +1931,16 @@ mod ssl_socket_methods {
         let fd = crate::module::_socket::interp_socket::socket_fd(transport)?;
         crate::module::_socket::interp_socket::socket_wait_for_data(transport, fd, false)?;
         let mut buf = vec![0u8; 32 * 1024];
+        let want = if track_record {
+            socket.shutdown_record.want().min(buf.len())
+        } else {
+            buf.len()
+        };
         let read = match crate::module::_socket::interp_socket::socket_recv_bytes(
-            transport, fd, &mut buf, 0,
+            transport,
+            fd,
+            &mut buf[..want],
+            0,
         ) {
             Ok(read) => read,
             Err(error) if is_blocking_error(&error) => {
@@ -1935,6 +1956,9 @@ mod ssl_socket_methods {
                 pyre_native::ssl::TLS_ERROR_EOF,
                 "EOF occurred in violation of protocol".to_string(),
             ));
+        }
+        if track_record {
+            socket.shutdown_record.consume(&buf[..read]);
         }
         receive_tls(socket, &buf[..read]).map(|_| ())
     }
@@ -2559,9 +2583,10 @@ mod ssl_socket_methods {
                 // A message callback requires returning to the interpreter
                 // after every record.  Keep PyPy's shutdown loop in that
                 // case too, but use the callback-aware transport helpers
-                // instead of the released pump.
+                // instead of the released pump -- reading to the same record
+                // boundary the pump stops at.
                 while !unsafe { pyre_native::ssl::connection_peer_closed(self.backend) } {
-                    receive_transport(self)?;
+                    receive_transport_bounded(self, true)?;
                     flush_transport(self)?;
                 }
             }


### PR DESCRIPTION
The six review findings still open when #1594 merged, one commit each.

| # | Finding | Severity | File |
|---|---|---|---|
| 1 | shutdown record state lost across a transport retry | P1 | `_ssl/mod.rs` |
| 2 | the `_msg_callback` shutdown loop reads past the record | Major | `_ssl/mod.rs` |
| 3 | decoded `__file__` unrooted across an allocating store | Major | `_cffi_backend/cffi1_module.rs` |
| 4 | an `int` subclass can spoof the autocommit sentinel | Minor | `lib_pypy/_sqlite3.py` |
| 5 | `setconfig`/`getconfig` skip the integer protocol for `op` | P2 | `lib_pypy/_sqlite3.py` |
| 6 | duplicated `PY_TPFLAGS_HAVE_VECTORCALL` inheritance check | Trivial | `cpyext/typeobject.rs` |

## What each changes

**1.** The TLS record header, the count read of it and the remaining body
length were `pump` locals. A `PumpGoal::Shutdown` run that unwound — a
non-blocking socket, a timed one, an interrupted read — lost them, and the
caller's re-entry restarted at "expecting a 5-byte header", mis-framing the
rest of the record. `ShutdownRecord` now lives on `W_SSLSocket` and is
threaded through `pump_record_bounded`; `pump` keeps its signature and passes
a fresh one, which is what the non-record-bounded goals already did.

**2.** When `pump_transport` declines — a message callback installed, or a
memory BIO instead of a socket — the shutdown loop called
`receive_transport`, which reads up to 32 KiB. On a socket that is whatever
the kernel holds, so the read could cross the close_notify record and feed
the plaintext after it into the TLS stream, which cannot give it back;
`unwrap()` hands the socket to the caller to read those bytes from.
`receive_transport_bounded` sizes the read with the connection's
`shutdown_record` and accounts what it read against it.

**3.** `load_cffi1_module` read the module dictionary once into a native local
and passed `fsdecode_os_str`'s result straight into the first
`module_ns_store`. `module_ns_store` allocates, so the two later stores used a
pre-collection address and the decoded pathname was live across a collection
unrooted. The pathname now has its own slot and the dictionary is taken off
the rooted module per store.

**4.** `value == LEGACY_TRANSACTION_CONTROL` dispatches an `int` subclass's
`__eq__`. `autocommit_converter` reads the value with `PyLong_AsLong` and
compares the C long, so such a subclass is rejected. Now
`int.__eq__(value, …) is True`.

**5.** Both methods tested `op not in _INT_DBCONFIGS` on the argument as
given, so a float, a list or an out-of-range int reached the `ValueError`
that names an unknown config. The signatures declare `op: int`: the argument
goes through `__index__` and is narrowed to a C int first — a `TypeError` for
the non-integers, an `OverflowError` for the out-of-range int.

**6.** `inherit_mirror_slots` and `inherit_slots` each carried the same offset
copy and flag test. No behaviour change.

## Verification

Gates, all on `pyre-dynasm` release:

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo check -p pyre-interpreter --features cpyext,dynasm` | pass |
| `scripts/check-new-line-citations.py --base origin/main` | pass, no new line-number citations |
| `scripts/check-gc-root-brackets.py` | pass; both invariants 0, `tier1_calls` 9 → 0 |
| `pyre/cpython_tests/run.py --backend dynasm` | pass (`test_ssl` is PASS in the baseline, so it covers 1 and 2) |
| `pyre/extra_tests/parity_tests/run.py --dynasm-only` | 1 failure, not this branch — see below |

The gc-root gate's `unbracketed_calls 2073 → 2096` WARN is main's drift from
the baseline commit, not this branch: dumping all 2096 findings
(`GC_FINDINGS_JSON`) and filtering by function name gives 3 hits in touched
functions, of which 2 are `receive_transport`'s existing `socket_fd` /
`socket_wait_for_data` calls reported under its new name and 1 is
`pump_transport`, which this branch does not change. `load_cffi1_module`,
`inherit_vectorcall`, `pump_record_bounded` and `ShutdownRecord` have none.

The parity failure is `foriter_stopiteration_exception_event.py [pypy]`. That
fixture is not touched here, and bare `pypy3 3.11.13` reproduces the identical
`AssertionError: consume_callable_iter` with no pyre binary in the picture.

### Pre-fix controls

Each behavioural finding was reproduced against a binary built from
`origin/main`'s version of the file, so the fix is measured rather than
argued.

`_ssl`, close_notify and the plaintext behind it delivered in one write, with
the client's `recv` synchronised so only the shutdown read can over-read:

| | plain pump | `_msg_callback` |
|---|---|---|
| CPython 3.14 | OK 1152/1152 | OK 1152/1152 |
| pre-fix | OK | **LOST 14/1152** |
| post-fix | OK | OK |

`_ssl`, the close_notify record split across a client timeout (3 timeouts, so
the shutdown call really unwound and re-entered):

| | plain pump | `_msg_callback` |
|---|---|---|
| CPython 3.14 | OK | OK |
| pre-fix | **LOST 14/1152** | **LOST 14/1152** |
| post-fix | OK | OK |

`_sqlite3`, the same binary with `origin/main`'s `_sqlite3.py`:

| input | pre-fix | CPython 3.14 = post-fix |
|---|---|---|
| `getconfig(<`__index__`>)` | `ValueError: unknown config 'op': 1002` | `False` |
| `getconfig(1.0)` | `ValueError: unknown config 'op': 1` | `TypeError` |
| `getconfig([])` | `TypeError: cannot use 'list' as a set element` | `TypeError: 'list' object cannot be interpreted as an integer` |
| `getconfig(2**64)` | `ValueError` | `OverflowError` |
| `autocommit=Spoof(0)` | **accepted** | `ValueError` |

Post-fix, all 15 sqlite3 probe cases are byte-identical to CPython 3.14.

Findings 3 and 6 have no runtime witness: 3 is a rooting correctness fix whose
failure needs a collection at one exact point, and 6 changes no behaviour.

## Separate defect found while probing, NOT fixed here

When the peer's close_notify and the plaintext behind it are already in the
kernel buffer at the time of an ordinary `recv` — before any shutdown — pyre's
read path swallows them. Over 5 runs of an unsynchronised probe, the
`_msg_callback` configuration loses the plaintext 5/5 on **both** the pre-fix
and post-fix binaries, and CPython 3.14 is 10/10 OK. It is therefore
pre-existing on `main` and untouched by this branch. It belongs to the
ordinary read path (`PumpGoal::Read` / `receive_transport`), which reads
whatever the transport has by design, so bounding it is a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQLite connection configuration validation, including clearer handling of invalid and out-of-range options.
  - Corrected autocommit handling for integer-like values.
  - Improved TLS socket shutdown and record processing for more reliable encrypted connections.
  - Increased stability when loading CFFI-based modules and handling vectorcall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->