### PR TITLE
majit: four blackhole parity fixes

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -17849,6 +17849,13 @@ impl majit_backend::Backend for CraneliftBackend {
         if gc_ptr != 0 {
             return gc_ptr;
         }
+        if sizedescr.resolve_gc_tid() != 0 && !sizedescr.is_headerless() {
+            // `GcLLDescr_framework._bh_malloc` must keep a typed allocation
+            // inside the GC heap.  NULL is the fallible result consumed by
+            // blackhole.py `_get_method`; a raw fallback would have no GC
+            // header or trace layout.
+            return 0;
+        }
         let layout =
             std::alloc::Layout::from_size_align(size, 8).unwrap_or(std::alloc::Layout::new::<u8>());
         unsafe { std::alloc::alloc_zeroed(layout) as i64 }
@@ -17889,7 +17896,9 @@ impl majit_backend::Backend for CraneliftBackend {
 
     /// llmodel.py bh_new_array / bh_new_array_clear.
     fn bh_new_array(&self, length: i64, arraydescr: &majit_translate::jitcode::BhDescr) -> i64 {
-        let length = usize::try_from(length).expect("bh_new_array length must be non-negative");
+        let Ok(length) = usize::try_from(length) else {
+            return 0;
+        };
         let (base_size, itemsize, _sign) = arraydescr.unpack_arraydescr_size();
         let len_offset = arraydescr
             .array_len_offset()
@@ -17939,13 +17948,17 @@ impl majit_backend::Backend for CraneliftBackend {
 
     /// `LLtypeMixin.bh_newstr` → `gc_ll_descr.gc_malloc_str`.
     fn bh_newstr(&self, length: i64) -> i64 {
-        let length = u64::try_from(length).expect("bh_newstr length must be non-negative");
+        let Ok(length) = u64::try_from(length) else {
+            return 0;
+        };
         gc_malloc_str_helper(majit_gc::lowlevel_str_type_id() as u64, length) as i64
     }
 
     /// `LLtypeMixin.bh_newunicode` → `gc_ll_descr.gc_malloc_unicode`.
     fn bh_newunicode(&self, length: i64) -> i64 {
-        let length = u64::try_from(length).expect("bh_newunicode length must be non-negative");
+        let Ok(length) = u64::try_from(length) else {
+            return 0;
+        };
         gc_malloc_unicode_helper(majit_gc::lowlevel_unicode_type_id() as u64, length) as i64
     }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -710,20 +710,29 @@ fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
 /// `base + GcHeader::SIZE`, which would shift every field offset the descr
 /// carries.
 ///
-/// Non-GC descrs (`type_id == 0`, raw buffers) and a runtime with no allocator
-/// hook installed (unit tests) keep the plain zeroed malloc.
+/// Non-GC descrs (`type_id == 0`, raw buffers) keep the plain zeroed malloc.
+/// A typed descr never does: absence/failure of its collector is NULL, the
+/// translated `do_malloc_fixedsize_clear` failure edge.
 fn bh_alloc_struct(sizedescr: &majit_translate::jitcode::BhDescr) -> *mut libc::c_void {
     let size = sizedescr.as_size();
+    let type_id = sizedescr.resolve_gc_tid();
     let gc_ptr = if sizedescr.is_headerless() {
         majit_gc::alloc_nursery_headerless_no_collect(size).0
     } else {
-        match sizedescr.resolve_gc_tid() {
+        match type_id {
             0 => 0,
             type_id => dynasm_alloc_oldgen_typed(type_id, size).0,
         }
     };
     if gc_ptr != 0 {
         return gc_ptr as *mut libc::c_void;
+    }
+    // `GcLLDescr_framework._bh_malloc` allocates a GC struct through
+    // `do_malloc_fixedsize_clear`; NULL is its OOM result and is converted to
+    // `MemoryError` by blackhole.py `_get_method`.  Falling through to a raw
+    // block for a typed descr loses the GC header and tracing layout.
+    if type_id != 0 && !sizedescr.is_headerless() {
+        return std::ptr::null_mut();
     }
     let ptr = unsafe { libc::malloc(size) };
     if !ptr.is_null() {
@@ -3510,7 +3519,9 @@ impl Backend for DynasmBackend {
 
     /// llmodel.py bh_new_array / bh_new_array_clear.
     fn bh_new_array(&self, length: i64, arraydescr: &majit_translate::jitcode::BhDescr) -> i64 {
-        let length = usize::try_from(length).expect("bh_new_array length must be non-negative");
+        let Ok(length) = usize::try_from(length) else {
+            return 0;
+        };
         let (base_size, itemsize, _sign) = arraydescr.unpack_arraydescr_size();
         let len_offset = arraydescr
             .array_len_offset()
@@ -3549,13 +3560,17 @@ impl Backend for DynasmBackend {
 
     /// `LLtypeMixin.bh_newstr` → `gc_ll_descr.gc_malloc_str`.
     fn bh_newstr(&self, length: i64) -> i64 {
-        let length = u64::try_from(length).expect("bh_newstr length must be non-negative");
+        let Ok(length) = u64::try_from(length) else {
+            return 0;
+        };
         dynasm_malloc_str(majit_gc::lowlevel_str_type_id() as u64, length) as i64
     }
 
     /// `LLtypeMixin.bh_newunicode` → `gc_ll_descr.gc_malloc_unicode`.
     fn bh_newunicode(&self, length: i64) -> i64 {
-        let length = u64::try_from(length).expect("bh_newunicode length must be non-negative");
+        let Ok(length) = u64::try_from(length) else {
+            return 0;
+        };
         dynasm_malloc_unicode(majit_gc::lowlevel_unicode_type_id() as u64, length) as i64
     }
 

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1488,11 +1488,17 @@ fn wasm_bh_alloc(type_id: u32, payload_size: usize) -> i64 {
         majit_gc::gc_write_barrier(GcRef(gc_ptr));
         return gc_ptr as i64;
     }
+    if type_id != 0 {
+        // `GcLLDescr_framework._bh_malloc` returns NULL on failure so the
+        // blackhole wrapper can raise `MemoryError`.  A raw fallback for a
+        // typed descr drops the GC header and its tracing layout.
+        return 0;
+    }
     wasm_bh_alloc_raw(payload_size)
 }
 
-/// Non-GC descrs (`type_id == 0`, raw buffers) and a runtime with no allocator
-/// installed keep the plain zeroed malloc the dynasm runner falls back to.
+/// Non-GC descrs (`type_id == 0`, raw buffers) keep the plain zeroed malloc the
+/// dynasm runner uses for the same descr shape.
 fn wasm_bh_alloc_raw(size: usize) -> i64 {
     let Ok(layout) = std::alloc::Layout::from_size_align(size.max(1), 8) else {
         return 0;
@@ -3387,13 +3393,21 @@ impl majit_backend::Backend for WasmBackend {
 
     /// llmodel.py bh_new_array(length, arraydescr).
     fn bh_new_array(&self, length: i64, arraydescr: &majit_translate::jitcode::BhDescr) -> i64 {
-        let length = usize::try_from(length).expect("bh_new_array length must be non-negative");
+        let Ok(length) = usize::try_from(length) else {
+            return 0;
+        };
         let (base_size, itemsize, _sign) = arraydescr.unpack_arraydescr_size();
         let len_offset = arraydescr
             .array_len_offset()
             .expect("bh_new_array requires ArrayDescr.lendescr");
         let type_id = arraydescr.resolve_gc_tid();
-        let ptr = wasm_bh_alloc(type_id, base_size + itemsize * length);
+        let Some(payload_size) = itemsize
+            .checked_mul(length)
+            .and_then(|items| base_size.checked_add(items))
+        else {
+            return 0;
+        };
+        let ptr = wasm_bh_alloc(type_id, payload_size);
         if ptr != 0 {
             unsafe {
                 *((ptr as *mut u8).add(len_offset) as *mut usize) = length;
@@ -3413,14 +3427,14 @@ impl majit_backend::Backend for WasmBackend {
 
     /// `LLtypeMixin.bh_newstr` → `gc_ll_descr.gc_malloc_str`.
     fn bh_newstr(&self, length: i64) -> i64 {
-        let length = usize::try_from(length).expect("bh_newstr length must be non-negative");
+        let Ok(length) = usize::try_from(length) else {
+            return 0;
+        };
         let base_size = 2 * std::mem::size_of::<usize>() + 1;
-        let ptr = wasm_bh_alloc(
-            majit_gc::lowlevel_str_type_id(),
-            base_size
-                .checked_add(length)
-                .expect("bh_newstr allocation size overflow"),
-        );
+        let Some(payload_size) = base_size.checked_add(length) else {
+            return 0;
+        };
+        let ptr = wasm_bh_alloc(majit_gc::lowlevel_str_type_id(), payload_size);
         if ptr != 0 {
             unsafe {
                 *((ptr as *mut u8).add(std::mem::size_of::<usize>()) as *mut usize) = length;
@@ -3431,15 +3445,17 @@ impl majit_backend::Backend for WasmBackend {
 
     /// `LLtypeMixin.bh_newunicode` → `gc_ll_descr.gc_malloc_unicode`.
     fn bh_newunicode(&self, length: i64) -> i64 {
-        let length = usize::try_from(length).expect("bh_newunicode length must be non-negative");
+        let Ok(length) = usize::try_from(length) else {
+            return 0;
+        };
         let base_size = 2 * std::mem::size_of::<usize>();
-        let ptr = wasm_bh_alloc(
-            majit_gc::lowlevel_unicode_type_id(),
-            length
-                .checked_mul(std::mem::size_of::<u32>())
-                .and_then(|items| base_size.checked_add(items))
-                .expect("bh_newunicode allocation size overflow"),
-        );
+        let Some(payload_size) = length
+            .checked_mul(std::mem::size_of::<u32>())
+            .and_then(|items| base_size.checked_add(items))
+        else {
+            return 0;
+        };
+        let ptr = wasm_bh_alloc(majit_gc::lowlevel_unicode_type_id(), payload_size);
         if ptr != 0 {
             unsafe {
                 *((ptr as *mut u8).add(std::mem::size_of::<usize>()) as *mut usize) = length;
@@ -5353,6 +5369,23 @@ mod tests {
     use majit_ir::forwarding::bound_operand_from_opref as rb;
 
     static WASM_COMPILE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn typed_blackhole_allocation_never_falls_back_to_raw_memory() {
+        // No active wasm GC is installed on this test thread.  A typed descr
+        // therefore has no legal allocator and must report NULL to
+        // blackhole.py `_get_method`; the previous raw fallback returned a
+        // headerless block that the collector could neither identify nor
+        // trace.
+        assert_eq!(wasm_bh_alloc(1, 32), 0);
+    }
+
+    #[test]
+    fn blackhole_varsize_rejects_negative_lengths_without_panicking() {
+        let backend = WasmBackend::new();
+        assert_eq!(backend.bh_newstr(-1), 0);
+        assert_eq!(backend.bh_newunicode(-1), 0);
+    }
 
     #[test]
     fn cross_loop_terminal_jump_uses_target_descr_identity() {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -8550,7 +8550,17 @@ impl GcAllocator for MiniMarkGC {
         let Some(total_size) = GcHeader::SIZE.checked_add(size) else {
             return GcRef(0);
         };
-        self.alloc_in_oldgen_clear(type_id, total_size)
+        // `GcLLDescr_framework._bh_malloc` reaches translated
+        // `do_malloc_fixedsize_clear`, whose rawmalloc failure is returned to
+        // the exception transformer as NULL and becomes `MemoryError`.
+        // Blackhole host calls need the same fallible edge; the infallible
+        // `oldgen.alloc()` path aborts the process before `_get_method` can
+        // deliver that exception.
+        let Some(obj) = self.try_alloc_in_oldgen(type_id, total_size) else {
+            return GcRef(0);
+        };
+        Self::raw_memclear(obj, total_size);
+        obj
     }
 
     fn collection_counts(&self) -> (usize, usize) {

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2755,8 +2755,10 @@ impl BlackholeInterpBuilder {
 )]
 fn handle_jitexception_dispatch(
     exc: JitException,
-    portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
-) -> Result<(BhReturnType, i64), JitException> {
+    portal_runner: Option<
+        &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
+    >,
+) -> Result<(BhReturnType, i64), PortalRunnerFailure> {
     match exc {
         // warmspot.py:986-987
         JitException::DoneWithThisFrameVoid => Ok((BhReturnType::Void, 0)),
@@ -2769,9 +2771,11 @@ fn handle_jitexception_dispatch(
             Ok((BhReturnType::Float, result.to_bits() as i64))
         }
         // warmspot.py:998-1005
-        JitException::ExitFrameWithExceptionRef(_) => Err(exc),
+        JitException::ExitFrameWithExceptionRef(_) => Err(PortalRunnerFailure::jit(exc)),
         // Not a result: a portal level has nothing to install for it.
-        JitException::BailToInterpreter => Err(exc),
+        JitException::BailToInterpreter => unreachable!(
+            "a recursive portal bail must cross the callback boundary with its terminal image"
+        ),
         // warmspot.py:970-983
         JitException::ContinueRunningNormally(_) => {
             // warmspot.py:976-978: result = portal_ptr(*args)
@@ -2802,8 +2806,10 @@ fn handle_jitexception_dispatch(
 fn handle_jitexception_in_portal(
     bhcaller: &mut BlackholeInterpreter,
     exc: JitException,
-    portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
-) -> Result<(), JitException> {
+    portal_runner: Option<
+        &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
+    >,
+) -> Result<(), PortalRunnerFailure> {
     // warmspot.py handle_jitexception: while True loop.
     // ContinueRunningNormally → portal_runner → may raise JitException → loop.
     let mut current_exc = exc;
@@ -2819,9 +2825,14 @@ fn handle_jitexception_in_portal(
                 }
                 return Ok(());
             }
-            Err(exc @ JitException::ExitFrameWithExceptionRef(_)) => {
+            Err(
+                failure @ PortalRunnerFailure {
+                    exception: JitException::ExitFrameWithExceptionRef(_),
+                    ..
+                },
+            ) => {
                 // warmspot.py:998-1005: raise as regular exception
-                return Err(exc);
+                return Err(failure);
             }
             // A `portal_runner` that re-entered the portal and hit an
             // `abort_permanent` marker or an unresolved callee reports the bail
@@ -2829,12 +2840,24 @@ fn handle_jitexception_in_portal(
             // same reason this arm refuses to redispatch it: dispatching a bail
             // neither invokes the runner nor changes the exception, so looping
             // back would spin on the same value forever.
-            Err(exc @ JitException::BailToInterpreter) => {
-                return Err(exc);
+            Err(
+                failure @ PortalRunnerFailure {
+                    exception: JitException::BailToInterpreter,
+                    ..
+                },
+            ) => {
+                return Err(failure);
             }
-            Err(next_exc) => {
+            Err(PortalRunnerFailure {
+                exception: next_exc,
+                terminal,
+            }) => {
                 // warmspot.py:967-968, 979-980: JitException from portal_runner
                 // or EnterJitAssembler → loop back in handle_jitexception
+                assert!(
+                    terminal.is_none(),
+                    "only BailToInterpreter may carry a terminal blackhole image"
+                );
                 current_exc = next_exc;
                 continue;
             }
@@ -2858,6 +2881,36 @@ pub struct BlackholeTerminalImage {
     pub registers_f: Vec<i64>,
     pub position: usize,
     pub last_opcode_position: usize,
+}
+
+/// Result that escaped a recursive portal runner.
+///
+/// PyPy propagates the live RPython blackhole object with the raised
+/// `JitException`.  Pyre releases that object before crossing the Rust callback
+/// boundary, so a pyre-only interpreter bail must carry the equivalent bank
+/// image explicitly.  Real JitExceptions need no image because the enclosing
+/// blackhole chain consumes them exactly as `_handle_jitexception_in_portal`
+/// does upstream.
+pub struct PortalRunnerFailure {
+    exception: JitException,
+    terminal: Option<BlackholeTerminalImage>,
+}
+
+impl PortalRunnerFailure {
+    pub fn jit(exception: JitException) -> Self {
+        assert!(!matches!(exception, JitException::BailToInterpreter));
+        Self {
+            exception,
+            terminal: None,
+        }
+    }
+
+    pub fn bail(terminal: BlackholeTerminalImage) -> Self {
+        Self {
+            exception: JitException::BailToInterpreter,
+            terminal: Some(terminal),
+        }
+    }
 }
 
 impl BlackholeTerminalImage {
@@ -2887,7 +2940,9 @@ fn handle_jitexception(
     builder: &mut BlackholeInterpBuilder,
     mut bh: Box<BlackholeInterpreter>,
     exc: JitException,
-    portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
+    portal_runner: Option<
+        &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
+    >,
     on_leave_level: Option<&dyn Fn(i64)>,
     terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> Result<(Box<BlackholeInterpreter>, i64), JitException> {
@@ -2951,34 +3006,34 @@ fn handle_jitexception(
     let portal_outcome = handle_jitexception_in_portal(caller, exc, portal_runner);
     let current_exc = match portal_outcome {
         Ok(()) => 0,
-        Err(JitException::ExitFrameWithExceptionRef(exc_ref)) => exc_ref.0 as i64,
-        // The bail leaves by the same exit the pre-walk refusal above takes:
-        // no level absorbs it, so the chain is released and it propagates to
-        // `_run_forever`'s caller.
-        //
-        // Unlike that exit, this one publishes no terminal image, and `bh` is
-        // not the image to publish: it is the portal level whose callee chain
-        // stopped, so its stamp names its own CALL rather than where the chain
-        // got to.  The image that would answer belongs to the re-entered
-        // portal, and no channel carries it back -- `portal_runner` returns a
-        // result or a `JitException`, nothing else.
-        //
-        // Reaching this arm at all takes a `portal_runner`, because the only
-        // two ways `handle_jitexception_dispatch` answers with a bail are an
-        // `exc` that already was one -- refused ahead of the walk above -- and
-        // a runner that reported one for a `ContinueRunningNormally`.  Every
-        // caller that runs a program passes `None` there (`run_forever` and
-        // `convert_and_run_from_pyjitpl` both do), so today only this module's
-        // own tests supply one, and they read no terminal image.  Wiring a
-        // real runner is what makes the missing image a resume that repeats
-        // the callee's effects; `trace.rs` already logs that shape as `bail
-        // terminal is not the root frame`.
-        Err(exc @ JitException::BailToInterpreter) => {
+        Err(PortalRunnerFailure {
+            exception: JitException::ExitFrameWithExceptionRef(exc_ref),
+            ..
+        }) => exc_ref.0 as i64,
+        // A recursive runner's bail belongs to the re-entered portal, not to
+        // `bh` (the outer portal level whose CALL is waiting for a result).
+        // PyPy still owns that inner blackhole object while the exception
+        // unwinds; pyre's callback therefore returns its moved bank image and
+        // this level publishes it before releasing the outer chain.  Using
+        // `bh` here would resume at the CALL and replay the inner effects.
+        Err(PortalRunnerFailure {
+            exception: exc @ JitException::BailToInterpreter,
+            terminal: Some(terminal),
+        }) => {
+            if let Some(terminal_out) = terminal_out {
+                *terminal_out = Some(terminal);
+            }
             builder.release_chain(Some(bh));
             return Err(exc);
         }
+        Err(PortalRunnerFailure {
+            exception: JitException::BailToInterpreter,
+            terminal: None,
+        }) => unreachable!("recursive portal runner returned a bail without its terminal image"),
         // `handle_jitexception_in_portal` returns only those two.
-        Err(other) => unreachable!("portal level reported {other:?}"),
+        Err(PortalRunnerFailure {
+            exception: other, ..
+        }) => unreachable!("portal level reported {other:?}"),
     };
     // blackhole.py:1780: return blackholeinterp, lle
     Ok((bh, current_exc))
@@ -3018,7 +3073,9 @@ pub fn run_forever_with_portal(
     builder: &mut BlackholeInterpBuilder,
     mut bh: Box<BlackholeInterpreter>,
     mut current_exc: i64,
-    portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
+    portal_runner: Option<
+        &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
+    >,
     on_enter_level: Option<&dyn Fn(i64)>,
     on_leave_level: Option<&dyn Fn(i64)>,
     mut terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
@@ -4245,6 +4302,38 @@ mod tests {
             assert!(bh2.registers_i.is_empty());
         }
 
+        /// `BlackholeInterpreter._get_method` stores the post-op position and
+        /// re-raises every exception from a `bhimpl_*`.  The translated
+        /// `do_malloc_*_clear` helpers use that edge for `MemoryError`; NULL
+        /// must never be installed as an ordinary reference result.
+        #[test]
+        fn allocation_failure_raises_memory_error_at_the_post_op_position() {
+            const MEMORY_ERROR: i64 = 0x5eed_0001;
+            fn memory_error() -> i64 {
+                MEMORY_ERROR
+            }
+            majit_backend::register_memory_error_provider(memory_error);
+
+            let err = super::blackhole_allocation_error(37);
+            assert!(matches!(
+                err,
+                super::DispatchError::RaiseException {
+                    exc: MEMORY_ERROR,
+                    resume_position: 37,
+                }
+            ));
+        }
+
+        #[test]
+        fn obsolete_vtable_method_opcode_bails_instead_of_panicking() {
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut bh = builder.acquire_interp();
+            let err = super::handler_vtable_method_ptr_bail(&mut bh, &[], 0)
+                .expect_err("unsupported named vtable lookup must leave blackhole");
+            assert!(matches!(err, super::DispatchError::LeaveFrame));
+            assert!(bh.aborted);
+        }
+
         /// A pooled interp must not carry the previous run's frame identity.
         ///
         /// `acquire_interp` refreshes only the six builder-shared fields
@@ -4743,6 +4832,72 @@ mod tests {
                 ),
                 "the caller must return the portal runner's result, got {outcome:?}",
             );
+        }
+
+        /// PyPy keeps the re-entered blackhole object live while
+        /// `_handle_jitexception_in_portal` propagates.  Pyre crosses a Rust
+        /// callback after releasing it, so the callback must return the
+        /// terminal banks with a pyre-only interpreter bail.  Publishing the
+        /// recursive portal frame instead would resume at its CALL and replay
+        /// the callee's already-performed effects.
+        #[test]
+        fn recursive_portal_bail_preserves_the_reentered_terminal_image() {
+            let mut sub = JitCodeBuilder::default();
+            sub.jit_merge_point(0, &[], &[], &[], &[], &[], &[]);
+            let sub_jitcode = sub.finish();
+
+            let mut inner_b = JitCodeBuilder::default();
+            let sub_idx = inner_b.add_sub_jitcode(sub_jitcode);
+            inner_b.inline_call_ir_v(sub_idx, &[], &[], None);
+            let inner_jitcode = inner_b.finish();
+            inner_jitcode.set_jitdriver_sd(0);
+
+            let mut caller_b = JitCodeBuilder::default();
+            caller_b.void_return();
+            let caller_jitcode = caller_b.finish();
+
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut caller = builder.acquire_interp();
+            caller.setposition(std::sync::Arc::new(caller_jitcode), 0);
+            let mut inner = builder.acquire_interp();
+            inner.setposition(std::sync::Arc::new(inner_jitcode), 0);
+            inner.nextblackholeinterp = Some(caller);
+
+            const TERMINAL_JITCODE: usize = 73;
+            const TERMINAL_POSITION: usize = 19;
+            let portal_runner = |_exc: &crate::jitexc::JitException| {
+                Err(super::PortalRunnerFailure::bail(
+                    super::BlackholeTerminalImage {
+                        jitcode_index: TERMINAL_JITCODE,
+                        registers_i: vec![111],
+                        registers_r: vec![222],
+                        registers_f: vec![333],
+                        position: TERMINAL_POSITION,
+                        last_opcode_position: 17,
+                    },
+                ))
+            };
+            let mut terminal = None;
+            let outcome = super::run_forever_with_portal(
+                &mut builder,
+                inner,
+                0,
+                Some(&portal_runner),
+                None,
+                None,
+                Some(&mut terminal),
+            );
+
+            assert!(matches!(
+                outcome,
+                crate::jitexc::JitException::BailToInterpreter
+            ));
+            let terminal = terminal.expect("recursive portal bail lost its terminal frame");
+            assert_eq!(terminal.jitcode_index, TERMINAL_JITCODE);
+            assert_eq!(terminal.position, TERMINAL_POSITION);
+            assert_eq!(terminal.registers_i, vec![111]);
+            assert_eq!(terminal.registers_r, vec![222]);
+            assert_eq!(terminal.registers_f, vec![333]);
         }
 
         /// `blackhole.py:1759` is the single position a returning level leaves
@@ -8060,8 +8215,9 @@ fn handler_new(
 ) -> Result<usize, DispatchError> {
     // @arguments("cpu", "d", returns="r")
     let (descr, pos) = read_descr(bh, code, position);
-    let cpu = bh.cpu();
-    bh.registers_r[code[pos] as usize] = cpu.bh_new(descr);
+    let result = bh.cpu().bh_new(descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 fn handler_new_with_vtable(
@@ -8070,8 +8226,9 @@ fn handler_new_with_vtable(
     position: usize,
 ) -> Result<usize, DispatchError> {
     let (descr, pos) = read_descr(bh, code, position);
-    let cpu = bh.cpu();
-    bh.registers_r[code[pos] as usize] = cpu.bh_new_with_vtable(descr);
+    let result = bh.cpu().bh_new_with_vtable(descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 fn handler_new_array(
@@ -8082,8 +8239,9 @@ fn handler_new_array(
     // @arguments("cpu", "i", "d", returns="r")
     let length = bh.registers_i[code[position] as usize];
     let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    bh.registers_r[code[pos] as usize] = cpu.bh_new_array(length, descr);
+    let result = bh.cpu().bh_new_array(length, descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 fn handler_new_array_clear(
@@ -8093,8 +8251,9 @@ fn handler_new_array_clear(
 ) -> Result<usize, DispatchError> {
     let length = bh.registers_i[code[position] as usize];
     let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    bh.registers_r[code[pos] as usize] = cpu.bh_new_array_clear(length, descr);
+    let result = bh.cpu().bh_new_array_clear(length, descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 
@@ -8107,8 +8266,9 @@ fn handler_new_array_clear_c(
 ) -> Result<usize, DispatchError> {
     let length = code[position] as i8 as i64;
     let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    bh.registers_r[code[pos] as usize] = cpu.bh_new_array_clear(length, descr);
+    let result = bh.cpu().bh_new_array_clear(length, descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 
@@ -8152,8 +8312,9 @@ fn handler_newstr(
     position: usize,
 ) -> Result<usize, DispatchError> {
     let length = bh.registers_i[code[position] as usize];
-    let cpu = bh.cpu();
-    bh.registers_r[code[position + 1] as usize] = cpu.bh_newstr(length);
+    let result = bh.cpu().bh_newstr(length);
+    check_blackhole_allocation_after(bh, result, position + 2)?;
+    bh.registers_r[code[position + 1] as usize] = result;
     Ok(position + 2)
 }
 fn handler_unicodelen(
@@ -8195,8 +8356,9 @@ fn handler_newunicode(
     position: usize,
 ) -> Result<usize, DispatchError> {
     let length = bh.registers_i[code[position] as usize];
-    let cpu = bh.cpu();
-    bh.registers_r[code[position + 1] as usize] = cpu.bh_newunicode(length);
+    let result = bh.cpu().bh_newunicode(length);
+    check_blackhole_allocation_after(bh, result, position + 2)?;
+    bh.registers_r[code[position + 1] as usize] = result;
     Ok(position + 2)
 }
 
@@ -8326,6 +8488,43 @@ fn check_residual_call_exception_after(
         exc: exc_val,
         resume_position: next_pos,
     })
+}
+
+/// The allocation-specialized edge of blackhole.py `_get_method`.
+///
+/// `GcLLDescr_framework._bh_malloc` / `_bh_malloc_array` call the translated
+/// `do_malloc_*_clear` helpers, which raise `MemoryError` instead of returning
+/// a null GC reference.  Rust backend helpers use NULL as that unwinding edge,
+/// so convert it before a handler writes its result register.  In particular,
+/// NULL is never an ordinary `r` result that the following opcode may consume.
+#[inline]
+fn check_blackhole_allocation_after(
+    bh: &BlackholeInterpreter,
+    result: i64,
+    next_pos: usize,
+) -> Result<(), DispatchError> {
+    if result != 0 {
+        return Ok(());
+    }
+    // String helpers also populate the compiled-code exception cell.  The
+    // blackhole delivers the same singleton through DispatchError, so consume
+    // the backend copy now; otherwise an unrelated later compiled call sees a
+    // stale MemoryError.
+    bh.cpu().clear_stored_exception();
+    Err(blackhole_allocation_error(next_pos))
+}
+
+#[inline]
+fn blackhole_allocation_error(next_pos: usize) -> DispatchError {
+    let exc = majit_backend::memory_error_singleton_ref();
+    assert!(
+        exc != 0,
+        "blackhole allocation failed before the MemoryError provider was installed"
+    );
+    DispatchError::RaiseException {
+        exc,
+        resume_position: next_pos,
+    }
 }
 
 /// Refuse to jump to a `residual_call_*` funcptr that is either null or a
@@ -9036,16 +9235,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "abort_permanent/".to_string(),
         majit_translate::insns::BC_ABORT_PERMANENT,
     );
-    // `vtable_method_ptr/rd>i` — the dyn-trait method-pointer reification.
-    // Routing `dyn Trait` calls through `CallTarget::Indirect` is the
-    // default, so the codewriter now emits this byte into real jitcodes and
-    // this builder's dispatch table has to span it: `setup_insns(asm.insns)`
-    // (`blackhole.py:58-59`) resolves every opname the assembler emitted, and
-    // a byte outside the curated set reaches the unwired-opcode placeholder
-    // instead of the handler.  The handler it binds is deliberately
-    // `handler_vtable_method_ptr_unimplemented` — no layer executes this op
-    // yet, so the point of the entry is that a resume landing here says which
-    // op is missing rather than reporting an unwired byte.
+    // The canonical MIR dyn-call path is now a concrete vtable FieldRead plus
+    // IndirectCall (`ClassRepr.getclsfield` / `FunctionReprBase.call`).  Keep
+    // the old pyre-only byte registered for frozen/abstract-trait fallback
+    // jitcodes; its handler safely bails to the source interpreter.
     insns.insert(
         "vtable_method_ptr/rd>i".to_string(),
         majit_translate::insns::BC_VTABLE_METHOD_PTR,
@@ -9907,15 +10100,8 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
         "record_quasiimmut_field/rdd",
         handler_record_quasiimmut_field,
     );
-    // TODO op for Rust fat-pointer dispatch — see
-    // `majit/majit-translate/src/model.rs OpKind::VtableMethodPtr`.
-    // No runtime consumer ships yet; the handler panics on dispatch so a
-    // future regression that triggers this path in pyre fails loudly
-    // instead of silently miscompiling.
-    builder.wire_handler(
-        "vtable_method_ptr/rd>i",
-        handler_vtable_method_ptr_unimplemented,
-    );
+    // Compatibility fallback for the obsolete name-based vtable opcode.
+    builder.wire_handler("vtable_method_ptr/rd>i", handler_vtable_method_ptr_bail);
     builder.wire_handler(
         "jit_force_quasi_immutable/rd",
         handler_jit_force_quasi_immutable,
@@ -10215,26 +10401,20 @@ fn handler_guard_class(
     bh.registers_i[code[p + 1] as usize] = typeptr;
     Ok(p + 2)
 }
-/// `vtable_method_ptr` reaches the blackhole only when a `dyn Trait`
-/// indirect call survives unfrozen into a metainterp resume.
+/// Safe fallback for the obsolete pyre-only named vtable lookup.
 ///
-/// The codewriter does emit the op + descriptor (TODO of
-/// `rpython/rtyper/rclass.py getclsfield()`) now that indirect
-/// routing is the default, but no layer consumes it: there is no backend
-/// lowering (`codewriter/assembler.rs`, "backend lowering of the actual
-/// vtable slot read is not yet implemented"), the walker answers
-/// `DispatchError::UnsupportedOpname`, and `PyreVtableMethodDescr` carries
-/// the `(trait_root, method_name)` pair as strings with nothing that
-/// resolves them to an address.  The walker's abort is what keeps this
-/// unreachable in practice — a trace meeting the op never compiles, so no
-/// resume can land past it.  Panic intentionally so that if one ever does,
-/// it is loud rather than a silent miscompile.
-fn handler_vtable_method_ptr_unimplemented(
-    _bh: &mut BlackholeInterpreter,
+/// PyPy's `ClassRepr.getclsfield` emits an ordinary field read; it never tries
+/// to resolve `(trait, method)` strings in the blackhole.  If an old frozen
+/// graph or the still-conservative abstract-trait path reaches this opcode, no
+/// faithful pointer can be manufactured from its descriptor.  Hand execution
+/// back to the source interpreter like the other unsupported-op markers.
+fn handler_vtable_method_ptr_bail(
+    bh: &mut BlackholeInterpreter,
     _code: &[u8],
     _p: usize,
 ) -> Result<usize, DispatchError> {
-    unimplemented!("vtable_method_ptr blackhole consumer (backend epic)");
+    bh.aborted = true;
+    Err(DispatchError::LeaveFrame)
 }
 
 fn handler_record_quasiimmut_field(
@@ -11322,19 +11502,21 @@ fn handler_newlist(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
-    let cpu = bh.cpu();
     // blackhole.py:1163: result = cpu.bh_new(structdescr)
-    let result = cpu.bh_new(structdescr);
+    let result = bh.cpu().bh_new(structdescr);
+    check_blackhole_allocation_after(bh, result, p + 1)?;
     // blackhole.py:1164: cpu.bh_setfield_gc_i(result, length, lengthdescr)
-    cpu.bh_setfield_gc_i(result, length, lengthdescr);
+    bh.cpu().bh_setfield_gc_i(result, length, lengthdescr);
     // blackhole.py:1165-1169: bh_new_array_clear when is_array_of_structs or is_array_of_pointers
     let items = if arraydescr.is_array_of_structs() || arraydescr.is_array_of_pointers() {
-        cpu.bh_new_array_clear(length, arraydescr)
+        bh.cpu().bh_new_array_clear(length, arraydescr)
     } else {
-        cpu.bh_new_array(length, arraydescr)
+        bh.cpu().bh_new_array(length, arraydescr)
     };
+    check_blackhole_allocation_after(bh, items, p + 1)?;
     // blackhole.py:1170: cpu.bh_setfield_gc_r(result, items, itemsdescr)
-    cpu.bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+    bh.cpu()
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }
@@ -11349,12 +11531,14 @@ fn handler_newlist_clear(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
-    let cpu = bh.cpu();
-    let result = cpu.bh_new(structdescr);
-    cpu.bh_setfield_gc_i(result, length, lengthdescr);
+    let result = bh.cpu().bh_new(structdescr);
+    check_blackhole_allocation_after(bh, result, p + 1)?;
+    bh.cpu().bh_setfield_gc_i(result, length, lengthdescr);
     // blackhole.py:1178: items = cpu.bh_new_array_clear(length, arraydescr)
-    let items = cpu.bh_new_array_clear(length, arraydescr);
-    cpu.bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+    let items = bh.cpu().bh_new_array_clear(length, arraydescr);
+    check_blackhole_allocation_after(bh, items, p + 1)?;
+    bh.cpu()
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }
@@ -11369,17 +11553,19 @@ fn handler_newlist_hint(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
-    let cpu = bh.cpu();
-    let result = cpu.bh_new(structdescr);
+    let result = bh.cpu().bh_new(structdescr);
+    check_blackhole_allocation_after(bh, result, p + 1)?;
     // blackhole.py:1186: cpu.bh_setfield_gc_i(result, 0, lengthdescr)
-    cpu.bh_setfield_gc_i(result, 0, lengthdescr);
+    bh.cpu().bh_setfield_gc_i(result, 0, lengthdescr);
     // blackhole.py:1187-1191: bh_new_array_clear when is_array_of_structs or is_array_of_pointers
     let items = if arraydescr.is_array_of_structs() || arraydescr.is_array_of_pointers() {
-        cpu.bh_new_array_clear(lengthhint, arraydescr)
+        bh.cpu().bh_new_array_clear(lengthhint, arraydescr)
     } else {
-        cpu.bh_new_array(lengthhint, arraydescr)
+        bh.cpu().bh_new_array(lengthhint, arraydescr)
     };
-    cpu.bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+    check_blackhole_allocation_after(bh, items, p + 1)?;
+    bh.cpu()
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -739,6 +739,13 @@ impl GraphStore {
             .filter_map(move |(p, k)| self.graphs.get(k).map(|s| (p, &s.graph)))
     }
 
+    /// Every source funcobj graph exactly once, irrespective of how many
+    /// alias paths name it.  Used by the rtyping boundary that attaches the
+    /// final PBC family to deferred indirect-call operations.
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut FunctionGraph> {
+        self.graphs.values_mut().map(|slot| &mut slot.graph)
+    }
+
     /// Number of registered alias spellings (path count), matching the old
     /// `HashMap<CallPath, _>::len()` so `iter()`-sized allocations stay correct.
     pub(crate) fn len(&self) -> usize {
@@ -3260,10 +3267,7 @@ impl CallControl {
         graph: FunctionGraph,
     ) {
         if let Some(trait_root) = trait_root {
-            self.trait_method_impls
-                .entry((trait_root.to_string(), method_name.to_string()))
-                .or_default()
-                .push(impl_type.to_string());
+            self.register_trait_family_member(method_name, trait_root, impl_type);
             self.method_to_impl_types
                 .entry(method_name.to_string())
                 .or_default()
@@ -3283,6 +3287,32 @@ impl CallControl {
             // qualified path; its `owner_root = Some(impl_type)` keeps it
             // separate from other impls' same-named methods.
             self.insert_function_graph_indexed(qualified_path, graph);
+        }
+    }
+
+    /// Add one concrete graph to the PBC row for an indirect trait call,
+    /// without also making it a name-based concrete-method candidate.
+    ///
+    /// RPython keeps these two relations separate: `FunctionReprBase.call`
+    /// obtains `c_graphs` from `row_of_graphs.values()`, while concrete
+    /// method lookup follows the receiver's class/MRO.  Pyre's concrete
+    /// trait-impl methods are registered through the inherent-method path to
+    /// preserve that receiver lookup, but they still belong to the PBC row
+    /// used by a `dyn Trait` vtable call.  Required trait methods have no
+    /// default graph, so omitting this membership makes their otherwise
+    /// closed family look unknown to every graph analyzer.
+    pub fn register_trait_family_member(
+        &mut self,
+        method_name: &str,
+        trait_root: &str,
+        impl_type: &str,
+    ) {
+        let members = self
+            .trait_method_impls
+            .entry((trait_root.to_string(), method_name.to_string()))
+            .or_default();
+        if !members.iter().any(|member| member == impl_type) {
+            members.push(impl_type.to_string());
         }
     }
 
@@ -3794,6 +3824,7 @@ impl CallControl {
             "find_all_graphs requires at least one portal target; \
              use find_all_graphs_for_tests() if no portal is available"
         );
+        self.materialize_deferred_indirect_families();
         self.find_all_graphs_bfs(policy);
     }
 
@@ -3801,6 +3832,7 @@ impl CallControl {
     /// Production code must use `find_all_graphs()` with portal seeded.
     #[cfg(test)]
     pub fn find_all_graphs_for_tests(&mut self) {
+        self.materialize_deferred_indirect_families();
         if self.jitdrivers_sd.is_empty() {
             let all_paths: Vec<CallPath> = self.function_graphs.keys().cloned().collect();
             for path in all_paths {
@@ -3810,6 +3842,49 @@ impl CallControl {
         }
         let mut policy = crate::policy::DefaultJitPolicy::new();
         self.find_all_graphs_bfs(&mut policy);
+    }
+
+    /// Attach the final `c_graphs` list to vtable calls the MIR frontend has
+    /// already expressed as [`OpKind::IndirectCall`].  RPython's
+    /// `FunctionReprBase.call` appends `row_of_graphs.values()` during
+    /// rtyping, before `CallControl.find_all_graphs` and every graph analyzer
+    /// read the operation.  Pyre registers the whole Rust program lazily, so
+    /// the frontend temporarily carries only `(trait_root, method_name)` in
+    /// `family_key`; this is the matching end of that rtyping boundary.
+    ///
+    /// Materialising the family on the shared graph object is essential.  A
+    /// transform-time fill on a cloned graph is too late: candidate discovery
+    /// and the recursive effect analyzers inspect the registered source graph
+    /// first and would read `graphs: None` as an unknown family/top result.
+    fn materialize_deferred_indirect_families(&mut self) {
+        let trait_method_impls = &self.trait_method_impls;
+        let function_graphs = &mut self.function_graphs;
+        for graph in function_graphs.values_mut() {
+            for op in graph
+                .blocks
+                .iter_mut()
+                .flat_map(|block| block.operations.iter_mut())
+            {
+                let OpKind::IndirectCall {
+                    graphs, family_key, ..
+                } = &mut op.kind
+                else {
+                    continue;
+                };
+                let Some((trait_root, method_name)) = family_key.take() else {
+                    continue;
+                };
+                let family = trait_method_impls
+                    .get(&(trait_root.clone(), method_name.clone()))
+                    .into_iter()
+                    .flatten()
+                    .map(|impl_type| {
+                        CallPath::for_impl_method(impl_type.as_str(), method_name.as_str())
+                    })
+                    .collect::<Vec<_>>();
+                *graphs = (!family.is_empty()).then_some(family);
+            }
+        }
     }
 
     fn find_all_graphs_bfs(&mut self, policy: &mut dyn JitPolicy) {
@@ -9536,6 +9611,7 @@ mod tests {
                 funcptr: crate::flowspace::model::Variable::new(),
                 args: vec![],
                 graphs,
+                family_key: None,
                 result_ty: ValueType::Void,
             },
         }
@@ -11712,6 +11788,60 @@ mod tests {
         assert_eq!(
             cc.guess_call_kind(&indirect_call_op(None)),
             CallKind::Residual
+        );
+    }
+
+    /// `FunctionReprBase.call` attaches the PBC graph row before
+    /// `CallControl.find_all_graphs`.  A MIR vtable call starts with the same
+    /// identity in `family_key`; graph discovery must materialise it on the
+    /// registered graph, not wait for the later jitcode clone.
+    #[test]
+    fn graph_discovery_materializes_deferred_vtable_family() {
+        let mut cc = CallControl::new();
+        for owner in ["A", "B"] {
+            cc.register_function_graph(
+                CallPath::for_impl_method(owner, "run"),
+                FunctionGraph::new(format!("{owner}::run")),
+            );
+            cc.register_trait_family_member("run", "Handler", owner);
+        }
+
+        let caller_path = CallPath::from_segments(["caller"]);
+        let mut caller = FunctionGraph::new("caller");
+        let funcptr = caller.alloc_value_var();
+        caller
+            .block_mut(caller.startblock)
+            .operations
+            .push(SpaceOperation {
+                result: None,
+                kind: OpKind::IndirectCall {
+                    funcptr,
+                    args: Vec::new(),
+                    graphs: None,
+                    family_key: Some(("Handler".to_string(), "run".to_string())),
+                    result_ty: ValueType::Void,
+                },
+            });
+        cc.register_function_graph(caller_path.clone(), caller);
+
+        cc.find_all_graphs_for_tests();
+
+        let caller = cc
+            .function_graphs
+            .get(&caller_path)
+            .expect("registered caller");
+        let op = &caller.block(caller.startblock).operations[0];
+        let OpKind::IndirectCall {
+            graphs, family_key, ..
+        } = &op.kind
+        else {
+            panic!("caller operation must remain an indirect call");
+        };
+        assert!(family_key.is_none(), "the rtyping key must be consumed");
+        assert_eq!(
+            graphs.as_ref().map(Vec::len),
+            Some(2),
+            "the registered source graph must carry the complete PBC family"
         );
     }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -1626,6 +1626,7 @@ impl<'a> Transformer<'a> {
                 funcptr,
                 args,
                 graphs,
+                family_key: _,
                 result_ty,
             } if self.config.classify_calls => self.lower_indirect_call_op(
                 op,
@@ -7580,6 +7581,7 @@ fn remap_op(
             funcptr,
             args,
             graphs,
+            family_key,
             result_ty,
         } => {
             let remap_var = |var: &crate::flowspace::model::Variable| remap_value(var, aliases);
@@ -7587,6 +7589,7 @@ fn remap_op(
                 funcptr: remap_var(funcptr),
                 args: args.iter().map(remap_var).collect(),
                 graphs: graphs.clone(),
+                family_key: family_key.clone(),
                 result_ty: result_ty.clone(),
             }
         }

--- a/majit/majit-translate/src/codewriter/support.rs
+++ b/majit/majit-translate/src/codewriter/support.rs
@@ -1343,6 +1343,7 @@ mod tests {
                 funcptr: crate::flowspace::model::Variable::new(),
                 args: vec![],
                 graphs: None,
+                family_key: None,
                 result_ty: crate::model::ValueType::Int,
             },
         };

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1116,15 +1116,16 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // (keyed exactly as `merge_hints_from_llbcs`), so the narrow
         // codewriter surface stays restricted to opaque stubs; every
         // other fn keeps the declared-void default.
-        // A trait default body is registered as the `<default methods of
-        // Trait>` family sentinel and picked as the Indirect-dispatch
-        // witness (`getcalldescr`'s indirect arm reads its `return_type` as
-        // `FUNC.RESULT`).  Left `None` it maps to `Void` and mismatches the
-        // caller's `Ref`/`Int` `result_ty`; stamp the same token an opaque
-        // callee gets so the witness reports its real return kind.
+        // Every trait method can be a member of an indirect-call PBC row:
+        // default bodies and concrete overrides alike.  RPython's
+        // `FunctionReprBase.call` gets the row's result from
+        // `FuncType.RESULT`, so each member must carry that type before the
+        // graph analyzers run.  Left `None`, pyre maps it to `Void` and the
+        // first concrete witness can mismatch a real `Ref`/`Int` result.
+        // Stamp the same signature token an opaque callee gets.
         let stamp_return_token = dont_look_inside.contains(&fn_path)
             || elidable_residual.contains(&fn_path)
-            || (trait_root.is_some() && self_ty_root.is_none());
+            || trait_root.is_some();
         let return_type = if gcref_result {
             Some(crate::translator::rtyper::cutover::GCREF_RETURN_TYPE.to_string())
         } else if stamp_return_token {
@@ -10657,10 +10658,11 @@ impl<'a> Lowering<'a> {
                 // the method fn-ptr straight out of the receiver's vtable
                 // (`(*recv).vtable.method_<name>`), so the operand's
                 // terminal projection is `Field[Adt(vtable_id), slot]`.
-                // Route those through the faithful `CallTarget::Indirect`
-                // vtable pipeline (`rpbc::lower_indirect_calls` →
-                // `VtableMethodPtr` + `IndirectCall`, carrying the full
-                // impl family) instead of the synthetic `__dyn_call`.  The
+                // Preserve that projection as the funcptr operand of an
+                // `IndirectCall`; `rpbc::lower_indirect_calls` supplies the
+                // full impl family, matching `ClassRepr.getclsfield` followed
+                // by `FunctionReprBase.call`, instead of routing through the
+                // synthetic `__dyn_call`.  The
                 // call args already carry the receiver in `args[0]` (the
                 // operand projection's base local), which is exactly the
                 // receiver slot `IndirectCall` expects, so the arg list
@@ -10680,9 +10682,18 @@ impl<'a> Lowering<'a> {
                 let fn_ptr_family = operand_fn_ptr_family(&dyn_operand, self.llbc);
                 let indirect = self.dyn_indirect_target(&dyn_operand);
                 if let Some((trait_root, method_name)) = indirect {
-                    OpKind::Call {
-                        target: CallTarget::indirect(trait_root, method_name),
+                    // RPython `ClassRepr.getclsfield` emits the concrete
+                    // vtable field read, then `FunctionReprBase.call` feeds
+                    // that pointer to `indirect_call`.  `resolve_operand`
+                    // already lowers this exact MIR Field projection, so keep
+                    // it instead of replacing it with a blackhole-only
+                    // name-based lookup that has no upstream counterpart.
+                    let funcptr = self.resolve_operand(mir_bb, dyn_operand)?;
+                    OpKind::IndirectCall {
+                        funcptr,
                         args,
+                        graphs: None,
+                        family_key: Some((trait_root, method_name)),
                         result_ty,
                     }
                 } else if let Some(family) = fn_ptr_family {
@@ -10695,6 +10706,7 @@ impl<'a> Lowering<'a> {
                         funcptr,
                         args,
                         graphs,
+                        family_key: None,
                         result_ty,
                     }
                 } else {
@@ -20385,6 +20397,16 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
             }
         }
     }
+    // RPython `history.getkind` classifies `Ptr(FuncType)` through the raw
+    // pointer arm, hence as `int`.  Charon's equivalent is a top-level
+    // `FnPtr`: it is the machine address that `FunctionReprBase.call` feeds
+    // to `indirect_call`, not a GC reference.  Keeping it in the Ref bank
+    // makes `jtransform.handle_regular_indirect_call` spell the otherwise
+    // impossible `int_guard_value/r` and gives every following residual call
+    // a Ref funcptr operand (`residual_call_*/r...`).
+    if type_node_is_fn_ptr(value, llbc) {
+        return ValueType::Int;
+    }
     // A densely numbered fieldless enum gives `Option<E>` a scalar niche
     // representation.  The whole Option therefore lives in the Int bank;
     // it is not an aggregate reference.
@@ -27253,7 +27275,7 @@ mod tests {
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         decode_literal, fn_ptr_family_for, json_ty_is_thin_pointer_element,
         json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
-        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
+        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -27380,6 +27402,35 @@ mod tests {
                  fnptr_indirect={fnptr_indirect}"
             );
         }
+    }
+
+    #[test]
+    fn function_pointer_uses_the_raw_pointer_int_bank() {
+        let file = serde_json::json!({
+            "charon_version": "0.1.201",
+            "has_errors": false,
+            "translated": {
+                "crate_name": "fixture",
+                "type_decls": [], "fun_decls": [], "global_decls": [],
+                "trait_decls": [], "trait_impls": [],
+            }
+        });
+        let llbc = Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses");
+        let ty = TyRef::Other(serde_json::json!({
+            "FnPtr": {
+                "skip_binder": {
+                    "inputs": [],
+                    "output": { "Literal": { "Int": "I64" } },
+                    "is_unsafe": false
+                }
+            }
+        }));
+
+        assert_eq!(
+            tyref_to_value_type(&ty, &llbc),
+            ValueType::Int,
+            "RPython history.getkind(Ptr(FuncType)) uses the int bank"
+        );
     }
 
     #[test]
@@ -33753,6 +33804,97 @@ mod tests {
             matches!(returned, LinkArg::Value(value) if value == input),
             "the adapter must return its input GCREF unchanged; graph: {graph:#?}"
         );
+    }
+
+    /// The Rust trait-object spelling of PyPy's
+    /// `W_DictMultiObject.getitem` / `getitem_str` strategy dispatch must
+    /// retain both halves RPython's PBC call carries: the concrete vtable
+    /// field read and the closed `DictStrategy` implementation family.
+    /// This uses the real extracted owner because a hand-written fixture can
+    /// accidentally make the trait leaf and vtable field shape agree.
+    #[test]
+    #[ignore]
+    fn dict_strategy_vtable_call_keeps_its_family_identity() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real pyre-object LLBC");
+        for (function, method) in [
+            ("w_dict_lookup", "getitem"),
+            ("w_dict_getitem_str_hashed", "getitem_str_hashed"),
+        ] {
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|error| panic!("lower {function}: {error}"));
+            let calls: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .filter_map(|op| match &op.kind {
+                    OpKind::IndirectCall {
+                        funcptr,
+                        family_key: Some(family_key),
+                        ..
+                    } => Some((funcptr.clone(), family_key.clone())),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                calls.len(),
+                1,
+                "{function} must carry one DictStrategy vtable call: {calls:?}"
+            );
+            assert_eq!(
+                calls[0].1,
+                ("DictStrategy".to_string(), method.to_string()),
+                "{function}'s MIR vtable slot must name the same PBC family as the trait impls"
+            );
+            let funcptr = &calls[0].0;
+            let producers: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .filter(|op| op.result.as_ref() == Some(funcptr))
+                .collect();
+            assert_eq!(
+                producers.len(),
+                1,
+                "{function}'s indirect funcptr must have one concrete producer"
+            );
+            assert!(
+                matches!(
+                    &producers[0].kind,
+                    OpKind::FieldRead { field, ty: ValueType::Int, .. }
+                        if field.name == format!("method_{method}")
+                ),
+                "{function}'s vtable method pointer must be a raw-pointer/int FieldRead: {:?}",
+                producers[0].kind
+            );
+        }
+
+        let program = super::build_semantic_program_from_llbc(&llbc)
+            .expect("build semantic pyre-object program");
+        for method in ["getitem", "getitem_str_hashed"] {
+            let members: Vec<_> = program
+                .functions
+                .iter()
+                .filter(|function| {
+                    function.name == method
+                        && function.trait_root.as_deref() == Some("DictStrategy")
+                })
+                .map(|function| (function.self_ty_root.clone(), function.return_type.clone()))
+                .collect();
+            assert!(
+                members.iter().any(|(owner, _)| owner.is_some()),
+                "DictStrategy.{method} must retain concrete impl owners: {members:?}"
+            );
+            assert!(
+                members
+                    .iter()
+                    .all(|(_, result)| result.as_deref() == Some("ref")),
+                "every DictStrategy.{method} PBC member must carry FuncType.RESULT: {members:?}"
+            );
+        }
     }
 
     /// The Sized gate: a shared reference to a fat pointee (`&[T]`, spelled

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -594,11 +594,13 @@ pub(crate) fn remap_op_kind(
             funcptr,
             args,
             graphs,
+            family_key,
             result_ty,
         } => OpKind::IndirectCall {
             funcptr: remap_var(funcptr),
             args: args.iter().map(&remap_var).collect(),
             graphs: graphs.clone(),
+            family_key: family_key.clone(),
             result_ty: result_ty.clone(),
         },
         OpKind::RecordQuasiImmutField {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1493,6 +1493,16 @@ fn analyze_pipeline_from_module_paths(
         }
     }
     prof.mark("  register concrete trait-impl identities");
+    // `rpbc.py FunctionReprBase.call`: the `c_graphs` constant is the full
+    // `row_of_graphs.values()` PBC family, including concrete overrides of a
+    // required trait method.  Concrete impl graphs stay on the
+    // receiver-driven inherent-method registration path below (so
+    // name-based method lookup is unchanged), but their graph identities
+    // must also populate the independent indirect-call family row.
+    for (trait_leaf, _, method_name, owner, _, _, _) in &concrete_trait_methods {
+        call_control.register_trait_family_member(method_name, trait_leaf, owner);
+    }
+    prof.mark("  register concrete indirect-call families");
     // Re-register free functions with their RPython-equivalent hints
     // (`elidable`, `loop_invariant`, `unroll_safe`, `jit_look_inside`)
     // so `JitPolicy::look_inside_graph` sees the same metadata RPython

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1058,6 +1058,12 @@ pub enum OpKind {
         funcptr: crate::flowspace::model::Variable,
         args: Vec<crate::flowspace::model::Variable>,
         graphs: Option<Vec<crate::parse::CallPath>>,
+        /// Pre-rtyping identity of a Rust dyn-trait vtable slot.  The MIR
+        /// frontend preserves the actual `Field[Adt(vtable), slot]` as
+        /// `funcptr`; `rpbc::lower_indirect_calls` consumes this key to fill
+        /// the same `c_graphs` family as `FunctionReprBase.call`, then clears
+        /// it.  Ordinary stored function pointers have no such key.
+        family_key: Option<(String, String)>,
         result_ty: ValueType,
     },
     /// Virtualizable field read → reads from boxes, no heap op.

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -6379,6 +6379,7 @@ mod tests {
                 funcptr: vars[1].clone(),
                 args: vec![vars[2].clone()],
                 graphs: None,
+                family_key: None,
                 result_ty: ValueType::Int,
             },
         };

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -338,9 +338,18 @@ pub fn lower_indirect_calls(graph: &mut JitFunctionGraph, call_control: &CallCon
     let builtin_wrappers = call_control.builtin_wrapper_indirect_graphs();
     for block in &mut graph.blocks {
         for op in &mut block.operations {
-            if let OpKind::IndirectCall { graphs, .. } = &mut op.kind
-                && graphs.as_deref().is_some_and(<[_]>::is_empty)
+            if let OpKind::IndirectCall {
+                graphs, family_key, ..
+            } = &mut op.kind
             {
+                if let Some((trait_root, method_name)) = family_key.take() {
+                    let family = call_control.all_impls_for_indirect(&trait_root, &method_name);
+                    *graphs = (!family.is_empty()).then_some(family);
+                    continue;
+                }
+                if !graphs.as_deref().is_some_and(<[_]>::is_empty) {
+                    continue;
+                }
                 // Filling the marker with an empty wrapper set would leave
                 // `Some([])`, which every family analyzer reads as "the
                 // family is known and has no members" and folds to its
@@ -466,6 +475,7 @@ pub fn lower_indirect_calls(graph: &mut JitFunctionGraph, call_control: &CallCon
                 funcptr: funcptr_var,
                 args,
                 graphs,
+                family_key: None,
                 result_ty,
             },
         };
@@ -907,6 +917,91 @@ pub(crate) mod tests {
         assert_eq!(indirect_call_count, 1);
     }
 
+    /// `ClassRepr.getclsfield` produces a real vtable `getfield`, and
+    /// `FunctionReprBase.call` only appends the PBC graph family before its
+    /// `indirect_call`.  A MIR dynamic-call operand already contains that
+    /// field projection, so rtyping must retain it rather than replace it with
+    /// pyre's name-only `VtableMethodPtr` pseudo-op (which no backend can
+    /// execute).
+    #[test]
+    fn existing_vtable_field_read_keeps_its_funcptr_and_only_fills_family() {
+        use crate::call::CallControl;
+        use crate::model::{FieldDescriptor, ValueType};
+
+        let mut cc = CallControl::new();
+        cc.register_trait_method(
+            "run",
+            Some("Handler"),
+            "A",
+            crate::model::FunctionGraph::new("A::run"),
+        );
+
+        let mut graph = crate::model::FunctionGraph::new("caller");
+        let receiver = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "vtable".to_string(),
+                    ty: ValueType::Ref(Some("Handler::{vtable}".to_string())),
+                    class_root: Some("Handler::{vtable}".to_string()),
+                },
+                true,
+            )
+            .unwrap();
+        let funcptr = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::FieldRead {
+                    base: receiver,
+                    field: FieldDescriptor::new(
+                        "method_run",
+                        Some("Handler::{vtable}".to_string()),
+                    ),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::IndirectCall {
+                    funcptr: funcptr.clone(),
+                    args: Vec::new(),
+                    graphs: None,
+                    family_key: Some(("Handler".to_string(), "run".to_string())),
+                    result_ty: ValueType::Void,
+                },
+                true,
+            )
+            .unwrap();
+
+        lower_indirect_calls(&mut graph, &cc);
+
+        let ops = &graph.blocks[graph.startblock.0].operations;
+        assert!(
+            !ops.iter()
+                .any(|op| matches!(op.kind, OpKind::VtableMethodPtr { .. })),
+            "an existing getfield must not be replaced by VtableMethodPtr",
+        );
+        let indirect = ops
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::IndirectCall {
+                    funcptr: actual,
+                    graphs,
+                    family_key,
+                    ..
+                } => Some((actual, graphs, family_key)),
+                _ => None,
+            })
+            .expect("indirect call survives rtyping");
+        assert_eq!(indirect.0, &funcptr);
+        assert_eq!(indirect.1.as_ref().map(Vec::len), Some(1));
+        assert!(indirect.2.is_none(), "rtyper must consume the family key");
+    }
+
     #[test]
     fn indirect_family_result_retypes_opaque_caller_result() {
         use crate::call::CallControl;
@@ -1061,6 +1156,7 @@ pub(crate) mod tests {
                 funcptr: funcptr_var,
                 args: vec![],
                 graphs: Some(Vec::new()),
+                family_key: None,
                 result_ty: ValueType::Void,
             },
             true,


### PR DESCRIPTION
Four independent parity defects on the blackhole path.

## A recursive portal bail lost its blackhole bank image

PyPy propagates the live RPython blackhole object with the raised
`JitException`. Pyre releases that object before crossing the Rust callback
boundary, so a pyre-only interpreter bail arrived with nothing to resume from.

`PortalRunnerFailure` carries the terminal image beside the exception. Only
`BailToInterpreter` may carry one — a real `JitException` needs no image,
because the enclosing blackhole chain consumes it exactly as
`_handle_jitexception_in_portal` does upstream. Both invariants are asserted.

## `_bh_malloc` had no fallible edge

`GcLLDescr_framework._bh_malloc` reaches translated
`do_malloc_fixedsize_clear`, whose rawmalloc failure is returned to the
exception transformer as NULL and becomes `MemoryError` in `blackhole.py`
`_get_method`.

Pyre had no such edge. The infallible `oldgen.alloc()` aborted the process
before `_get_method` could deliver the exception, and a typed descr that fell
through to a raw block lost its GC header and trace layout. Both backends now
refuse a typed descr outside the GC heap and return NULL/0 on failure; the
negative-length `expect`s in `bh_new_array` / `bh_newstr` / `bh_newunicode`
return 0 as well.

## A `dyn Trait` vtable call never received its PBC graph family

`FunctionReprBase.call` appends `row_of_graphs.values()` during rtyping,
*before* `CallControl.find_all_graphs` and every graph analyzer reads the
operation. Pyre registers the Rust program lazily, so the MIR frontend
temporarily carries only `(trait_root, method_name)` in `family_key`;
`lower_indirect_calls` is the matching end of that boundary.

The row is materialised on the shared source graph. A transform-time fill on a
cloned graph is too late — candidate discovery and the recursive effect
analyzers inspect the registered source graph first and read `graphs: None` as
an unknown family, i.e. a top result. Concrete trait-impl graphs join the row
without becoming name-based concrete-method candidates, so receiver-driven
method lookup is unchanged.

## Rtyping replaced the vtable projection with an unexecutable pseudo-op

`ClassRepr.getclsfield` produces a real vtable `getfield`, and
`FunctionReprBase.call` only appends the PBC graph family before its
`indirect_call`. A MIR dynamic-call operand already contains that field
projection, so rtyping must retain it rather than substitute pyre's name-only
`VtableMethodPtr` pseudo-op, which no backend can execute. This removes the
`unimplemented!("vtable_method_ptr blackhole consumer (backend epic)")`.

## Verification

`cargo check --workspace --all-targets` green. `pyre/check.py` was started but
not completed: `origin/main` moved under the run twice, and a result from a
tree that changed mid-flight is not evidence. CI is the gate here.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-allocation failure handling so errors now raise `MemoryError` instead of causing crashes or invalid allocations.
  * Negative array, string, and Unicode lengths are rejected safely without panics.
  * Improved handling of recursive execution failures and preserved diagnostic information.
  * Unsupported virtual-table operations now exit safely instead of triggering an internal panic.
* **Improvements**
  * Dynamic dispatch and function-pointer handling are more accurate, improving compatibility with trait-based calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->