### PR TITLE
Step the set-like dict-view walks one item at a time, and root their operands across user code

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -865,7 +865,7 @@ fn lower_extended_arg_inner_while(
         quote::quote! { let _ = __builder.live_placeholder(); },
     );
     lowerer.emit_op(
-        OpMeta::conditional_guard_int_eq(
+        OpMeta::conditional_guard_compare(
             Register::int(opcode_reg),
             Register::int(extended_arg_const_reg),
             after_loop.clone(),
@@ -1085,7 +1085,7 @@ fn try_lower_have_argument_guard(lowerer: &mut Lowerer, stmt: &Stmt) -> bool {
         quote! { let _ = __builder.live_placeholder(); },
     );
     lowerer.emit_op(
-        OpMeta::conditional_guard_int_eq(
+        OpMeta::conditional_guard_compare(
             Register::int(local_reg),
             Register::int(const_reg),
             ok_label.clone(),
@@ -2727,7 +2727,7 @@ pub(super) fn lower_dispatch_chain(
                 // Fused goto_if_not_int_eq: branch to the next alternative (or the
                 // arm skip label) if opcode != const.
                 lowerer.emit_op(
-                    OpMeta::conditional_guard_int_eq(
+                    OpMeta::conditional_guard_compare(
                         Register::int(opcode_reg),
                         Register::int(const_reg),
                         miss_label.clone(),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -12,20 +12,6 @@ fn literal_nonnegative_i64(expr: &Expr) -> Option<i64> {
 }
 
 impl<'c> Lowerer<'c> {
-    /// True when any op recorded since index `since` is a float
-    /// comparison — an `OpKind::BinopF` whose result register is int
-    /// banked.  Float arithmetic writes a float result; only the value-
-    /// form `float_lt/le/eq/ne/gt/ge` (`ff>i`) writes an int.  A float
-    /// comparison feeding a conditional guard grows a bridge that hangs the
-    /// compiled trace, so the branch lowerers roll back and use interpreter
-    /// fallback when the condition lowered through one.
-    fn ops_since_contain_float_compare(&self, since: usize) -> bool {
-        self.op_metadata[since..].iter().any(|op| {
-            matches!(op.kind, OpKind::BinopF)
-                && op.writes.iter().any(|w| matches!(w.kind, BindingKind::Int))
-        })
-    }
-
     /// Lower an `if` / `while` condition, peeling a leading `!` into the
     /// branch instead of computing it.
     ///
@@ -40,7 +26,7 @@ impl<'c> Lowerer<'c> {
     /// and does not exist. A condition is `bool` by the language's own typing
     /// rule, which is the guarantee `optimize_goto_if_not` spells out as
     /// `v.concretetype != lltype.Bool: return False`.
-    pub(super) fn lower_condition(&mut self, cond: &Expr) -> Option<(Binding, bool)> {
+    pub(super) fn lower_condition(&mut self, cond: &Expr) -> Option<LoweredCondition> {
         let mut negated = false;
         let mut expr = cond;
         loop {
@@ -57,31 +43,61 @@ impl<'c> Lowerer<'c> {
                 _ => break,
             }
         }
+
+        // RPython `jtransform.py` `optimize_goto_if_not`: when the boolean
+        // comparison result is used only as this block's exitswitch, remove
+        // the value-producing op and carry its operands in the exitswitch.
+        // Flatten then emits `goto_if_not_<opname>/{ii,ff}L`.
+        //
+        // Do not fuse through `!`: `!(a < b)` is not `a >= b` for NaNs.
+        if !negated {
+            let fused = self.transactional(|s| {
+                let Expr::Binary(binary) = expr else {
+                    return None;
+                };
+                let suffix = match &binary.op {
+                    BinOp::Lt(_) => "lt",
+                    BinOp::Le(_) => "le",
+                    BinOp::Eq(_) => "eq",
+                    BinOp::Ne(_) => "ne",
+                    BinOp::Gt(_) => "gt",
+                    BinOp::Ge(_) => "ge",
+                    _ => return None,
+                };
+                let lhs = s.lower_value_expr(&binary.left)?;
+                let rhs = s.lower_value_expr(&binary.right)?;
+                if lhs.kind != rhs.kind
+                    || !matches!(lhs.kind, BindingKind::Int | BindingKind::Float)
+                {
+                    return None;
+                }
+                let prefix = match lhs.kind {
+                    BindingKind::Int => "goto_if_not_int_",
+                    BindingKind::Float => "goto_if_not_float_",
+                    BindingKind::Ref => unreachable!(),
+                };
+                Some(LoweredCondition::Compare {
+                    lhs,
+                    rhs,
+                    branch: format_ident!("{prefix}{suffix}"),
+                })
+            });
+            if fused.is_some() {
+                return fused;
+            }
+        }
+
         let binding = self.lower_value_expr(expr)?;
         // The int bank is what `goto_if_not_int_is_zero` reads. An unnegated
         // condition keeps whatever the caller already accepted.
         if negated && !matches!(binding.kind, BindingKind::Int) {
             return None;
         }
-        Some((binding, negated))
+        Some(LoweredCondition::Value { binding, negated })
     }
 
     pub(super) fn lower_if_stmt(&mut self, expr_if: &ExprIf) -> Option<()> {
-        let snap_stmts = self.statements.len();
-        let snap_meta = self.op_metadata.len();
-        let snap_reg = self.next_reg;
-        let snap_bindings = self.bindings.clone();
-        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
-        if self.ops_since_contain_float_compare(snap_meta) {
-            // Guard over a float comparison hangs the compiled trace; roll
-            // back the condition ops and bail so the arm runs interpreted.
-            self.statements.truncate(snap_stmts);
-            self.op_metadata.truncate(snap_meta);
-            self.next_reg = snap_reg;
-            self.bindings = snap_bindings;
-            return None;
-        }
-        let cond_reg = cond.reg;
+        let cond = self.lower_condition(&expr_if.cond)?;
         let then_seq = self.lower_branch_expr(&Expr::Block(syn::ExprBlock {
             attrs: Vec::new(),
             label: None,
@@ -112,7 +128,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
+        self.emit_lowered_condition_guard(&cond, &else_label);
         self.append_lowered_sequence(then_seq);
         self.emit_jump(&end_label);
         self.emit_label_def(&else_label);
@@ -280,8 +296,6 @@ impl<'c> Lowerer<'c> {
     }
 
     fn lower_while_loop_inner(&mut self, expr_while: &syn::ExprWhile) -> Option<()> {
-        let snap_meta = self.op_metadata.len();
-
         // `loop_start` has to be marked *before* the condition lowers:
         // `mark_label` records the builder's current bytecode position, the
         // back edge re-enters there, and the condition must be re-tested on
@@ -298,18 +312,12 @@ impl<'c> Lowerer<'c> {
         self.emit_label_def(&loop_start);
 
         // Evaluate the condition
-        let (cond, cond_negated) = self.lower_condition(&expr_while.cond)?;
-        if self.ops_since_contain_float_compare(snap_meta) {
-            // Guard over a float comparison hangs the compiled trace; bail so
-            // the arm runs interpreted instead.
-            return None;
-        }
-        let cond_reg = cond.reg;
+        let cond = self.lower_condition(&expr_while.cond)?;
         self.emit_op(
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard_negatable(cond_reg, &loop_end, cond_negated);
+        self.emit_lowered_condition_guard(&cond, &loop_end);
 
         // Lower the body, with break targets pointing to loop_end
         let body_seq = self.lower_loop_body(&expr_while.body, &loop_end, &loop_start)?;
@@ -570,16 +578,9 @@ impl<'c> Lowerer<'c> {
             return None; // no break/continue, fall back to normal lowering
         }
 
-        let snap_meta = self.op_metadata.len();
-        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
-        if self.ops_since_contain_float_compare(snap_meta) {
-            // Guard over a float comparison hangs the compiled trace; bail so
-            // the arm runs interpreted instead.
-            return None;
-        }
+        let cond = self.lower_condition(&expr_if.cond)?;
         let else_label = self.alloc_label();
         let end_label = self.alloc_label();
-        let cond_reg = cond.reg;
 
         self.emit_aux(quote! { let #else_label = __builder.new_label(); });
         self.emit_aux(quote! { let #end_label = __builder.new_label(); });
@@ -587,7 +588,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
+        self.emit_lowered_condition_guard(&cond, &else_label);
 
         // Lower then-branch with loop control
         let then_seq = self.lower_loop_body(&expr_if.then_branch, break_label, continue_label)?;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1457,8 +1457,18 @@ impl<'c> Lowerer<'c> {
     }
 
     pub(super) fn lower_config_call_stmt(&mut self, expr: &Expr) -> Option<()> {
-        let Expr::Call(call) = expr else {
-            return None;
+        // RPython `Transformer.rewrite_call` sees a method receiver as the
+        // first ordinary argument.  Normalize Rust method syntax through the
+        // same call-policy path as value-position calls instead of silently
+        // dropping a void/result-discarding method statement.
+        let normalized;
+        let call = match expr {
+            Expr::Call(call) => call,
+            Expr::MethodCall(method_call) => {
+                normalized = self.normalize_method_call(method_call)?;
+                &normalized
+            }
+            _ => return None,
         };
         let policy = self.resolve_call_policy(&call.func)?;
         if call.args.len() > MAX_HELPER_CALL_ARITY {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1779,12 +1779,11 @@ impl<'c> Lowerer<'c> {
         })
     }
 
-    /// Lower an `Expr::MethodCall` by mapping the receiver ident to its
-    /// canonical owning type (via `LowererConfig.state_type_name` /
-    /// `env_type_name`) and dispatching through the existing call-policy
-    /// table keyed on `<type>::<method>` segments. The receiver is lowered
-    /// as the first call argument so the owning type's `&self` parameter
-    /// gets a real register binding.
+    /// Normalize an `Expr::MethodCall` to the associated free-call shape used
+    /// by the codewriter call-policy machinery.  Both value- and
+    /// statement-position lowering call this helper: RPython
+    /// `Transformer.rewrite_call` receives the receiver as the first ordinary
+    /// argument and does not distinguish the two Rust surface syntaxes.
     ///
     /// Receiver-resolution policy: only the env parameter (`program`) and
     /// the state parameter (`state`) are accepted; any other receiver
@@ -1794,15 +1793,7 @@ impl<'c> Lowerer<'c> {
     /// preserves that fidelity. Arbitrary receivers cannot be resolved
     /// without the owning type identity, so they fall through.
     ///
-    /// Currently only the `Elidable*` Int policy family is supported
-    /// (the consumer set required for `Program::get_req_size`-shaped
-    /// helpers). Wrapped / inline / non-int return policies fall through;
-    /// extending them mirrors the corresponding `lower_call_value` arms
-    /// when needed.
-    ///
-    /// RPython parity: `jtransform.py:456-470 rewrite_op` (graph-identity
-    /// lookup) + `call.py getcalldescr`.
-    fn lower_method_call_value(&mut self, call: &ExprMethodCall) -> Option<Binding> {
+    pub(super) fn normalize_method_call(&self, call: &ExprMethodCall) -> Option<ExprCall> {
         let receiver_ident = match &*call.receiver {
             Expr::Path(ExprPath { path, .. }) => path.get_ident()?,
             _ => return None,
@@ -1815,89 +1806,34 @@ impl<'c> Lowerer<'c> {
             _ => return None,
         };
 
-        let method_segments = vec![type_name.clone(), call.method.to_string()];
-        let policy = self
-            .call_policies
-            .iter()
-            .find(|(p, _)| *p == method_segments)
-            .map(|(_, spec)| spec.clone())?;
-        let kind = match policy {
-            CallPolicySpec::Explicit(kind) => kind,
-            // Method-call inference is not supported; the policy table
-            // must declare the method explicitly.
-            CallPolicySpec::Infer => return None,
-        };
-
-        // Receiver counts as the first call argument; RPython
-        // `jtransform.py:456 rewrite_op` similarly threads `op.args[0]`
-        // (the receiver / first positional) ahead of the rest.
-        if call.args.len() + 1 > MAX_HELPER_CALL_ARITY {
-            return None;
-        }
-
-        let receiver_binding = self.lower_value_expr(&call.receiver)?;
-        let mut arg_bindings = Vec::with_capacity(call.args.len() + 1);
-        let mut depends_on_stack = receiver_binding.depends_on_stack;
-        arg_bindings.push(receiver_binding);
-        for arg in &call.args {
-            let binding = self.lower_value_expr(arg)?;
-            depends_on_stack |= binding.depends_on_stack;
-            arg_bindings.push(binding);
-        }
-
-        // Construct the `<Type>::<method>` path tokens for `add_fn_ptr`.
+        // Construct the `Type::method` function item.  Preserve an explicit
+        // method turbofish: `recv.method::<T>(x)` becomes
+        // `Type::method::<T>(recv, x)`.
         let type_ident = format_ident!("{}", type_name);
         let method_ident = &call.method;
-        let func_path = quote! { <#type_ident>::#method_ident };
-
-        let reg = self.alloc_reg();
-        let result_kind = BindingKind::Int;
-        match kind {
-            crate::jit_interp::CallPolicyKind::ElidableInt
-            | crate::jit_interp::CallPolicyKind::ElidableIntCannotRaise
-            | crate::jit_interp::CallPolicyKind::ElidableIntOrMemerror => {
-                let typed_args = typed_call_arg_tokens(&arg_bindings);
-                let __arg_regs: Vec<Register> =
-                    arg_bindings.iter().map(Register::from_binding).collect();
-                let arg_kinds: Vec<BindingKind> = arg_bindings.iter().map(|b| b.kind).collect();
-                let word_result_addr = word_result_addr_tokens(&func_path, &arg_kinds);
-                let call_stmt = match kind {
-                    crate::jit_interp::CallPolicyKind::ElidableInt => quote! {
-                        __builder.call_pure_int_canonical_via_target(__fn_idx, #typed_args, #reg);
-                    },
-                    crate::jit_interp::CallPolicyKind::ElidableIntCannotRaise => quote! {
-                        __builder.call_pure_int_canonical_via_target_cannot_raise(__fn_idx, #typed_args, #reg);
-                    },
-                    crate::jit_interp::CallPolicyKind::ElidableIntOrMemerror => quote! {
-                        __builder.call_pure_int_canonical_via_target_or_memerror(__fn_idx, #typed_args, #reg);
-                    },
-                    _ => unreachable!(),
-                };
-                self.emit_op(
-                    OpMeta::linear(
-                        OpKind::Call,
-                        __arg_regs,
-                        vec![Register::new(result_kind, reg)],
-                    ),
-                    quote! {
-                        let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
-                        #call_stmt
-                    },
-                );
-            }
-            // Other policy kinds are not yet wired for method-call RHS.
-            // Consumers needing residual / may_force / wrapped / inline
-            // method-call lowering must add the corresponding arm here
-            // mirroring `lower_call_value`'s shape.
-            _ => return None,
-        }
-
-        Some(Binding {
-            reg,
-            kind: result_kind,
-            depends_on_stack,
-            struct_type: None,
+        let func: Expr = if let Some(turbofish) = &call.turbofish {
+            syn::parse_quote! { #type_ident::#method_ident #turbofish }
+        } else {
+            syn::parse_quote! { #type_ident::#method_ident }
+        };
+        let mut args = syn::punctuated::Punctuated::new();
+        args.push((*call.receiver).clone());
+        args.extend(call.args.iter().cloned());
+        Some(ExprCall {
+            attrs: call.attrs.clone(),
+            func: Box::new(func),
+            paren_token: call.paren_token,
+            args,
         })
+    }
+
+    /// Method syntax does not select a smaller policy/result-kind universe.
+    /// Reuse `lower_call_value` so residual, elidable, may-force, release-gil,
+    /// loop-invariant, wrapped, inline and inferred policies all keep the same
+    /// `Transformer.rewrite_call` contract.
+    fn lower_method_call_value(&mut self, call: &ExprMethodCall) -> Option<Binding> {
+        let normalized = self.normalize_method_call(call)?;
+        self.lower_call_value(&normalized)
     }
 
     fn lower_if_value(&mut self, expr_if: &ExprIf) -> Option<Binding> {
@@ -1905,10 +1841,8 @@ impl<'c> Lowerer<'c> {
             return Some(binding);
         }
 
-        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
-        if !matches!(cond.kind, BindingKind::Int) {
-            return None;
-        }
+        let cond = self.lower_condition(&expr_if.cond)?;
+        let cond_depends_on_stack = cond.depends_on_stack();
         let (_, else_expr) = expr_if.else_branch.as_ref()?;
         // A branch that fails to lower fails the whole if-expression as
         // unsupported (`?`): the codewriter lowers expressible ops exactly
@@ -1933,15 +1867,13 @@ impl<'c> Lowerer<'c> {
         let else_label = self.alloc_label();
         let end_label = self.alloc_label();
         let result_reg = self.alloc_reg();
-        let cond_reg = cond.reg;
-
         self.emit_aux(quote! { let #else_label = __builder.new_label(); });
         self.emit_aux(quote! { let #end_label = __builder.new_label(); });
         self.emit_op(
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
+        self.emit_lowered_condition_guard(&cond, &else_label);
         self.append_lowered_sequence(then_seq);
         self.emit_op(
             OpMeta::linear(
@@ -1967,7 +1899,7 @@ impl<'c> Lowerer<'c> {
         Some(Binding {
             reg: result_reg,
             kind: BindingKind::Int,
-            depends_on_stack: cond.depends_on_stack
+            depends_on_stack: cond_depends_on_stack
                 || then_binding.depends_on_stack
                 || else_binding.depends_on_stack,
             struct_type: None,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -404,6 +404,30 @@ impl<'c> Lowerer<'c> {
         );
     }
 
+    /// Emit the exitswitch shape chosen by `jtransform.py`'s
+    /// `optimize_goto_if_not`.
+    pub(super) fn emit_lowered_condition_guard(
+        &mut self,
+        condition: &LoweredCondition,
+        target: &Ident,
+    ) {
+        match condition {
+            LoweredCondition::Value { binding, negated } => {
+                self.emit_conditional_guard_negatable(binding.reg, target, *negated);
+            }
+            LoweredCondition::Compare { lhs, rhs, branch } => {
+                let lhs_reg = Register::new(lhs.kind, lhs.reg);
+                let rhs_reg = Register::new(rhs.kind, rhs.reg);
+                let lhs_index = lhs.reg;
+                let rhs_index = rhs.reg;
+                self.emit_op(
+                    OpMeta::conditional_guard_compare(lhs_reg, rhs_reg, target.clone()),
+                    quote! { __builder.#branch(#lhs_index, #rhs_index, #target); },
+                );
+            }
+        }
+    }
+
     /// Emit a builder-side aux statement (no BC_* op, no def/use).
     pub(super) fn emit_aux(&mut self, tokens: TokenStream) {
         self.emit_op(OpMeta::aux(), tokens);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -1642,6 +1642,34 @@ pub(super) struct Binding {
     pub(super) struct_type: Option<syn::Path>,
 }
 
+/// A condition after `jtransform.py`'s `optimize_goto_if_not` decision.
+///
+/// A comparison whose boolean result is consumed only by the branch is kept
+/// as its two operands and becomes `goto_if_not_<comparison>` directly.
+/// Other conditions retain their materialized int result. In particular a
+/// leading `!` stays in the latter form: inverting a float comparison would
+/// change its NaN semantics.
+pub(super) enum LoweredCondition {
+    Value {
+        binding: Binding,
+        negated: bool,
+    },
+    Compare {
+        lhs: Binding,
+        rhs: Binding,
+        branch: Ident,
+    },
+}
+
+impl LoweredCondition {
+    pub(super) fn depends_on_stack(&self) -> bool {
+        match self {
+            Self::Value { binding, .. } => binding.depends_on_stack,
+            Self::Compare { lhs, rhs, .. } => lhs.depends_on_stack || rhs.depends_on_stack,
+        }
+    }
+}
+
 /// Mirror of RPython `rpython/jit/codewriter/flatten.py:Register(kind, index)`.
 /// Each emitted register carries its bank with it; the liveness walker
 /// (`liveness.py:33-79`) keeps a single `set()` of `Register` objects per
@@ -1958,10 +1986,10 @@ impl OpMeta {
         }
     }
 
-    /// Two-register conditional guard for `goto_if_not_int_eq(a, b, target)`.
-    /// jtransform.py `optimize_goto_if_not` fuses `int_eq + goto_if_not`
-    /// into `goto_if_not_int_eq/iiL`. Both `a_reg` and `b_reg` are read uses.
-    pub(super) fn conditional_guard_int_eq(
+    /// Two-register conditional guard produced by `optimize_goto_if_not`.
+    /// Both comparison operands are read uses; their register banks carry the
+    /// `/iiL` versus `/ffL` distinction used by `assembler.py`.
+    pub(super) fn conditional_guard_compare(
         a_reg: Register,
         b_reg: Register,
         target: Ident,
@@ -2539,6 +2567,21 @@ mod tests {
         syn::parse_str(code).expect("failed to parse call")
     }
 
+    fn method_call_config(
+        owner: &str,
+        method: &str,
+        kind: crate::jit_interp::CallPolicyKind,
+    ) -> LowererConfig {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.state_type_name = "Machine".to_string();
+        config.env_type_name = "Program".to_string();
+        config.calls.push((
+            vec![owner.to_string(), method.to_string()],
+            CallPolicySpec::Explicit(kind),
+        ));
+        config
+    }
+
     fn inline_call_tokens_combined(bindings: &[Binding], result_reg: u16) -> String {
         let (call_match, post_live) = inline_call_tokens(bindings, result_reg);
         format!("{} {}", call_match, post_live)
@@ -2562,6 +2605,108 @@ mod tests {
         lowerer.append_lowered_sequence(seq);
         assert_eq!(lowerer.statements.len(), lowerer.op_metadata.len());
         assert!(matches!(lowerer.op_metadata[1].kind, OpKind::LoadConstI));
+    }
+
+    #[test]
+    fn method_call_uses_the_shared_residual_ref_lowering() {
+        let mut config = method_call_config(
+            "Program",
+            "lookup",
+            crate::jit_interp::CallPolicyKind::ResidualRef,
+        );
+        config.call_returns.insert(
+            vec!["Program".to_string(), "lookup".to_string()],
+            syn::parse_quote!(Node),
+        );
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer
+            .bindings
+            .insert("program".to_string(), binding(0, BindingKind::Ref));
+        lowerer
+            .bindings
+            .insert("pc".to_string(), binding(0, BindingKind::Int));
+        let call: Expr = syn::parse_quote! { program.lookup(pc) };
+
+        let result = lowerer
+            .lower_value_expr(&call)
+            .expect("a method has the same residual-ref policy surface as a free call");
+
+        assert!(matches!(result.kind, BindingKind::Ref));
+        assert_eq!(result.struct_type, Some(syn::parse_quote!(Node)));
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("Program :: lookup"), "{body}");
+        assert!(
+            body.contains("residual_call_ref_canonical_via_target"),
+            "{body}"
+        );
+        assert!(body.contains("live_placeholder"), "{body}");
+    }
+
+    #[test]
+    fn method_call_uses_the_shared_wrapped_float_lowering() {
+        let config = method_call_config(
+            "Machine",
+            "ratio",
+            crate::jit_interp::CallPolicyKind::ElidableFloatCannotRaiseWrapped,
+        );
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer
+            .bindings
+            .insert("state".to_string(), binding(0, BindingKind::Ref));
+        lowerer
+            .bindings
+            .insert("value".to_string(), binding(0, BindingKind::Int));
+        let call: Expr = syn::parse_quote! { state.ratio(value) };
+
+        let result = lowerer
+            .lower_value_expr(&call)
+            .expect("method syntax must not narrow the wrapped float policy surface");
+
+        assert!(matches!(result.kind, BindingKind::Float));
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(
+            body.contains("Machine :: __majit_call_policy_ratio"),
+            "{body}"
+        );
+        assert!(
+            body.contains("call_pure_float_canonical_via_target_cannot_raise"),
+            "{body}"
+        );
+        assert!(!body.contains("live_placeholder"), "{body}");
+    }
+
+    #[test]
+    fn method_statement_uses_the_shared_void_lowering() {
+        let config = method_call_config(
+            "Machine",
+            "mutate",
+            crate::jit_interp::CallPolicyKind::ResidualVoid,
+        );
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer
+            .bindings
+            .insert("state".to_string(), binding(0, BindingKind::Ref));
+        lowerer
+            .bindings
+            .insert("value".to_string(), binding(0, BindingKind::Int));
+        let call: Expr = syn::parse_quote! { state.mutate(value) };
+
+        lowerer
+            .lower_config_call_stmt(&call)
+            .expect("method statements share the free-call void policy surface");
+
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("Machine :: mutate"), "{body}");
+        assert!(
+            body.contains("residual_call_void_canonical_via_target"),
+            "{body}"
+        );
+        assert!(body.contains("live_placeholder"), "{body}");
+        assert_eq!(lowerer.op_metadata[0].reads.len(), 2);
+        assert!(matches!(lowerer.op_metadata[1].kind, OpKind::LiveMarker));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -5862,9 +5862,13 @@ impl JitCodeBuilder {
             // descriptor banks are empty.
             str_consts: Vec::new(),
             unit_variant_consts: Vec::new(),
-            c_num_regs_i: self.num_regs_i,
-            c_num_regs_r: self.num_regs_r,
-            c_num_regs_f: self.num_regs_f,
+            // `jitcode.py JitCode.setup`: the three register counts are
+            // stored as one `chr` apiece.  The gate above proves these casts
+            // lossless; keeping the builder counters wide is useful only
+            // while detecting an unencodable source body.
+            c_num_regs_i: self.num_regs_i as u8,
+            c_num_regs_r: self.num_regs_r as u8,
+            c_num_regs_f: self.num_regs_f as u8,
             // RPython `assembler.py make_jitcode(startpoints=
             // self.startpoints, alllabels=self.alllabels, ...)` —
             // assembled jitcodes always carry the recorded set, never

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -2656,15 +2656,20 @@ mod residual_call_not_dropped {
     }
 }
 
-/// A float comparison can lower as an integer value, but using it directly as
-/// a conditional guard must degrade until guard-bridge lowering is supported.
+/// `jtransform.py`'s `optimize_goto_if_not` keeps a float comparison as a
+/// value when it escapes, but fuses it into the branch when it is consumed
+/// only by the exitswitch.
 mod float_compare_branch_gate {
     use super::Bytecode;
-    use majit_metainterp::jitcode::insns::BC_FLOAT_GE;
+    use majit_metainterp::jitcode::insns::{
+        BC_FLOAT_GE, BC_GOTO_IF_NOT_FLOAT_GE, BC_GOTO_IF_NOT_INT_GE, BC_GOTO_IF_NOT_INT_IS_ZERO,
+    };
     use majit_metainterp::{Assembler, JitDriver};
 
     const OP_VALUE: u8 = 6;
     const OP_BRANCH: u8 = 7;
+    const OP_INT_BRANCH: u8 = 8;
+    const OP_NEGATED_BRANCH: u8 = 9;
 
     struct FloatCmpState {
         fa: f64,
@@ -2700,9 +2705,23 @@ mod float_compare_branch_gate {
             match opcode {
                 // Value form: float compare materialized to an int — lowers.
                 OP_VALUE => state.acc += (state.fa >= state.fb) as i64,
-                // Branch form: float compare feeding a guard — must abort.
+                // Branch form: lowers to goto_if_not_float_ge/ffL.
                 OP_BRANCH => {
                     if state.fa >= state.fb {
+                        state.acc += 1;
+                    }
+                }
+                // The same upstream optimization covers integer comparisons.
+                OP_INT_BRANCH => {
+                    if state.acc >= 0 {
+                        state.acc += 1;
+                    }
+                }
+                // An odd negation must not invert a float comparison: that
+                // would change the result for NaNs. PyPy materializes the
+                // comparison and fuses bool_not as int_is_zero instead.
+                OP_NEGATED_BRANCH => {
+                    if !(state.fa >= state.fb) {
                         state.acc += 1;
                     }
                 }
@@ -2713,7 +2732,7 @@ mod float_compare_branch_gate {
     }
 
     #[test]
-    fn float_compare_lowers_as_value_but_not_as_branch_guard() {
+    fn float_compare_lowers_as_value_and_fused_branch_guard() {
         let mut asm = Assembler::new();
         asm.set_canonical_liveness_triple(vec![2], vec![], vec![0, 1]);
         __prebuild_jitcode_liveness_dispatch_float_cmp(&mut asm);
@@ -2727,12 +2746,62 @@ mod float_compare_branch_gate {
             .filter_map(|descr| descr.as_jitcode())
             .map(|sub| sub.code.iter().filter(|&&b| b == BC_FLOAT_GE).count())
             .sum();
-        // The value-form arm emits exactly one float_ge; the branch-form arm
-        // must abort lowering (no float_ge feeding a guard), so the total is
-        // 1 rather than 2.
+        let guard_ge_count: usize = dispatch_jc
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode())
+            .map(|sub| {
+                sub.code
+                    .iter()
+                    .filter(|&&b| b == BC_GOTO_IF_NOT_FLOAT_GE)
+                    .count()
+            })
+            .sum();
+        let int_guard_ge_count: usize = dispatch_jc
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode())
+            .map(|sub| {
+                sub.code
+                    .iter()
+                    .filter(|&&b| b == BC_GOTO_IF_NOT_INT_GE)
+                    .count()
+            })
+            .sum();
+        let negated_guard_count: usize = dispatch_jc
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode())
+            .map(|sub| {
+                sub.code
+                    .iter()
+                    .filter(|&&b| b == BC_GOTO_IF_NOT_INT_IS_ZERO)
+                    .count()
+            })
+            .sum();
+        // The value and odd-negation arms retain float_ge/ff>i. The direct
+        // branch arm has no materialized boolean and emits the fused ffL
+        // exitswitch instead.
         assert_eq!(
-            ge_count, 1,
-            "float compare must lower as value but not as branch guard; float_ge={ge_count}"
+            ge_count, 2,
+            "only the escaping and negated float comparisons should materialize; \
+             float_ge={ge_count}"
+        );
+        assert_eq!(
+            guard_ge_count, 1,
+            "branch comparison must fuse; goto_if_not_float_ge={guard_ge_count}"
+        );
+        assert_eq!(
+            int_guard_ge_count, 1,
+            "integer branch comparison must fuse too; goto_if_not_int_ge={int_guard_ge_count}"
+        );
+        assert_eq!(
+            negated_guard_count, 1,
+            "odd float negation must preserve NaN semantics via int_is_zero; \
+             goto_if_not_int_is_zero={negated_guard_count}"
         );
     }
 }

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -644,9 +644,9 @@ impl Assembler {
             constants_f: state.constants_f,
             str_consts: state.str_consts,
             unit_variant_consts: state.unit_variant_consts,
-            c_num_regs_i: num_regs_i as u16,
-            c_num_regs_r: num_regs_r as u16,
-            c_num_regs_f: num_regs_f as u16,
+            c_num_regs_i: num_regs_i as u8,
+            c_num_regs_r: num_regs_r as u8,
+            c_num_regs_f: num_regs_f as u8,
             // self.startpoints, alllabels=self.alllabels,
             // resulttypes=self.resulttypes, ...)` — assembled jitcodes
             // always carry the recorded set, never `None`. Wrap in

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -218,16 +218,14 @@ pub struct JitCodeBody {
     #[serde(default)]
     pub unit_variant_consts: Vec<UnitVariantConstDescriptor>,
     /// RPython `jitcode.py` `self.c_num_regs_i = chr(num_regs_i)`.
-    /// RPython packs into a single chr (`assert num_regs_i < 256`); pyre
-    /// uses `u16` to keep CPython 3.13 codes that legitimately exceed 255
-    /// registers per kind reachable.  The codewriter still asserts
-    /// `< 256` for now (assembler.rs); widening the field is a parity
-    /// preparation for that limit being lifted.
-    pub c_num_regs_i: u16,
+    /// The one-byte carrier is part of the JitCode format; both
+    /// `JitCode.setup` and `Assembler.check_result` reject values that do not
+    /// fit it before the body is published.
+    pub c_num_regs_i: u8,
     /// RPython `jitcode.py` `self.c_num_regs_r = chr(num_regs_r)`.
-    pub c_num_regs_r: u16,
+    pub c_num_regs_r: u8,
     /// RPython `jitcode.py` `self.c_num_regs_f = chr(num_regs_f)`.
-    pub c_num_regs_f: u16,
+    pub c_num_regs_f: u8,
     /// RPython `jitcode.py` `self._startpoints = startpoints` —
     /// debug-only set of bytecode offsets where instructions start.
     /// `setup(..., startpoints=None)` (jitcode.py) is the upstream

--- a/majit/majit-translate/src/codewriter/liveness.rs
+++ b/majit/majit-translate/src/codewriter/liveness.rs
@@ -139,11 +139,11 @@ pub fn remove_repeated_live(ops: &mut Vec<FlatOp>) {
             continue;
         }
         let mut labels = Vec::new();
-        let mut merged_live: HashSet<Register> = HashSet::new();
+        let mut lives = Vec::new();
         while i < ops.len() {
             match &ops[i] {
                 FlatOp::Live { live_values } => {
-                    merged_live.extend(live_values.iter().copied());
+                    lives.push(live_values.clone());
                     i += 1;
                 }
                 FlatOp::Label(_) => {
@@ -154,6 +154,19 @@ pub fn remove_repeated_live(ops: &mut Vec<FlatOp>) {
             }
         }
         result.extend(labels);
+        if lives.len() == 1 {
+            // RPython `remove_repeated_live`: a lone marker is moved after
+            // interleaved labels but otherwise preserved byte-for-byte. The
+            // union/sort step belongs only to a genuinely repeated run.
+            result.push(FlatOp::Live {
+                live_values: lives.pop().unwrap(),
+            });
+            continue;
+        }
+        let mut merged_live: HashSet<Register> = HashSet::new();
+        for live in lives {
+            merged_live.extend(live);
+        }
         // Stable order so the final bytecode encoding is reproducible.
         let mut merged: Vec<Register> = merged_live.into_iter().collect();
         merged.sort_by_key(|r| (r.kind as u8, r.index));
@@ -562,6 +575,31 @@ mod tests {
 
     use crate::flatten::FlatOp;
     use crate::model::{OpKind, SpaceOperation, ValueType};
+
+    #[test]
+    fn lone_live_marker_keeps_its_original_register_sequence() {
+        // RPython `remove_repeated_live`: labels move before a lone marker,
+        // but the marker itself bypasses the multi-marker set/sort path.
+        let live = vec![
+            Register::new(RegKind::Int, 2),
+            Register::new(RegKind::Int, 1),
+            Register::new(RegKind::Int, 2),
+        ];
+        let mut ops = vec![
+            FlatOp::Live {
+                live_values: live.clone(),
+            },
+            FlatOp::Label(Label(7)),
+        ];
+
+        remove_repeated_live(&mut ops);
+
+        assert!(matches!(ops.first(), Some(FlatOp::Label(Label(7)))));
+        assert!(matches!(
+            ops.get(1),
+            Some(FlatOp::Live { live_values }) if live_values == &live
+        ));
+    }
 
     #[test]
     fn basic_liveness() {

--- a/pyre/bench/synth/dict_view_setlike_lazy_walk_regression.py
+++ b/pyre/bench/synth/dict_view_setlike_lazy_walk_regression.py
@@ -1,0 +1,245 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=warm
+# Self-checking regression guard for the two `SetLikeDictView` walks that step
+# their operand one item at a time.
+#
+# `dictmultiobject.py descr_isdisjoint` opens `space.iter(w_other)` and tests
+# `space.contains_w(self, w_item)` per step, so it answers `False` at the first
+# common element and never asks the iterable for the rest.  Materialising the
+# operand first instead reaches items the walk had already decided against: an
+# iterable that yields a common element and then raises propagated that
+# exception rather than answering, and a generator was drained past the answer.
+#
+# `dictmultiobject.py _all_contained_in` walks `space.iter(w_dictview)` for the
+# same reason on the other side.  A `contains_w` that mutates the dict behind
+# the view is caught by the view iterator's own size check on the next step; a
+# snapshot taken before the loop answers from the pre-mutation copy, so the
+# mutation went unreported and the comparison returned an answer at all.
+#
+# A set answers `NotImplemented` for a view, so `set OP view` is decided by the
+# reflected call on the view with the operator flipped -- the same two walks.
+# Reducing both sides to sets instead answers those from a snapshot as well,
+# which is why the reflected forms are asserted here beside the direct ones.
+#
+# Every expectation below is the value CPython 3.14 and PyPy both produce.
+try:
+    import pypyjit
+
+    pypyjit.set_param("threshold=20,function_threshold=20")
+except ImportError:
+    pass
+
+failures = []
+
+
+class Consumed:
+    n = 0
+
+
+def counted(items):
+    for item in items:
+        Consumed.n += 1
+        yield item
+
+
+def raising_after(items):
+    for item in items:
+        yield item
+    raise ValueError("the walk should have stopped before here")
+
+
+class MutatesOnEq:
+    """Grows `victim` from inside the comparison the containment test runs."""
+
+    def __init__(self, i):
+        self.i = i
+
+    def __hash__(self):
+        return hash(self.i)
+
+    def __eq__(self, other):
+        victim[len(victim) + 100] = "grown"
+        return isinstance(other, MutatesOnEq) and other.i == self.i
+
+
+victim = {}
+
+
+def check(label, fn, expected):
+    """Assert `fn()` answers `expected`, or raises it when it names a type."""
+    try:
+        got = repr(fn())
+    except BaseException as e:  # noqa: BLE001 - the type is the assertion
+        got = "!! " + type(e).__name__
+    if got != expected:
+        failures.append("%s: expected %s, got %s" % (label, expected, got))
+
+
+def isdisjoint_stops_at_first_hit():
+    Consumed.n = 0
+    answer = {1: "a"}.keys().isdisjoint(counted([1, 2, 3, 4, 5]))
+    return answer, Consumed.n
+
+
+def isdisjoint_walks_all_when_disjoint():
+    Consumed.n = 0
+    answer = {9: "a"}.keys().isdisjoint(counted([1, 2, 3]))
+    return answer, Consumed.n
+
+
+def warm(n):
+    """The hot loop the JIT has to compile for this guard to cover it."""
+    hits = 0
+    keys = {1: "a", 2: "b"}
+    other = {2: "b", 3: "c"}
+    for _ in range(n):
+        if not keys.keys().isdisjoint(other.keys()):
+            hits += 1
+        if keys.keys() == {1, 2}:
+            hits += 1
+        if {1, 2} >= keys.keys():
+            hits += 1
+        if keys.keys().isdisjoint((7, 8)):
+            hits += 1
+    return hits
+
+
+def lazy_isdisjoint_cases():
+    # The operand raises only after the element that decides the answer.
+    check(
+        "isdisjoint_keys_hit_then_raise",
+        lambda: {1: "a", 2: "b"}.keys().isdisjoint(raising_after([1])),
+        "False",
+    )
+    check(
+        "isdisjoint_items_hit_then_raise",
+        lambda: {1: "a"}.items().isdisjoint(raising_after([(1, "a")])),
+        "False",
+    )
+    # A genuinely disjoint operand has to be walked to the end, so the same
+    # iterable does raise there.
+    check(
+        "isdisjoint_keys_miss_then_raise",
+        lambda: {9: "a"}.keys().isdisjoint(raising_after([1])),
+        "!! ValueError",
+    )
+    # How much of the operand the walk consumed.
+    check("isdisjoint_stops_at_first_hit", isdisjoint_stops_at_first_hit, "(False, 1)")
+    check("isdisjoint_walks_all_when_disjoint", isdisjoint_walks_all_when_disjoint, "(True, 3)")
+    # `self is w_other` short-circuits on the length before any walk, so it
+    # needs the identical view object, not an equal one.
+    same = {1: "a"}.keys()
+    check("isdisjoint_identical_view", lambda: same.isdisjoint(same), "False")
+    same_empty = {}.keys()
+    check("isdisjoint_identical_empty_view", lambda: same_empty.isdisjoint(same_empty), "True")
+    check(
+        "isdisjoint_equal_but_distinct",
+        lambda: {1: "a"}.keys().isdisjoint({1: "a"}.keys()),
+        "False",
+    )
+    # Set-like operands keep answering the same way.
+    check("isdisjoint_set_hit", lambda: {1: "a"}.keys().isdisjoint({1, 2}), "False")
+    check("isdisjoint_set_miss", lambda: {1: "a"}.keys().isdisjoint({7, 8}), "True")
+    check(
+        "isdisjoint_big_set_miss",
+        lambda: {1: "a"}.keys().isdisjoint(set(range(100, 400))),
+        "True",
+    )
+    check(
+        "isdisjoint_big_set_hit",
+        lambda: {150: "a"}.keys().isdisjoint(set(range(100, 400))),
+        "False",
+    )
+    # A non-iterable operand still raises from `iter`.
+    check("isdisjoint_int", lambda: {1: "a"}.keys().isdisjoint(1), "!! TypeError")
+
+
+def live_walk_cases():
+    global victim
+
+    # The comparison walks the view live, so a mutation from inside the
+    # containment test is reported by the iterator's size check.
+    victim = {MutatesOnEq(0): 1, MutatesOnEq(1): 2}
+    check(
+        "eq_mutating_eq",
+        lambda: victim.keys() == {MutatesOnEq(0), MutatesOnEq(1)},
+        "!! RuntimeError",
+    )
+    check("eq_mutating_eq_len", lambda: len(victim), "3")
+    victim = {MutatesOnEq(0): 1, MutatesOnEq(1): 2}
+    check(
+        "le_mutating_eq",
+        lambda: victim.keys() <= {MutatesOnEq(0), MutatesOnEq(1)},
+        "!! RuntimeError",
+    )
+    # `ge` walks the other operand, so the set is what is iterated and the
+    # view's size check is not the one on duty.
+    victim = {MutatesOnEq(0): 1}
+    check("ge_mutating_eq", lambda: victim.keys() >= {MutatesOnEq(0)}, "True")
+    # The same mutation, reached from the set side.
+    victim = {MutatesOnEq(0): 1, MutatesOnEq(1): 2}
+    check(
+        "set_eq_view_mutating_eq",
+        lambda: {MutatesOnEq(0), MutatesOnEq(1)} == victim.keys(),
+        "!! RuntimeError",
+    )
+    check("set_eq_view_mutating_eq_len", lambda: len(victim), "3")
+
+
+def plain_comparison_cases():
+    a = {"a": 1, "b": 2}
+    b = {"a": 1, "b": 2, "c": 3}
+    check("eq_plain", lambda: a.keys() == {"a", "b"}, "True")
+    check("lt_plain", lambda: a.keys() < b.keys(), "True")
+    check("le_plain", lambda: a.keys() <= b.keys(), "True")
+    check("gt_plain", lambda: b.keys() > a.keys(), "True")
+    check("ge_plain", lambda: b.keys() >= a.keys(), "True")
+    check("ne_plain", lambda: a.keys() != b.keys(), "True")
+    check("eq_items", lambda: a.items() == {("a", 1), ("b", 2)}, "True")
+    check("eq_not_set_like", lambda: a.keys() == [1, 2], "False")
+    # A set answers `NotImplemented` for a view, so every one of these is
+    # decided by the reflected call on the view with the operator flipped.
+    check("set_eq_view", lambda: {"a", "b"} == a.keys(), "True")
+    check("set_ne_view", lambda: {"a", "b"} != a.keys(), "False")
+    check("set_lt_view", lambda: {"a"} < a.keys(), "True")
+    check("set_lt_view_equal", lambda: {"a", "b"} < a.keys(), "False")
+    check("set_le_view", lambda: {"a", "b"} <= a.keys(), "True")
+    check("set_le_view_bigger", lambda: {"a", "b", "z"} <= a.keys(), "False")
+    check("set_gt_view", lambda: {"a", "b", "c"} > a.keys(), "True")
+    check("set_gt_view_equal", lambda: {"a", "b"} > a.keys(), "False")
+    check("set_ge_view", lambda: {"a", "b"} >= a.keys(), "True")
+    check("set_ge_view_smaller", lambda: {"a"} >= a.keys(), "False")
+    check("view_lt_set", lambda: a.keys() < {"a", "b", "c"}, "True")
+    check("view_le_set", lambda: a.keys() <= {"a", "b"}, "True")
+    check("view_gt_set", lambda: a.keys() > {"a"}, "True")
+    check("view_ge_set", lambda: a.keys() >= {"a", "b"}, "True")
+    check("frozenset_eq_view", lambda: frozenset({"a", "b"}) == a.keys(), "True")
+    check("view_eq_frozenset", lambda: a.keys() == frozenset({"a", "b"}), "True")
+    check("set_eq_items_view", lambda: {("a", 1), ("b", 2)} == a.items(), "True")
+    # A values view is not set-like, so the comparison never reaches the walk.
+    check("set_eq_values_view", lambda: {1, 2} == a.values(), "False")
+    check("values_view_eq_set", lambda: a.values() == {1, 2}, "False")
+
+
+def main():
+    lazy_isdisjoint_cases()
+    live_walk_cases()
+    plain_comparison_cases()
+    # The same walks under the JIT, after the loop above has compiled.
+    hot = warm(3000)
+    if hot != 3000 * 4:
+        failures.append("warm() answered %d, expected %d" % (hot, 3000 * 4))
+    # The interpreter-level cases again, now that the walks are compiled.
+    lazy_isdisjoint_cases()
+    live_walk_cases()
+    plain_comparison_cases()
+
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS dict-view set-like lazy walk")
+    return 0
+
+
+raise SystemExit(main())

--- a/pyre/bench/synth/dict_view_setlike_lazy_walk_regression.py
+++ b/pyre/bench/synth/dict_view_setlike_lazy_walk_regression.py
@@ -22,6 +22,8 @@
 # which is why the reflected forms are asserted here beside the direct ones.
 #
 # Every expectation below is the value CPython 3.14 and PyPy both produce.
+import gc
+
 try:
     import pypyjit
 
@@ -30,6 +32,34 @@ except ImportError:
     pass
 
 failures = []
+
+
+class CollectingLen(set):
+    """A set subclass whose length is a Python call that collects.
+
+    `space.len_w` on either operand reaches this, so it is the window a dict
+    view -- which is nursery-allocated and therefore moves -- has to survive.
+    """
+
+    def __len__(self):
+        gc.collect(0)
+        return set.__len__(self)
+
+
+class CollectsOnIter:
+    """An iterable whose `__iter__` collects before yielding anything.
+
+    A generator's `iter()` runs no user code, so the receiver has to be rooted
+    before `space.iter(w_other)` for this shape rather than only around the
+    steps after it.
+    """
+
+    def __init__(self, items):
+        self.items = items
+
+    def __iter__(self):
+        gc.collect(0)
+        return iter(self.items)
 
 
 class Consumed:
@@ -152,6 +182,23 @@ def lazy_isdisjoint_cases():
     )
     # A non-iterable operand still raises from `iter`.
     check("isdisjoint_int", lambda: {1: "a"}.keys().isdisjoint(1), "!! TypeError")
+    # The receiver has to survive the collection `space.iter(w_other)` runs,
+    # and the view handed in is a temporary with nothing else holding it.
+    check(
+        "isdisjoint_collecting_iter_hit",
+        lambda: {1: "a", 2: "b"}.keys().isdisjoint(CollectsOnIter([2, 3])),
+        "False",
+    )
+    check(
+        "isdisjoint_collecting_iter_miss",
+        lambda: {1: "a", 2: "b"}.keys().isdisjoint(CollectsOnIter([7, 8])),
+        "True",
+    )
+    check(
+        "isdisjoint_collecting_len_operand",
+        lambda: {1: "a"}.keys().isdisjoint(CollectingLen({9})),
+        "True",
+    )
 
 
 def live_walk_cases():
@@ -219,6 +266,17 @@ def plain_comparison_cases():
     # A values view is not set-like, so the comparison never reaches the walk.
     check("set_eq_values_view", lambda: {1, 2} == a.values(), "False")
     check("values_view_eq_set", lambda: a.values() == {1, 2}, "False")
+    # Both length calls dispatch a Python `__len__` that collects, and the
+    # view on the other side is a temporary nothing else holds.
+    check("collecting_len_eq_view", lambda: CollectingLen({"a", "b"}) == a.keys(), "True")
+    check("view_eq_collecting_len", lambda: a.keys() == CollectingLen({"a", "b"}), "True")
+    check("collecting_len_lt_view", lambda: CollectingLen({"a"}) < a.keys(), "True")
+    check("collecting_len_le_view", lambda: CollectingLen({"a", "b"}) <= a.keys(), "True")
+    check("collecting_len_gt_view", lambda: CollectingLen({"a", "b", "c"}) > a.keys(), "True")
+    check("collecting_len_ge_view", lambda: CollectingLen({"a", "b"}) >= a.keys(), "True")
+    check("collecting_len_ne_view", lambda: CollectingLen({"a"}) != a.keys(), "True")
+    check("view_gt_collecting_len", lambda: a.keys() > CollectingLen({"a"}), "True")
+    check("view_ge_collecting_len", lambda: a.keys() >= CollectingLen({"a"}), "True")
 
 
 def main():

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5526,12 +5526,17 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                 // Building the second set hashes every element it stores,
                 // which runs Python, and a set `as_set` had to mint is not
                 // held by anything else — it is old-gen, so it never moves,
-                // but an unreachable one is still swept.
-                let _roots = pyre_object::gc_roots::push_roots();
-                let a_set = as_set(a)?;
-                let a_set = pyre_object::gc_roots::pin_root(a_set);
-                let b_set = as_set(b)?;
-                let b_set = pyre_object::gc_roots::pin_root(b_set);
+                // but an unreachable one is still swept.  Building the *first*
+                // one collects with `b` still to be read, and `b` is a native
+                // copy no root walker updates, so both operands are published
+                // before either conversion runs.
+                let roots = pyre_object::gc_roots::push_roots();
+                let base = roots.publish(&[a, b]);
+                roots.normalize(base, 2);
+                let a_set = as_set(roots.get(base))?;
+                let a_set = roots.pin_root(a_set);
+                let b_set = as_set(roots.get(base + 1))?;
+                let b_set = roots.pin_root(b_set);
                 let la = pyre_object::w_set_len(a_set);
                 let lb = pyre_object::w_set_len(b_set);
                 let a_subset_b = || crate::typedef::set_is_subset_of(a_set, b_set);

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5512,43 +5512,30 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                 false
             };
             if view_set_like(a) && view_set_like(b) {
-                // A set operand stands in for itself; only a view is walked and
-                // hashed into one. Rebuilding a set from its own elements would
-                // hand each of them back to a user `__hash__`.
-                let as_set = |obj: PyObjectRef| -> Result<PyObjectRef, PyError> {
-                    if pyre_object::is_set_or_frozenset(obj) {
-                        return Ok(obj);
-                    }
-                    crate::builtins::builtin_set_from_items(
-                        &crate::type_methods::dict_view_snapshot(obj),
-                    )
+                // `SetLikeDictView` owns every one of these comparisons
+                // upstream: a set answers `NotImplemented` for a view, and the
+                // reflected call on the view side is what decides.  Reaching
+                // that method is what this arm stands in for, so it hands the
+                // pair to the same walk with the operator reflected when the
+                // view is the right-hand operand — rather than reducing both
+                // sides to sets, which answers from a snapshot taken before
+                // the first user `__eq__` and so cannot see that dict change
+                // size under the comparison.
+                use crate::typedef::DictViewCmp;
+                // At least one operand is a set here, so a view on the left is
+                // the whole test for which side the reflected call names as
+                // `self`.
+                let view_on_left = pyre_object::dictmultiobject::is_dict_view(a);
+                let op = match (op, view_on_left) {
+                    (CompareOp::Eq, _) => DictViewCmp::Eq,
+                    (CompareOp::Ne, _) => DictViewCmp::Ne,
+                    (CompareOp::Lt, true) | (CompareOp::Gt, false) => DictViewCmp::Lt,
+                    (CompareOp::Le, true) | (CompareOp::Ge, false) => DictViewCmp::Le,
+                    (CompareOp::Gt, true) | (CompareOp::Lt, false) => DictViewCmp::Gt,
+                    (CompareOp::Ge, true) | (CompareOp::Le, false) => DictViewCmp::Ge,
                 };
-                // Building the second set hashes every element it stores,
-                // which runs Python, and a set `as_set` had to mint is not
-                // held by anything else — it is old-gen, so it never moves,
-                // but an unreachable one is still swept.  Building the *first*
-                // one collects with `b` still to be read, and `b` is a native
-                // copy no root walker updates, so both operands are published
-                // before either conversion runs.
-                let roots = pyre_object::gc_roots::push_roots();
-                let base = roots.publish(&[a, b]);
-                roots.normalize(base, 2);
-                let a_set = as_set(roots.get(base))?;
-                let a_set = roots.pin_root(a_set);
-                let b_set = as_set(roots.get(base + 1))?;
-                let b_set = roots.pin_root(b_set);
-                let la = pyre_object::w_set_len(a_set);
-                let lb = pyre_object::w_set_len(b_set);
-                let a_subset_b = || crate::typedef::set_is_subset_of(a_set, b_set);
-                let b_subset_a = || crate::typedef::set_is_subset_of(b_set, a_set);
-                return Ok(w_bool_from(match op {
-                    CompareOp::Eq => la == lb && a_subset_b()?,
-                    CompareOp::Ne => la != lb || !a_subset_b()?,
-                    CompareOp::Le => la <= lb && a_subset_b()?,
-                    CompareOp::Lt => la < lb && a_subset_b()?,
-                    CompareOp::Ge => la >= lb && b_subset_a()?,
-                    CompareOp::Gt => la > lb && b_subset_a()?,
-                }));
+                let (view, other) = if view_on_left { (a, b) } else { (b, a) };
+                return crate::typedef::dict_view_compare(view, other, op);
             }
         }
         // set / frozenset comparison — subset / superset / equality.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9070,20 +9070,37 @@ pub(crate) fn dict_view_compare(
         // the bytecode dispatch, so emit it directly here.
         return Ok(pyre_object::w_not_implemented());
     }
-    let self_len = unsafe { crate::baseobjspace::len(self_view)? };
-    let other_len = unsafe { crate::baseobjspace::len(other)? };
-    let self_n = unsafe { pyre_object::w_int_get_value(self_len) };
-    let other_n = unsafe { pyre_object::w_int_get_value(other_len) };
+    // `len` reaches a user `__len__` whenever an operand is a set subclass
+    // that overrides it, and a dict view is `try_gc_alloc_nursery_raw` and so
+    // moves, so both operands are published before the first length call and
+    // read back from their slots afterwards.  Each length is reduced to its
+    // native value where it is taken, so the boxed int the first call returns
+    // is never held across the second.
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = roots.publish(&[self_view, other]);
+    roots.normalize(base, 2);
+    let self_n =
+        unsafe { pyre_object::w_int_get_value(crate::baseobjspace::len(roots.get(base))?) };
+    let other_n =
+        unsafe { pyre_object::w_int_get_value(crate::baseobjspace::len(roots.get(base + 1))?) };
+    let contained = |view_first: bool| -> Result<bool, crate::PyError> {
+        let (view, other) = if view_first {
+            (roots.get(base), roots.get(base + 1))
+        } else {
+            (roots.get(base + 1), roots.get(base))
+        };
+        dict_view_all_contained_in(view, other)
+    };
     let result = match op {
         // dictmultiobject.py descr_eq
-        DictViewCmp::Eq => self_n == other_n && dict_view_all_contained_in(self_view, other)?,
-        DictViewCmp::Ne => !(self_n == other_n && dict_view_all_contained_in(self_view, other)?),
+        DictViewCmp::Eq => self_n == other_n && contained(true)?,
+        DictViewCmp::Ne => !(self_n == other_n && contained(true)?),
         // dictmultiobject.py descr_lt
-        DictViewCmp::Lt => self_n < other_n && dict_view_all_contained_in(self_view, other)?,
-        DictViewCmp::Le => self_n <= other_n && dict_view_all_contained_in(self_view, other)?,
+        DictViewCmp::Lt => self_n < other_n && contained(true)?,
+        DictViewCmp::Le => self_n <= other_n && contained(true)?,
         // dictmultiobject.py descr_gt — flips direction.
-        DictViewCmp::Gt => self_n > other_n && dict_view_all_contained_in(other, self_view)?,
-        DictViewCmp::Ge => self_n >= other_n && dict_view_all_contained_in(other, self_view)?,
+        DictViewCmp::Gt => self_n > other_n && contained(false)?,
+        DictViewCmp::Ge => self_n >= other_n && contained(false)?,
     };
     Ok(pyre_object::w_bool_from(result))
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9080,16 +9080,20 @@ fn dict_view_isdisjoint(
             unsafe { pyre_object::w_int_get_value(n) } == 0,
         ));
     }
+    // `collect_iterable` runs a user `__iter__` and `__next__`, and the
+    // receiver it is not handed is a native copy no root walker updates -- a
+    // dict view is `try_gc_alloc_nursery_raw` and so moves -- which is why the
+    // receiver is published before that call rather than after it.  Its own
+    // scope has popped by the time it returns, so the items sit in an untraced
+    // native Vec while each `contains` runs a user `__eq__`; those are pinned
+    // as well, the shape `dict_view_all_contained_in` above uses.
+    let roots = pyre_object::gc_roots::push_roots();
+    let view_slot = roots.publish(&[self_view]);
+    roots.normalize(view_slot, 1);
     let other_items = crate::builtins::collect_iterable(other)?;
-    // `collect_iterable`'s own scope has popped by the time it returns, so the
-    // items sit in an untraced native Vec while each `contains` runs a user
-    // `__eq__`.  Same shape as `dict_view_all_contained_in` above.
-    let _roots = pyre_object::gc_roots::push_roots();
-    let view_slot = pyre_object::gc_roots::shadow_stack_len();
-    let self_view = pyre_object::gc_roots::pin_root(self_view);
     let item_base = pyre_object::gc_roots::pin_roots(&other_items);
     for index in 0..other_items.len() {
-        let self_view = pyre_object::gc_roots::shadow_stack_get(view_slot);
+        let self_view = roots.get(view_slot);
         let item = pyre_object::gc_roots::shadow_stack_get(item_base + index);
         if crate::baseobjspace::contains(self_view, item)? {
             return Ok(pyre_object::w_bool_from(false));
@@ -9109,19 +9113,30 @@ fn dict_view_as_set_op(
     rhs: pyre_object::PyObjectRef,
     methname: &str,
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    // Materialising the left operand hashes every element it stores, which
+    // runs Python, and `rhs` is a native copy no root walker updates.  A dict
+    // view is `try_gc_alloc_nursery_raw` and so moves, and `dict_view_rset_op`
+    // reaches here with one as `rhs` for every reflected operator, so both
+    // operands are published before the materialisation runs.  The set itself
+    // is old-gen and never moves, but nothing else holds it while the named
+    // method runs, so it is pinned rather than read back.
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = roots.publish(&[lhs, rhs]);
+    roots.normalize(base, 2);
     let w_set = if methname == "intersection_update" {
-        let w_set = pyre_object::w_set_new();
-        set_init_from_iterable_impl(w_set, lhs, false)?;
+        let w_set = roots.pin_root(pyre_object::w_set_new());
+        set_init_from_iterable_impl(w_set, roots.get(base), false)?;
         w_set
     } else {
         let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
-        crate::call::call_function_impl_result(w_set_type, &[lhs])?
+        let w_set = crate::call::call_function_impl_result(w_set_type, &[roots.get(base)])?;
+        roots.pin_root(w_set)
     };
     // `dictmultiobject.py _as_set_op` — `space.call_method(w_set, methname,
     // w_other)`, which is `callmethod.py call_method_opt`: the in-place set
     // method is a method descriptor on an instance with no dictionary, so the
     // call reaches it without materialising a bound method first.
-    crate::baseobjspace::call_method_result(w_set, methname, &[rhs])?;
+    crate::baseobjspace::call_method_result(w_set, methname, &[roots.get(base + 1)])?;
     Ok(w_set)
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9009,18 +9009,40 @@ fn dict_view_all_contained_in(
     view: pyre_object::PyObjectRef,
     other: pyre_object::PyObjectRef,
 ) -> Result<bool, crate::PyError> {
-    let snapshot = crate::type_methods::dict_view_snapshot(view);
-    // `contains` runs a user `__contains__`/`__eq__`, so `other` and every
-    // item still waiting in this native Vec move under the loop.  Pin them and
-    // read each one back at its use.
-    let _roots = pyre_object::gc_roots::push_roots();
-    let other_slot = pyre_object::gc_roots::shadow_stack_len();
-    let other = pyre_object::gc_roots::pin_root(other);
-    let item_base = pyre_object::gc_roots::pin_roots(&snapshot);
-    for i in 0..snapshot.len() {
-        let other = pyre_object::gc_roots::shadow_stack_get(other_slot);
-        let item = pyre_object::gc_roots::shadow_stack_get(item_base + i);
-        if !crate::baseobjspace::contains(other, item)? {
+    // `_all_contained_in` walks a live `space.iter(w_dictview)`, so a
+    // `contains_w` that mutates the dict behind the view is caught by the
+    // iterator's own size check on the next step.  A snapshot taken up front
+    // answers from the pre-mutation copy and never reaches that check.
+    //
+    // `iter`, `next` and `contains` each run user Python, and a dict view is
+    // `try_gc_alloc_nursery_raw` and so moves, so both operands are read back
+    // from their slots at each use.
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = roots.publish(&[view, other]);
+    roots.normalize(base, 2);
+    let iterator = crate::baseobjspace::iter(roots.get(base))?;
+    let iterator_slot = roots.publish(&[iterator]);
+    roots.normalize(iterator_slot, 1);
+    // A dict-view iterator is an off-GC carrier whose registered raw-field
+    // walker covers frame reachability only, so the source dict is retained
+    // for the native loop the way `collect_iterator` retains it.
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(roots.get(iterator_slot)) } {
+        let w_dict = unsafe {
+            pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(roots.get(iterator_slot))
+        };
+        let _ = roots.pin_root(w_dict);
+    }
+    // The yielded item is dead once its `contains` answers, so one slot is
+    // rewritten per turn rather than a fresh root pinned for every item.
+    let item_slot = roots.publish(&[pyre_object::w_none()]);
+    loop {
+        let item = match crate::baseobjspace::next(roots.get(iterator_slot)) {
+            Ok(item) => item,
+            Err(e) if e.matches_stop_iteration() => break,
+            Err(e) => return Err(e),
+        };
+        roots.set(item_slot, item);
+        if !crate::baseobjspace::contains(roots.get(base + 1), roots.get(item_slot))? {
             return Ok(false);
         }
     }
@@ -9028,7 +9050,7 @@ fn dict_view_all_contained_in(
 }
 
 #[derive(Clone, Copy)]
-enum DictViewCmp {
+pub(crate) enum DictViewCmp {
     Eq,
     Ne,
     Lt,
@@ -9037,7 +9059,7 @@ enum DictViewCmp {
     Ge,
 }
 
-fn dict_view_compare(
+pub(crate) fn dict_view_compare(
     self_view: pyre_object::PyObjectRef,
     other: pyre_object::PyObjectRef,
     op: DictViewCmp,
@@ -9070,6 +9092,11 @@ fn dict_view_compare(
 /// reject as soon as any item is in self.  Pyre's snapshot-based
 /// `contains` over the view materialises the (k, v) tuple wrapping
 /// for items views, matching the PyPy semantics.
+///
+/// The operand is stepped one item at a time rather than materialised: the
+/// walk stops at the first common element, so an iterable that yields one and
+/// then raises answers `False` instead of propagating, and a generator is left
+/// holding the items the walk never needed.
 fn dict_view_isdisjoint(
     self_view: pyre_object::PyObjectRef,
     other: pyre_object::PyObjectRef,
@@ -9080,22 +9107,50 @@ fn dict_view_isdisjoint(
             unsafe { pyre_object::w_int_get_value(n) } == 0,
         ));
     }
-    // `collect_iterable` runs a user `__iter__` and `__next__`, and the
-    // receiver it is not handed is a native copy no root walker updates -- a
-    // dict view is `try_gc_alloc_nursery_raw` and so moves -- which is why the
-    // receiver is published before that call rather than after it.  Its own
-    // scope has popped by the time it returns, so the items sit in an untraced
-    // native Vec while each `contains` runs a user `__eq__`; those are pinned
-    // as well, the shape `dict_view_all_contained_in` above uses.
+    // `iter`, `next` and `contains` each run user Python, and a dict view is
+    // `try_gc_alloc_nursery_raw` and so moves, so both operands live in
+    // shadow-stack slots that are read back at each use rather than in the
+    // native copies handed to this function.
     let roots = pyre_object::gc_roots::push_roots();
-    let view_slot = roots.publish(&[self_view]);
-    roots.normalize(view_slot, 1);
-    let other_items = crate::builtins::collect_iterable(other)?;
-    let item_base = pyre_object::gc_roots::pin_roots(&other_items);
-    for index in 0..other_items.len() {
-        let self_view = roots.get(view_slot);
-        let item = pyre_object::gc_roots::shadow_stack_get(item_base + index);
-        if crate::baseobjspace::contains(self_view, item)? {
+    let base = roots.publish(&[self_view, other]);
+    roots.normalize(base, 2);
+    // `descr_isdisjoint` iterates the shorter operand when both are set-like,
+    // so which slot is walked and which is asked `contains` is decided here
+    // instead of being fixed by the argument order.
+    let (mut container, mut iterated) = (base, base + 1);
+    if dict_view_is_set_like(roots.get(base + 1)) {
+        let self_n =
+            unsafe { pyre_object::w_int_get_value(crate::baseobjspace::len(roots.get(base))?) };
+        let other_n =
+            unsafe { pyre_object::w_int_get_value(crate::baseobjspace::len(roots.get(base + 1))?) };
+        if other_n > self_n {
+            (container, iterated) = (base + 1, base);
+        }
+    }
+    let iterator = crate::baseobjspace::iter(roots.get(iterated))?;
+    let iterator_slot = roots.publish(&[iterator]);
+    roots.normalize(iterator_slot, 1);
+    // A dict-view iterator is an off-GC carrier whose registered raw-field
+    // walker covers frame reachability only, so the source dict is retained
+    // for the native loop the way `collect_iterator` retains it.
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(roots.get(iterator_slot)) } {
+        let w_dict = unsafe {
+            pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(roots.get(iterator_slot))
+        };
+        let _ = roots.pin_root(w_dict);
+    }
+    // The yielded item is dead once its `contains` answers, and the walk has
+    // no bound, so one slot is rewritten per turn rather than a fresh root
+    // pinned for every item the iterator produces.
+    let item_slot = roots.publish(&[pyre_object::w_none()]);
+    loop {
+        let item = match crate::baseobjspace::next(roots.get(iterator_slot)) {
+            Ok(item) => item,
+            Err(e) if e.matches_stop_iteration() => break,
+            Err(e) => return Err(e),
+        };
+        roots.set(item_slot, item);
+        if crate::baseobjspace::contains(roots.get(container), roots.get(item_slot))? {
             return Ok(pyre_object::w_bool_from(false));
         }
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -12945,7 +12945,7 @@ mod tests {
             live.iter()
                 .copied()
                 .max()
-                .map_or(4u16, |m| (m as u16 + 1).max(4))
+                .map_or(4u8, |m| m.saturating_add(1).max(4))
         };
         let runtime_jc = {
             let inner = majit_metainterp::jitcode::JitCode::new("close_loop_args_test");


### PR DESCRIPTION
Rebased onto `afc274b880c`. The two bench commits this PR opened with are **gone** — main fixed both reds itself while this branch sat, and replaying my recordings would have made things worse. Details below, because one of them applied cleanly and would have shipped a new red.

## What the branch carries now

| commit | what it does |
|---|---|
| `6909dee9acf` | root both `compare_slot` operands across the set conversion |
| `7030b35acfb` | root the dict-view operands the set ops hold across user code |
| `67c11db8288` | **`Port JitCode lowerer parity fixes`** — not mine, it is the JitCode lowerer work that already lived on this branch |
| `22262b7eb1a` | step the set-like dict-view walks one item at a time (the review fix, below) |

## The two dropped commits

Main's own CI at `d5d186a98ef` (the run after #1624) says both problems are already solved:

| fixture | ubuntu dyn | ubuntu cl | windows | macos dyn / cl | on main |
|---|---|---|---|---|---|
| `load_name_builtin_cell_fold` | 1.7x / 1.8x | 2.3x | 0.9x | 0.7x / 0.5x | **passes** at ceiling 2.5, floor 0.4167 |
| `loop_in_try_tail_unbound_check` | — | — | — | 1.6x / 2.0x | passes, floor 0.9667 |
| `short_circuit_boxed_int_cross_fn` | — | — | — | 1.5x / 2.1x | passes, floor 1.0 |
| `short_circuit_value_kept_stack` | — | — | — | 1.5x / **3.8x** | passes, floor 1.0 |
| `swap_except_return_resume` | 1.4x / 1.8x | 2.3x | ?1.8x | 1.5x / 1.9x | passes, floor 0.8667 |

`pyre/check.py` is `170/170 passed` on ubuntu dynasm and cranelift there; macos's only check.py failure is `cranelift raise_catch 5.0x`, which is reserved.

- **`retire load_name_builtin_cell_fold's pypy ratio again`** — my premise was that no single ceiling covers the host span while still deriving a floor beneath it. #1624 refuted it: `max-pypy-ratio=2.5` covers `[0.5, 2.3]` with floor 0.4167 under it. My commit would have deleted a working gate. It conflicted, which is what made me look.
- **`re-record four ceilings the derived floor no longer fits`** — applied **with no conflict at all**, and would have introduced a new failure: its `short_circuit_value_kept_stack` ceiling is 3.7 against main's macos cranelift reading of **3.8x**. The four floor failures it was written for no longer happen (pyre now reads 0.22s on macos where it read 0.05s), so the commit was simply obsolete.

A bench header is a recording of a measurement, not source. Replaying one onto a newer base replays a stale reading, and a clean apply is not evidence.

## The code review

Codex's parity review of the previous head reported **no regressions introduced** and no other new mismatches. Its two section-3 findings were pre-existing deviations, both in the functions these commits already touch. Both reproduce as wrong answers, so `22262b7eb1a` fixes them.

**1. `descr_isdisjoint` materialised its operand.** Upstream opens `space.iter(w_other)` and tests `space.contains_w(self, w_item)` per step, answering `False` at the first common element. `dict_view_isdisjoint` called `collect_iterable` first:

```python
def gen():
    yield 1
    raise ValueError("boom")
{1: 'a'}.keys().isdisjoint(gen())
```

CPython 3.14 and PyPy both answer `False` having consumed one item. pyre raised `ValueError` and consumed all of it. The set-like branch that iterates the shorter operand was missing too, so it is added.

**2. `_all_contained_in` read a snapshot.** Upstream walks `space.iter(w_dictview)`, so a `contains_w` that resizes the dict is caught by the view iterator's own size check. With a `__eq__` that grows the dict, CPython and PyPy both raise `RuntimeError: dictionary changed size during iteration`; pyre answered `True`. pyre's dict-view iterator already implements the guard — only the snapshot bypassed it.

**3. `compare_slot`'s set-vs-view arm** reduced both operands to sets built from that same snapshot, so `set == view` had the same blind spot from the other side. A set answers `NotImplemented` for a view and the reflected call on the view decides, so the arm now hands the pair to `dict_view_compare` with the operator reflected when the view is on the right. Every non-mutating ordering case already agreed before and after, which is the evidence that the reflection mapping is answer-preserving.

Both walks keep their operands, the iterator and the yielded item in shadow-stack slots and read them back at each use; the item slot is rewritten per turn rather than pinned per item.

## Witness

`pyre/bench/synth/dict_view_setlike_lazy_walk_regression.py`, a `selfcheck` guard with `selfcheck-compiles=warm` so the JIT has to compile the walks it covers. Every expectation is the value CPython 3.14 and PyPy both produce. On the pre-fix binary **8 assertions fail**, before and after warmup:

```
FAIL isdisjoint_keys_hit_then_raise: expected False, got !! ValueError
FAIL isdisjoint_items_hit_then_raise: expected False, got !! ValueError
FAIL isdisjoint_stops_at_first_hit: expected (False, 1), got (False, 5)
FAIL eq_mutating_eq: expected !! RuntimeError, got True
FAIL eq_mutating_eq_len: expected 3, got 4
FAIL le_mutating_eq: expected !! RuntimeError, got True
FAIL set_eq_view_mutating_eq: expected !! RuntimeError, got True
FAIL set_eq_view_mutating_eq_len: expected 3, got 4
```

## Verification

- `pyre/check.py --backend dynasm` — **532/532, ALL PASSED** (531 before; the new fixture is the extra).
- `cargo fmt --all -- --check` — clean.
- `scripts/check-new-line-citations.py` — clean.
- `dict_view_set_ops.py` output unchanged against CPython.
- The two rooting commits remain latent: their witnesses pass on the pre-fix binary too, with and without the JIT, so neither has a witness of its own. That is stated in their commit messages.

The 532/532 run was made just before the last rebase onto `afc274b880c`; the rebuild and re-gate at that base is running now and I will report it here if anything moves.

## Not touched

- `cranelift raise_catch` on macos — reserved.
- `baseobjspace::call_method` / `call_method_result` publish the receiver and args *inside* the `method_descriptor_shortcut` arm, leaving the args slice unrooted across the shortcut probe and the `getattr_str` fallback. Upstream `callmethod.py call_method_opt` receives `arg_w` as a tuple the collector traces, which argues the rooting belongs in the callee — but `pyframe.rs call_mapping_method` publishes in the caller, so the contract wants settling before a hot generic path is changed.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Method-call syntax is now supported across configuration and value-lowering paths.
  * Integer and floating-point comparisons in branches are compiled more directly, including negated conditions while preserving expected behavior.

* **Bug Fixes**
  * Improved garbage-collection safety and live mutation handling during dictionary-view and set operations.
  * Preserved live-register ordering when processing individual liveness markers.

* **Improvements**
  * JIT register counts now use a compact format with validation for supported limits.
  * Expanded coverage for method calls, dictionary views, lazy iteration, and optimized comparison branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->