### PR TITLE
jit-trace: guard the frame-finished store on a non-null carrier

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1151,7 +1151,13 @@ fn finish_current_frame_execution<Sym: WalkSym>(
     // post-store heapcache value against a still-pre-store concrete carrier.
     // `execute_and_record` would have applied the graph store while tracing;
     // mirror only that recording-time side effect here.
-    unsafe { (*concrete_frame).set_frame_finished_execution(true) };
+    //
+    // The top-level arm hands this a null carrier on purpose — the live red
+    // frame is transitioned by the no-replay commit, not by the walk — so the
+    // store belongs to an escaped inline callee alone.
+    if !concrete_frame.is_null() {
+        unsafe { (*concrete_frame).set_frame_finished_execution(true) };
+    }
 }
 
 fn recording_raise_keeps_existing_traceback<Sym: WalkSym>(


### PR DESCRIPTION
`finish_current_frame_execution`'s top-level arm passes a null concrete carrier deliberately: the live red frame's transition belongs to the no-replay commit in `compile_and_run_once`, not to a speculative walk.  The early return above the store tests that carrier only for an inline callee, so a top-level walk that reaches the store dereferences the null.

The guard sat on the store until the recording half of the function was removed.  A release build carries no null-dereference check, so the fault surfaces only in a debug build.

Assisted-by: Claude

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [ ] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash that could occur when completing execution for a top-level frame.
  * Improved handling of frame transitions when no concrete frame is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->