### PR TITLE
object, jit, backends: the step-one range iterator shapes, an eval-breaker floor compare, and per-op machine-code offsets

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -110,6 +110,13 @@ fn majit_verify_enabled() -> bool {
     *ENABLED
 }
 
+/// Whether `MAJIT_DUMP` is set, cached at first access.
+fn majit_dump_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_DUMP").is_some());
+    *ENABLED
+}
+
 use crate::asm_memory::{CraneliftArenaHandle, CraneliftArenaMemoryProvider};
 use crate::guard::{BridgeData, JitFrameDeadFrame, drop_bridge_payload};
 use majit_backend::deadframe::ExitDescr;
@@ -10579,7 +10586,17 @@ impl CraneliftBackend {
         }
         // else: linear trace — already in entry_block with vars defined
 
+        let dump_offsets = majit_dump_enabled();
         for op_idx in 0..ops.len() {
+            // Carry the trace's op index through codegen as a source location.
+            // Cranelift closes a srcloc region when the next one opens, so
+            // every byte the op emits — including the block plumbing a LABEL
+            // lowers to below — lands in that op's span, and the emitted bytes
+            // are unaffected either way. Only the dump reads the mapping back,
+            // so the regions are recorded only when it is asked for.
+            if dump_offsets {
+                builder.set_srcloc(cranelift_codegen::ir::SourceLoc::new(op_idx as u32));
+            }
             if let Some((_, label_block)) = label_blocks
                 .iter()
                 .find(|(label_idx, _)| *label_idx == op_idx)
@@ -15485,6 +15502,23 @@ impl CraneliftBackend {
             eprintln!("[jit][code-size] trace_id={trace_id} body_bytes={body_code_bytes}");
             if let Some(text) = ctx.compiled_code().and_then(|code| code.vcode.as_deref()) {
                 eprintln!("[jit][disasm-body] trace_id={trace_id}\n{text}");
+            }
+        }
+        if dump_offsets {
+            // Same line shape the dynasm backend prints, so a per-op byte
+            // count can be read off either backend and compared. Offsets are
+            // relative to the start of the trace body. One op can own several
+            // regions: the scheduler is free to interleave two ops' machine
+            // code, and each contiguous run is its own region.
+            if let Some(code) = ctx.compiled_code() {
+                for region in code.buffer.get_srclocs_sorted() {
+                    let op_idx = region.loc.bits() as usize;
+                    let Some(op) = ops.get(op_idx) else { continue };
+                    eprintln!(
+                        "[clif] @{:#06x} op[{}] {:?}",
+                        region.start, op_idx, op.opcode
+                    );
+                }
             }
         }
         self.module.clear_context(&mut ctx);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2041,6 +2041,18 @@ impl<'a> AssemblerARM64<'a> {
                             faillocs.len()
                         );
                     }
+                    // A guard owns bytes like any other op, so it opens its
+                    // own span. Without this line the guard's code is read as
+                    // part of the preceding op's span and every span after the
+                    // trace's first guard names the wrong operation.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
+                        );
+                    }
                     self.regalloc_perform_guard(
                         op,
                         *op_index,
@@ -2060,6 +2072,17 @@ impl<'a> AssemblerARM64<'a> {
                             op_index,
                             op.opcode,
                             al.join(", ")
+                        );
+                    }
+                    // A result-less op still emits code — the stores that
+                    // advance a loop's mutable state are all discards — so it
+                    // opens its own span too.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
                         );
                     }
                     self.regalloc_perform(op, *op_index, arglocs, None, fail_index, ops);

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2779,6 +2779,18 @@ impl<'a> Assembler386<'a> {
                             faillocs.len()
                         );
                     }
+                    // A guard owns bytes like any other op, so it opens its
+                    // own span. Without this line the guard's code is read as
+                    // part of the preceding op's span and every span after the
+                    // trace's first guard names the wrong operation.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
+                        );
+                    }
                     self.regalloc_perform_guard(
                         op,
                         *op_index,
@@ -2798,6 +2810,17 @@ impl<'a> Assembler386<'a> {
                             op_index,
                             op.opcode,
                             al.join(", ")
+                        );
+                    }
+                    // A result-less op still emits code — the stores that
+                    // advance a loop's mutable state are all discards — so it
+                    // opens its own span too.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
                         );
                     }
                     self.regalloc_perform(op, *op_index, arglocs, None, fail_index, ops);

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -1,17 +1,21 @@
 //! The single process-global eval-breaker word polled by JIT-compiled loop
 //! back-edges. One `AtomicUsize` whose bits fold the two former back-edge
 //! polls into one load + one nonzero branch:
-//!   bit0 EB_ASYNC — an async ticker request; OR'd in by the OS signal handler
+//!   bit0 EB_GC_INTERP — process-stable `PYRE_GC_INTERP` dispatch gate.  It
+//!                       shares the word to spare the interpreter a second
+//!                       per-opcode atomic load, but it is not itself a reason
+//!                       to leave machine code.  It occupies the lowest bit so
+//!                       that every breaker bit outranks it numerically and a
+//!                       compiled poll can separate the two with one unsigned
+//!                       compare against `JIT_BREAKER_FLOOR` — see that
+//!                       constant.
+//!   bit1 EB_ASYNC — an async ticker request; OR'd in by the OS signal handler
 //!                   and action dispatcher, then copied into
 //!                   `ActionFlag._ticker` at a safe interpreter checkpoint.
-//!   bit1 EB_STW   — mirrors `GC_SYNC.stw_requested`; OR'd in by the collector
+//!   bit2 EB_STW   — mirrors `GC_SYNC.stw_requested`; OR'd in by the collector
 //!                   while it drains mutators to safepoints.
-//!   bit2 EB_FINALIZING — mirrors interpreter finalization; once armed,
+//!   bit3 EB_FINALIZING — mirrors interpreter finalization; once armed,
 //!                        non-owner mutators park before their next opcode.
-//!   bit3 EB_GC_INTERP — process-stable `PYRE_GC_INTERP` dispatch gate.  This
-//!                       is masked out of compiled back-edge polls: it avoids
-//!                       a second per-opcode atomic load in the interpreter,
-//!                       but is not itself a reason to leave machine code.
 //!   bit4 EB_GC    — the old-gen allocator reached the next-major threshold;
 //!                   OR'd in by the collector, consumed by the interpreter
 //!                   dispatch-loop GC safepoint.
@@ -37,14 +41,15 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// bit0 — async action / signal pending (mirrors a negative ticker).
-pub const EB_ASYNC: usize = 1;
-/// bit1 — GC stop-the-world requested (mirrors `GC_SYNC.stw_requested`).
-pub const EB_STW: usize = 2;
-/// bit2 — interpreter finalization has begun (terminal, never cleared).
-pub const EB_FINALIZING: usize = 4;
-/// bit3 — interpreter-path allocation/collection integration is enabled.
-pub const EB_GC_INTERP: usize = 8;
+/// bit0 — interpreter-path allocation/collection integration is enabled.
+/// Lowest bit so that it is the only value below `JIT_BREAKER_FLOOR`.
+pub const EB_GC_INTERP: usize = 1;
+/// bit1 — async action / signal pending (mirrors a negative ticker).
+pub const EB_ASYNC: usize = 2;
+/// bit2 — GC stop-the-world requested (mirrors `GC_SYNC.stw_requested`).
+pub const EB_STW: usize = 4;
+/// bit3 — interpreter finalization has begun (terminal, never cleared).
+pub const EB_FINALIZING: usize = 8;
 /// bit4 — the old-gen allocator crossed the next-major threshold and a
 /// collection is owed at the next root-complete point.
 pub const EB_GC: usize = 16;
@@ -61,6 +66,27 @@ pub const EB_MEMORY_ERROR: usize = 32;
 /// by the dispatch loop, so a compiled loop that never returns to it would run
 /// on past a heap the collector has already declared exhausted.
 pub const JIT_BREAKER_MASK: usize = EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC | EB_MEMORY_ERROR;
+
+/// Every bit the word can carry, breaker or not.
+pub const ALL_EVAL_BREAKER_BITS: usize =
+    EB_GC_INTERP | EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC | EB_MEMORY_ERROR;
+
+/// The lowest breaker bit. Every bit in `JIT_BREAKER_MASK` is at or above it
+/// and every other bit is below it, so `word >= JIT_BREAKER_FLOOR` decides
+/// "some breaker is armed" for the whole word. That lets a compiled back-edge
+/// poll test the word with a single unsigned compare instead of masking and
+/// then testing the remainder, while the interpreter keeps reading its own
+/// bits out of the same load.
+pub const JIT_BREAKER_FLOOR: usize = EB_ASYNC;
+
+// The compare above is only equivalent to the mask while the two bit groups
+// stay separated by `JIT_BREAKER_FLOOR`. Adding a non-breaker bit above the
+// floor, or a breaker bit below it, would silently turn every back-edge poll
+// into the wrong answer, so state the partition as a compile-time fact.
+const _: () = {
+    assert!(JIT_BREAKER_MASK & (JIT_BREAKER_FLOOR - 1) == 0);
+    assert!(ALL_EVAL_BREAKER_BITS & !JIT_BREAKER_MASK & !(JIT_BREAKER_FLOOR - 1) == 0);
+};
 
 /// The shared eval-breaker word (see module docs).
 static EVAL_BREAKER_WORD: AtomicUsize = AtomicUsize::new(0);
@@ -315,8 +341,8 @@ pub extern "C" fn take_memory_error_jit_abi() -> i64 {
 
 /// Depth of the operation chain between the poll's load and its guard.
 ///
-/// The recorder emits `RawLoadI -> IntAnd -> IntIsTrue -> GuardFalse`, so two
-/// links separate the guard's condition from the load. The walk below allows
+/// The recorder emits `RawLoadI -> UintGe -> GuardFalse`, so one link
+/// separates the guard's condition from the load. The walk below allows
 /// a few more so that an optimizer pass inserting or splitting one link does
 /// not silently stop matching, and stops well before a long pure chain.
 const POLL_CHAIN_DEPTH: usize = 6;
@@ -324,7 +350,7 @@ const POLL_CHAIN_DEPTH: usize = 6;
 /// Whether `guard`'s condition is a back-edge poll of this word.
 ///
 /// The poll is recorded as
-/// `GuardFalse(IntIsTrue(IntAnd(RawLoadI(addr, 0), JIT_BREAKER_MASK)))`. The
+/// `GuardFalse(UintGe(RawLoadI(addr, 0), JIT_BREAKER_FLOOR))`. The
 /// match anchors on the `RawLoadI` of the published address rather than on the
 /// whole shape: that load is the one link the recorder cannot drop (it must
 /// stay non-pure and outside the always-pure range, or CSE forwards the
@@ -362,14 +388,7 @@ pub fn is_back_edge_poll_guard(guard: &crate::resoperation::Op) -> bool {
 /// Every flag must fit in the word the poll actually loads. Checked per target,
 /// so a flag too wide for a 32-bit `usize` fails the wasm32 build rather than
 /// silently reading as unarmed there.
-// `ineffective_bit_mask` reads the fold as a runtime `x | 16` tested against a
-// constant; both sides here are constants and the whole item is a static
-// assertion, so there is no operand to compare directly.
-#[allow(clippy::ineffective_bit_mask)]
-const _: () = assert!(
-    (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP | EB_GC | EB_MEMORY_ERROR)
-        < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1))
-);
+const _: () = assert!(ALL_EVAL_BREAKER_BITS < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1)));
 
 #[cfg(test)]
 mod tests {
@@ -536,15 +555,30 @@ mod tests {
         crate::operand::Operand::const_(Const::Int(value))
     }
 
+    /// The compiled poll compares the whole word against `JIT_BREAKER_FLOOR`
+    /// where it used to mask and then test the remainder. That is only the
+    /// same question while the non-breaker bits stay below the floor, so
+    /// assert the equivalence over every word the flags can build rather than
+    /// over the handful the other tests happen to produce.
+    #[test]
+    fn the_floor_compare_answers_the_mask_test_for_every_representable_word() {
+        for word in 0..=ALL_EVAL_BREAKER_BITS {
+            assert_eq!(
+                word >= JIT_BREAKER_FLOOR,
+                word & JIT_BREAKER_MASK != 0,
+                "word {word:#b} disagrees"
+            );
+        }
+    }
+
     /// Build the recorded back-edge poll over `load_addr`, which the caller
     /// varies to separate "this word" from "some other raw load".
     fn poll_guard(load_addr: usize) -> Op {
         let load = bind(Op::new(OpCode::RawLoadI, &[int(load_addr as i64), int(0)]));
-        let masked = bind(Op::new(
-            OpCode::IntAnd,
-            &[load, int(JIT_BREAKER_MASK as i64)],
+        let armed = bind(Op::new(
+            OpCode::UintGe,
+            &[load, int(JIT_BREAKER_FLOOR as i64)],
         ));
-        let armed = bind(Op::new(OpCode::IntIsTrue, &[masked]));
         Op::new(OpCode::GuardFalse, &[armed])
     }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2437,7 +2437,9 @@ unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult 
     // lane even when its value is 0 (notably for `r[-1:-3:-1]`).
     let w_substop = pyre_object::range_bigint_to_obj(substop.translated_alias());
     let w_substop = pyre_object::gc_roots::pin_root(w_substop);
-    Ok(pyre_object::w_range_new(w_substart, w_substop, w_substep))
+    Ok(pyre_object::w_range_new(
+        w_substart, w_substop, w_substep, false,
+    ))
 }
 
 /// `space.type(w_item) is space.w_int or space.w_bool` used by
@@ -3093,6 +3095,7 @@ pub(crate) fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
             pyre_object::gc_roots::shadow_stack_get(current_slot),
             pyre_object::gc_roots::shadow_stack_get(stop_slot),
             pyre_object::gc_roots::shadow_stack_get(step_slot),
+            false,
         );
         let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
@@ -3132,6 +3135,7 @@ pub(crate) fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
             pyre_object::gc_roots::shadow_stack_get(current_slot),
             pyre_object::gc_roots::shadow_stack_get(stop_slot),
             pyre_object::gc_roots::shadow_stack_get(step_slot),
+            false,
         );
         let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4924,7 +4924,9 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 let _ = pyre_object::gc_roots::pin_root(w_step);
             }
         }
-        Ok(pyre_object::w_range_new(w_start, w_stop, w_step))
+        // `descr_new` promotes the step exactly when no step argument was
+        // given, so `range(0, 10, 1)` keeps the general iterator.
+        Ok(pyre_object::w_range_new(w_start, w_stop, w_step, n != 3))
     }
 }
 

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1121,9 +1121,9 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
     use pyre_object::lltype::PyreClassPyTypeOf;
     use pyre_object::pyobject::subclass_range_alias;
     #[cfg(all(not(feature = "sandbox"), not(target_arch = "wasm32"), windows))]
-    const CFFI_FIRST_TYPE_ID: u32 = 194;
+    const CFFI_FIRST_TYPE_ID: u32 = 196;
     #[cfg(all(not(feature = "sandbox"), not(target_arch = "wasm32"), not(windows)))]
-    const CFFI_FIRST_TYPE_ID: u32 = 191;
+    const CFFI_FIRST_TYPE_ID: u32 = 193;
 
     fn typed<T: PyreClassPyTypeOf>() -> &'static pyre_object::PyType {
         // Every `#[pyre_class]` descriptor points at its macro-emitted static
@@ -1234,49 +1234,49 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         subclass_range_alias(180, typed::<crate::pycode::W_LineIterObject>()),
         subclass_range_alias(181, typed::<crate::pycode::W_PositionsIterObject>()),
         subclass_range_alias(182, typed::<crate::pycode::W_BranchesIterObject>()),
-        // Native-only posix aliases 183 and 184 preserve `build_gc`'s rclass
+        // Native-only posix aliases 185 and 186 preserve `build_gc`'s rclass
         // registration order after the unconditional aliases.  `scandir` has
         // no seam on wasm32, so neither type exists there.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(183, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(185, typed::<crate::module::posix::W_DirEntry>()),
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(184, typed::<crate::module::posix::W_ScandirIterator>()),
+        subclass_range_alias(186, typed::<crate::module::posix::W_ScandirIterator>()),
         // The rustls-backed `_ssl` aliases preserve `build_gc`'s registration
         // order for `W_SSLContext`, `W_MemoryBIO`, and `W_SSLSession`.
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(185, typed::<crate::module::_ssl::W_SSLContext>()),
+        subclass_range_alias(187, typed::<crate::module::_ssl::W_SSLContext>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(186, typed::<crate::module::_ssl::W_MemoryBIO>()),
+        subclass_range_alias(188, typed::<crate::module::_ssl::W_MemoryBIO>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(187, typed::<crate::module::_ssl::W_SSLSession>()),
+        subclass_range_alias(189, typed::<crate::module::_ssl::W_SSLSession>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(188, typed::<crate::module::_ssl::W_SSLSocket>()),
+        subclass_range_alias(190, typed::<crate::module::_ssl::W_SSLSocket>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(189, typed::<crate::module::_ssl::W_Certificate>()),
+        subclass_range_alias(191, typed::<crate::module::_ssl::W_Certificate>()),
         // `mmap.mmap` follows the optional SSL tail on ordinary Unix builds.
         // A sandbox build has no `mmap` module at all (`module/mod.rs`), so it
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        subclass_range_alias(190, typed::<crate::module::mmap::W_MMap>()),
+        subclass_range_alias(192, typed::<crate::module::mmap::W_MMap>()),
         // Windows asyncio's Overlapped owner follows mmap at the native tail.
         // It is a non-subclassable builtin in Python, but still participates
         // in the rclass hierarchy because its managed header and retained
         // buffer/result fields are traced by the ordinary object marker.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(191, typed::<crate::module::_overlapped::W_Overlapped>()),
+        subclass_range_alias(193, typed::<crate::module::_overlapped::W_Overlapped>()),
         // `_winapi.Overlapped` follows it: a second record of the same kind,
         // owning its own event and transfer buffer rather than retained
         // Python objects, so nothing of it is traced beyond the header.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         subclass_range_alias(
-            192,
+            194,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
         // PEP 528's raw console stream follows the two overlapped owners at
         // the append-only Windows tail.  It is subclassable and therefore
         // participates in the same rclass hierarchy as every typed IO base.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(193, typed::<crate::module::_io::W_WindowsConsoleIO>()),
+        subclass_range_alias(195, typed::<crate::module::_io::W_WindowsConsoleIO>()),
         // `_cffi_backend` is absent without `host_env`, on wasm32, and under
         // `sandbox`, so its thirteen aliases sit at the tail where the active
         // hierarchy filter can remove them as one contiguous trailing slice.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1119,6 +1119,20 @@ pub fn init_typeobjects() {
             &pyre_object::functional::RANGE_ITER_TYPE as *const PyType as usize,
             range_iterator_type as usize,
         );
+        // `functional.py` gives `W_IntRangeStepOneIterator` and
+        // `W_IntRangeOneArgIterator` the same `W_AbstractRangeIterator`
+        // typedef as the general shape.  Mapping all three internal statics to
+        // the one type object keeps `type()` identical across them, and the
+        // `set_instantiate` loop below stamps that object as the `w_class` a
+        // JIT-materialized iterator of either shape is born with.
+        reg.insert(
+            &pyre_object::functional::RANGE_ITER_STEP_ONE_TYPE as *const PyType as usize,
+            range_iterator_type as usize,
+        );
+        reg.insert(
+            &pyre_object::functional::RANGE_ITER_ONE_ARG_TYPE as *const PyType as usize,
+            range_iterator_type as usize,
+        );
         // rangeobject.c PyRange_Type carries no Py_TPFLAGS_BASETYPE, so
         // `range` is not an acceptable base class.
         let range_type = new_typeobject_with_base_and_layout(

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -592,6 +592,12 @@ pub const W_BOOL_GC_TYPE_ID: u32 = 5;
 /// GC type id for W_IntRangeIterator. Inherits from `object`
 /// (`RANGE_ITER_TYPE` in functional.rs).
 pub const RANGE_ITER_GC_TYPE_ID: u32 = 6;
+/// GC type ids for the two `step == 1` iterator shapes.  They are separate
+/// layouts behind one `range_iterator` Python type, so each needs its own id
+/// for `GuardClass` to tell them apart and reach `stop` at a fixed offset.
+pub use pyre_object::functional::{
+    W_RANGE_ITER_ONE_ARG_GC_TYPE_ID, W_RANGE_ITER_STEP_ONE_GC_TYPE_ID,
+};
 // `W_LIST_GC_TYPE_ID` / `W_TUPLE_GC_TYPE_ID` live in `pyre-object`
 // alongside their structs (matching W_INT/W_FLOAT pattern); re-exported
 // here for existing call sites.
@@ -1594,6 +1600,79 @@ static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(||
     )
 });
 
+/// `functional.py W_IntRangeStepOneIterator` — `_immutable_fields_ =
+/// ['stop']`, and `start` never moves either, so both carry the immutable
+/// column and a compiled loop keeps the bound in a register.
+static RANGE_ITER_STEP_ONE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        std::mem::size_of::<pyre_object::functional::W_IntRangeStepOneIterator>(),
+        W_RANGE_ITER_STEP_ONE_GC_TYPE_ID,
+        &pyre_object::functional::RANGE_ITER_STEP_ONE_TYPE as *const _ as usize,
+        &[
+            (
+                "current",
+                RANGE_ITER_STEP_ONE_CURRENT_OFFSET,
+                8,
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+            (
+                "stop",
+                RANGE_ITER_STEP_ONE_STOP_OFFSET,
+                8,
+                Type::Int,
+                true,
+                true,
+                false,
+            ),
+            (
+                "start",
+                RANGE_ITER_STEP_ONE_START_OFFSET,
+                8,
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+        ],
+        "W_IntRangeStepOneIterator",
+        "functional::W_IntRangeStepOneIterator",
+    )
+});
+
+/// `functional.py W_IntRangeOneArgIterator` — the `range(stop)` shape.
+static RANGE_ITER_ONE_ARG_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        std::mem::size_of::<pyre_object::functional::W_IntRangeOneArgIterator>(),
+        W_RANGE_ITER_ONE_ARG_GC_TYPE_ID,
+        &pyre_object::functional::RANGE_ITER_ONE_ARG_TYPE as *const _ as usize,
+        &[
+            (
+                "current",
+                RANGE_ITER_ONE_ARG_CURRENT_OFFSET,
+                8,
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+            (
+                "stop",
+                RANGE_ITER_ONE_ARG_STOP_OFFSET,
+                8,
+                Type::Int,
+                true,
+                true,
+                false,
+            ),
+        ],
+        "W_IntRangeOneArgIterator",
+        "functional::W_IntRangeOneArgIterator",
+    )
+});
+
 static SEQ_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::iterobject::W_SeqIterObject>(),
@@ -1777,6 +1856,15 @@ static RANGE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 Type::Ref,
                 false,
                 true,
+                false,
+            ),
+            (
+                "promote_step",
+                RANGE_PROMOTE_STEP_OFFSET,
+                1,
+                Type::Int,
+                false,
+                false,
                 false,
             ),
         ],
@@ -3217,8 +3305,10 @@ use pyre_object::floatobject::{
     FLOAT_FLOATVAL_OFFSET, FLOAT_W_DICT_OFFSET, FLOAT_W_SLOTS_OFFSET, W_FloatObject,
 };
 use pyre_object::functional::{
-    RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_REMAINING_OFFSET, RANGE_ITER_STEP_OFFSET,
-    RANGE_LENGTH_OFFSET, RANGE_START_OFFSET, RANGE_STEP_OFFSET, RANGE_STOP_OFFSET, W_Range,
+    RANGE_ITER_CURRENT_OFFSET, RANGE_ITER_ONE_ARG_CURRENT_OFFSET, RANGE_ITER_ONE_ARG_STOP_OFFSET,
+    RANGE_ITER_REMAINING_OFFSET, RANGE_ITER_STEP_OFFSET, RANGE_ITER_STEP_ONE_CURRENT_OFFSET,
+    RANGE_ITER_STEP_ONE_START_OFFSET, RANGE_ITER_STEP_ONE_STOP_OFFSET, RANGE_LENGTH_OFFSET,
+    RANGE_PROMOTE_STEP_OFFSET, RANGE_START_OFFSET, RANGE_STEP_OFFSET, RANGE_STOP_OFFSET, W_Range,
 };
 use pyre_object::interp_exceptions::{
     EXC_ARGS_W_OFFSET, EXC_KIND_COUNT, EXC_KIND_OFFSET, EXC_SUPPRESS_CONTEXT_OFFSET,
@@ -3349,6 +3439,31 @@ pub fn range_iter_step_descr() -> DescrRef {
     field_descr_from_group(&RANGE_ITER_DESCR_GROUP, 2)
 }
 
+/// Field descriptor for `W_IntRangeStepOneIterator.current` (i64, signed).
+pub fn range_iter_step_one_current_descr() -> DescrRef {
+    field_descr_from_group(&RANGE_ITER_STEP_ONE_DESCR_GROUP, 0)
+}
+
+/// Field descriptor for `W_IntRangeStepOneIterator.stop` (i64, immutable).
+pub fn range_iter_step_one_stop_descr() -> DescrRef {
+    field_descr_from_group(&RANGE_ITER_STEP_ONE_DESCR_GROUP, 1)
+}
+
+/// Field descriptor for `W_IntRangeStepOneIterator.start` (i64, immutable).
+pub fn range_iter_step_one_start_descr() -> DescrRef {
+    field_descr_from_group(&RANGE_ITER_STEP_ONE_DESCR_GROUP, 2)
+}
+
+/// Field descriptor for `W_IntRangeOneArgIterator.current` (i64, signed).
+pub fn range_iter_one_arg_current_descr() -> DescrRef {
+    field_descr_from_group(&RANGE_ITER_ONE_ARG_DESCR_GROUP, 0)
+}
+
+/// Field descriptor for `W_IntRangeOneArgIterator.stop` (i64, immutable).
+pub fn range_iter_one_arg_stop_descr() -> DescrRef {
+    field_descr_from_group(&RANGE_ITER_ONE_ARG_DESCR_GROUP, 1)
+}
+
 /// Field descriptor for `W_SeqIterObject.seq`.
 pub fn seq_iter_seq_descr() -> DescrRef {
     field_descr_from_group(&SEQ_ITER_DESCR_GROUP, 0)
@@ -3420,6 +3535,11 @@ pub fn range_step_descr() -> DescrRef {
 /// Field descriptor for `W_Range.length` (wrapped PyObjectRef).
 pub fn range_length_descr() -> DescrRef {
     range_field_descr(RANGE_LENGTH_OFFSET)
+}
+
+/// Field descriptor for `W_Range.promote_step` (one byte).
+pub fn range_promote_step_descr() -> DescrRef {
+    range_field_descr(RANGE_PROMOTE_STEP_OFFSET)
 }
 
 /// `Method.w_function` — the underlying function (`Function` or
@@ -4807,6 +4927,18 @@ pub fn w_bool_size_descr() -> DescrRef {
 /// vtable = &RANGE_ITER_TYPE; type_id = 0.
 pub fn w_range_iter_size_descr() -> DescrRef {
     RANGE_ITER_DESCR_GROUP.size_descr.clone()
+}
+
+/// Size descriptor for `W_IntRangeStepOneIterator` allocation via
+/// NewWithVtable.  vtable = &RANGE_ITER_STEP_ONE_TYPE.
+pub fn w_range_iter_step_one_size_descr() -> DescrRef {
+    RANGE_ITER_STEP_ONE_DESCR_GROUP.size_descr.clone()
+}
+
+/// Size descriptor for `W_IntRangeOneArgIterator` allocation via
+/// NewWithVtable.  vtable = &RANGE_ITER_ONE_ARG_TYPE.
+pub fn w_range_iter_one_arg_size_descr() -> DescrRef {
+    RANGE_ITER_ONE_ARG_DESCR_GROUP.size_descr.clone()
 }
 
 /// Size descriptor for W_Range allocation via NewWithVtable.
@@ -7219,6 +7351,12 @@ static DECLARED_GROUPS: &[(&str, fn())] = &[
     }),
     ("functional::W_IntRangeIterator", || {
         LazyLock::force(&RANGE_ITER_DESCR_GROUP);
+    }),
+    ("functional::W_IntRangeStepOneIterator", || {
+        LazyLock::force(&RANGE_ITER_STEP_ONE_DESCR_GROUP);
+    }),
+    ("functional::W_IntRangeOneArgIterator", || {
+        LazyLock::force(&RANGE_ITER_ONE_ARG_DESCR_GROUP);
     }),
     ("functional::W_Range", || {
         LazyLock::force(&RANGE_DESCR_GROUP);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10731,6 +10731,21 @@ pub(crate) fn try_walker_specialize_builtin_range<Sym: WalkSym>(
             .heapcache_setfield_cached(new, descr_index, boxed);
     }
 
+    // `descr_new`'s `promote_step` — a property of the call shape, not of the
+    // bounds, so it is a constant here.  `descr_iter` reads it to pick the
+    // iterator shape; leaving it unwritten would hand a forced range an
+    // uninitialized byte.
+    let promote_step = ctx.trace_ctx.const_int((raw_args.len() != 3) as i64);
+    let promote_step_descr = crate::descr::range_promote_step_descr();
+    let promote_step_index = promote_step_descr.index();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[new, promote_step],
+        promote_step_descr,
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(new, promote_step_index, promote_step);
+
     let range_type_addr = &pyre_object::functional::RANGE_TYPE as *const _ as i64;
     ctx.trace_ctx
         .heap_cache_mut()
@@ -18153,7 +18168,14 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
         return Ok(Some(range_op));
     }
 
-    let (concrete_start, concrete_step, concrete_length, concrete_mul, concrete_one_past) = unsafe {
+    let (
+        concrete_start,
+        concrete_step,
+        concrete_length,
+        concrete_mul,
+        concrete_one_past,
+        concrete_promote_step,
+    ) = unsafe {
         if !pyre_object::functional::is_w_range(range_obj)
             || !pyre_object::functional::is_exact_w_range(range_obj)
         {
@@ -18188,7 +18210,14 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
             return Ok(None);
         };
         debug_assert_eq!(one_past_checked, one_past);
-        (start, step, length, mul, one_past)
+        (
+            start,
+            step,
+            length,
+            mul,
+            one_past,
+            pyre_object::functional::w_range_promote_step(range_obj),
+        )
     };
 
     let range_type_addr = &pyre_object::functional::RANGE_TYPE as *const _ as i64;
@@ -18277,38 +18306,101 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
         .set_opref_concrete(one_past, majit_ir::Value::Int(concrete_one_past));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoOverflow, &[])?;
 
-    let new = ctx.trace_ctx.record_op_with_descr(
-        OpCode::NewWithVtable,
-        &[],
-        crate::descr::w_range_iter_size_descr(),
+    // `descr_iter` reads `promote_step` to choose the iterator shape.  The
+    // field never changes after construction, so this read and its guard lift
+    // out of the loop, and fold away entirely when the range is a virtual
+    // `range(...)` allocation of this same trace.
+    let promote_step_i = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        range_op,
+        crate::descr::range_promote_step_descr(),
     );
+    ctx.trace_ctx.set_opref_concrete(
+        promote_step_i,
+        majit_ir::Value::Int(concrete_promote_step as i64),
+    );
+    let promoted = ctx
+        .trace_ctx
+        .record_op(OpCode::IntIsTrue, &[promote_step_i]);
+    ctx.trace_ctx
+        .set_opref_concrete(promoted, majit_ir::Value::Int(concrete_promote_step as i64));
+    let promote_guard = if concrete_promote_step {
+        OpCode::GuardTrue
+    } else {
+        OpCode::GuardFalse
+    };
+    walker_emit_guard_with_snapshot(ctx, op_pc, promote_guard, &[promoted])?;
+
+    // A promoted step means `descr_new` saw no step argument, so the walk is
+    // `start, start+1, ... start+length`.  The one-argument shape additionally
+    // needs `start == 0`, which the guard below pins for the trace.
+    let one_arg = concrete_promote_step && concrete_start == 0;
+    if concrete_promote_step {
+        let zero = ctx.trace_ctx.const_int(0);
+        let starts_at_zero = ctx.trace_ctx.record_op(OpCode::IntEq, &[start_i, zero]);
+        ctx.trace_ctx
+            .set_opref_concrete(starts_at_zero, majit_ir::Value::Int(one_arg as i64));
+        let start_guard = if one_arg {
+            OpCode::GuardTrue
+        } else {
+            OpCode::GuardFalse
+        };
+        walker_emit_guard_with_snapshot(ctx, op_pc, start_guard, &[starts_at_zero])?;
+    }
+
+    let (size_descr, iter_type_addr) = if !concrete_promote_step {
+        (
+            crate::descr::w_range_iter_size_descr(),
+            &pyre_object::functional::RANGE_ITER_TYPE as *const _ as i64,
+        )
+    } else if one_arg {
+        (
+            crate::descr::w_range_iter_one_arg_size_descr(),
+            &pyre_object::functional::RANGE_ITER_ONE_ARG_TYPE as *const _ as i64,
+        )
+    } else {
+        (
+            crate::descr::w_range_iter_step_one_size_descr(),
+            &pyre_object::functional::RANGE_ITER_STEP_ONE_TYPE as *const _ as i64,
+        )
+    };
+    let new = ctx
+        .trace_ctx
+        .record_op_with_descr(OpCode::NewWithVtable, &[], size_descr);
     ctx.trace_ctx.heap_cache_mut().new_object(new);
 
-    let current_descr = crate::descr::range_iter_current_descr();
-    let current_index = current_descr.index();
-    ctx.trace_ctx
-        .record_op_with_descr(OpCode::SetfieldGc, &[new, start_i], current_descr);
-    ctx.trace_ctx
-        .heapcache_setfield_cached(new, current_index, start_i);
+    // `stop` is `start + length` rather than the range's own stop: a promoted
+    // step is one, so the two agree over any non-empty span, and an empty or
+    // backwards span this way ends the walk on its first compare instead of
+    // carrying a bound below `start`.
+    let iter_fields: Vec<(majit_ir::DescrRef, OpRef)> = if !concrete_promote_step {
+        vec![
+            (crate::descr::range_iter_current_descr(), start_i),
+            (crate::descr::range_iter_remaining_descr(), length_i),
+            (crate::descr::range_iter_step_descr(), step_i),
+        ]
+    } else if one_arg {
+        vec![
+            (crate::descr::range_iter_one_arg_current_descr(), start_i),
+            (crate::descr::range_iter_one_arg_stop_descr(), one_past),
+        ]
+    } else {
+        vec![
+            (crate::descr::range_iter_step_one_current_descr(), start_i),
+            (crate::descr::range_iter_step_one_stop_descr(), one_past),
+            (crate::descr::range_iter_step_one_start_descr(), start_i),
+        ]
+    };
+    for (descr, value) in iter_fields {
+        let index = descr.index();
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::SetfieldGc, &[new, value], descr);
+        ctx.trace_ctx.heapcache_setfield_cached(new, index, value);
+    }
 
-    let remaining_descr = crate::descr::range_iter_remaining_descr();
-    let remaining_index = remaining_descr.index();
-    ctx.trace_ctx
-        .record_op_with_descr(OpCode::SetfieldGc, &[new, length_i], remaining_descr);
-    ctx.trace_ctx
-        .heapcache_setfield_cached(new, remaining_index, length_i);
-
-    let step_descr = crate::descr::range_iter_step_descr();
-    let step_index = step_descr.index();
-    ctx.trace_ctx
-        .record_op_with_descr(OpCode::SetfieldGc, &[new, step_i], step_descr);
-    ctx.trace_ctx
-        .heapcache_setfield_cached(new, step_index, step_i);
-
-    let range_iter_type_addr = &pyre_object::functional::RANGE_ITER_TYPE as *const _ as i64;
     ctx.trace_ctx
         .heap_cache_mut()
-        .class_now_known(new, range_iter_type_addr);
+        .class_now_known(new, iter_type_addr);
 
     let real_iter = unsafe { pyre_object::functional::w_range_iter(range_obj) };
     ctx.trace_ctx.set_opref_concrete(
@@ -18927,6 +19019,138 @@ fn try_walker_specialize_for_iter_list<Sym: WalkSym>(
     Ok(Some(item))
 }
 
+/// Which of the two `step == 1` iterator shapes a FOR_ITER is walking.
+/// They differ only in the class they guard and the descriptors they read;
+/// `W_IntRangeOneArgIterator` additionally promises a non-negative cursor.
+#[derive(Clone, Copy)]
+pub(crate) enum RangeStepOneShape {
+    StepOne,
+    OneArg,
+}
+
+impl RangeStepOneShape {
+    fn type_addr(self) -> i64 {
+        match self {
+            Self::StepOne => &pyre_object::functional::RANGE_ITER_STEP_ONE_TYPE as *const _ as i64,
+            Self::OneArg => &pyre_object::functional::RANGE_ITER_ONE_ARG_TYPE as *const _ as i64,
+        }
+    }
+
+    fn current_descr(self) -> majit_ir::DescrRef {
+        match self {
+            Self::StepOne => crate::descr::range_iter_step_one_current_descr(),
+            Self::OneArg => crate::descr::range_iter_one_arg_current_descr(),
+        }
+    }
+
+    fn stop_descr(self) -> majit_ir::DescrRef {
+        match self {
+            Self::StepOne => crate::descr::range_iter_step_one_stop_descr(),
+            Self::OneArg => crate::descr::range_iter_one_arg_stop_descr(),
+        }
+    }
+}
+
+/// Walker-native `ForIterNext` for the two `step == 1` range-iterator shapes.
+///
+/// `stop` is immutable, so its read hoists out of the loop and the body keeps
+/// one compare, one add and one store — the countdown field and its store that
+/// the three-field shape needs are not there to write.  Everything else
+/// matches [`try_walker_specialize_for_iter_next`]'s range arm: the same
+/// class guard tagged with the FOR_ITER green key, the same exhausted-arrival
+/// edge, the same irreversible concrete advance.
+fn try_walker_specialize_for_iter_range_step_one<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    iter_op: OpRef,
+    iter_obj: pyre_object::PyObjectRef,
+    range_green_key: Option<u64>,
+    shape: RangeStepOneShape,
+) -> Result<Option<OpRef>, DispatchError> {
+    let (concrete_current, concrete_remaining, _concrete_step) =
+        unsafe { pyre_object::functional::w_range_iter_fields(iter_obj) };
+    let concrete_continues = concrete_remaining != 0;
+
+    let body = fbw_foriter_body_from_op_pc(ctx, op_pc)
+        .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
+    fbw_foriter_inflight_mark_attempt(body);
+
+    let type_addr = shape.type_addr();
+    if !iter_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(iter_op) {
+        let type_const = ctx.trace_ctx.const_int(type_addr);
+        match range_green_key {
+            Some(green_key) => {
+                let descr = majit_metainterp::make_resume_guard_descr_range_foriter(green_key);
+                ctx.trace_ctx.record_guard_with_descr(
+                    OpCode::GuardClass,
+                    &[iter_op, type_const],
+                    descr,
+                );
+            }
+            None => {
+                ctx.trace_ctx
+                    .record_guard(OpCode::GuardClass, &[iter_op, type_const], 0);
+            }
+        }
+        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(iter_op, type_addr);
+
+    let current_descr = shape.current_descr();
+    let current = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, iter_op, current_descr.clone());
+    let stop = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, iter_op, shape.stop_descr());
+    let continues = ctx.trace_ctx.record_op(OpCode::IntLt, &[current, stop]);
+    ctx.trace_ctx
+        .set_opref_concrete(continues, Value::Int(concrete_continues as i64));
+
+    if !concrete_continues {
+        // Exhausted arrival, presented the way the residual does: a NULL Ref
+        // the codewriter's trailing GuardNonnull consumes as the loop exit.
+        // The iterator is already exhausted, so no cursor advance and no
+        // in-flight capture.
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[continues])?;
+        let zero = ctx.trace_ctx.const_int(0);
+        let null_item = ctx.trace_ctx.record_op(OpCode::CastIntToPtr, &[zero]);
+        ctx.trace_ctx
+            .set_opref_concrete(null_item, Value::Ref(majit_ir::GcRef(0)));
+        return Ok(Some(null_item));
+    }
+
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[continues])?;
+
+    let one = ctx.trace_ctx.const_int(1);
+    let next_current = ctx.trace_ctx.record_op(OpCode::IntAdd, &[current, one]);
+    ctx.trace_ctx
+        .set_opref_concrete(next_current, Value::Int(concrete_current.wrapping_add(1)));
+    let current_index = current_descr.index();
+    ctx.trace_ctx
+        .record_op_with_descr(OpCode::SetfieldGc, &[iter_op, next_current], current_descr);
+    ctx.trace_ctx
+        .heapcache_setfield_cached(iter_op, current_index, next_current);
+
+    let item = crate::state::wrapint(ctx.trace_ctx, current);
+
+    let concrete_item = unsafe { pyre_object::functional::w_range_iter_next(iter_obj) };
+    debug_assert_eq!(concrete_item.is_some(), concrete_continues);
+    let concrete_item_ptr = concrete_item.expect("GuardTrue(continues) implies a range item");
+    ctx.trace_ctx.set_opref_concrete(
+        item,
+        Value::Ref(majit_ir::GcRef(concrete_item_ptr as usize)),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(current, Value::Int(concrete_current));
+
+    if ctx.trace_ctx.is_bridge_trace {
+        fbw_bridge_iter_journal_push(iter_obj, concrete_current, concrete_remaining);
+    }
+    fbw_foriter_inflight_capture(concrete_item_ptr, body);
+    ctx.vstack_last_ref = item;
+
+    Ok(Some(item))
+}
+
 pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -18960,8 +19184,28 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
             try_walker_specialize_for_iter_list(ctx, op_pc, iter_op, iter_obj)
         });
     }
+    if unsafe { pyre_object::functional::is_range_iter_one_arg(iter_obj) } {
+        return try_walker_specialize_for_iter_range_step_one(
+            ctx,
+            op_pc,
+            iter_op,
+            iter_obj,
+            range_green_key,
+            RangeStepOneShape::OneArg,
+        );
+    }
+    if unsafe { pyre_object::functional::is_range_iter_step_one(iter_obj) } {
+        return try_walker_specialize_for_iter_range_step_one(
+            ctx,
+            op_pc,
+            iter_op,
+            iter_obj,
+            range_green_key,
+            RangeStepOneShape::StepOne,
+        );
+    }
     let (concrete_current, concrete_remaining, concrete_step) = unsafe {
-        if !pyre_object::functional::is_range_iter(iter_obj) {
+        if !pyre_object::functional::is_range_iter_general(iter_obj) {
             return Ok(None);
         }
         pyre_object::functional::w_range_iter_fields(iter_obj)

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2027,11 +2027,13 @@ impl MIFrame {
     ) -> Vec<OpRef> {
         // Mirror pypy/module/pypyjit/test_pypy_c/model.py's `--TICK--` shape:
         // load a process-global raw word through a baked constant address,
-        // compare it, then guard the result. The folded eval-breaker word is a
-        // bitmask, so this uses a nonzero test rather than upstream's
-        // `int_lt(ticker, 0)`.  EB_GC_INTERP is a process-stable dispatch
-        // configuration bit sharing the word to avoid another interpreter
-        // load; mask it out because it is not a compiled-loop breaker.
+        // compare it, then guard the result — three operations, upstream's
+        // `int_lt(ticker, 0)` being the compare there. The folded eval-breaker
+        // word is a bitmask rather than a counter, so the compare is against
+        // `JIT_BREAKER_FLOOR`: the word's one non-breaker bit
+        // (`EB_GC_INTERP`, a process-stable dispatch gate that shares the word
+        // to spare the interpreter a second load) sits below every breaker
+        // bit, so an unsigned compare separates them without a mask.
         //
         // Load-bearing invariant: RawLoadI must remain outside the always-pure
         // range and this descriptor must remain non-pure. Otherwise CSE can
@@ -2051,9 +2053,8 @@ impl MIFrame {
                 &[base, offset],
                 eval_breaker_word_descr(),
             );
-            let mask = ctx.const_int(majit_ir::eval_breaker_word::JIT_BREAKER_MASK as i64);
-            let breaker_bits = ctx.record_op(OpCode::IntAnd, &[word, mask]);
-            let armed = ctx.record_op(OpCode::IntIsTrue, &[breaker_bits]);
+            let floor = ctx.const_int(majit_ir::eval_breaker_word::JIT_BREAKER_FLOOR as i64);
+            let armed = ctx.record_op(OpCode::UintGe, &[word, floor]);
             // The poll is synthesized while this MIFrame is anchored at the
             // target merge point, but semantically it belongs to the
             // JUMP_BACKWARD that reached that target.  Temporarily install the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4173,6 +4173,25 @@ fn build_gc() -> Box<MiniMarkGC> {
         register_pyre_class(&mut gc, &mut pytype_to_tid, descriptor);
     }
 
+    // The two `step == 1` iterator shapes.  Their ids are explicit
+    // (`type_id = 183` / `184`) because their descr groups bake them at
+    // compile time to guard and virtualize a FOR_ITER, and an explicit id only
+    // holds where registration order does: they are unconditional, so they
+    // close the ungated block here, ahead of the target-gated tail whose ids
+    // move per target.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::functional::W_IntRangeStepOneIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::functional::W_IntRangeOneArgIterator
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+
     // Register `posix.DirEntry`'s four inline GC edges and
     // `posix.ScandirIterator`'s entries-list edge. The entries in
     // `SUBCLASS_RANGE_HIERARCHY` and `all_subclass_range_aliases` are

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -512,8 +512,19 @@ pub extern "C" fn jit_range_iter_new(current: i64, remaining: i64, step: i64) ->
 /// # Safety
 /// `obj` must point to a valid `W_IntRangeIterator`.
 pub unsafe fn w_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
-    let iter = obj as *mut W_IntRangeIterator;
     unsafe {
+        if is_range_iter_step_one_shape(obj) {
+            let iter = obj as *mut W_IntRangeOneArgIterator;
+            let current = (*iter).current;
+            if current < (*iter).stop {
+                // Advance before allocating: `w_int_new` can collect, and the
+                // cursor write must not land through a stale pointer.
+                (*iter).current = current + 1;
+                return Some(crate::intobject::w_int_new(current));
+            }
+            return None;
+        }
+        let iter = obj as *mut W_IntRangeIterator;
         if (*iter).remaining > 0 {
             let current = (*iter).current;
             let step = (*iter).step;
@@ -531,17 +542,141 @@ pub unsafe fn w_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
 /// # Safety
 /// `obj` must point to a valid `W_IntRangeIterator`.
 pub unsafe fn w_range_iter_has_next(obj: PyObjectRef) -> bool {
-    let iter = obj as *const W_IntRangeIterator;
-    unsafe { (*iter).remaining > 0 }
+    unsafe { w_range_iter_remaining(obj) > 0 }
 }
 
-/// Check if an object is a range iterator.
+/// `functional.py W_IntRangeStepOneIterator` — the shape `descr_iter` picks
+/// when the `range` was built without a step argument and does not start at
+/// zero.
+///
+/// Layout: `[ob_type | current: i64 | stop: i64 | start: i64]`
+/// `stop` is the sole `_immutable_fields_` entry, so a compiled loop hoists
+/// the bound and the per-iteration cursor work is one load, one add and one
+/// store — `step` is the constant 1 and `remaining` is derived as
+/// `stop - current`.
+#[pyre_class("range_iterator", type_id = 183, static_name = "RANGE_ITER_STEP_ONE")]
+pub struct W_IntRangeStepOneIterator {
+    pub current: i64,
+    pub stop: i64,
+    pub start: i64,
+}
+
+/// `functional.py W_IntRangeOneArgIterator` — the shape for `range(stop)`.
+/// Its values are always `>= 0`, which is the property the JIT reads off the
+/// class.
+///
+/// Layout: `[ob_type | current: i64 | stop: i64]`
+#[pyre_class("range_iterator", type_id = 184, static_name = "RANGE_ITER_ONE_ARG")]
+pub struct W_IntRangeOneArgIterator {
+    pub current: i64,
+    pub stop: i64,
+}
+
+pub const RANGE_ITER_STEP_ONE_CURRENT_OFFSET: usize =
+    std::mem::offset_of!(W_IntRangeStepOneIterator, current);
+pub const RANGE_ITER_STEP_ONE_STOP_OFFSET: usize =
+    std::mem::offset_of!(W_IntRangeStepOneIterator, stop);
+pub const RANGE_ITER_STEP_ONE_START_OFFSET: usize =
+    std::mem::offset_of!(W_IntRangeStepOneIterator, start);
+pub const RANGE_ITER_ONE_ARG_CURRENT_OFFSET: usize =
+    std::mem::offset_of!(W_IntRangeOneArgIterator, current);
+pub const RANGE_ITER_ONE_ARG_STOP_OFFSET: usize =
+    std::mem::offset_of!(W_IntRangeOneArgIterator, stop);
+
+/// Both `step == 1` shapes open with `current` then `stop`;
+/// `W_IntRangeStepOneIterator` only adds `start` behind them.  The cursor
+/// accessors below read that shared prefix through one of the two types, so
+/// the shapes need one implementation rather than two copies.
+const _: () = {
+    assert!(RANGE_ITER_STEP_ONE_CURRENT_OFFSET == RANGE_ITER_ONE_ARG_CURRENT_OFFSET);
+    assert!(RANGE_ITER_STEP_ONE_STOP_OFFSET == RANGE_ITER_ONE_ARG_STOP_OFFSET);
+};
+
+/// Allocate a `W_IntRangeStepOneIterator` positioned at `start`.
+///
+/// The header splits the two identities the way the specialised tuples do:
+/// `ob_type` is this shape's own static, which is what `GuardClass` compares
+/// and what lets a trace reach `stop` at a fixed offset, while `w_class` is
+/// the `range_iterator` tag, so all three machine-int shapes are one Python
+/// type.
+pub fn w_range_iter_step_one_new(start: i64, stop: i64) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    let full = W_IntRangeStepOneIterator {
+        ob: PyObject {
+            ob_type: &RANGE_ITER_STEP_ONE_TYPE as *const PyType,
+            w_class: get_instantiate(&RANGE_ITER_TYPE),
+        },
+        current: start,
+        stop,
+        start,
+    };
+    crate::lltype::malloc_typed(full) as PyObjectRef
+}
+
+/// Allocate a `W_IntRangeOneArgIterator` positioned at zero.
+pub fn w_range_iter_one_arg_new(stop: i64) -> PyObjectRef {
+    let _roots = crate::gc_roots::push_roots();
+    let full = W_IntRangeOneArgIterator {
+        ob: PyObject {
+            ob_type: &RANGE_ITER_ONE_ARG_TYPE as *const PyType,
+            w_class: get_instantiate(&RANGE_ITER_TYPE),
+        },
+        current: 0,
+        stop,
+    };
+    crate::lltype::malloc_typed(full) as PyObjectRef
+}
+
+/// Whether `obj` is the `step == 1` shape.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_range_iter_step_one(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &RANGE_ITER_STEP_ONE_TYPE) }
+}
+
+/// Whether `obj` is the `range(stop)` shape.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_range_iter_one_arg(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &RANGE_ITER_ONE_ARG_TYPE) }
+}
+
+/// Whether `obj` is either `step == 1` shape — the ones whose whole cursor
+/// state is a `current` bounded by an immutable `stop`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_range_iter_step_one_shape(obj: PyObjectRef) -> bool {
+    unsafe { is_range_iter_step_one(obj) || is_range_iter_one_arg(obj) }
+}
+
+/// Whether `obj` is the general three-field shape, and not one of the two
+/// `step == 1` specialisations.  The JIT needs this exact answer because the
+/// three layouts put different fields at the same offsets; interpreter code
+/// wants [`is_range_iter`], which answers for all three.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_range_iter_general(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &RANGE_ITER_TYPE) }
+}
+
+/// Check if an object is a range iterator, in any of the three machine-int
+/// shapes — the `isinstance(w_obj, W_IntRangeIterator)` answer.
 ///
 /// # Safety
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 #[inline]
 pub unsafe fn is_range_iter(obj: PyObjectRef) -> bool {
-    unsafe { py_type_check(obj, &RANGE_ITER_TYPE) }
+    unsafe {
+        is_range_iter_general(obj) || is_range_iter_step_one(obj) || is_range_iter_one_arg(obj)
+    }
 }
 
 /// Read the `(current, remaining, step)` triple of a range iterator.
@@ -549,8 +684,14 @@ pub unsafe fn is_range_iter(obj: PyObjectRef) -> bool {
 /// # Safety
 /// `obj` must point to a valid `W_IntRangeIterator`.
 pub unsafe fn w_range_iter_fields(obj: PyObjectRef) -> (i64, i64, i64) {
-    let iter = obj as *const W_IntRangeIterator;
-    unsafe { ((*iter).current, (*iter).remaining, (*iter).step) }
+    unsafe {
+        if is_range_iter_step_one_shape(obj) {
+            let iter = obj as *const W_IntRangeOneArgIterator;
+            return ((*iter).current, (*iter).stop - (*iter).current, 1);
+        }
+        let iter = obj as *const W_IntRangeIterator;
+        ((*iter).current, (*iter).remaining, (*iter).step)
+    }
 }
 
 /// Count of elements not yet produced by a range iterator.
@@ -558,8 +699,14 @@ pub unsafe fn w_range_iter_fields(obj: PyObjectRef) -> (i64, i64, i64) {
 /// # Safety
 /// `obj` must point to a valid `W_IntRangeIterator`.
 pub unsafe fn w_range_iter_remaining(obj: PyObjectRef) -> i64 {
-    let iter = obj as *const W_IntRangeIterator;
-    unsafe { (*iter).remaining }
+    unsafe {
+        if is_range_iter_step_one_shape(obj) {
+            let iter = obj as *const W_IntRangeOneArgIterator;
+            return (*iter).stop - (*iter).current;
+        }
+        let iter = obj as *const W_IntRangeIterator;
+        (*iter).remaining
+    }
 }
 
 /// Restore the machine range iterator's live cursor fields.
@@ -568,8 +715,14 @@ pub unsafe fn w_range_iter_remaining(obj: PyObjectRef) -> i64 {
 /// `obj` must point to a valid `W_IntRangeIterator`; `remaining` must be
 /// non-negative and `current` must be the value yielded next.
 pub unsafe fn w_range_iter_set_cursor(obj: PyObjectRef, current: i64, remaining: i64) {
-    let iter = obj as *mut W_IntRangeIterator;
     unsafe {
+        // The two `step == 1` shapes derive `remaining` from `stop`, which is
+        // immutable, so the cursor is the whole state they carry.
+        if is_range_iter_step_one_shape(obj) {
+            (*(obj as *mut W_IntRangeOneArgIterator)).current = current;
+            return;
+        }
+        let iter = obj as *mut W_IntRangeIterator;
         (*iter).current = current;
         (*iter).remaining = remaining;
     }
@@ -660,6 +813,83 @@ mod range_iter_tests {
         assert_eq!(RANGE_ITER_REMAINING_OFFSET, 24);
         assert_eq!(RANGE_ITER_STEP_OFFSET, 32);
     }
+
+    #[test]
+    fn test_range_iter_one_arg_walks_and_reports_itself_as_a_range_iter() {
+        let iter = w_range_iter_one_arg_new(3);
+        unsafe {
+            assert!(is_range_iter(iter));
+            assert!(is_range_iter_one_arg(iter));
+            assert!(!is_range_iter_general(iter));
+            assert_eq!(w_range_iter_fields(iter), (0, 3, 1));
+
+            for expected in 0..3 {
+                assert!(w_range_iter_has_next(iter));
+                let item = w_range_iter_next(iter).unwrap();
+                assert_eq!(w_int_get_value(item), expected);
+            }
+            assert!(!w_range_iter_has_next(iter));
+            assert!(w_range_iter_next(iter).is_none());
+            assert_eq!(w_range_iter_remaining(iter), 0);
+        }
+    }
+
+    #[test]
+    fn test_range_iter_step_one_walks_from_its_start() {
+        let iter = w_range_iter_step_one_new(5, 8);
+        unsafe {
+            assert!(is_range_iter(iter));
+            assert!(is_range_iter_step_one(iter));
+            assert_eq!(w_range_iter_fields(iter), (5, 3, 1));
+
+            for expected in 5..8 {
+                let item = w_range_iter_next(iter).unwrap();
+                assert_eq!(w_int_get_value(item), expected);
+            }
+            assert!(w_range_iter_next(iter).is_none());
+        }
+    }
+
+    #[test]
+    fn test_range_iter_set_cursor_moves_a_step_one_shape() {
+        let iter = w_range_iter_step_one_new(0, 10);
+        unsafe {
+            // The remaining count is derived from the immutable `stop`, so the
+            // cursor is the whole state a restore has to write.
+            w_range_iter_set_cursor(iter, 7, 3);
+            assert_eq!(w_range_iter_fields(iter), (7, 3, 1));
+            let item = w_range_iter_next(iter).unwrap();
+            assert_eq!(w_int_get_value(item), 7);
+        }
+    }
+
+    #[test]
+    fn test_promote_step_picks_the_iterator_shape() {
+        unsafe {
+            // `range(4)` — no step argument, starting at zero.
+            let one_arg = w_range_iter(w_range_new(
+                crate::intobject::w_int_new(0),
+                crate::intobject::w_int_new(4),
+                crate::intobject::w_int_new(1),
+                true,
+            ));
+            assert!(is_range_iter_one_arg(one_arg));
+
+            // `range(2, 6)` — no step argument, but not from zero.
+            let step_one = w_range_iter(w_range_new(
+                crate::intobject::w_int_new(2),
+                crate::intobject::w_int_new(6),
+                crate::intobject::w_int_new(1),
+                true,
+            ));
+            assert!(is_range_iter_step_one(step_one));
+
+            // `range(0, 4, 1)` — the step is one, but it was spelled out, so
+            // the promotion does not apply.
+            let general = w_range_iter(w_range_new_i64(0, 4, 1));
+            assert!(is_range_iter_general(general));
+        }
+    }
 }
 
 // ── Range sequence object ──
@@ -689,12 +919,18 @@ pub struct W_Range {
     pub stop: PyObjectRef,
     pub step: PyObjectRef,
     pub length: PyObjectRef,
+    /// `descr_new`'s `promote_step` — true when the constructor was given no
+    /// step argument.  `descr_iter` reads it to pick the `step == 1`
+    /// iterator shapes; a range built as `range(0, 10, 1)` carries a step of
+    /// one but not the promotion, and keeps the general iterator.
+    pub promote_step: bool,
 }
 
 pub const RANGE_START_OFFSET: usize = std::mem::offset_of!(W_Range, start);
 pub const RANGE_STOP_OFFSET: usize = std::mem::offset_of!(W_Range, stop);
 pub const RANGE_STEP_OFFSET: usize = std::mem::offset_of!(W_Range, step);
 pub const RANGE_LENGTH_OFFSET: usize = std::mem::offset_of!(W_Range, length);
+pub const RANGE_PROMOTE_STEP_OFFSET: usize = std::mem::offset_of!(W_Range, promote_step);
 
 /// Allocate a `W_Range` from three wrapped int/long bounds.  `step` must
 /// already be non-zero (the caller raises `ValueError` for a zero step
@@ -704,7 +940,12 @@ pub const RANGE_LENGTH_OFFSET: usize = std::mem::offset_of!(W_Range, length);
     clippy::not_unsafe_ptr_arg_deref,
     reason = "PyObjectRef is a GC-managed VM handle whose validity is established at the interpreter boundary; this item is the safe object-space facade"
 )]
-pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> PyObjectRef {
+pub fn w_range_new(
+    start: PyObjectRef,
+    stop: PyObjectRef,
+    step: PyObjectRef,
+    promote_step: bool,
+) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let start = crate::gc_roots::pin_root(start);
     let stop = crate::gc_roots::pin_root(stop);
@@ -727,15 +968,18 @@ pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
         stop,
         step,
         length,
+        promote_step,
     })
 }
 
-/// Convenience constructor wrapping three machine-int bounds.
+/// Convenience constructor wrapping three machine-int bounds.  The explicit
+/// step spells `promote_step = false`, matching `range(start, stop, step)`.
 pub fn w_range_new_i64(start: i64, stop: i64, step: i64) -> PyObjectRef {
     w_range_new(
         crate::intobject::w_int_new(start),
         crate::intobject::w_int_new(stop),
         crate::intobject::w_int_new(step),
+        false,
     )
 }
 
@@ -744,6 +988,16 @@ pub fn w_range_new_i64(start: i64, stop: i64, step: i64) -> PyObjectRef {
 #[inline]
 pub unsafe fn is_w_range(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &RANGE_TYPE) }
+}
+
+/// `descr_new`'s `promote_step` — whether the range was built without a step
+/// argument.
+///
+/// # Safety
+/// `obj` must point to a valid `W_Range`.
+#[inline]
+pub unsafe fn w_range_promote_step(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const W_Range)).promote_step }
 }
 
 /// # Safety
@@ -859,9 +1113,12 @@ pub unsafe fn w_range_bool(obj: PyObjectRef) -> bool {
     unsafe { !range_obj_to_bigint(w_range_length(obj)).is_zero() }
 }
 
-/// `descr_iter` — a `rangeiterator` (`W_IntRangeIterator`, machine-int and
-/// JIT-specializable) when every bound fits a machine word, otherwise a
-/// `longrange_iterator` (`W_LongRangeIterator`).
+/// `descr_iter` — a `rangeiterator` (machine-int and JIT-specializable) when
+/// every bound fits a machine word, otherwise a `longrange_iterator`
+/// (`W_LongRangeIterator`).
+///
+/// A promoted step picks one of the two `step == 1` shapes, whose `stop` is
+/// immutable and whose cursor needs no separate countdown.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_Range`.
@@ -877,6 +1134,18 @@ pub unsafe fn w_range_iter(obj: PyObjectRef) -> PyObjectRef {
         {
             let one_past = start as i128 + length as i128 * step as i128;
             if i64::try_from(one_past).is_ok() {
+                if w_range_promote_step(obj) {
+                    // The promotion is only spelled by `descr_new`'s missing
+                    // step argument, so `step` is one and `start + length` is
+                    // the end of the walk. An empty or backwards span would
+                    // make `stop` unreachable from `start` by +1 steps, so the
+                    // bound is rebuilt from the length rather than read back.
+                    let end = start + length;
+                    if start == 0 {
+                        return w_range_iter_one_arg_new(end);
+                    }
+                    return w_range_iter_step_one_new(start, end);
+                }
                 return w_range_iter_new(start, length, step);
             }
         }

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -480,9 +480,9 @@ pub const fn subclass_range_alias(type_id: u32, pytype: &'static PyType) -> Subc
 /// payloads ahead of them exist only there, so the group begins three ids
 /// later on Windows than anywhere else.
 #[cfg(all(not(target_arch = "wasm32"), windows))]
-const CFFI_HIERARCHY_FIRST_TYPE_ID: u32 = 194;
+const CFFI_HIERARCHY_FIRST_TYPE_ID: u32 = 196;
 #[cfg(all(not(target_arch = "wasm32"), not(windows)))]
-const CFFI_HIERARCHY_FIRST_TYPE_ID: u32 = 191;
+const CFFI_HIERARCHY_FIRST_TYPE_ID: u32 = 193;
 
 /// Canonical `rclass.OBJECT` inheritance census in GC registration order.
 ///
@@ -692,26 +692,31 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (180, Some(0)),
     (181, Some(0)),
     (182, Some(0)),
-    // Native-only type IDs 183 and 184 represent `posix.DirEntry` and
-    // `posix.ScandirIterator`, matching `build_gc`'s registration order.
-    #[cfg(not(target_arch = "wasm32"))]
+    // The two `step == 1` range-iterator shapes are unconditional, so they
+    // close the ungated block behind the code-object walks rather than joining
+    // the target-gated tail.
     (183, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
     (184, Some(0)),
-    // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
-    // extend the append-only native rclass tail; wasm omits the host TLS
-    // module and therefore the hierarchy entries as well. Sandbox filtering
-    // belongs to pyre-interpreter, which owns that module configuration.
+    // Native-only type IDs 185 and 186 represent `posix.DirEntry` and
+    // `posix.ScandirIterator`, matching `build_gc`'s registration order.
     #[cfg(not(target_arch = "wasm32"))]
     (185, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (186, Some(0)),
+    // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
+    // extend the append-only native rclass tail; wasm omits the host TLS
+    // module and therefore the hierarchy entries as well. Sandbox filtering
+    // belongs to pyre-interpreter, which owns that module configuration.
     #[cfg(not(target_arch = "wasm32"))]
     (187, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (188, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (189, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (190, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (191, Some(0)),
     // `mmap.mmap` owns its native mapping payload — the duplicated fd on POSIX
     // and the file handle on Windows — and follows the optional SSL tail
     // wherever the module is compiled.  The gate must match the alias gate in
@@ -720,20 +725,20 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // A sandbox build has no `mmap` module either, so
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
-    (190, Some(0)),
+    (192, Some(0)),
     // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
     // retained Python buffers.  pyre-interpreter supplies the vtable alias;
     // the object layer owns only the append-only hierarchy slot.
     #[cfg(windows)]
-    (191, Some(0)),
+    (193, Some(0)),
     // `_winapi.Overlapped` owns a second Windows OVERLAPPED record, the one
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
-    (192, Some(0)),
+    (194, Some(0)),
     // PEP 528 `_io._WindowsConsoleIO` is a subclassable `_RawIOBase` payload.
     // Its append-only vtable id follows both Windows overlapped owners.
     #[cfg(windows)]
-    (193, Some(0)),
+    (195, Some(0)),
     // `_cffi_backend` is absent on wasm32 and in sandbox builds.  Its thirteen
     // hierarchy slots sit at the tail because the interpreter's sandbox
     // filter can only remove a contiguous trailing slice.
@@ -1222,6 +1227,12 @@ pub fn all_subclass_range_aliases() -> Vec<SubclassRangeAlias> {
         subclass_range_alias(122, typed::<crate::interp_itertools::W_FilterFalse>()),
         subclass_range_alias(123, typed::<crate::interp_itertools::W_Pairwise>()),
         subclass_range_alias(124, typed::<crate::operation::_CallableIterator>()),
+        // The two `step == 1` range-iterator shapes do not follow W_Range: they
+        // register behind the unconditional code-object walks, the last block
+        // before `build_gc`'s target-gated tail, so their ids are the same on
+        // every target.
+        subclass_range_alias(183, typed::<crate::functional::W_IntRangeStepOneIterator>()),
+        subclass_range_alias(184, typed::<crate::functional::W_IntRangeOneArgIterator>()),
         subclass_range_alias(26, &crate::typedef::MEMBER_TYPE),
         subclass_range_alias(27, &crate::bytesobject::BYTES_TYPE),
         subclass_range_alias(28, &crate::bytearrayobject::BYTEARRAY_TYPE),


### PR DESCRIPTION
Three independent changes, each measured.

### `object`: the two `step == 1` range iterator shapes

`descr_iter` now picks `W_IntRangeStepOneIterator` or `W_IntRangeOneArgIterator`
when `W_Range.promote_step` is set, which `descr_new` sets when it saw no step
argument. Both shapes hold `stop` instead of the general shape's `remaining`
counter. `stop` is the sole `_immutable_fields_` entry on either shape,
matching `functional.py:766` and `:797`; `start` and `W_Range.promote_step`
are plain fields, since `W_Range` upstream declares no `_immutable_fields_`.

They register behind the unconditional code-object walks as type ids 183 and
184. Type ids are positional — `build_gc`'s registration order assigns them and
`#[pyre_class(type_id = N)]` only drift-checks — and the conditionally-compiled
types have to stay one contiguous trailing slice, because that is what
`active_subclass_range_hierarchy()` truncates under `sandbox`. So the two new
shapes go behind the last unconditional registration, and the gated tail
(posix, `_ssl`, `mmap`, both Windows overlapped owners, `_WindowsConsoleIO`,
`_cffi_backend`) moves up by two in `SUBCLASS_RANGE_HIERARCHY` and in both
`all_subclass_range_aliases` lists.

All three shapes carry the same `range_iterator` type object in their
`w_class`, so `type()` identity holds across them and `is_range_iter` covers
all three.

Measured, same program, one binary, optimized trace between LABEL and JUMP:

| loop | body | iterator ops |
| --- | --- | --- |
| `range(1, n, 1)` (general) | 12 ops | `IntGt`, `IntAdd`, **`IntSub`**, **`SetfieldGc` x2** |
| `range(1, n)` / `range(n)` | **10 ops** | `IntLt`, `IntAdd`, `SetfieldGc` x1 |

No `GetfieldGc` survives in either body — `stop` is loop-invariant and hoists. Because the shape turns on `promote_step`
rather than on `step == 1`, `range(a, b, 1)` keeps the general shape.

Parity: a fixture covering all three shapes with `__length_hint__`,
`__reduce__`, `__setstate__`, pickling and `type()` identity matches CPython
byte for byte, and the vendored `test.test_range` passes against its baseline.

### `jit`: an eval-breaker floor compare instead of a mask

The eval-breaker bits are renumbered so the flags a compiled loop must stop for
sort above the ones it may ignore (`EB_GC_INTERP = 1`, `EB_ASYNC = 2`,
`EB_STW = 4`, `EB_FINALIZING = 8`). The back-edge poll then emits
`UintGe(word, JIT_BREAKER_FLOOR)` instead of a mask and a test, one op fewer
per poll.

### `backend`: a per-op machine-code offset from both native backends

dynasm printed the `MAJIT_DUMP` offset line only from the arms that produce a
result, so a guard's or a discard's bytes were read as part of the preceding
op's span and every span after a trace's first guard named the wrong operation.
Both arches now open a span for those two arms too, 3 -> 5 dump sites each.

cranelift carried no source locations at all. Under the same switch it stamps
each op's trace index as a `SourceLoc` before lowering and reads the regions
back off the compiled buffer, printing `[clif] @0xNNNN op[i] OpCode` next to
dynasm's lines. Regions are recorded only when the dump is asked for; the
emitted bytes are unaffected.

### CI

The previous head of this branch was red on five checks. Graded against main's
own CI at the same time, three of them are main's:

| check | main control | this branch |
| --- | --- | --- |
| `cranelift raise_catch` (macos) | FAIL | FAIL |
| `the_answer_is_the_same_at_every_carrier_depth_cap` | FAILED | FAILED |
| `the_depth_decline_is_the_arm_this_program_reaches` | FAILED | FAILED |
| `dynasm synth/load_name_builtin_cell_fold` (ubuntu) | — | FAIL 1.7x |
| `cranelift synth/load_name_builtin_cell_fold` (ubuntu) | — | FAIL 2.3x |

The two branch-owned rows are on the fixture the eval-breaker change targets,
and they were measured before these commits existed. They are ubuntu-only, so
this run is what grades them.

`pyre/check.py` is green locally on all three backends (dynasm 531/531,
cranelift 531/531, wasm 524/524).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optimized handling for common `range()` iterations, including one-argument ranges and ranges with a step of one.
  - Range iterators now provide consistent type information across supported forms.

- **Bug Fixes**
  - Prevented garbage-collection signals from unnecessarily interrupting optimized execution.
  - Improved range construction and iteration when an explicit step is provided.

- **Diagnostics**
  - Enhanced optional JIT dump output with more precise machine-code and operation mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->