### PR TITLE
_ssl, _sqlite3: the two review findings left open on #1628

### DIFF
--- a/lib_pypy/_sqlite3.py
+++ b/lib_pypy/_sqlite3.py
@@ -326,17 +326,25 @@ LEGACY_TRANSACTION_CONTROL = -1
 
 
 def _check_autocommit(value):
-    # `autocommit_converter` takes True and False by identity, then requires an
-    # int whose *value* is the sentinel: it reads the value with
-    # `PyLong_AsLong`.  So a float -1.0, an object whose `__eq__` answers True,
-    # and an int subclass that overrides `__eq__` to spoof -1 are all rejected
-    # -- hence `int.__eq__` rather than `==`.
-    if (value is not True and value is not False and
-            not (isinstance(value, int) and
-                 int.__eq__(value, LEGACY_TRANSACTION_CONTROL) is True)):
-        raise ValueError(
-            "autocommit must be True, False, or "
-            "sqlite3.LEGACY_TRANSACTION_CONTROL")
+    """The accepted value, narrowed to what the connection may store.
+
+    `autocommit_converter` takes True and False by identity, then reads an int
+    with `PyLong_AsLong` and keeps the C long.  So a float -1.0, an object
+    whose `__eq__` answers True, and an int subclass that overrides `__eq__` to
+    spoof -1 are all rejected -- hence `int.__eq__` rather than `==` -- and an
+    accepted subclass is narrowed to the sentinel itself.  Narrowing is what
+    keeps the later `_autocommit == LEGACY_TRANSACTION_CONTROL` tests off a
+    subclass's `__eq__`, which would otherwise deny the legacy branch a
+    transaction and run DML in SQLite's own autocommit mode.
+    """
+    if value is True or value is False:
+        return value
+    if (isinstance(value, int) and
+            int.__eq__(value, LEGACY_TRANSACTION_CONTROL) is True):
+        return LEGACY_TRANSACTION_CONTROL
+    raise ValueError(
+        "autocommit must be True, False, or "
+        "sqlite3.LEGACY_TRANSACTION_CONTROL")
 
 
 # SQLite version information
@@ -503,7 +511,7 @@ class Connection(object):
     def __init__(self, database, timeout=5.0, detect_types=0, isolation_level="",
                  check_same_thread=True, factory=None, cached_statements=100,
                  uri=0, *, autocommit=LEGACY_TRANSACTION_CONTROL):
-        _check_autocommit(autocommit)
+        autocommit = _check_autocommit(autocommit)
         sys.audit("sqlite3.connect", database)
         self.__initialized = False
         db_star = _ffi.new('sqlite3 **')
@@ -1158,7 +1166,7 @@ class Connection(object):
         return LEGACY_TRANSACTION_CONTROL
 
     def __set_autocommit(self, value):
-        _check_autocommit(value)
+        value = _check_autocommit(value)
         self._check_thread()
         self._check_closed()
         self._autocommit = value

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -75,22 +75,27 @@ pub struct W_SSLSession {
 /// and the two that hold the body's length.
 const TLS_RECORD_HEADER_LEN: usize = 5;
 
-/// Where the shutdown exchange stands inside the record it is reading.
+/// Where the connection stands inside the TLS record it is reading.
 ///
-/// OpenSSL's record layer reads a header and then the body its length names,
-/// which is what keeps a socket-backed `SSL_shutdown` from lifting the
-/// plaintext that follows the peer's close_notify out of the kernel.  A
-/// transport that returns short -- a non-blocking socket, a timed one, an
+/// `ssl3_read_n` takes the 5-byte header and then exactly the body its length
+/// names, so OpenSSL never lifts more off the transport than the record it is
+/// parsing.  That is what leaves the plaintext following the peer's
+/// close_notify in the kernel for the socket `unwrap()` hands back, and it
+/// holds for every read rather than only the shutdown exchange: a `recv` that
+/// took the close_notify and the bytes behind it would drop those bytes into
+/// the TLS stream, where nothing can return them.
+///
+/// A transport that returns short -- a non-blocking socket, a timed one, an
 /// interrupted read -- unwinds back to the caller, which asks again, so this
 /// belongs to the connection and not to one call.
 #[derive(Default)]
-pub struct ShutdownRecord {
+pub struct RecordCursor {
     header: [u8; TLS_RECORD_HEADER_LEN],
     header_read: usize,
     body_left: usize,
 }
 
-impl ShutdownRecord {
+impl RecordCursor {
     /// The bytes still owed before the next record boundary.
     fn want(&self) -> usize {
         if self.body_left > 0 {
@@ -102,7 +107,7 @@ impl ShutdownRecord {
 
     /// Account for `data`, which must be no longer than [`want`].
     ///
-    /// [`want`]: ShutdownRecord::want
+    /// [`want`]: RecordCursor::want
     fn consume(&mut self, data: &[u8]) {
         if self.body_left > 0 {
             self.body_left -= data.len();
@@ -134,7 +139,7 @@ pub struct W_SSLSocket {
     pub server_hostname: PyObjectRef,
     pub server_side: bool,
     pub shutdown_started: bool,
-    pub shutdown_record: ShutdownRecord,
+    pub record: RecordCursor,
     pub requested_session: *mut pyre_native::ssl::NativeSession,
 }
 
@@ -548,7 +553,7 @@ fn allocate_ssl_socket(
         },
         server_side,
         shutdown_started: false,
-        shutdown_record: ShutdownRecord::default(),
+        record: RecordCursor::default(),
         requested_session,
     })
 }
@@ -1618,7 +1623,7 @@ mod ssl_socket_methods {
         if let Some((transport, fd)) = pump_transport(socket)? {
             let backend = socket.backend;
             loop {
-                match pump(backend, fd, &mut [], PumpGoal::Flush) {
+                match pump(backend, fd, &mut [], PumpGoal::Flush, &mut socket.record) {
                     PumpExit::Done(_) => return Ok(()),
                     PumpExit::Interrupted => {
                         crate::module::signal::interp_signal::checksignals_now()?
@@ -1696,17 +1701,6 @@ mod ssl_socket_methods {
         Rejected((i32, String)),
     }
 
-    /// [`pump_record_bounded`] for the goals that read whatever the transport
-    /// has, rather than one TLS record at a time.
-    fn pump(
-        backend: *mut pyre_native::ssl::TlsConnection,
-        fd: crate::module::_socket::rsocket_rffi::Socket,
-        buf: &mut [u8],
-        goal: PumpGoal,
-    ) -> PumpExit {
-        pump_record_bounded(backend, fd, buf, goal, &mut ShutdownRecord::default())
-    }
-
     /// The `PySSL_BEGIN_ALLOW_THREADS` bracket that `SSL_do_handshake`,
     /// `SSL_read` and `SSL_write` each put around their whole exchange: the
     /// peer's records are read, answered and parsed without the interpreter,
@@ -1719,15 +1713,15 @@ mod ssl_socket_methods {
     /// server context to choose, a signal to deliver, an error to raise - end
     /// the run and are answered by the caller.
     ///
-    /// `record` carries where a [`PumpGoal::Shutdown`] run stands inside the
-    /// record it is reading, so it has to outlive the call: a transport that
-    /// returns short unwinds to the caller, which re-enters here.
-    fn pump_record_bounded(
+    /// `record` is the connection's cursor into the record being read, so it
+    /// outlives the call: a transport that returns short unwinds to the
+    /// caller, which re-enters here and has to resume where it stopped.
+    fn pump(
         backend: *mut pyre_native::ssl::TlsConnection,
         fd: crate::module::_socket::rsocket_rffi::Socket,
         buf: &mut [u8],
         goal: PumpGoal,
-        record: &mut ShutdownRecord,
+        record: &mut RecordCursor,
     ) -> PumpExit {
         use crate::module::_socket::interp_socket::{socket_recv_raw, socket_send_raw};
         use crate::module::_socket::rsocket_rffi::error_is_interrupted;
@@ -1789,16 +1783,15 @@ mod ssl_socket_methods {
                     }
                 }
             }
-            let want = match goal {
-                PumpGoal::Shutdown => record.want().min(buf.len()),
-                _ => buf.len(),
-            };
+            // Every goal, not only `Shutdown`: a read that stops at the
+            // boundary is what keeps the cursor describing the transport, and
+            // it is also what leaves a later close_notify's trailing plaintext
+            // where `unwrap()` can still hand it over.
+            let want = record.want().min(buf.len());
             match socket_recv_raw(fd, &mut buf[..want], 0) {
                 Ok(0) => return PumpExit::Eof,
                 Ok(read) => {
-                    if matches!(goal, PumpGoal::Shutdown) {
-                        record.consume(&buf[..read]);
-                    }
+                    record.consume(&buf[..read]);
                     if let Err(error) =
                         unsafe { pyre_native::ssl::connection_receive_tls(backend, &buf[..read]) }
                     {
@@ -1889,20 +1882,10 @@ mod ssl_socket_methods {
         Ok(Some((transport, fd)))
     }
 
+    /// The callback-aware counterpart of [`pump`], which returns to the
+    /// interpreter after every record instead of holding it across the
+    /// exchange.  It stops at the same boundary, for the same reason.
     fn receive_transport(socket: &mut W_SSLSocket) -> Result<(), crate::PyError> {
-        receive_transport_bounded(socket, false)
-    }
-
-    /// `track_record` stops the socket read at the boundary the connection's
-    /// `shutdown_record` is tracking, and accounts what it read against it.
-    /// The shutdown exchange needs that: what follows the peer's close_notify
-    /// is the plaintext `unwrap()` hands back with the socket, and a read that
-    /// crossed the boundary would feed those bytes to the TLS stream, where
-    /// nothing can return them.
-    fn receive_transport_bounded(
-        socket: &mut W_SSLSocket,
-        track_record: bool,
-    ) -> Result<(), crate::PyError> {
         ensure_connection(socket)?;
         if !unsafe { is_none(socket.incoming) } {
             let incoming = W_MemoryBIO::from_obj(socket.incoming)
@@ -1930,11 +1913,7 @@ mod ssl_socket_methods {
         let fd = crate::module::_socket::interp_socket::socket_fd(transport)?;
         crate::module::_socket::interp_socket::socket_wait_for_data(transport, fd, false)?;
         let mut buf = vec![0u8; 32 * 1024];
-        let want = if track_record {
-            socket.shutdown_record.want().min(buf.len())
-        } else {
-            buf.len()
-        };
+        let want = socket.record.want().min(buf.len());
         let read = match crate::module::_socket::interp_socket::socket_recv_bytes(
             transport,
             fd,
@@ -1956,9 +1935,7 @@ mod ssl_socket_methods {
                 "EOF occurred in violation of protocol".to_string(),
             ));
         }
-        if track_record {
-            socket.shutdown_record.consume(&buf[..read]);
-        }
+        socket.record.consume(&buf[..read]);
         receive_tls(socket, &buf[..read]).map(|_| ())
     }
 
@@ -2171,7 +2148,13 @@ mod ssl_socket_methods {
                         pump_buffer.resize(32 * 1024, 0u8);
                     }
                     let backend = self.backend;
-                    match pump(backend, fd, &mut pump_buffer, PumpGoal::Handshake) {
+                    match pump(
+                        backend,
+                        fd,
+                        &mut pump_buffer,
+                        PumpGoal::Handshake,
+                        &mut self.record,
+                    ) {
                         PumpExit::Done(_) => {
                             settle_received_tls(self)?;
                             return Ok(());
@@ -2292,7 +2275,13 @@ mod ssl_socket_methods {
                 let mut buf = vec![0u8; 32 * 1024];
                 let backend = self.backend;
                 loop {
-                    match pump(backend, fd, &mut buf, PumpGoal::Read(size)) {
+                    match pump(
+                        backend,
+                        fd,
+                        &mut buf,
+                        PumpGoal::Read(size),
+                        &mut self.record,
+                    ) {
                         PumpExit::Done(data) => {
                             settle_received_tls(self)?;
                             break data;
@@ -2555,12 +2544,12 @@ mod ssl_socket_methods {
             if let Some((transport, fd)) = pump_transport(self)? {
                 let mut buf = vec![0u8; 32 * 1024];
                 loop {
-                    match pump_record_bounded(
+                    match pump(
                         self.backend,
                         fd,
                         &mut buf,
                         PumpGoal::Shutdown,
-                        &mut self.shutdown_record,
+                        &mut self.record,
                     ) {
                         PumpExit::Done(_) => {
                             settle_received_tls(self)?;
@@ -2582,10 +2571,10 @@ mod ssl_socket_methods {
                 // A message callback requires returning to the interpreter
                 // after every record.  Keep PyPy's shutdown loop in that
                 // case too, but use the callback-aware transport helpers
-                // instead of the released pump -- reading to the same record
-                // boundary the pump stops at.
+                // instead of the released pump -- which reads to the same
+                // record boundary.
                 while !unsafe { pyre_native::ssl::connection_peer_closed(self.backend) } {
-                    receive_transport_bounded(self, true)?;
+                    receive_transport(self)?;
                     flush_transport(self)?;
                 }
             }


### PR DESCRIPTION
Two follow-ups to #1628, one commit each. Both come out of the review on that
PR: one is a defect the merged fix introduced, the other is the pre-existing
defect #1628's description recorded but left alone.

| # | Finding | Source | File |
|---|---|---|---|
| 1 | an accepted `int` subclass is stored, so `_autocommit == LEGACY_TRANSACTION_CONTROL` runs its `__eq__` | CodeRabbit, on #1628's own change | `lib_pypy/_sqlite3.py` |
| 2 | an ordinary `recv` reads past the record and swallows the plaintext behind a close_notify | #1628's "separate defect found while probing", and Codex's P2 on the same path | `_ssl/mod.rs` |

## 1 — `_sqlite3`, store the sentinel and not the object

#1628 fixed the spoofing half: `int.__eq__(value, LEGACY_TRANSACTION_CONTROL)`
rejects an `int` subclass whose `__eq__` lies. It left the accepting half —
a subclass whose *value* really is -1 is accepted, and both callers stored the
object they were handed. `Connection._autocommit` then held that object, and
the two later `_autocommit == LEGACY_TRANSACTION_CONTROL` tests dispatched its
`__eq__`: one answering False denies the legacy branch its transaction and the
DML after it runs in SQLite's own autocommit mode.

`autocommit_converter` reads the int with `PyLong_AsLong` and keeps the C long,
so the connection holds the sentinel. `_check_autocommit` now returns the
narrowed value and both callers store what it returns.

## 2 — `_ssl`, bound every read to the record, not just the shutdown exchange

`ssl3_read_n` takes the 5-byte header and then exactly the body its length
names, so OpenSSL never lifts more off the transport than the record it is
parsing. #1628 gave `PumpGoal::Shutdown` that bound. Every other goal still
read up to 32 KiB, so an ordinary `recv` that found the peer's close_notify
and the plaintext behind it in one kernel buffer took both and fed them to the
TLS stream, which has no way to return them — the socket `unwrap()` hands back
comes up empty.

`pump` and `receive_transport` now size every read with the connection's
cursor and account what they read against it. Two consequences:

- The cursor now always describes the transport, which is also the answer to
  Codex's P2 on #1628 (a `shutdown()` that unwound mid-record and then saw an
  ordinary `read()` came back to a stale offset). There are no reads left that
  do not count against the cursor, so there is nothing to go stale.
- `ShutdownRecord` is renamed `RecordCursor` and `receive_transport_bounded`
  collapses back into `receive_transport`.

## Verification

Gates on `pyre-dynasm` release, run on `7a4aecb0111` with these two commits
(the branch has since been rebased onto `62bf39a880b`; the diff is unchanged
and a re-run on that base is in flight):

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `scripts/check-new-line-citations.py --base origin/main` | pass, no new line-number citations |
| `pyre/cpython_tests/run.py --backend dynasm` | pass |
| `scripts/check-gc-root-brackets.py` | pass; both invariants 0, `tier1_calls` 9 → 0 |
| `pyre/extra_tests/parity_tests/run.py --dynasm-only` | 2 failures, neither this branch's — see below |

The gc-root gate's `unbracketed_calls 2073 → 2086` WARN is main's drift: the
baseline was recorded at `903151ee679a` and the run sits on `7a4aecb0111`.

Both parity failures are inherited:

- `foriter_stopiteration_exception_event.py [pypy]` — bare `pypy3 3.11.13`
  reproduces the identical `AssertionError: consume_callable_iter` with no
  pyre binary involved.
- `jit_traceback_frame_clear.py [dynasm]` — `frame.clear()` on a **returned**
  frame raises `RuntimeError: cannot clear an executing frame` after the JIT
  warms up. It regressed on main in #1611 (`099f711f72b`), which merged with
  its own CI already red on this fixture: four other PRs whose runs merged the
  same base `5845c442dfc` (#1631, #1630, #1608, #1624) are all OK on both
  backends, #1611's own run is FAIL on both, and #1629 — the first run whose
  base contains #1611 — inherits the FAIL. Locally a `pyre-dynasm` built at
  `d8c4664953a` *carrying every change from #1628 and this branch* exits 0 on
  the fixture, and one built at `7a4aecb0111` exits 1.

### Pre/post witness for 2

The probe puts `close_notify` + plaintext in one `sendall` from a memory-BIO
peer (an ordinary `wrap_socket` server cannot: TLS shutdown is bidirectional,
so its `unwrap()` blocks on the client's own close_notify first), and the
client reads *before* any shutdown, so only the ordinary read path can
over-read.

| binary | `probe_ssl_early`, `_msg_callback` |
|---|---|
| CPython 3.14 | OK 10/10 |
| #1628 as merged | **LOST 5/5** |
| this branch | **OK 10/10** |

The three probes #1628 already used (`sync`, `split`, `intervening`) stay OK.


`probe_sqlite3.py`'s 15 cases stay byte-identical to CPython 3.14, and the
regression CodeRabbit found is now measured on three binaries:

`FalseEqInt(int)` overrides `__eq__` to answer False; its value really is -1,
so CPython accepts it and stores the sentinel.

| binary | `autocommit=FalseEqInt(-1)` | `in_transaction` after DML |
|---|---|---|
| before #1628 | `ValueError` — `==` dispatched the lying `__eq__` | — |
| #1628 as merged | accepted, the object stored | **False** |
| this branch | accepted, `_autocommit` is `-1` of type `int` | True |
| CPython 3.14 | accepted | True |
