### PR TITLE
native, deps, argument: share the RustPython zlib engine, pin the merged compression engines, and enter the runtime thread in two star-arg tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,16 +532,6 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1808,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c12cd6e7e66c601f22d849241e2257b38b4685a34b41401f4aefdd9c431c1c6"
+checksum = "03dcace986b149f29509af6ca70e6182bccce916b644424ecf484faa8ddc899a"
 dependencies = [
  "zlib-rs",
 ]
@@ -3263,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3286,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "ascii",
  "base64",
@@ -3314,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3328,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3344,7 +3334,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3378,7 +3368,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3457,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3469,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3483,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
+source = "git+https://github.com/youknowone/RustPython.git?rev=294ba6ba8f6205f6857eea74712ec8e943f95326#294ba6ba8f6205f6857eea74712ec8e943f95326"
 dependencies = [
  "ascii",
  "bstr",
@@ -3628,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3882,12 +3872,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "501336eb7ba9e417300a6a0fa985721065467aa83a6dcf0422a8e43e4c0328fa"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -5173,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,16 +1122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "miniz_oxide",
- "zlib-rs",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c12cd6e7e66c601f22d849241e2257b38b4685a34b41401f4aefdd9c431c1c6"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linkme"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,16 +2223,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "nibble_vec"
@@ -2842,7 +2825,6 @@ dependencies = [
  "bzip2",
  "cc",
  "der",
- "flate2",
  "libc",
  "lz4_flex",
  "md-5",
@@ -2853,6 +2835,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki",
+ "rustpython-common",
  "rustpython-host_env",
  "scrypt 0.11.0",
  "sha1",
@@ -2860,7 +2843,6 @@ dependencies = [
  "sha3",
  "x509-parser",
  "xz-core",
- "zlib-rs",
 ]
 
 [[package]]
@@ -3281,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3304,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "ascii",
  "base64",
@@ -3313,6 +3295,7 @@ dependencies = [
  "getrandom 0.4.3",
  "itertools 0.15.0",
  "libc",
+ "libz-rs-sys",
  "lock_api",
  "malachite-base",
  "malachite-bigint",
@@ -3325,12 +3308,13 @@ dependencies = [
  "rustpython-unicode",
  "rustpython-wtf8",
  "siphasher",
+ "zlib-rs",
 ]
 
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3344,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3360,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3394,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3473,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3485,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3499,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=6a3a8b0f1123d29f48a7755f058488f417f0419c#6a3a8b0f1123d29f48a7755f058488f417f0419c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=c3dff8fb171779fe58d13c893c530b2ba46fe109#c3dff8fb171779fe58d13c893c530b2ba46fe109"
 dependencies = [
  "ascii",
  "bstr",
@@ -3770,12 +3754,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,16 +79,19 @@ pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 # names `MarshalError::DataTooShort` / `EofObject` and `CFormatType::Bytes`,
 # which arrived with it.
 #
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c", features = ["binascii", "cjk-codecs", "inet", "json"] }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
+# Moved to the head of RustPython #8631 for the feature-gated, VM-independent
+# zlib stream engine shared by rustpython-stdlib and pyre-native.
+#
+rustpython-common = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109", features = ["binascii", "cjk-codecs", "inet", "json", "zlib"] }
+rustpython-literal = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "6a3a8b0f1123d29f48a7755f058488f417f0419c" }
+rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-unicode = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }
@@ -179,10 +182,6 @@ sha3 = "0.10"
 blake2b_simd = { version = "1.0.4" }
 blake2s_simd = { version = "1.0.4" }
 scrypt = { version = "0.11", default-features = false }
-# zlib backend (pyre-native only): zlib-rs is a pure-Rust zlib port whose
-# DEFLATE output is byte-identical to the reference C zlib.
-flate2 = { version = "1.1.9", default-features = false }
-zlib-rs = { version = "0.6.5", default-features = false, features = ["rust-allocator", "__internal-api"] }
 # bzip2 backend (pyre-native only): the crate's default feature selects
 # libbz2-rs-sys, the pure-Rust libbz2 port from the same source as zlib-rs,
 # whose output is byte-identical to the reference C libbz2.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,19 +79,19 @@ pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 # names `MarshalError::DataTooShort` / `EofObject` and `CFormatType::Bytes`,
 # which arrived with it.
 #
-# Moved to the head of RustPython #8631 for the feature-gated, VM-independent
-# zlib stream engine shared by rustpython-stdlib and pyre-native.
+# Pinned to the merge of RustPython #8631 for the feature-gated,
+# VM-independent zlib stream engine shared by rustpython-stdlib and pyre-native.
 #
-rustpython-common = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109", features = ["binascii", "cjk-codecs", "inet", "json", "zlib"] }
-rustpython-literal = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
-rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
-rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-common = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326", features = ["binascii", "cjk-codecs", "inet", "json", "zlib"] }
+rustpython-literal = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
+rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
+rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
-rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
-rustpython-unicode = { git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "c3dff8fb171779fe58d13c893c530b2ba46fe109" }
+rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
+rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
+rustpython-unicode = { git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "294ba6ba8f6205f6857eea74712ec8e943f95326" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -2145,8 +2145,15 @@ mod tests {
 
     /// pypy/interpreter/argument.py:97-103 — non-iterable star arg
     /// surfaces "argument after * must be an iterable".
+    ///
+    /// Rejecting the operand runs `space.iter`, whose `__iter__` probe is a
+    /// type-MRO `lookup`; that lookup needs `init_typeobjects()` to have
+    /// populated the W_TypeObject MRO, and its hash-hook install is what
+    /// enters the runtime thread this test's method-cache probe needs a GIL
+    /// from.
     #[test]
     fn combine_starargs_wrapped_non_iterable_raises() {
+        crate::typedef::init_typeobjects();
         let mut args: Vec<PyObjectRef> = vec![];
         let stararg = pyre_object::w_int_new(42); // ints aren't iterable
         let err = combine_starargs_wrapped(&mut args, stararg, pyre_object::PY_NULL)
@@ -2363,9 +2370,12 @@ mod tests {
 
     /// pypy/interpreter/argument.py:97-103 — non-iterable `*` arg
     /// surfaces as `Err(PyError)` from `Arguments::new` rather than the
-    /// previous `unimplemented!()` panic.
+    /// previous `unimplemented!()` panic.  The rejection takes the same
+    /// `space.iter` route as the test above, so it needs the same
+    /// `init_typeobjects()`.
     #[test]
     fn new_with_w_stararg_non_iterable_returns_err() {
+        crate::typedef::init_typeobjects();
         let pos: [PyObjectRef; 0] = [];
         let stararg = pyre_object::w_int_new(42); // not iterable
         match Arguments::new(&pos, None, None, Some(stararg), None, false, None) {

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1263,7 +1263,7 @@ fn typeids_z_bytes() -> Result<Vec<u8>, crate::PyError> {
     let text = majit_gc::get_typeids_text()
         .ok_or_else(|| crate::PyError::not_implemented("operation not implemented by this GC"))?;
     pyre_native::zlib::compress(&text, 9, pyre_native::zlib::MAX_WBITS)
-        .map_err(crate::PyError::os_error)
+        .map_err(|error| crate::PyError::os_error(error.into_message()))
 }
 
 /// The spelling each typeid sidecar wants. `app_referents.py:34` opens

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -1,9 +1,9 @@
 //! zlib module — PyPy: `pypy/module/zlib/`.
 //!
 //! CRC-32 / Adler-32 checksums plus the DEFLATE compress/decompress surface.
-//! The DEFLATE machinery is a deliberate duplication of RustPython's zlib
-//! implementation, ported into `pyre_native::zlib` (flate2 / zlib-rs) and kept
-//! outside the LLBC extraction; this module is the W_Root object glue.
+//! The DEFLATE machinery is shared with RustPython through
+//! `rustpython_common::compression::zlib`.  `pyre_native::zlib` keeps an opaque
+//! adapter outside LLBC extraction; this module is the W_Root object glue.
 //!
 //! `Compress` / `Decompress` / `_ZlibDecompressor` own their native stream
 //! directly, matching `interp_zlib.py`'s `self.stream`.  Each stream also owns

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -125,6 +125,15 @@ fn zlib_error(msg: impl Into<String>) -> crate::PyError {
     err
 }
 
+fn init_error(error: backend::InitError) -> crate::PyError {
+    match error {
+        backend::InitError::InvalidOption => {
+            crate::PyError::value_error("Invalid initialization option")
+        }
+        backend::InitError::Zlib(message) => zlib_error(message),
+    }
+}
+
 fn eof_error(msg: &str) -> crate::PyError {
     crate::PyError::new(crate::PyErrorKind::EOFError, msg)
 }
@@ -373,7 +382,7 @@ fn make_compress_for(
         return Err(crate::PyError::value_error("Invalid initialization option"));
     }
     let c = backend::Compressor::new(level, method, wbits, mem_level, strategy, zdict.as_deref())
-        .map_err(zlib_error)?;
+        .map_err(init_error)?;
     allocate_compress(cls, c)
 }
 
@@ -624,7 +633,7 @@ fn make_decompress_for(
         // conversion for inflateInit2.
         return Err(crate::PyError::value_error("Invalid initialization option"));
     }
-    let d = backend::Decompressor::new(wbits, zdict).map_err(zlib_error)?;
+    let d = backend::Decompressor::new(wbits, zdict).map_err(init_error)?;
     allocate_decompress(cls, d)
 }
 
@@ -719,7 +728,7 @@ fn zdecompress_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         backend::MAX_WBITS as i64,
     )?);
     let zdict = zdict_or_none(args.get(2).copied().unwrap_or(PY_NULL))?;
-    let d = backend::ZlibDecompressor::new(wbits, zdict).map_err(zlib_error)?;
+    let d = backend::ZlibDecompressor::new(wbits, zdict).map_err(init_error)?;
     let cls = args.first().copied().unwrap_or_else(zdecompress_type);
     allocate_zdecompress(cls, d)
 }
@@ -892,7 +901,7 @@ crate::py_module! {
         ) -> Result<PyObjectRef, crate::PyError> {
             let level = int_or_default(level, -1)? as i32;
             let wbits = to_wbits(int_or_default(wbits, backend::MAX_WBITS as i64)?);
-            let out = backend::compress(&data, level, wbits).map_err(zlib_error)?;
+            let out = backend::compress(&data, level, wbits).map_err(init_error)?;
             Ok(bytesobject::w_bytes_from_bytes(&out))
         }
         // interp_zlib.py `decompress(string, __posonly__=None, wbits, bufsize)`.
@@ -909,7 +918,7 @@ crate::py_module! {
             if bufsize < 0 {
                 return Err(crate::PyError::value_error("bufsize must be non-negative"));
             }
-            let out = backend::decompress(&data, wbits, bufsize as usize).map_err(zlib_error)?;
+            let out = backend::decompress(&data, wbits, bufsize as usize).map_err(init_error)?;
             Ok(bytesobject::w_bytes_from_bytes(&out))
         }
         // interp_zlib.py `Compress___new__(level, method, wbits, memLevel,

--- a/pyre/pyre-native/Cargo.toml
+++ b/pyre/pyre-native/Cargo.toml
@@ -21,8 +21,7 @@ sha3 = { workspace = true }
 blake2b_simd = { workspace = true }
 blake2s_simd = { workspace = true }
 scrypt = { workspace = true }
-flate2 = { workspace = true, features = ["zlib-rs"] }
-zlib-rs = { workspace = true }
+rustpython-common = { workspace = true }
 bzip2 = { workspace = true }
 xz-core = { workspace = true }
 rustpython-host_env = { workspace = true, optional = true }

--- a/pyre/pyre-native/src/zlib.rs
+++ b/pyre/pyre-native/src/zlib.rs
@@ -1,452 +1,31 @@
-//! zlib DEFLATE backend — deliberate duplication of RustPython's zlib
-//! machinery (`stdlib/src/zlib.rs` + the shared `compression.rs` state
-//! machine), stripped of the `vm`/`PyResult` layer and specialised to the
-//! `flate2` zlib-rs backend.  Errors surface as plain messages the
-//! interpreter maps onto `zlib.error`.  Kept outside the LLBC extraction so
-//! the native codec never lowers into the traceable graph.
+//! Opaque adapter for the VM-independent zlib engine in rustpython-common.
+//!
+//! Keep the wrapper methods in pyre-native: the interpreter's LLBC extraction
+//! treats this crate as its native boundary and must not lower the compression
+//! engine into the traceable graph.
 
-use core::mem::MaybeUninit;
-use std::ffi::CStr;
+use rustpython_common::compression::zlib as common;
 
-use zlib_rs::{
-    DeflateError, DeflateFlush, InflateError, InflateFlush, ReturnCode, Status,
-    c_api::z_stream,
-    deflate::{self, DeflateConfig, DeflateStream, Method, Strategy},
-    inflate::{self, InflateConfig, InflateStream},
-};
+pub const MAX_WBITS: i32 = common::MAX_WBITS;
+pub const DEF_BUF_SIZE: usize = common::DEF_BUF_SIZE;
 
-pub const MAX_WBITS: i32 = 15;
-pub const DEF_BUF_SIZE: usize = 16 * 1024;
+pub const Z_NO_FLUSH: i32 = common::Z_NO_FLUSH;
+pub const Z_PARTIAL_FLUSH: i32 = common::Z_PARTIAL_FLUSH;
+pub const Z_SYNC_FLUSH: i32 = common::Z_SYNC_FLUSH;
+pub const Z_FULL_FLUSH: i32 = common::Z_FULL_FLUSH;
+pub const Z_FINISH: i32 = common::Z_FINISH;
 
-// flush modes (libz values); mirrored as module constants on the Python side.
-pub const Z_NO_FLUSH: i32 = 0;
-pub const Z_PARTIAL_FLUSH: i32 = 1;
-pub const Z_SYNC_FLUSH: i32 = 2;
-pub const Z_FULL_FLUSH: i32 = 3;
-pub const Z_FINISH: i32 = 4;
-
-const Z_DEFAULT_COMPRESSION: i32 = -1;
-const Z_NO_COMPRESSION: i32 = 0;
-const Z_BEST_COMPRESSION: i32 = 9;
-
-const CHUNKSIZE: usize = u32::MAX as usize;
-const USE_AFTER_FINISH_ERR: &str = "Error -2: inconsistent stream state";
-
-fn valid_level(level: i32) -> bool {
-    matches!(
-        level,
-        Z_DEFAULT_COMPRESSION | Z_NO_COMPRESSION..=Z_BEST_COMPRESSION
-    )
-}
-
-enum InitOptions {
-    Standard { header: bool, wbits: i32 },
-    Gzip { wbits: i32 },
-    Auto { wbits: i32 },
-    HeaderWindow,
-}
-
-impl InitOptions {
-    fn new(wbits: i32) -> Result<Self, String> {
-        let header = wbits >= 0;
-        let wbits = wbits
-            .checked_abs()
-            .ok_or_else(|| "Invalid initialization option".to_owned())?;
-        match wbits {
-            0 if header => Ok(Self::HeaderWindow),
-            8..=15 => Ok(Self::Standard { header, wbits }),
-            24..=31 => Ok(Self::Gzip { wbits: wbits - 16 }),
-            40..=47 => Ok(Self::Auto { wbits: wbits - 32 }),
-            _ => Err("Invalid initialization option".to_owned()),
-        }
-    }
-
-    fn inflate_window_bits(self) -> i32 {
-        match self {
-            Self::Standard { header, wbits } => {
-                if header {
-                    wbits
-                } else {
-                    -wbits
-                }
-            }
-            Self::Gzip { wbits } => wbits + 16,
-            Self::Auto { wbits } => wbits + 32,
-            Self::HeaderWindow => 0,
-        }
-    }
-
-    fn deflate_window_bits(self) -> Result<i32, String> {
-        match self {
-            Self::Standard { header, wbits } => Ok(if header { wbits } else { -wbits }),
-            Self::Gzip { wbits } => Ok(wbits + 16),
-            Self::Auto { .. } | Self::HeaderWindow => {
-                Err("Invalid initialization option".to_owned())
-            }
-        }
-    }
-}
-
-fn return_code_message(code: ReturnCode) -> &'static str {
-    match code {
-        ReturnCode::Ok => "",
-        ReturnCode::StreamEnd => "stream end",
-        ReturnCode::NeedDict => "need dictionary",
-        ReturnCode::ErrNo => "file error",
-        ReturnCode::StreamError => "stream error",
-        ReturnCode::DataError => "data error",
-        ReturnCode::MemError => "insufficient memory",
-        ReturnCode::BufError => "buffer error",
-        ReturnCode::VersionError => "incompatible version",
-    }
-}
-
-fn stream_message(stream: &z_stream) -> Option<&str> {
-    if stream.msg.is_null() {
-        None
-    } else {
-        unsafe { CStr::from_ptr(stream.msg).to_str().ok() }
-    }
-}
-
-/// The public `zlib_rs::Deflate` wrapper deliberately exposes only the common
-/// constructor.  PyPy's `rzlib.deflateInit` and `deflateCopy` require the full
-/// zlib configuration and an exact native-state copy, so keep the crate's
-/// public low-level `z_stream` here instead.  This is the pure-Rust equivalent
-/// of the stream pointer owned by `interp_zlib.py:Compress`.
-struct RawDeflate {
-    stream: z_stream,
-}
-
-impl RawDeflate {
-    fn new(config: DeflateConfig) -> Result<Self, String> {
-        let mut stream = z_stream::default();
-        let code = deflate::init(&mut stream, config);
-        if code == ReturnCode::Ok {
-            Ok(Self { stream })
-        } else {
-            Err(return_code_message(code).to_owned())
-        }
-    }
-
-    fn total_in(&self) -> u64 {
-        self.stream.total_in as u64
-    }
-
-    fn total_out(&self) -> u64 {
-        self.stream.total_out as u64
-    }
-
-    fn compress(
-        &mut self,
-        input: &[u8],
-        output: &mut [u8],
-        flush: DeflateFlush,
-    ) -> Result<Status, DeflateError> {
-        self.stream.avail_in = input.len().min(u32::MAX as usize) as u32;
-        self.stream.avail_out = output.len().min(u32::MAX as usize) as u32;
-        self.stream.next_in = input.as_ptr();
-        self.stream.next_out = output.as_mut_ptr();
-        let stream = unsafe { DeflateStream::from_stream_mut(&mut self.stream) }
-            .expect("initialized deflate stream");
-        match deflate::deflate(stream, flush) {
-            ReturnCode::Ok => Ok(Status::Ok),
-            ReturnCode::StreamEnd => Ok(Status::StreamEnd),
-            ReturnCode::BufError => Ok(Status::BufError),
-            ReturnCode::StreamError => Err(DeflateError::StreamError),
-            ReturnCode::DataError => Err(DeflateError::DataError),
-            ReturnCode::MemError => Err(DeflateError::MemError),
-            ReturnCode::NeedDict => unreachable!("compression does not use dictionaries here"),
-            ReturnCode::ErrNo | ReturnCode::VersionError => {
-                unreachable!("pure-Rust deflate returned an unsupported status")
-            }
-        }
-    }
-
-    fn set_dictionary(&mut self, dictionary: &[u8]) -> Result<(), DeflateError> {
-        let stream = unsafe { DeflateStream::from_stream_mut(&mut self.stream) }
-            .expect("initialized deflate stream");
-        match deflate::set_dictionary(stream, dictionary) {
-            ReturnCode::Ok => Ok(()),
-            ReturnCode::StreamError => Err(DeflateError::StreamError),
-            ReturnCode::DataError => Err(DeflateError::DataError),
-            ReturnCode::MemError => Err(DeflateError::MemError),
-            code => unreachable!("deflate set_dictionary returned {code:?}"),
-        }
-    }
-
-    fn copy(&mut self) -> Result<Self, String> {
-        let mut destination = MaybeUninit::<DeflateStream<'static>>::uninit();
-        let code = {
-            let source = unsafe { DeflateStream::from_stream_mut(&mut self.stream) }
-                .expect("initialized deflate stream");
-            deflate::copy(&mut destination, source)
-        };
-        if code != ReturnCode::Ok {
-            return Err(return_code_message(code).to_owned());
-        }
-        let copied = unsafe { destination.assume_init() };
-        let stream = unsafe { core::mem::transmute::<DeflateStream<'static>, z_stream>(copied) };
-        Ok(Self { stream })
-    }
-}
-
-impl Drop for RawDeflate {
-    fn drop(&mut self) {
-        if let Some(stream) = unsafe { DeflateStream::from_stream_mut(&mut self.stream) } {
-            let _ = deflate::end(stream);
-        }
-    }
-}
-
-/// Low-level inflate owner paired with [`RawDeflate`].  `inflate::copy` fixes
-/// every internal allocation in the clone, exactly like zlib's `inflateCopy`;
-/// no replay log or side table is involved.
-struct RawInflate {
-    stream: z_stream,
-}
-
-impl RawInflate {
-    fn new(window_bits: i32) -> Result<Self, String> {
-        let mut stream = z_stream::default();
-        let code = inflate::init(&mut stream, InflateConfig { window_bits });
-        if code == ReturnCode::Ok {
-            // zlib-rs' low-level `inflate::copy` requires a non-null next_out
-            // even when avail_out is zero.  Its stable wrapper gets exactly
-            // such a dangling empty-slice pointer from `Writer::new(&mut [])`;
-            // reproduce that initialized-stream shape so a pristine PyPy
-            // `Decompress.copy()` succeeds before the first input byte.
-            stream.next_out = core::ptr::NonNull::<u8>::dangling().as_ptr();
-            Ok(Self { stream })
-        } else {
-            Err(return_code_message(code).to_owned())
-        }
-    }
-
-    fn total_in(&self) -> u64 {
-        self.stream.total_in as u64
-    }
-
-    fn total_out(&self) -> u64 {
-        self.stream.total_out as u64
-    }
-
-    fn error_message(&self) -> Option<&str> {
-        stream_message(&self.stream)
-    }
-
-    fn decompress(
-        &mut self,
-        input: &[u8],
-        output: &mut [u8],
-        flush: InflateFlush,
-    ) -> Result<Status, InflateError> {
-        self.stream.avail_in = input.len().min(u32::MAX as usize) as u32;
-        self.stream.avail_out = output.len().min(u32::MAX as usize) as u32;
-        self.stream.next_in = input.as_ptr();
-        self.stream.next_out = output.as_mut_ptr();
-        let stream = unsafe { InflateStream::from_stream_mut(&mut self.stream) }
-            .expect("initialized inflate stream");
-        match unsafe { inflate::inflate(stream, flush) } {
-            ReturnCode::Ok => Ok(Status::Ok),
-            ReturnCode::StreamEnd => Ok(Status::StreamEnd),
-            ReturnCode::BufError => Ok(Status::BufError),
-            ReturnCode::NeedDict => Err(InflateError::NeedDict {
-                dict_id: self.stream.adler as u32,
-            }),
-            ReturnCode::StreamError => Err(InflateError::StreamError),
-            ReturnCode::DataError => Err(InflateError::DataError),
-            ReturnCode::MemError => Err(InflateError::MemError),
-            ReturnCode::ErrNo | ReturnCode::VersionError => {
-                unreachable!("pure-Rust inflate returned an unsupported status")
-            }
-        }
-    }
-
-    fn set_dictionary(&mut self, dictionary: &[u8]) -> Result<(), InflateError> {
-        let stream = unsafe { InflateStream::from_stream_mut(&mut self.stream) }
-            .expect("initialized inflate stream");
-        match inflate::set_dictionary(stream, dictionary) {
-            ReturnCode::Ok => Ok(()),
-            ReturnCode::StreamError => Err(InflateError::StreamError),
-            ReturnCode::DataError => Err(InflateError::DataError),
-            code => unreachable!("inflate set_dictionary returned {code:?}"),
-        }
-    }
-
-    fn copy(&self) -> Result<Self, String> {
-        let source = unsafe { InflateStream::from_stream_ref(&self.stream) }
-            .expect("initialized inflate stream");
-        let mut destination = MaybeUninit::<InflateStream<'static>>::uninit();
-        let code = unsafe { inflate::copy(&mut destination, source) };
-        if code != ReturnCode::Ok {
-            return Err(return_code_message(code).to_owned());
-        }
-        let copied = unsafe { destination.assume_init() };
-        let stream = unsafe { core::mem::transmute::<InflateStream<'static>, z_stream>(copied) };
-        Ok(Self { stream })
-    }
-}
-
-impl Drop for RawInflate {
-    fn drop(&mut self) {
-        if let Some(stream) = unsafe { InflateStream::from_stream_mut(&mut self.stream) } {
-            inflate::end(stream);
-        }
-    }
-}
-
-// ── input chunker (compression.rs Chunker) ──────────────────────────────
-
-struct Chunker<'a> {
-    data1: &'a [u8],
-    data2: &'a [u8],
-}
-
-impl<'a> Chunker<'a> {
-    const fn new(data: &'a [u8]) -> Self {
-        Self {
-            data1: data,
-            data2: &[],
-        }
-    }
-    fn chain(data1: &'a [u8], data2: &'a [u8]) -> Self {
-        if data1.is_empty() {
-            Self {
-                data1: data2,
-                data2: &[],
-            }
-        } else {
-            Self { data1, data2 }
-        }
-    }
-    const fn len(&self) -> usize {
-        self.data1.len() + self.data2.len()
-    }
-    const fn is_empty(&self) -> bool {
-        self.data1.is_empty()
-    }
-    fn to_vec(&self) -> Vec<u8> {
-        [self.data1, self.data2].concat()
-    }
-    fn chunk(&self) -> &'a [u8] {
-        self.data1.get(..CHUNKSIZE).unwrap_or(self.data1)
-    }
-    fn advance(&mut self, consumed: usize) {
-        self.data1 = &self.data1[consumed..];
-        if self.data1.is_empty() {
-            self.data1 = core::mem::take(&mut self.data2);
-        }
-    }
-}
-
-/// compression.rs `_decompress_chunks`, specialised to `Decompress` with an
-/// optional dictionary retry (the `DecompressWithDict::maybe_set_dict` path).
-fn decompress_chunks(
-    data: &mut Chunker<'_>,
-    d: &mut RawInflate,
-    zdict: Option<&[u8]>,
-    bufsize: usize,
-    max_length: Option<usize>,
-    calc_flush: impl Fn(bool) -> InflateFlush,
-) -> Result<(Vec<u8>, bool), String> {
-    if data.is_empty() {
-        return Ok((Vec::new(), true));
-    }
-    let max_length = max_length.unwrap_or(usize::MAX);
-    let mut buf = Vec::new();
-
-    'outer: loop {
-        let chunk = data.chunk();
-        let flush = calc_flush(chunk.len() == data.len());
-        loop {
-            let additional = core::cmp::min(bufsize, max_length - buf.len());
-            if additional == 0 {
-                return Ok((buf, false));
-            }
-            let mut output = vec![0; additional];
-
-            let prev_in = d.total_in();
-            let prev_out = d.total_out();
-            let res = d.decompress(chunk, &mut output, flush);
-            let consumed = d.total_in() - prev_in;
-            let produced = (d.total_out() - prev_out) as usize;
-            buf.extend_from_slice(&output[..produced]);
-
-            data.advance(consumed as usize);
-
-            match res {
-                Ok(status) => {
-                    let stream_end = status == Status::StreamEnd;
-                    if stream_end || data.is_empty() {
-                        buf.shrink_to_fit();
-                        return Ok((buf, stream_end));
-                    } else if !chunk.is_empty() && consumed == 0 {
-                        continue;
-                    }
-                    continue 'outer;
-                }
-                Err(e) => {
-                    // maybe_set_dict: retry once with the stored dictionary.
-                    match zdict.filter(|_| matches!(e, InflateError::NeedDict { .. })) {
-                        Some(zd) => {
-                            d.set_dictionary(zd).map_err(|e| e.as_str().to_owned())?;
-                            continue 'outer;
-                        }
-                        None => {
-                            return Err(d.error_message().unwrap_or(e.as_str()).to_owned());
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn decompress_all(
-    data: &[u8],
-    d: &mut RawInflate,
-    zdict: Option<&[u8]>,
-    bufsize: usize,
-    max_length: Option<usize>,
-    calc_flush: impl Fn(bool) -> InflateFlush,
-) -> Result<(Vec<u8>, bool), String> {
-    let mut chunker = Chunker::new(data);
-    decompress_chunks(&mut chunker, d, zdict, bufsize, max_length, calc_flush)
-}
-
-// ── one-shot entry points ───────────────────────────────────────────────
-
-/// `zlib.compress(data, level, wbits)`.
 #[inline(never)]
 pub fn compress(data: &[u8], level: i32, wbits: i32) -> Result<Vec<u8>, String> {
-    if !valid_level(level) {
-        return Err("Bad compression level".to_owned());
-    }
-    let mut compressor = Compressor::new(level, 8, wbits, 8, 0, None)?;
-    let mut output = compressor.compress(data)?;
-    output.extend(compressor.flush(Z_FINISH)?);
-    Ok(output)
+    common::compress(data, level, wbits)
 }
 
-/// `zlib.decompress(data, wbits, bufsize)`.
 #[inline(never)]
 pub fn decompress(data: &[u8], wbits: i32, bufsize: usize) -> Result<Vec<u8>, String> {
-    let mut d = RawInflate::new(InitOptions::new(wbits)?.inflate_window_bits())?;
-    let (buf, stream_end) = decompress_all(data, &mut d, None, bufsize, None, |_| {
-        InflateFlush::SyncFlush
-    })?;
-    if !stream_end {
-        return Err("Error -5 while decompressing data: incomplete or truncated stream".to_owned());
-    }
-    Ok(buf)
+    common::decompress(data, wbits, bufsize)
 }
 
-// ── streaming compressor (zlib.Compress) ────────────────────────────────
-
-pub struct Compressor {
-    compress: Option<RawDeflate>,
-}
+pub struct Compressor(common::Compressor);
 
 impl Compressor {
     #[inline(never)]
@@ -458,371 +37,119 @@ impl Compressor {
         strategy: i32,
         zdict: Option<&[u8]>,
     ) -> Result<Self, String> {
-        if !valid_level(level) {
-            return Err("Invalid initialization option".to_owned());
-        }
-        let method =
-            Method::try_from(method).map_err(|_| "Invalid initialization option".to_owned())?;
-        let strategy =
-            Strategy::try_from(strategy).map_err(|_| "Invalid initialization option".to_owned())?;
-        let window_bits = InitOptions::new(wbits)?.deflate_window_bits()?;
-        let mut compress = RawDeflate::new(DeflateConfig {
-            level,
-            method,
-            window_bits,
-            mem_level,
-            strategy,
-        })?;
-        if let Some(zdict) = zdict {
-            compress
-                .set_dictionary(zdict)
-                .map_err(|e| e.as_str().to_owned())?;
-        }
-        Ok(Self {
-            compress: Some(compress),
-        })
+        common::Compressor::new(level, method, wbits, mem_level, strategy, zdict).map(Self)
     }
 
     #[inline(never)]
     pub fn compress(&mut self, data: &[u8]) -> Result<Vec<u8>, String> {
-        let compressor = self
-            .compress
-            .as_mut()
-            .ok_or_else(|| USE_AFTER_FINISH_ERR.to_owned())?;
-        let mut buf = Vec::new();
-        for mut chunk in data.chunks(CHUNKSIZE) {
-            while !chunk.is_empty() {
-                let mut output = [0; DEF_BUF_SIZE];
-                let prev_in = compressor.total_in();
-                let prev_out = compressor.total_out();
-                compressor
-                    .compress(chunk, &mut output, DeflateFlush::NoFlush)
-                    .map_err(|e| e.as_str().to_owned())?;
-                let consumed = (compressor.total_in() - prev_in) as usize;
-                let produced = (compressor.total_out() - prev_out) as usize;
-                buf.extend_from_slice(&output[..produced]);
-                chunk = &chunk[consumed..];
-            }
-        }
-        buf.shrink_to_fit();
-        Ok(buf)
+        self.0.compress(data)
     }
 
-    /// Returns the flushed bytes; `finished` is true once a `Z_FINISH` flush
-    /// has consumed the stream (the object may no longer be used).
     #[inline(never)]
     pub fn flush(&mut self, mode: i32) -> Result<Vec<u8>, String> {
-        let flush = match mode {
-            Z_NO_FLUSH => return Ok(vec![]),
-            Z_PARTIAL_FLUSH => DeflateFlush::PartialFlush,
-            Z_SYNC_FLUSH => DeflateFlush::SyncFlush,
-            Z_FULL_FLUSH => DeflateFlush::FullFlush,
-            Z_FINISH => DeflateFlush::Finish,
-            5 => DeflateFlush::Block,
-            _ => return Err("invalid mode".to_owned()),
-        };
-        let compressor = self
-            .compress
-            .as_mut()
-            .ok_or_else(|| USE_AFTER_FINISH_ERR.to_owned())?;
-        let mut buf = Vec::new();
-        let status = loop {
-            let mut output = [0; DEF_BUF_SIZE];
-            let prev_out = compressor.total_out();
-            let status = compressor
-                .compress(&[], &mut output, flush)
-                .map_err(|e| e.as_str().to_owned())?;
-            let produced = (compressor.total_out() - prev_out) as usize;
-            buf.extend_from_slice(&output[..produced]);
-            if produced != output.len() || status == Status::StreamEnd {
-                break status;
-            }
-        };
-        if status == Status::StreamEnd {
-            if mode == Z_FINISH {
-                self.compress = None;
-            } else {
-                return Err("unexpected eof".to_owned());
-            }
-        }
-        buf.shrink_to_fit();
-        Ok(buf)
+        self.0.flush(mode)
     }
 
+    #[inline(never)]
     pub fn is_finished(&self) -> bool {
-        self.compress.is_none()
+        self.0.is_finished()
     }
 
-    /// PyPy `Compress.copy`: clone the live native deflate stream.  The
-    /// caller holds this object's per-instance lock while copying.
     #[inline(never)]
     pub fn copy(&mut self) -> Result<Self, String> {
-        let compress = self
-            .compress
-            .as_mut()
-            .ok_or_else(|| "Compressor was already flushed".to_owned())?
-            .copy()?;
-        Ok(Self {
-            compress: Some(compress),
-        })
+        self.0.copy().map(Self)
     }
 }
 
-// ── streaming decompressor (zlib.Decompress) ────────────────────────────
-
-pub struct Decompressor {
-    decompress: Option<RawInflate>,
-    zdict: Option<Vec<u8>>,
-    eof: bool,
-    unused_data: Vec<u8>,
-    unconsumed_tail: Vec<u8>,
-}
+pub struct Decompressor(common::Decompressor);
 
 impl Decompressor {
     #[inline(never)]
     pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, String> {
-        let mut decompress = RawInflate::new(InitOptions::new(wbits)?.inflate_window_bits())?;
-        if let Some(d) = &zdict
-            && wbits < 0
-        {
-            decompress
-                .set_dictionary(d)
-                .map_err(|e| e.as_str().to_owned())?;
-        }
-        Ok(Self {
-            decompress: Some(decompress),
-            zdict,
-            eof: false,
-            unused_data: Vec::new(),
-            unconsumed_tail: Vec::new(),
-        })
+        common::Decompressor::new(wbits, zdict).map(Self)
     }
 
+    #[inline(never)]
     pub fn eof(&self) -> bool {
-        self.eof
-    }
-    pub fn unused_data(&self) -> &[u8] {
-        &self.unused_data
-    }
-    pub fn unconsumed_tail(&self) -> &[u8] {
-        &self.unconsumed_tail
-    }
-    pub fn is_finished(&self) -> bool {
-        self.decompress.is_none()
+        self.0.eof()
     }
 
-    /// PyPy `Decompress.copy`: the inflate stream and all Python-visible
-    /// buffered state are copied together.
+    #[inline(never)]
+    pub fn unused_data(&self) -> &[u8] {
+        self.0.unused_data()
+    }
+
+    #[inline(never)]
+    pub fn unconsumed_tail(&self) -> &[u8] {
+        self.0.unconsumed_tail()
+    }
+
+    #[inline(never)]
+    pub fn is_finished(&self) -> bool {
+        self.0.is_finished()
+    }
+
     #[inline(never)]
     pub fn copy(&self) -> Result<Self, String> {
-        let decompress = self
-            .decompress
-            .as_ref()
-            .ok_or_else(|| "Decompressor was already flushed".to_owned())?
-            .copy()?;
-        Ok(Self {
-            decompress: Some(decompress),
-            zdict: self.zdict.clone(),
-            eof: self.eof,
-            unused_data: self.unused_data.clone(),
-            unconsumed_tail: self.unconsumed_tail.clone(),
-        })
+        self.0.copy().map(Self)
     }
 
-    /// zlib.rs `PyDecompress::decompress_inner`.
-    fn decompress_inner(
-        &mut self,
-        data: &[u8],
-        bufsize: usize,
-        max_length: Option<usize>,
-        is_flush: bool,
-    ) -> Result<(Result<Vec<u8>, String>, bool), String> {
-        let Self {
-            decompress,
-            zdict,
-            unused_data,
-            unconsumed_tail,
-            ..
-        } = self;
-        let Some(d) = decompress.as_mut() else {
-            return Err(USE_AFTER_FINISH_ERR.to_owned());
-        };
-
-        let prev_in = d.total_in();
-        let res = if is_flush {
-            // ignore zdict on a flush, finish on the final chunk
-            let calc_flush = |final_chunk| {
-                if final_chunk {
-                    InflateFlush::Finish
-                } else {
-                    InflateFlush::NoFlush
-                }
-            };
-            decompress_all(data, d, None, bufsize, max_length, calc_flush)
-        } else {
-            decompress_all(data, d, zdict.as_deref(), bufsize, max_length, |_| {
-                InflateFlush::SyncFlush
-            })
-        };
-        let (ret, stream_end) = match res {
-            Ok((buf, stream_end)) => (Ok(buf), stream_end),
-            Err(err) => (Err(err), false),
-        };
-        let consumed = (d.total_in() - prev_in) as usize;
-
-        // save unused input
-        let unconsumed = &data[consumed..];
-        if !unconsumed.is_empty() {
-            if stream_end {
-                unused_data.extend_from_slice(unconsumed);
-            } else {
-                *unconsumed_tail = unconsumed.to_vec();
-            }
-        } else if !unconsumed_tail.is_empty() {
-            unconsumed_tail.clear();
-        }
-
-        Ok((ret, stream_end))
-    }
-
-    /// `Decompress.decompress(data, max_length)`; `max_length` of `None` is
-    /// unlimited.
     #[inline(never)]
     pub fn decompress(
         &mut self,
         data: &[u8],
         max_length: Option<usize>,
     ) -> Result<Vec<u8>, String> {
-        let (ret, stream_end) = self.decompress_inner(data, DEF_BUF_SIZE, max_length, false)?;
-        self.eof |= stream_end;
-        ret
+        self.0.decompress(data, max_length)
     }
 
-    /// `Decompress.flush(length)`.
     #[inline(never)]
     pub fn flush(&mut self, length: usize) -> Result<Vec<u8>, String> {
-        let data = core::mem::take(&mut self.unconsumed_tail);
-        let (ret, stream_end) = self.decompress_inner(&data, length, None, true)?;
-        if stream_end {
-            self.decompress = None;
-        }
-        ret
+        self.0.flush(length)
     }
 }
 
-// ── buffered decompressor (zlib._ZlibDecompressor, DecompressState) ──────
-
-/// Error surface of [`ZlibDecompressor::decompress`]: `Zlib` maps to
-/// `zlib.error`, `Eof` to `EOFError` ("End of stream already reached").
 #[derive(Debug)]
 pub enum DecompressError {
     Zlib(String),
     Eof,
 }
 
-pub struct ZlibDecompressor {
-    decompress: Option<RawInflate>,
-    zdict: Option<Vec<u8>>,
-    unused_data: Vec<u8>,
-    input_buffer: Vec<u8>,
-    eof: bool,
-    needs_input: bool,
-}
+pub struct ZlibDecompressor(common::ZlibDecompressor);
 
 impl ZlibDecompressor {
     #[inline(never)]
     pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, String> {
-        let mut decompress = RawInflate::new(InitOptions::new(wbits)?.inflate_window_bits())?;
-        if let Some(d) = &zdict
-            && wbits < 0
-        {
-            decompress
-                .set_dictionary(d)
-                .map_err(|e| e.as_str().to_owned())?;
-        }
-        Ok(Self {
-            decompress: Some(decompress),
-            zdict,
-            unused_data: Vec::new(),
-            input_buffer: Vec::new(),
-            eof: false,
-            needs_input: true,
-        })
+        common::ZlibDecompressor::new(wbits, zdict).map(Self)
     }
 
+    #[inline(never)]
     pub fn eof(&self) -> bool {
-        self.eof
-    }
-    pub fn unused_data(&self) -> &[u8] {
-        &self.unused_data
-    }
-    pub fn needs_input(&self) -> bool {
-        self.needs_input
+        self.0.eof()
     }
 
-    /// compression.rs `DecompressState::decompress`.
+    #[inline(never)]
+    pub fn unused_data(&self) -> &[u8] {
+        self.0.unused_data()
+    }
+
+    #[inline(never)]
+    pub fn needs_input(&self) -> bool {
+        self.0.needs_input()
+    }
+
     #[inline(never)]
     pub fn decompress(
         &mut self,
         data: &[u8],
         max_length: Option<usize>,
     ) -> Result<Vec<u8>, DecompressError> {
-        if self.eof {
-            return Err(DecompressError::Eof);
-        }
-
-        let Self {
-            decompress: decompress_slot,
-            zdict,
-            unused_data,
-            input_buffer,
-            eof,
-            needs_input,
-        } = self;
-        let decompress = decompress_slot.as_mut().ok_or(DecompressError::Eof)?;
-
-        let mut chunks = Chunker::chain(input_buffer.as_slice(), data);
-
-        let prev_len = chunks.len();
-        let (ret, stream_end) = match decompress_chunks(
-            &mut chunks,
-            decompress,
-            zdict.as_deref(),
-            DEF_BUF_SIZE,
-            max_length,
-            |_| InflateFlush::SyncFlush,
-        ) {
-            Ok((buf, stream_end)) => (Ok(buf), stream_end),
-            Err(err) => (Err(err), false),
-        };
-        let consumed = prev_len - chunks.len();
-
-        *eof |= stream_end;
-
-        if *eof {
-            *needs_input = false;
-            if !chunks.is_empty() {
-                *unused_data = chunks.to_vec();
-            }
-            // interp_zlib.py frees this stream immediately at EOF and
-            // unregisters its finalizer; retaining it until object sweep is a
-            // lifetime divergence and keeps a full inflate window alive.
-            *decompress_slot = None;
-        } else if chunks.is_empty() {
-            input_buffer.clear();
-            *needs_input = true;
-        } else {
-            *needs_input = false;
-            if let Some(n_consumed_from_data) = consumed.checked_sub(input_buffer.len()) {
-                input_buffer.clear();
-                input_buffer.extend_from_slice(&data[n_consumed_from_data..]);
-            } else {
-                input_buffer.drain(..consumed);
-                input_buffer.extend_from_slice(data);
-            }
-        }
-
-        ret.map_err(DecompressError::Zlib)
+        self.0
+            .decompress(data, max_length)
+            .map_err(|err| match err {
+                common::DecompressError::Zlib(err) => DecompressError::Zlib(err),
+                common::DecompressError::Eof => DecompressError::Eof,
+            })
     }
 }
 
@@ -831,151 +158,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip_default() {
-        let data = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit";
-        let c = compress(data, -1, MAX_WBITS).unwrap();
-        let d = decompress(&c, MAX_WBITS, DEF_BUF_SIZE).unwrap();
-        assert_eq!(d, data);
-    }
-
-    #[test]
-    fn roundtrip_all_levels_and_wbits() {
-        let data = b"the quick brown fox jumps over the lazy dog".repeat(20);
-        for level in 0..=9 {
-            for &wbits in &[15i32, 31, -15] {
-                let c = compress(&data, level, wbits).unwrap();
-                let d = decompress(&c, wbits, DEF_BUF_SIZE).unwrap();
-                assert_eq!(d, data, "level={level} wbits={wbits}");
-            }
-        }
-    }
-
-    #[test]
-    fn bad_level_rejected() {
-        assert!(compress(b"x", 10, MAX_WBITS).is_err());
-        assert!(compress(b"x", -40, MAX_WBITS).is_err());
-    }
-
-    #[test]
-    fn streaming_roundtrip() {
-        let mut co = Compressor::new(-1, 8, MAX_WBITS, 8, 0, None).unwrap();
-        let mut out = co.compress(b"hello ").unwrap();
-        out.extend(co.compress(b"world").unwrap());
-        out.extend(co.flush(Z_FINISH).unwrap());
-        assert!(co.is_finished());
-
-        let mut do_ = Decompressor::new(MAX_WBITS, None).unwrap();
-        let got = do_.decompress(&out, None).unwrap();
-        assert_eq!(got, b"hello world");
-        assert!(do_.eof());
-    }
-
-    #[test]
-    fn streaming_block_flush_roundtrip() {
-        let data = b"block-flush payload ".repeat(200);
-        let mut co = Compressor::new(6, 8, MAX_WBITS, 8, 0, None).unwrap();
-        let mut encoded = co.compress(&data[..1000]).unwrap();
-        encoded.extend(co.flush(5).unwrap());
-        encoded.extend(co.compress(&data[1000..]).unwrap());
-        encoded.extend(co.flush(Z_FINISH).unwrap());
+    fn adapter_roundtrip() {
+        let data = b"shared zlib engine";
+        let encoded = compress(data, -1, MAX_WBITS).unwrap();
         assert_eq!(decompress(&encoded, MAX_WBITS, DEF_BUF_SIZE).unwrap(), data);
-    }
-
-    #[test]
-    fn compressor_options_are_validated_by_deflate_init() {
-        assert!(Compressor::new(6, 7, 15, 8, 0, None).is_err());
-        assert!(Compressor::new(6, 8, 15, 0, 0, None).is_err());
-        assert!(Compressor::new(6, 8, 15, 8, 99, None).is_err());
-        assert!(Compressor::new(6, 8, -8, 8, 0, None).is_err());
-        assert!(Compressor::new(6, 8, 24, 8, 0, None).is_err());
-    }
-
-    #[test]
-    fn compressor_copy_forks_native_stream() {
-        let prefix = b"shared prefix ".repeat(50);
-        let left = b"left branch".repeat(20);
-        let right = b"right branch".repeat(20);
-        let mut original = Compressor::new(6, 8, 15, 8, 0, None).unwrap();
-        let shared = original.compress(&prefix).unwrap();
-        let mut copied = original.copy().unwrap();
-
-        let mut left_encoded = shared.clone();
-        left_encoded.extend(original.compress(&left).unwrap());
-        left_encoded.extend(original.flush(Z_FINISH).unwrap());
-        let mut right_encoded = shared;
-        right_encoded.extend(copied.compress(&right).unwrap());
-        right_encoded.extend(copied.flush(Z_FINISH).unwrap());
-
-        assert_eq!(
-            decompress(&left_encoded, 15, DEF_BUF_SIZE).unwrap(),
-            [prefix.as_slice(), left.as_slice()].concat()
-        );
-        assert_eq!(
-            decompress(&right_encoded, 15, DEF_BUF_SIZE).unwrap(),
-            [prefix.as_slice(), right.as_slice()].concat()
-        );
-    }
-
-    #[test]
-    fn decompressor_copy_forks_native_stream() {
-        let data = b"decompress copy payload ".repeat(100);
-        let encoded = compress(&data, 6, 15).unwrap();
-        let mut original = Decompressor::new(15, None).unwrap();
-        let prefix = original.decompress(&encoded[..16], None).unwrap();
-        let mut copied = original.copy().unwrap();
-        let left = original.decompress(&encoded[16..], None).unwrap();
-        let right = copied.decompress(&encoded[16..], None).unwrap();
-        assert_eq!([prefix.as_slice(), left.as_slice()].concat(), data);
-        assert_eq!(left, right);
-    }
-
-    #[test]
-    fn pristine_streams_can_be_copied() {
-        let mut compressor = Compressor::new(6, 8, 15, 8, 0, None).unwrap();
-        compressor.copy().unwrap();
-        let decompressor = Decompressor::new(15, None).unwrap();
-        decompressor.copy().unwrap();
-    }
-
-    #[test]
-    fn header_window_autodetection() {
-        let data = b"window-sized-from-zlib-header".repeat(20);
-        let encoded = compress(&data, 1, MAX_WBITS).unwrap();
-        assert_eq!(decompress(&encoded, 0, DEF_BUF_SIZE).unwrap(), data);
-    }
-
-    #[test]
-    fn buffered_decompressor_gzip_roundtrip() {
-        // gzip uses _ZlibDecompressor(wbits=-MAX_WBITS) over raw deflate.
-        let raw = compress(b"gzip payload contents", -1, -15).unwrap();
-        let mut d = ZlibDecompressor::new(-15, None).unwrap();
-        let got = d.decompress(&raw, None).unwrap();
-        assert_eq!(got, b"gzip payload contents");
-        assert!(d.eof());
-        // decompress after eof raises Eof
-        assert!(matches!(d.decompress(b"", None), Err(DecompressError::Eof)));
-    }
-
-    #[test]
-    fn buffered_decompressor_incremental_needs_input() {
-        let full = compress(&b"streamed content ".repeat(100), -1, MAX_WBITS).unwrap();
-        let mut d = ZlibDecompressor::new(MAX_WBITS, None).unwrap();
-        let mut out = Vec::new();
-        for byte in full.chunks(1) {
-            out.extend(d.decompress(byte, None).unwrap());
-        }
-        assert_eq!(out, b"streamed content ".repeat(100));
-        assert!(d.eof());
-    }
-
-    #[test]
-    fn streaming_max_length_unconsumed_tail() {
-        let full = compress(&b"abcdefghij".repeat(50), -1, MAX_WBITS).unwrap();
-        let mut d = Decompressor::new(MAX_WBITS, None).unwrap();
-        let first = d.decompress(&full, Some(5)).unwrap();
-        assert_eq!(first.len(), 5);
-        assert!(!d.unconsumed_tail().is_empty());
-        let rest = d.flush(DEF_BUF_SIZE).unwrap();
-        assert_eq!([first, rest].concat(), b"abcdefghij".repeat(50));
     }
 }

--- a/pyre/pyre-native/src/zlib.rs
+++ b/pyre/pyre-native/src/zlib.rs
@@ -15,14 +15,38 @@ pub const Z_SYNC_FLUSH: i32 = common::Z_SYNC_FLUSH;
 pub const Z_FULL_FLUSH: i32 = common::Z_FULL_FLUSH;
 pub const Z_FINISH: i32 = common::Z_FINISH;
 
-#[inline(never)]
-pub fn compress(data: &[u8], level: i32, wbits: i32) -> Result<Vec<u8>, String> {
-    common::compress(data, level, wbits)
+#[derive(Debug)]
+pub enum InitError {
+    InvalidOption,
+    Zlib(String),
+}
+
+impl InitError {
+    pub fn into_message(self) -> String {
+        match self {
+            Self::InvalidOption => "Invalid initialization option".to_owned(),
+            Self::Zlib(message) => message,
+        }
+    }
+}
+
+impl From<common::InitError> for InitError {
+    fn from(error: common::InitError) -> Self {
+        match error {
+            common::InitError::InvalidOption => Self::InvalidOption,
+            common::InitError::Zlib(message) => Self::Zlib(message),
+        }
+    }
 }
 
 #[inline(never)]
-pub fn decompress(data: &[u8], wbits: i32, bufsize: usize) -> Result<Vec<u8>, String> {
-    common::decompress(data, wbits, bufsize)
+pub fn compress(data: &[u8], level: i32, wbits: i32) -> Result<Vec<u8>, InitError> {
+    common::compress(data, level, wbits).map_err(Into::into)
+}
+
+#[inline(never)]
+pub fn decompress(data: &[u8], wbits: i32, bufsize: usize) -> Result<Vec<u8>, InitError> {
+    common::decompress(data, wbits, bufsize).map_err(Into::into)
 }
 
 pub struct Compressor(common::Compressor);
@@ -36,8 +60,10 @@ impl Compressor {
         mem_level: i32,
         strategy: i32,
         zdict: Option<&[u8]>,
-    ) -> Result<Self, String> {
-        common::Compressor::new(level, method, wbits, mem_level, strategy, zdict).map(Self)
+    ) -> Result<Self, InitError> {
+        common::Compressor::new(level, method, wbits, mem_level, strategy, zdict)
+            .map(Self)
+            .map_err(Into::into)
     }
 
     #[inline(never)]
@@ -65,8 +91,10 @@ pub struct Decompressor(common::Decompressor);
 
 impl Decompressor {
     #[inline(never)]
-    pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, String> {
-        common::Decompressor::new(wbits, zdict).map(Self)
+    pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, InitError> {
+        common::Decompressor::new(wbits, zdict)
+            .map(Self)
+            .map_err(Into::into)
     }
 
     #[inline(never)]
@@ -119,8 +147,10 @@ pub struct ZlibDecompressor(common::ZlibDecompressor);
 
 impl ZlibDecompressor {
     #[inline(never)]
-    pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, String> {
-        common::ZlibDecompressor::new(wbits, zdict).map(Self)
+    pub fn new(wbits: i32, zdict: Option<Vec<u8>>) -> Result<Self, InitError> {
+        common::ZlibDecompressor::new(wbits, zdict)
+            .map(Self)
+            .map_err(Into::into)
     }
 
     #[inline(never)]


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [ ] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

