### PR TITLE
majit: USE_C_FORM short-constant blackhole operands, the string hash header cache, and the portal runner hook

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3409,7 +3409,15 @@ impl majit_backend::Backend for WasmBackend {
         let len_offset = arraydescr
             .array_len_offset()
             .expect("bh_new_array requires ArrayDescr.lendescr");
+        // descr.py `ArrayDescr.get_type_id(): assert self.tid` — allocation
+        // requires a real GC type id; tid=0 means the descr never went through
+        // `gc.py:548 set_type_id` and the GC tracer would lack the per-item
+        // visit shape.  The dynasm and cranelift runners assert the same.
         let type_id = arraydescr.resolve_gc_tid();
+        assert!(
+            type_id != 0,
+            "bh_new_array requires ArrayDescr.tid (descr.py:340) — got 0"
+        );
         let Some(payload_size) = itemsize
             .checked_mul(length)
             .and_then(|items| base_size.checked_add(items))

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -3529,15 +3529,17 @@ pub trait Backend: Send {
 
     /// `LLtypeMixin.bh_strhash` computes the RPython content hash.
     fn bh_strhash(&self, string_ptr: i64) -> i64 {
-        let length = self.bh_strlen(string_ptr) as usize;
-        if length == 0 {
-            return -1;
-        }
-        let mut x = self.bh_strgetitem(string_ptr, 0) << 7;
-        for index in 0..length {
-            x = 1_000_003i64.wrapping_mul(x) ^ self.bh_strgetitem(string_ptr, index as i64);
-        }
-        x ^ length as i64
+        blackhole_cached_hash(string_ptr, || {
+            let length = self.bh_strlen(string_ptr) as usize;
+            if length == 0 {
+                return -1;
+            }
+            let mut x = self.bh_strgetitem(string_ptr, 0) << 7;
+            for index in 0..length {
+                x = 1_000_003i64.wrapping_mul(x) ^ self.bh_strgetitem(string_ptr, index as i64);
+            }
+            x ^ length as i64
+        })
     }
     /// model.py bh_call_i(func, args_i, args_r, args_f, calldescr).
     /// `llmodel.py:816 call_stub_i`: ABI-correct dispatch via the shared
@@ -3691,15 +3693,17 @@ pub trait Backend: Send {
 
     /// `LLtypeMixin.bh_unicodehash` computes the RPython content hash.
     fn bh_unicodehash(&self, string_ptr: i64) -> i64 {
-        let length = self.bh_unicodelen(string_ptr) as usize;
-        if length == 0 {
-            return -1;
-        }
-        let mut x = self.bh_unicodegetitem(string_ptr, 0) << 7;
-        for index in 0..length {
-            x = 1_000_003i64.wrapping_mul(x) ^ self.bh_unicodegetitem(string_ptr, index as i64);
-        }
-        x ^ length as i64
+        blackhole_cached_hash(string_ptr, || {
+            let length = self.bh_unicodelen(string_ptr) as usize;
+            if length == 0 {
+                return -1;
+            }
+            let mut x = self.bh_unicodegetitem(string_ptr, 0) << 7;
+            for index in 0..length {
+                x = 1_000_003i64.wrapping_mul(x) ^ self.bh_unicodegetitem(string_ptr, index as i64);
+            }
+            x ^ length as i64
+        })
     }
     /// model.py: bh_copystrcontent(src, dst, srcstart, dststart, length)
     fn bh_copystrcontent(&self, src: i64, dst: i64, srcstart: i64, dststart: i64, length: i64) {
@@ -4145,6 +4149,34 @@ pub fn we_are_jitted() -> bool {
 /// own `cast_instance_to_gcref(memory_error)` fallback for that case.
 static MEMORY_ERROR_PROVIDER: std::sync::OnceLock<fn() -> i64> = std::sync::OnceLock::new();
 
+/// `LLHelpers.ll_strhash` / `LLHelpers._ll_strhash`: the first Signed word of
+/// an RPython STR or UNICODE is a zero-sentinel hash cache.  The selected hash
+/// is stored there, with zero replaced by 29872897 so a computed value is
+/// distinguishable from the sentinel.
+///
+/// PyPy relies on process serialization here.  Pyre's CPython-3.14t contract
+/// permits concurrent readers, so the same one-word owner is accessed
+/// atomically rather than duplicated in a side table.
+fn blackhole_cached_hash(string_ptr: i64, compute: impl FnOnce() -> i64) -> i64 {
+    assert_ne!(string_ptr, 0, "blackhole string hash: null string");
+    let cache = unsafe { &*(string_ptr as usize as *const std::sync::atomic::AtomicIsize) };
+    let cached = cache.load(std::sync::atomic::Ordering::Acquire);
+    if cached != 0 {
+        return cached as i64;
+    }
+    let computed = compute() as isize;
+    let computed = if computed == 0 { 29_872_897 } else { computed };
+    match cache.compare_exchange(
+        0,
+        computed,
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+    ) {
+        Ok(_) => computed as i64,
+        Err(winner) => winner as i64,
+    }
+}
+
 /// Install the `memory_error` singleton provider.  Called once from
 /// pyre-jit's `install_jit_call_bridge` after the interpreter has
 /// initialized the exception type registry.
@@ -4463,6 +4495,30 @@ mod tests {
         // to a non-null pointer (the singleton).  Either way, the
         // accessor must not panic when called before registration.
         let _ = memory_error_singleton_ref();
+    }
+
+    #[test]
+    fn blackhole_string_hash_uses_rpython_cache_and_zero_substitute() {
+        #[repr(C)]
+        struct Header {
+            hash: std::sync::atomic::AtomicIsize,
+            len: usize,
+        }
+
+        let header = Header {
+            hash: std::sync::atomic::AtomicIsize::new(0),
+            len: 0,
+        };
+        let ptr = (&header as *const Header) as i64;
+        assert_eq!(blackhole_cached_hash(ptr, || 0), 29_872_897);
+        assert_eq!(
+            header.hash.load(std::sync::atomic::Ordering::Acquire),
+            29_872_897
+        );
+        assert_eq!(
+            blackhole_cached_hash(ptr, || panic!("cached hash recomputed")),
+            29_872_897
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5645,6 +5645,115 @@ mod tests {
             assert_eq!(bh.return_type, BhReturnType::Int);
         }
 
+        /// Literal port of `test_blackhole.py test_simple_const` and
+        /// `test_simple_loop`: these are the oracle fixtures that require
+        /// independently decoded `c` operands in arithmetic and fused
+        /// comparison branches.
+        #[test]
+        fn pypy_short_constant_arithmetic_and_branch_forms_execute() {
+            let mut const_insns = indexmap::IndexMap::new();
+            const_insns.insert("int_sub/ci>i".to_string(), 0);
+            const_insns.insert("int_return/i".to_string(), 1);
+            let mut builder = BlackholeInterpBuilder::new();
+            builder.setup_insns(&const_insns);
+            super::wire_bhimpl_handlers(&mut builder);
+            let code = [0, 48, 1, 2, 1, 2];
+            let mut bh = builder.acquire_interp();
+            bh.registers_i = vec![0; 3];
+            bh.registers_i[1] = 6;
+            let result = builder.dispatch_loop(&mut bh, &code, 0);
+            assert!(matches!(result, Err(DispatchError::LeaveFrame)));
+            assert_eq!(bh.tmpreg_i, 42);
+
+            let mut loop_insns = indexmap::IndexMap::new();
+            loop_insns.insert("goto_if_not_int_gt/icL".to_string(), 0);
+            loop_insns.insert("int_add/ii>i".to_string(), 1);
+            loop_insns.insert("int_sub/ic>i".to_string(), 2);
+            loop_insns.insert("goto/L".to_string(), 3);
+            loop_insns.insert("int_return/i".to_string(), 4);
+            let mut builder = BlackholeInterpBuilder::new();
+            builder.setup_insns(&loop_insns);
+            super::wire_bhimpl_handlers(&mut builder);
+            let code = [
+                0, 0x16, 2, 0x10, 0, 1, 0x17, 0x16, 0x17, 2, 0x16, 1, 0x16, 3, 0, 0, 4, 0x17,
+            ];
+            let mut bh = builder.acquire_interp();
+            bh.registers_i = vec![0; 0x18];
+            bh.registers_i[0x16] = 6;
+            bh.registers_i[0x17] = 100;
+            let result = builder.dispatch_loop(&mut bh, &code, 0);
+            assert!(matches!(result, Err(DispatchError::LeaveFrame)));
+            assert_eq!(bh.tmpreg_i, 118);
+        }
+
+        #[test]
+        fn every_pypy_short_constant_shape_is_wired() {
+            // `getarrayitem_gc_pure_{i,r}` in `USE_C_FORM` has no literal
+            // `bhimpl_*` owner: blackhole.py names the aliases
+            // `getarrayitem_gc_{i,r}_pure`, so those spellings never select
+            // the short form in Assembler.write_insn.
+            let mut keys = Vec::new();
+            for opname in [
+                "int_add", "int_sub", "int_and", "int_eq", "int_ne", "int_lt", "int_le", "int_gt",
+                "int_ge",
+            ] {
+                for args in ["ci>i", "ic>i", "cc>i"] {
+                    keys.push(format!("{opname}/{args}"));
+                }
+            }
+            for opname in [
+                "goto_if_not_int_eq",
+                "goto_if_not_int_ne",
+                "goto_if_not_int_lt",
+                "goto_if_not_int_le",
+                "goto_if_not_int_gt",
+                "goto_if_not_int_ge",
+            ] {
+                for args in ["ciL", "icL", "ccL"] {
+                    keys.push(format!("{opname}/{args}"));
+                }
+            }
+            keys.extend(
+                [
+                    "int_copy/c>i",
+                    "int_return/c",
+                    "jit_merge_point/cIRFIRF",
+                    "new_array/cd>r",
+                    "new_array_clear/cd>r",
+                    "newstr/c>r",
+                    "strgetitem/rc>i",
+                    "strsetitem/rci",
+                    "strsetitem/ric",
+                    "strsetitem/rcc",
+                    "getarrayitem_gc_i/rcd>i",
+                    "getarrayitem_gc_r/rcd>r",
+                    "setarrayitem_gc_i/rcid",
+                    "setarrayitem_gc_i/ricd",
+                    "setarrayitem_gc_i/rccd",
+                    "setarrayitem_gc_r/rcrd",
+                    "setfield_gc_i/rcd",
+                    "copystrcontent/rrcii",
+                    "copystrcontent/rrici",
+                    "copystrcontent/rriic",
+                    "copystrcontent/rrcci",
+                    "copystrcontent/rrcic",
+                    "copystrcontent/rricc",
+                    "copystrcontent/rrccc",
+                ]
+                .into_iter()
+                .map(str::to_string),
+            );
+            let insns = keys
+                .into_iter()
+                .enumerate()
+                .map(|(opcode, key)| (key, opcode as u8))
+                .collect();
+            let mut builder = BlackholeInterpBuilder::new();
+            builder.setup_insns(&insns);
+            super::wire_bhimpl_handlers(&mut builder);
+            assert!(builder.unwired_opnames().is_empty());
+        }
+
         #[test]
         fn wire_bhimpl_handlers_wires_tagged_int_base_access_aliases() {
             // Canonical RPython opnames (`_i`/`_r`/`_f`) emitted by pyre's
@@ -5872,6 +5981,47 @@ macro_rules! bhhandler_ii_i {
         ) -> Result<usize, DispatchError> {
             let a = bh.registers_i[code[position] as usize];
             let b = bh.registers_i[code[position + 1] as usize];
+            bh.registers_i[code[position + 2] as usize] = $bhimpl(a, b);
+            Ok(position + 3)
+        }
+    };
+}
+
+/// The three short-constant variants assembler.py creates for an
+/// `@arguments("i", "i", returns="i")` operation in `USE_C_FORM`.
+/// A `c` operand is the signed byte itself (`blackhole.py` `_get_method`),
+/// while an `i` operand indexes the int register/constant namespace.
+macro_rules! bhhandler_short_binop_i {
+    ($ci:ident, $ic:ident, $cc:ident, $bhimpl:ident) => {
+        fn $ci(
+            bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = code[position] as i8 as i64;
+            let b = bh.registers_i[code[position + 1] as usize];
+            bh.registers_i[code[position + 2] as usize] = $bhimpl(a, b);
+            Ok(position + 3)
+        }
+
+        fn $ic(
+            bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = bh.registers_i[code[position] as usize];
+            let b = code[position + 1] as i8 as i64;
+            bh.registers_i[code[position + 2] as usize] = $bhimpl(a, b);
+            Ok(position + 3)
+        }
+
+        fn $cc(
+            bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = code[position] as i8 as i64;
+            let b = code[position + 1] as i8 as i64;
             bh.registers_i[code[position + 2] as usize] = $bhimpl(a, b);
             Ok(position + 3)
         }
@@ -6768,6 +6918,63 @@ bhhandler_ii_i!(handler_int_ne, bhimpl_int_ne);
 bhhandler_ii_i!(handler_int_gt, bhimpl_int_gt);
 bhhandler_ii_i!(handler_int_ge, bhimpl_int_ge);
 
+// assembler.py `USE_C_FORM`: every Constant operand of these canonical
+// integer operations takes the inline signed-byte form independently.
+bhhandler_short_binop_i!(
+    handler_int_add_ci,
+    handler_int_add_ic,
+    handler_int_add_cc,
+    bhimpl_int_add
+);
+bhhandler_short_binop_i!(
+    handler_int_sub_ci,
+    handler_int_sub_ic,
+    handler_int_sub_cc,
+    bhimpl_int_sub
+);
+bhhandler_short_binop_i!(
+    handler_int_and_ci,
+    handler_int_and_ic,
+    handler_int_and_cc,
+    bhimpl_int_and
+);
+bhhandler_short_binop_i!(
+    handler_int_eq_ci,
+    handler_int_eq_ic,
+    handler_int_eq_cc,
+    bhimpl_int_eq
+);
+bhhandler_short_binop_i!(
+    handler_int_ne_ci,
+    handler_int_ne_ic,
+    handler_int_ne_cc,
+    bhimpl_int_ne
+);
+bhhandler_short_binop_i!(
+    handler_int_lt_ci,
+    handler_int_lt_ic,
+    handler_int_lt_cc,
+    bhimpl_int_lt
+);
+bhhandler_short_binop_i!(
+    handler_int_le_ci,
+    handler_int_le_ic,
+    handler_int_le_cc,
+    bhimpl_int_le
+);
+bhhandler_short_binop_i!(
+    handler_int_gt_ci,
+    handler_int_gt_ic,
+    handler_int_gt_cc,
+    bhimpl_int_gt
+);
+bhhandler_short_binop_i!(
+    handler_int_ge_ci,
+    handler_int_ge_ic,
+    handler_int_ge_cc,
+    bhimpl_int_ge
+);
+
 // blackhole.py `bhimpl_int_copy(a): return a` — @arguments("i", returns="i").
 // Decoded as `i>i` (same as int_same_as). Already have handler_int_same_as.
 // Wire as alias.
@@ -7410,6 +7617,46 @@ macro_rules! bhhandler_goto_if_not_ii {
     };
 }
 
+macro_rules! bhhandler_goto_if_not_short {
+    ($ci:ident, $ic:ident, $cc:ident, $cmp:expr) => {
+        fn $ci(
+            bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = code[position] as i8 as i64;
+            let b = bh.registers_i[code[position + 1] as usize];
+            let target = (code[position + 2] as usize) | ((code[position + 3] as usize) << 8);
+            let pc = position + 4;
+            if $cmp(a, b) { Ok(pc) } else { Ok(target) }
+        }
+
+        fn $ic(
+            bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = bh.registers_i[code[position] as usize];
+            let b = code[position + 1] as i8 as i64;
+            let target = (code[position + 2] as usize) | ((code[position + 3] as usize) << 8);
+            let pc = position + 4;
+            if $cmp(a, b) { Ok(pc) } else { Ok(target) }
+        }
+
+        fn $cc(
+            _bh: &mut BlackholeInterpreter,
+            code: &[u8],
+            position: usize,
+        ) -> Result<usize, DispatchError> {
+            let a = code[position] as i8 as i64;
+            let b = code[position + 1] as i8 as i64;
+            let target = (code[position + 2] as usize) | ((code[position + 3] as usize) << 8);
+            let pc = position + 4;
+            if $cmp(a, b) { Ok(pc) } else { Ok(target) }
+        }
+    };
+}
+
 bhhandler_goto_if_not_ii!(handler_goto_if_not_int_lt, |a: i64, b: i64| a < b);
 bhhandler_goto_if_not_ii!(handler_goto_if_not_int_le, |a: i64, b: i64| a <= b);
 // Temporarily expanded from `bhhandler_goto_if_not_ii!` for MAJIT_BH_DEBUG
@@ -7440,6 +7687,42 @@ fn handler_goto_if_not_int_eq(
 bhhandler_goto_if_not_ii!(handler_goto_if_not_int_ne, |a: i64, b: i64| a != b);
 bhhandler_goto_if_not_ii!(handler_goto_if_not_int_gt, |a: i64, b: i64| a > b);
 bhhandler_goto_if_not_ii!(handler_goto_if_not_int_ge, |a: i64, b: i64| a >= b);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_lt_ci,
+    handler_goto_if_not_int_lt_ic,
+    handler_goto_if_not_int_lt_cc,
+    |a: i64, b: i64| a < b
+);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_le_ci,
+    handler_goto_if_not_int_le_ic,
+    handler_goto_if_not_int_le_cc,
+    |a: i64, b: i64| a <= b
+);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_eq_ci,
+    handler_goto_if_not_int_eq_ic,
+    handler_goto_if_not_int_eq_cc,
+    |a: i64, b: i64| a == b
+);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_ne_ci,
+    handler_goto_if_not_int_ne_ic,
+    handler_goto_if_not_int_ne_cc,
+    |a: i64, b: i64| a != b
+);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_gt_ci,
+    handler_goto_if_not_int_gt_ic,
+    handler_goto_if_not_int_gt_cc,
+    |a: i64, b: i64| a > b
+);
+bhhandler_goto_if_not_short!(
+    handler_goto_if_not_int_ge_ci,
+    handler_goto_if_not_int_ge_ic,
+    handler_goto_if_not_int_ge_cc,
+    |a: i64, b: i64| a >= b
+);
 
 /// Decode pattern `@arguments("i", "L", "pc", returns="L")` — 1 int read +
 /// 2-byte label target; bhimpl chooses target or fall-through pc.
@@ -8134,6 +8417,18 @@ fn handler_getarrayitem_gc_i(
     bh.registers_i[code[pos] as usize] = cpu.bh_getarrayitem_gc_i(array, index, descr);
     Ok(pos + 1)
 }
+fn handler_getarrayitem_gc_i_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let array = bh.registers_r[code[position] as usize];
+    let index = code[position + 1] as i8 as i64;
+    let (descr, pos) = read_descr(bh, code, position + 2);
+    let result = bh.cpu().bh_getarrayitem_gc_i(array, index, descr);
+    bh.registers_i[code[pos] as usize] = result;
+    Ok(pos + 1)
+}
 fn handler_getarrayitem_gc_i_intbase(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -8156,6 +8451,18 @@ fn handler_getarrayitem_gc_r(
     let (descr, pos) = read_descr(bh, code, position + 2);
     let cpu = bh.cpu();
     bh.registers_r[code[pos] as usize] = cpu.bh_getarrayitem_gc_r(array, index, descr).0 as i64;
+    Ok(pos + 1)
+}
+fn handler_getarrayitem_gc_r_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let array = bh.registers_r[code[position] as usize];
+    let index = code[position + 1] as i8 as i64;
+    let (descr, pos) = read_descr(bh, code, position + 2);
+    let result = bh.cpu().bh_getarrayitem_gc_r(array, index, descr).0 as i64;
+    bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
 
@@ -8224,6 +8531,32 @@ fn handler_setarrayitem_gc_i_c(
     let (descr, pos) = read_descr(bh, code, position + 3);
     let cpu = bh.cpu();
     cpu.bh_setarrayitem_gc_i(array, index, value, descr);
+    Ok(pos)
+}
+
+fn handler_setarrayitem_gc_i_index_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let array = bh.registers_r[code[position] as usize];
+    let index = code[position + 1] as i8 as i64;
+    let value = bh.registers_i[code[position + 2] as usize];
+    let (descr, pos) = read_descr(bh, code, position + 3);
+    bh.cpu().bh_setarrayitem_gc_i(array, index, value, descr);
+    Ok(pos)
+}
+
+fn handler_setarrayitem_gc_i_both_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let array = bh.registers_r[code[position] as usize];
+    let index = code[position + 1] as i8 as i64;
+    let value = code[position + 2] as i8 as i64;
+    let (descr, pos) = read_descr(bh, code, position + 3);
+    bh.cpu().bh_setarrayitem_gc_i(array, index, value, descr);
     Ok(pos)
 }
 
@@ -8317,6 +8650,19 @@ fn handler_new_array(
     bh.registers_r[code[pos] as usize] = result;
     Ok(pos + 1)
 }
+
+fn handler_new_array_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let length = code[position] as i8 as i64;
+    let (descr, pos) = read_descr(bh, code, position + 1);
+    let result = bh.cpu().bh_new_array(length, descr);
+    check_blackhole_allocation_after(bh, result, pos + 1)?;
+    bh.registers_r[code[pos] as usize] = result;
+    Ok(pos + 1)
+}
 fn handler_new_array_clear(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -8367,6 +8713,17 @@ fn handler_strgetitem(
     bh.registers_i[code[position + 2] as usize] = cpu.bh_strgetitem(s, index);
     Ok(position + 3)
 }
+fn handler_strgetitem_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let s = bh.registers_r[code[position] as usize];
+    let index = code[position + 1] as i8 as i64;
+    let result = bh.cpu().bh_strgetitem(s, index);
+    bh.registers_i[code[position + 2] as usize] = result;
+    Ok(position + 3)
+}
 fn handler_strsetitem(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -8379,12 +8736,42 @@ fn handler_strsetitem(
     cpu.bh_strsetitem(s, index, value);
     Ok(position + 3)
 }
+fn handler_strsetitem_short<const INDEX_SHORT: bool, const VALUE_SHORT: bool>(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let s = bh.registers_r[code[position] as usize];
+    let index = if INDEX_SHORT {
+        code[position + 1] as i8 as i64
+    } else {
+        bh.registers_i[code[position + 1] as usize]
+    };
+    let value = if VALUE_SHORT {
+        code[position + 2] as i8 as i64
+    } else {
+        bh.registers_i[code[position + 2] as usize]
+    };
+    bh.cpu().bh_strsetitem(s, index, value);
+    Ok(position + 3)
+}
 fn handler_newstr(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     position: usize,
 ) -> Result<usize, DispatchError> {
     let length = bh.registers_i[code[position] as usize];
+    let result = bh.cpu().bh_newstr(length);
+    check_blackhole_allocation_after(bh, result, position + 2)?;
+    bh.registers_r[code[position + 1] as usize] = result;
+    Ok(position + 2)
+}
+fn handler_newstr_c(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    position: usize,
+) -> Result<usize, DispatchError> {
+    let length = code[position] as i8 as i64;
     let result = bh.cpu().bh_newstr(length);
     check_blackhole_allocation_after(bh, result, position + 2)?;
     bh.registers_r[code[position + 1] as usize] = result;
@@ -9884,6 +10271,37 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("int_ne/ii>i", handler_int_ne);
     builder.wire_handler("int_gt/ii>i", handler_int_gt);
     builder.wire_handler("int_ge/ii>i", handler_int_ge);
+    for (key, handler) in [
+        ("int_add/ci>i", handler_int_add_ci as BhOpcodeHandler),
+        ("int_add/ic>i", handler_int_add_ic),
+        ("int_add/cc>i", handler_int_add_cc),
+        ("int_sub/ci>i", handler_int_sub_ci),
+        ("int_sub/ic>i", handler_int_sub_ic),
+        ("int_sub/cc>i", handler_int_sub_cc),
+        ("int_and/ci>i", handler_int_and_ci),
+        ("int_and/ic>i", handler_int_and_ic),
+        ("int_and/cc>i", handler_int_and_cc),
+        ("int_eq/ci>i", handler_int_eq_ci),
+        ("int_eq/ic>i", handler_int_eq_ic),
+        ("int_eq/cc>i", handler_int_eq_cc),
+        ("int_ne/ci>i", handler_int_ne_ci),
+        ("int_ne/ic>i", handler_int_ne_ic),
+        ("int_ne/cc>i", handler_int_ne_cc),
+        ("int_lt/ci>i", handler_int_lt_ci),
+        ("int_lt/ic>i", handler_int_lt_ic),
+        ("int_lt/cc>i", handler_int_lt_cc),
+        ("int_le/ci>i", handler_int_le_ci),
+        ("int_le/ic>i", handler_int_le_ic),
+        ("int_le/cc>i", handler_int_le_cc),
+        ("int_gt/ci>i", handler_int_gt_ci),
+        ("int_gt/ic>i", handler_int_gt_ic),
+        ("int_gt/cc>i", handler_int_gt_cc),
+        ("int_ge/ci>i", handler_int_ge_ci),
+        ("int_ge/ic>i", handler_int_ge_ic),
+        ("int_ge/cc>i", handler_int_ge_cc),
+    ] {
+        builder.wire_handler(key, handler);
+    }
 
     // Copy operations
     builder.wire_handler("int_copy/i>i", handler_int_copy);
@@ -9940,6 +10358,31 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("goto_if_not_int_ne/iiL", handler_goto_if_not_int_ne);
     builder.wire_handler("goto_if_not_int_gt/iiL", handler_goto_if_not_int_gt);
     builder.wire_handler("goto_if_not_int_ge/iiL", handler_goto_if_not_int_ge);
+    for (key, handler) in [
+        (
+            "goto_if_not_int_lt/ciL",
+            handler_goto_if_not_int_lt_ci as BhOpcodeHandler,
+        ),
+        ("goto_if_not_int_lt/icL", handler_goto_if_not_int_lt_ic),
+        ("goto_if_not_int_lt/ccL", handler_goto_if_not_int_lt_cc),
+        ("goto_if_not_int_le/ciL", handler_goto_if_not_int_le_ci),
+        ("goto_if_not_int_le/icL", handler_goto_if_not_int_le_ic),
+        ("goto_if_not_int_le/ccL", handler_goto_if_not_int_le_cc),
+        ("goto_if_not_int_eq/ciL", handler_goto_if_not_int_eq_ci),
+        ("goto_if_not_int_eq/icL", handler_goto_if_not_int_eq_ic),
+        ("goto_if_not_int_eq/ccL", handler_goto_if_not_int_eq_cc),
+        ("goto_if_not_int_ne/ciL", handler_goto_if_not_int_ne_ci),
+        ("goto_if_not_int_ne/icL", handler_goto_if_not_int_ne_ic),
+        ("goto_if_not_int_ne/ccL", handler_goto_if_not_int_ne_cc),
+        ("goto_if_not_int_gt/ciL", handler_goto_if_not_int_gt_ci),
+        ("goto_if_not_int_gt/icL", handler_goto_if_not_int_gt_ic),
+        ("goto_if_not_int_gt/ccL", handler_goto_if_not_int_gt_cc),
+        ("goto_if_not_int_ge/ciL", handler_goto_if_not_int_ge_ci),
+        ("goto_if_not_int_ge/icL", handler_goto_if_not_int_ge_ic),
+        ("goto_if_not_int_ge/ccL", handler_goto_if_not_int_ge_cc),
+    ] {
+        builder.wire_handler(key, handler);
+    }
     // upstream `flatten.py:247` registers opname `goto_if_not`
     // (the `_int_is_true` suffix is a Python class-attribute alias of
     // the bhimpl function, not a separate opname — `blackhole.py:913`).
@@ -10048,11 +10491,15 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     // class differs.
     builder.wire_handler("getarrayitem_gc_i/rid>i", handler_getarrayitem_gc_i);
     builder.wire_handler("getarrayitem_gc_r/rid>r", handler_getarrayitem_gc_r);
+    builder.wire_handler("getarrayitem_gc_i/rcd>i", handler_getarrayitem_gc_i_c);
+    builder.wire_handler("getarrayitem_gc_r/rcd>r", handler_getarrayitem_gc_r_c);
     builder.wire_handler("getarrayitem_gc_i/iid>i", handler_getarrayitem_gc_i_intbase);
     builder.wire_handler("getarrayitem_gc_i_pure/rid>i", handler_getarrayitem_gc_i);
     builder.wire_handler("getarrayitem_gc_r_pure/rid>r", handler_getarrayitem_gc_r);
     builder.wire_handler("setarrayitem_gc_i/riid", handler_setarrayitem_gc_i);
     builder.wire_handler("setarrayitem_gc_i/ricd", handler_setarrayitem_gc_i_c);
+    builder.wire_handler("setarrayitem_gc_i/rcid", handler_setarrayitem_gc_i_index_c);
+    builder.wire_handler("setarrayitem_gc_i/rccd", handler_setarrayitem_gc_i_both_c);
     builder.wire_handler("setarrayitem_gc_r/rird", handler_setarrayitem_gc_r);
     builder.wire_handler("setarrayitem_gc_r/rcrd", handler_setarrayitem_gc_r_c);
 
@@ -10071,13 +10518,19 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("new/d>r", handler_new);
     builder.wire_handler("new_with_vtable/d>r", handler_new_with_vtable);
     builder.wire_handler("new_array/id>r", handler_new_array);
+    builder.wire_handler("new_array/cd>r", handler_new_array_c);
     builder.wire_handler("new_array_clear/id>r", handler_new_array_clear);
     builder.wire_handler("new_array_clear/cd>r", handler_new_array_clear_c);
     // String operations (blackhole.py:1200-1283)
     builder.wire_handler("strlen/r>i", handler_strlen);
     builder.wire_handler("strgetitem/ri>i", handler_strgetitem);
+    builder.wire_handler("strgetitem/rc>i", handler_strgetitem_c);
     builder.wire_handler("strsetitem/rii", handler_strsetitem);
+    builder.wire_handler("strsetitem/rci", handler_strsetitem_short::<true, false>);
+    builder.wire_handler("strsetitem/ric", handler_strsetitem_short::<false, true>);
+    builder.wire_handler("strsetitem/rcc", handler_strsetitem_short::<true, true>);
     builder.wire_handler("newstr/i>r", handler_newstr);
+    builder.wire_handler("newstr/c>r", handler_newstr_c);
     builder.wire_handler("unicodelen/r>i", handler_unicodelen);
     builder.wire_handler("unicodegetitem/ri>i", handler_unicodegetitem);
     builder.wire_handler("unicodesetitem/rii", handler_unicodesetitem);
@@ -10190,6 +10643,34 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("str_guard_value/rid>r", handler_str_guard_value);
     builder.wire_handler("rvmprof_code/ii", handler_rvmprof_code);
     builder.wire_handler("copystrcontent/rriii", handler_copystrcontent);
+    builder.wire_handler(
+        "copystrcontent/rrcii",
+        handler_copystrcontent_short::<true, false, false>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rrici",
+        handler_copystrcontent_short::<false, true, false>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rriic",
+        handler_copystrcontent_short::<false, false, true>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rrcci",
+        handler_copystrcontent_short::<true, true, false>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rrcic",
+        handler_copystrcontent_short::<true, false, true>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rricc",
+        handler_copystrcontent_short::<false, true, true>,
+    );
+    builder.wire_handler(
+        "copystrcontent/rrccc",
+        handler_copystrcontent_short::<true, true, true>,
+    );
     builder.wire_handler("copyunicodecontent/rriii", handler_copyunicodecontent);
     builder.wire_handler("current_trace_length/>i", handler_current_trace_length);
 
@@ -10576,6 +11057,37 @@ fn handler_copystrcontent(
     let srcstart = bh.registers_i[code[p + 2] as usize];
     let dststart = bh.registers_i[code[p + 3] as usize];
     let length = bh.registers_i[code[p + 4] as usize];
+    bh.cpu()
+        .bh_copystrcontent(src, dst, srcstart, dststart, length);
+    Ok(p + 5)
+}
+
+fn handler_copystrcontent_short<
+    const SRCSTART_SHORT: bool,
+    const DSTSTART_SHORT: bool,
+    const LENGTH_SHORT: bool,
+>(
+    bh: &mut BlackholeInterpreter,
+    code: &[u8],
+    p: usize,
+) -> Result<usize, DispatchError> {
+    let src = bh.registers_r[code[p] as usize];
+    let dst = bh.registers_r[code[p + 1] as usize];
+    let srcstart = if SRCSTART_SHORT {
+        code[p + 2] as i8 as i64
+    } else {
+        bh.registers_i[code[p + 2] as usize]
+    };
+    let dststart = if DSTSTART_SHORT {
+        code[p + 3] as i8 as i64
+    } else {
+        bh.registers_i[code[p + 3] as usize]
+    };
+    let length = if LENGTH_SHORT {
+        code[p + 4] as i8 as i64
+    } else {
+        bh.registers_i[code[p + 4] as usize]
+    };
     bh.cpu()
         .bh_copystrcontent(src, dst, srcstart, dststart, length);
     Ok(p + 5)

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3231,11 +3231,21 @@ pub fn convert_and_run_from_pyjitpl(
         0
     };
 
+    // `warmspot.py:1010-1013` hands `ll_portal_runner` to the blackhole so a
+    // recursive portal level can re-enter the portal function.  Without it
+    // `handle_jitexception_dispatch` has nothing to call and
+    // `ContinueRunningNormally` reaches its `expect`.
+    let hook = PORTAL_RUNNER_HOOK.get().copied();
+    let portal_runner = hook.as_ref().map(|hook| {
+        hook as &dyn Fn(
+            &crate::jitexc::JitException,
+        ) -> Result<(BhReturnType, i64), PortalRunnerFailure>
+    });
     let outcome = run_forever_with_portal(
         builder,
         first_bh,
         current_exc,
-        None,
+        portal_runner,
         on_enter_level,
         on_leave_level,
         terminal_out,
@@ -6909,6 +6919,25 @@ fn bhimpl_hint_force_virtualizable(_r: i64) {}
 /// colouring reusing that register almost immediately
 /// (`rpython/tool/algo/regalloc.py:28-75`); a codewriter whose colours are
 /// not reused that densely needs the same clear at marker granularity.
+/// The interpreter's `portal_runner`, re-entering the portal function when
+/// `ContinueRunningNormally` is raised at a recursive portal level
+/// (`warmspot.py handle_jitexception_from_blackhole`).
+///
+/// Registered as a module hook rather than held on `JitDriver`, because the two
+/// production entries into `convert_and_run_from_pyjitpl` reach it with
+/// `MetaInterpStaticData` only — neither can name the driver that owns the
+/// callback.  Same shape as [`LiveMarkerHook`] beside it.
+pub type PortalRunnerHook =
+    fn(&crate::jitexc::JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>;
+
+static PORTAL_RUNNER_HOOK: std::sync::OnceLock<PortalRunnerHook> = std::sync::OnceLock::new();
+
+/// Install the [`PortalRunnerHook`]. First registration wins; later calls are
+/// ignored, so a consumer may call it from every driver install path.
+pub fn register_portal_runner_hook(hook: PortalRunnerHook) {
+    let _ = PORTAL_RUNNER_HOOK.set(hook);
+}
+
 pub type LiveMarkerHook = fn(&mut BlackholeInterpreter, usize);
 
 static LIVE_MARKER_HOOK: std::sync::OnceLock<LiveMarkerHook> = std::sync::OnceLock::new();

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -78,6 +78,15 @@ fn field_slot_in(fields: &[BhFieldSpec], name: &str, offset: usize) -> Option<us
     at_offset.next().is_none().then_some(idx)
 }
 
+/// One integer operand in assembler.py's bytecode namespace. `Register`
+/// also covers an int constants-pool slot (`argcode == 'i'`), while
+/// `ShortConst` is the inline signed byte selected by `USE_C_FORM`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JitCodeIntOperand {
+    Register(u16),
+    ShortConst(i8),
+}
+
 #[derive(Default)]
 pub struct JitCodeBuilder {
     /// RPython `jitcode.py` `self.name = name`. Propagated to the
@@ -2439,6 +2448,57 @@ impl JitCodeBuilder {
         self.push_u8(lhs as u8);
         self.push_u8(rhs as u8);
         self.push_u8(dst as u8);
+    }
+
+    /// Emit a dynamically-numbered `USE_C_FORM` integer operation. PyPy's
+    /// assembler allocates the `(opname, argcodes)` byte only when that shape
+    /// appears; the runtime assembler supplies that byte here.
+    pub fn record_binop_i_operands(
+        &mut self,
+        dst: u16,
+        opcode_byte: u8,
+        lhs: JitCodeIntOperand,
+        rhs: JitCodeIntOperand,
+    ) {
+        self.touch_reg(dst);
+        for operand in [lhs, rhs] {
+            if let JitCodeIntOperand::Register(reg) = operand {
+                self.touch_int_reg_or_pool_slot(reg);
+            }
+        }
+        self.start_instr(opcode_byte);
+        self.pending_resulttype = Some('i');
+        for operand in [lhs, rhs] {
+            match operand {
+                JitCodeIntOperand::Register(reg) => self.push_reg_u8(reg, "integer operand"),
+                JitCodeIntOperand::ShortConst(value) => self.push_u8(value as u8),
+            }
+        }
+        self.push_reg_u8(dst, "integer result");
+    }
+
+    /// Fused integer comparison branch with independently short-constant
+    /// operands (`goto_if_not_int_*/{ci,ic,cc}L`).
+    pub fn goto_if_not_int_operands(
+        &mut self,
+        opcode_byte: u8,
+        lhs: JitCodeIntOperand,
+        rhs: JitCodeIntOperand,
+        label: u16,
+    ) {
+        for operand in [lhs, rhs] {
+            if let JitCodeIntOperand::Register(reg) = operand {
+                self.touch_int_reg_or_pool_slot(reg);
+            }
+        }
+        self.start_instr(opcode_byte);
+        for operand in [lhs, rhs] {
+            match operand {
+                JitCodeIntOperand::Register(reg) => self.push_reg_u8(reg, "integer branch operand"),
+                JitCodeIntOperand::ShortConst(value) => self.push_u8(value as u8),
+            }
+        }
+        self.push_label_ref(label);
     }
 
     /// `blackhole.py:478-497` `bhimpl_int_{add,sub,mul}_jump_if_ovf(label,

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -2,7 +2,7 @@ mod assembler;
 mod embedded;
 
 pub(crate) use assembler::scalar_size;
-pub use assembler::{JitCodeBuilder, live_slots_for_state_field_jit};
+pub use assembler::{JitCodeBuilder, JitCodeIntOperand, live_slots_for_state_field_jit};
 pub use embedded::EmbeddedJitCodeTable;
 pub use majit_translate::jitcode::{
     BhCallDescr as CanonicalBhCallDescr, BhDescr as CanonicalBhDescr, BhInteriorFieldSpec,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1777,21 +1777,6 @@ pub struct JitDriver<S: JitState> {
     blackhole_allocator: Option<Box<dyn crate::resume::BlackholeAllocator + Send>>,
     /// warmspot.py handle_jitexception parity: portal runner callback.
     /// Called when ContinueRunningNormally is raised at a recursive portal
-    /// level during blackhole execution. Re-enters the portal function
-    /// with green/red args and returns the result.
-    #[expect(
-        clippy::type_complexity,
-        reason = "This is the literal nested tuple/list/dict/callable shape at an RPython parity boundary; a wrapper would change structural ownership, while a one-use alias would conceal the audited upstream shape"
-    )]
-    portal_runner: Option<
-        Box<
-            dyn Fn(
-                    &crate::jitexc::JitException,
-                )
-                    -> Result<(crate::blackhole::BhReturnType, i64), crate::jitexc::JitException>
-                + Send,
-        >,
-    >,
     /// jtransform.py `portal_jd.index` — the `jitdrivers_sd` slot this
     /// driver's portal occupies. `call.py:147 jd.mainjitcode` holds the portal
     /// JitCode itself, so this driver stores only the slot; `None` until
@@ -2039,7 +2024,6 @@ impl<S: JitState> JitDriver<S> {
             entry_points: Vec::new(),
             is_recursive: false,
             blackhole_allocator: None,
-            portal_runner: None,
             portal_jd_index: None,
             state_field_fvc: None,
             entry_scratch: Some(Box::default()),
@@ -2097,23 +2081,6 @@ impl<S: JitState> JitDriver<S> {
         asm: &majit_translate::codewriter::assembler::Assembler,
     ) {
         self.meta.install_canonical_liveness(asm);
-    }
-
-    /// Register a portal runner callback for blackhole ContinueRunningNormally.
-    ///
-    /// warmspot.py handle_jitexception_from_blackhole parity:
-    /// called when ContinueRunningNormally is raised at a recursive portal
-    /// level. The callback re-enters the portal function and returns the result.
-    pub fn register_portal_runner(
-        &mut self,
-        runner: impl Fn(
-            &crate::jitexc::JitException,
-        )
-            -> Result<(crate::blackhole::BhReturnType, i64), crate::jitexc::JitException>
-        + Send
-        + 'static,
-    ) {
-        self.portal_runner = Some(Box::new(runner));
     }
 
     /// Register the dispatch JitCode singleton. Called once at install time

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7430,8 +7430,10 @@ impl<'a> Lowering<'a> {
     }
 
     /// Decode an inline-Field `dyn Trait` call operand into the
-    /// `(trait_root, method_name)` pair the `CallTarget::Indirect`
-    /// vtable-dispatch pipeline keys on.
+    /// `(trait_root, method_name)` pair carried as the `family_key` of the
+    /// [`OpKind::IndirectCall`] this lowers to.  `rpbc::lower_indirect_calls`
+    /// consumes that key to attach the same `c_graphs` PBC family
+    /// `FunctionReprBase.call` appends, then clears it.
     ///
     /// The inline dispatch reads the method fn-ptr straight out of the
     /// receiver's vtable — the operand's terminal projection is

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5486,7 +5486,7 @@ fn build_jit_driver_pair() -> JitDriverPair {
     // warmspot.py handle_jitexception_from_blackhole parity:
     // portal_runner is called when ContinueRunningNormally is raised
     // at a recursive portal level during blackhole execution.
-    d.register_portal_runner(pyre_portal_runner);
+    majit_metainterp::blackhole::register_portal_runner_hook(pyre_portal_runner);
     // pypy/module/pypyjit/interp_jit.py PyPyJitDriver(..., is_recursive=True).
     // Drives MetaInterp.is_main_jitcode() / is_portal_jitcode dispatch
     // — without this flag the recursive-portal bookkeeping stays
@@ -9549,9 +9549,11 @@ fn portal_activation_bracketed(
 /// itself raises a JitException (warmspot.py:979-980 loop back).
 pub(crate) fn pyre_portal_runner(
     exc: &majit_metainterp::jitexc::JitException,
-) -> Result<(majit_metainterp::blackhole::BhReturnType, i64), majit_metainterp::jitexc::JitException>
-{
-    use majit_metainterp::blackhole::BhReturnType;
+) -> Result<
+    (majit_metainterp::blackhole::BhReturnType, i64),
+    majit_metainterp::blackhole::PortalRunnerFailure,
+> {
+    use majit_metainterp::blackhole::{BhReturnType, PortalRunnerFailure};
     use majit_metainterp::jitexc::JitException;
 
     let JitException::ContinueRunningNormally(args) = exc else {
@@ -9578,7 +9580,9 @@ pub(crate) fn pyre_portal_runner(
     let frame_ptr = all_r.get(1).copied().unwrap_or(0) as *mut PyFrame;
     let ec = all_r.get(2).copied().unwrap_or(0) as *const pyre_interpreter::PyExecutionContext;
     if frame_ptr.is_null() {
-        return Err(JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(0)));
+        return Err(PortalRunnerFailure::jit(
+            JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(0)),
+        ));
     }
     let frame = unsafe { &mut *frame_ptr };
     // warmspot.py:976 forwards the CRN values to `portal_ptr`; it does not
@@ -9602,9 +9606,11 @@ pub(crate) fn pyre_portal_runner(
     pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     match result {
         Ok(result) => Ok((BhReturnType::Ref, result as i64)),
-        Err(mut err) => Err(JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(
-            err.to_exc_object() as usize,
-        ))),
+        // Never a `BailToInterpreter`: the re-entered portal body either
+        // returns or raises, so no terminal blackhole image is in flight here.
+        Err(mut err) => Err(PortalRunnerFailure::jit(
+            JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(err.to_exc_object() as usize)),
+        )),
     }
 }
 

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, LazyLock};
 
 use indexmap::IndexMap;
 use majit_ir::IndexMapExt;
-use majit_metainterp::jitcode::{JitCallArg, JitCode, JitCodeBuilder};
+use majit_metainterp::jitcode::{JitCallArg, JitCode, JitCodeBuilder, JitCodeIntOperand};
 use vecset::VecSet;
 
 use super::flatten::{DescrOperand, Insn, Kind, ListOfKind, Operand, Register, SSARepr, TLabel};
@@ -45,11 +45,12 @@ pub struct NumRegs {
 pub struct Assembler {
     /// `assembler.py` `self.insns = {}`.
     ///
-    /// RPython grows this dict in `write_insn()` with dense opcode ids.
-    /// pyre still emits majit's fixed runtime bytecodes, so the mirror here
-    /// records only the actually-emitted well-known keys with their runtime
-    /// opcode byte. That is sufficient for the lazy `finish_setup` cache
-    /// refresh in `pyre_jit_trace::state`.
+    /// RPython grows this dict in `write_insn()` with one opcode id per shape.
+    /// Pyre reuses majit's reserved byte for a serialized well-known shape and
+    /// lazily allocates an unreserved byte for a runtime-only shape such as a
+    /// `USE_C_FORM` combination.  In both cases only shapes actually emitted
+    /// by this assembler enter the map consumed by the lazy `finish_setup`
+    /// cache refresh in `pyre_jit_trace::state`.
     insns: IndexMap<String, u8>,
     /// `assembler.py` `self.all_liveness = []`.
     all_liveness: Vec<u8>,
@@ -368,7 +369,7 @@ impl Assembler {
                         }
                     }
                 }
-                self.record_insn_key(opname, args, result.as_ref());
+                let opcode_byte = self.record_insn_key(opname, args, result.as_ref());
                 // `assembler.py:197-206` registers descrs inline during op
                 // encoding into `Assembler.descrs`. pyre's runtime
                 // codewriter has no descr-consuming ops today, so no
@@ -377,7 +378,7 @@ impl Assembler {
                 // `BlackholeInterpBuilder.descrs` pool (`blackhole.py:
                 // 102-103 setup_descrs`), not a per-jitcode duplicate.
                 CURRENT_DISPATCH_OP.with(|cur| cur.borrow_mut().replace_range(.., opname));
-                dispatch_op(state, opname, args, result.as_ref());
+                dispatch_op(state, opname, args, result.as_ref(), opcode_byte);
             }
         }
     }
@@ -497,18 +498,41 @@ impl Assembler {
         pos
     }
 
-    fn record_insn_key(&mut self, opname: &str, args: &[Operand], result: Option<&Register>) {
+    fn record_insn_key(
+        &mut self,
+        opname: &str,
+        args: &[Operand],
+        result: Option<&Register>,
+    ) -> Option<u8> {
         if is_adapter_only_helper_call_family(opname) {
-            return;
+            return None;
         }
         let key = if opname == super::flatten::OPNAME_LIVE {
             "live/".to_string()
         } else {
             insn_key(opname, args, result)
         };
-        if let Some(&opcode) = WELLKNOWN_BH_INSNS.get(key.as_str()) {
-            self.insns.entry_or_insert_with(key, || opcode);
+        if let Some(&opcode) = self.insns.get(&key) {
+            return Some(opcode);
         }
+        let opcode = WELLKNOWN_BH_INSNS
+            .get(key.as_str())
+            .copied()
+            .unwrap_or_else(|| {
+                // assembler.py `self.insns.setdefault(key, len(self.insns))`,
+                // adjusted only for pyre's serialized fixed-byte reservation.
+                // Allocate an opcode for the shape that actually appeared; do not
+                // reserve the Cartesian product of every USE_C_FORM variant.
+                (0u16..=u8::MAX as u16)
+                    .map(|value| value as u8)
+                    .find(|value| {
+                        !majit_translate::insns::is_reserved_opcode_byte(*value)
+                            && !self.insns.values().any(|used| used == value)
+                    })
+                    .unwrap_or_else(|| panic!("runtime assembler opcode space exhausted for {key}"))
+            });
+        self.insns.insert(key, opcode);
+        Some(opcode)
     }
 }
 
@@ -719,6 +743,7 @@ fn dispatch_op(
     opname: &str,
     args: &[Operand],
     result: Option<&Register>,
+    opcode_byte: Option<u8>,
 ) {
     match opname {
         "goto" => {
@@ -733,46 +758,106 @@ fn dispatch_op(
             state.builder.goto_if_not_int_is_true(cond, label_id);
         }
         "goto_if_not_int_eq" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_eq(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_eq(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_eq opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_ne" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_ne(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_ne(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_ne opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_lt" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_lt(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_lt(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_lt opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_le" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_le(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_le(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_le opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_gt" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_gt(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_gt(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_gt opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_ge" => {
-            let lhs = expect_reg(&args[0], Kind::Int);
-            let rhs = expect_reg(&args[1], Kind::Int);
+            let lhs = expect_jitcode_int_operand(state, &args[0], true);
+            let rhs = expect_jitcode_int_operand(state, &args[1], true);
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
-            state.builder.goto_if_not_int_ge(lhs, rhs, label_id);
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.goto_if_not_int_ge(lhs, rhs, label_id)
+                }
+                _ => state.builder.goto_if_not_int_operands(
+                    opcode_byte.expect("short goto_if_not_int_ge opcode"),
+                    lhs,
+                    rhs,
+                    label_id,
+                ),
+            }
         }
         "goto_if_not_int_is_zero" => {
             let cond = expect_reg(&args[0], Kind::Int);
@@ -1436,12 +1521,19 @@ fn dispatch_op(
                 "uint_ge" => majit_ir::OpCode::UintGe,
                 _ => unreachable!(),
             };
-            state.builder.record_binop_i(
-                dst,
-                opcode,
-                expect_reg(&args[0], Kind::Int),
-                expect_reg(&args[1], Kind::Int),
-            );
+            let lhs = expect_jitcode_int_operand(state, &args[0], use_c_form(opname));
+            let rhs = expect_jitcode_int_operand(state, &args[1], use_c_form(opname));
+            match (lhs, rhs) {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                    state.builder.record_binop_i(dst, opcode, lhs, rhs)
+                }
+                _ => state.builder.record_binop_i_operands(
+                    dst,
+                    opcode_byte.expect("short integer binop opcode"),
+                    lhs,
+                    rhs,
+                ),
+            }
         }
         "int_neg" | "int_invert" => {
             let dst = expect_result_reg(result, Kind::Int, "int unary needs result");
@@ -2063,6 +2155,19 @@ fn expect_int_reg_or_pool(state: &mut AssemblyState, op: &Operand) -> u16 {
     }
 }
 
+fn expect_jitcode_int_operand(
+    state: &mut AssemblyState,
+    op: &Operand,
+    allow_short: bool,
+) -> JitCodeIntOperand {
+    match op {
+        Operand::ConstInt(value) if allow_short && (-128..=127).contains(value) => {
+            JitCodeIntOperand::ShortConst(*value as i8)
+        }
+        _ => JitCodeIntOperand::Register(expect_int_reg_or_pool(state, op)),
+    }
+}
+
 /// Normalize a `ConstRef` value before it enters the jitcode `constants_r`
 /// pool.  A tagged small-int immediate would be baked verbatim as a
 /// `ConstPtr(GcRef(tagged))` that an in-trace `GuardClass` derefs as a heap
@@ -2406,6 +2511,50 @@ mod tests {
         assert_eq!(insns.get("live/"), wellknown.get("live/"));
         assert_eq!(insns.get("ref_return/r"), wellknown.get("ref_return/r"));
         assert_eq!(insns.get("goto/L"), wellknown.get("goto/L"));
+    }
+
+    #[test]
+    fn assemble_allocates_only_the_short_constant_shapes_that_appear() {
+        let mut assembler = Assembler::new();
+        let mut ssarepr = SSARepr::new("short_constants");
+        ssarepr.insns.push(Insn::op_with_result(
+            "int_sub",
+            vec![Operand::ConstInt(48), Operand::Register(r(Kind::Int, 1))],
+            r(Kind::Int, 2),
+        ));
+        ssarepr.insns.push(Insn::op(
+            "goto_if_not_int_gt",
+            vec![
+                Operand::Register(r(Kind::Int, 2)),
+                Operand::ConstInt(2),
+                Operand::TLabel(TLabel::new("done")),
+            ],
+        ));
+        ssarepr.insns.push(Insn::Label(Label::new("done")));
+        ssarepr.insns.push(Insn::op(
+            "ref_return",
+            vec![Operand::Register(r(Kind::Ref, 0))],
+        ));
+
+        let jitcode = assembler.assemble(
+            &mut ssarepr,
+            JitCodeBuilder::default(),
+            Some(NumRegs {
+                int: 3,
+                ref_: 1,
+                ..NumRegs::default()
+            }),
+        );
+        let insns = assembler.insns_snapshot();
+        let sub = *insns.get("int_sub/ci>i").expect("short lhs key");
+        let branch = *insns
+            .get("goto_if_not_int_gt/icL")
+            .expect("short rhs branch key");
+        assert_ne!(sub, branch);
+        assert!(!majit_translate::insns::is_reserved_opcode_byte(sub));
+        assert!(!majit_translate::insns::is_reserved_opcode_byte(branch));
+        assert_eq!(jitcode.code[0], sub);
+        assert_eq!(jitcode.code[4], branch);
     }
 
     #[test]


### PR DESCRIPTION
Six commits on top of `main`, continuing the blackhole work after #1630 merged.

### Blackhole execution

- **`decode and emit the USE_C_FORM short-constant blackhole operands`** — `assembler.py USE_C_FORM` gives a Constant operand of the canonical integer operations an inline signed-byte encoding, chosen *per operand*: `ci`/`ic`/`cc` for the binops and `ciL`/`icL`/`ccL` for the fused comparison branches. `JitCodeIntOperand` names the two kinds one integer position can take; `record_binop_i_operands` / `goto_if_not_int_operands` emit them and `bhhandler_short_binop_i` / `bhhandler_goto_if_not_short` decode them. `record_insn_key` now allocates an unreserved opcode byte for a shape `WELLKNOWN_BH_INSNS` has none for, as `assembler.py`'s `self.insns.setdefault(key, len(self.insns))` does, rather than reserving the Cartesian product up front. `test_blackhole.py test_simple_const` / `test_simple_loop` port over as execution oracles.
- **`cache the RPython string hash in its header word`** — `LLHelpers.ll_strhash`'s zero-sentinel cache in the first Signed word, with the 29872897 substitution. PyPy relies on process serialization for that word; pyre's free-threading contract permits concurrent readers, so the one-word owner is accessed atomically instead of duplicated in a side table.

### Portal runner

- **`reach the portal runner from the blackhole`** — `handle_jitexception_dispatch`'s `ContinueRunningNormally` arm ends at `portal_runner.expect(...)`, and `convert_and_run_from_pyjitpl` passed it a literal `None`. The supplier was `JitDriver::register_portal_runner`, which had **one write and zero reads** and could not have any: the production chain `trace.rs -> drive_multi_frame_blackhole -> convert_and_run_from_pyjitpl` arrives holding `MetaInterpStaticData` and cannot name the driver. Registered as a module hook instead, the shape `register_live_marker_hook` already uses beside it.

  The suite stayed green because the only other caller of `convert_and_run_from_pyjitpl` is a `mod tests` parity test that passes `None` deliberately.

  **Reachability: latent.** An A/B from one binary (an env gate at the consumer restoring the `None`) ran the synthetic corpus both ways: `521/521` on both arms, zero panics, differences confined to startup-timing noise. The defect is real and statically proven; no fixture currently reaches a `ContinueRunningNormally` at a recursive portal level.

### Carried over from #1630 review

- **`assert a real GC type id in bh_new_array`** (wasm) — `descr.py ArrayDescr.get_type_id(): assert self.tid`, which the dynasm and cranelift runners already assert.
- **`name the family_key in the dyn_indirect_target docstring`** — the doc named the wrong consumer of the `(trait_root, method_name)` pair.

### Verification

Rebased onto `1438c0fb04a`. That commit reworks `finish_current_frame_execution`'s inline arm for the `CalleeLocalsShadow` escape, and a sixth commit of ours restructured the same region's `is_top_level` split; it is dropped in favour of main's, which keeps the `frame_finished_execution` store `pyopcode.py:240` performs on every returning frame and retains main's `callee_shadow` fix. The file is now identical to `main`.

`cargo fmt --all --check` and `cargo check --workspace --all-targets` clean; `pyre/check.py --backend dynasm --synthetic-only` `ALL PASSED 521/521` against freshly extracted LLBC artefacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ
