### PR TITLE
cranelift: guard-exit coldness and an opt-in loop-closing bridge merge; metainterp: share a guard's resume arrays

### DIFF
--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -362,7 +362,9 @@ C** (555,383 against 4,514,372). So "if you don't change the `and` and `or`
 ... it's not particularly fast" is not a majit artifact and not a Rust
 artifact — it is a property of the spelling, and upstream pays it in the same
 direction and the same order of magnitude. majit pays it 4.1x harder than
-upstream does, which is the one gap in this table that is majit's own.
+upstream does, which is the one gap in this table that is majit's own — read
+that figure with the re-measurement below, which puts it at the top of a
+3.0-4.1x range.
 
 `PYPYLOG=jit-summary:-` on the `and`/`or` build at 262,144 characters says
 where upstream's time goes: 1 loop, **1185 bridges**, `Tracing 0.145s` +
@@ -372,7 +374,37 @@ so a pass of `n` characters grows at most about `n / 200` bridges however many
 distinct mark patterns the tree has. majit is rate-limited by the same
 parameter and grows 84 over 32,768 characters.
 
-### Where majit's 4.1x goes
+#### Re-measured 2026-09-01: the ratio is 3.0-4.1x, and the absolutes do not travel
+
+The table above was one sitting. Six same-round pairs taken on another --
+three at 1-minute load 4.0-4.6 and three at 5.9-9.2, every pair being the two
+binaries run back to back so one load spike moves both -- put the `and`/`or`
+ratio at **3.02, 3.22, 3.45, 3.56, 3.58 and 4.11**, median about 3.5x. The
+table's 4.09x (555,383 / 135,690) is the top of that range, so whatever the
+allocation work bought is inside this instrument's resolution rather than
+clearly above it. Claiming a speedup from it would not be supportable.
+
+What the six rounds do settle is that **the absolute columns are machine
+state, not results.** Between the two sittings majit's `and`/`or` row moved
+135,690 -> 181,717-330,438 and RPython's moved 555,383 -> 548,352-1,269,859:
+both about 2x, in the same direction, from nothing but the machine. Inside the
+second sitting the *same* RPython binary read 1,184,427 and then 663,658 a few
+minutes later as load went 4.0 to 9.2 -- 1.78x on one arm with nothing
+changed. Read every chars/s figure in this file as a ratio against the number
+printed beside it in the same round, never against a number from another day.
+
+Three things did reproduce. RPython's two `--opt=2` columns come back within
+1.11x and 1.13x of what is tabulated, and its JIT is 6.7x slower than its own
+C on this spelling against the 8.1x recorded -- so "both JITs lose to their
+own C, and majit loses harder" survives. The masking row read 0.88x, 1.61x and
+1.08x of RPython, but RPython's own masking column swung 2.02x across those
+same rounds, so that round resolves nothing finer than "consistent with the
+parity the table reports". And the allocation census, which does not depend on
+the machine at all, reproduces to the digit: 11.4 allocations and 1,360.4
+bytes per input character. That is why the census is the instrument this gap
+is graded with.
+
+### Where majit's share of that gap goes
 
 Three theories about that gap were measured and two of them were wrong, so the
 numbers matter more than the reasoning:
@@ -395,7 +427,7 @@ halves of that were wrong:
 
 The native callee call is at parity. `[bh-setpos]` and `[bh-frame]` are both
 33,222, so not one `inline_call` seats an interpreted frame — every one takes
-the native arm. The blackhole is 1.5x, not 55x, and 1.5x cannot produce 4.1x.
+the native arm. The blackhole is 1.5x, not 55x, and 1.5x cannot produce a 3-4x.
 
 The register-copy row was a real deviation. The proc-macro lowerer allocated
 every temporary monotonically, while upstream runs

--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -432,7 +432,8 @@ its resume data in a nursery; majit still builds both out of `Rc<Op>` and
 per-guard vectors. This pass removes one common-case tax: upstream stores
 `GuardResOp._fail_args` only on guards, so the unified Rust `Op` no longer
 embeds three inline `Operand` slots in every ordinary operation. `Op` allocations
-fall from 296 to 256 bytes. The remaining allocation traffic is still the
+fall from 280 to 240 bytes: that field measures 72 bytes as a
+`SmallVec<[Operand; 3]>` against 32 as a `Vec` header. The remaining allocation traffic is still the
 largest majit-only cost; it is now smaller, not gone.
 
 ### Driver ownership is now the same on both sides
@@ -514,11 +515,12 @@ already stable:
   to ask `is_const` or obtain its value. `OptBoxEnv` and `force_box` now answer
   directly from the resolved operand, and `TraceIterator` preserves an already
   decoded constant.
-* `bhimpl_jit_merge_point` allocated six new `Vec` backings and boxed the
-  144-byte `ContinueRunningNormallyArgs` payload on every deopt. The pooled
-  blackhole frame retains the cleared backing capacities, while the control
-  payload moves inline through `DispatchError` and `JitException` and then back
-  into that frame.
+* `bhimpl_jit_merge_point` allocated six new `Vec` backings and a fresh
+  144-byte `ContinueRunningNormallyArgs` box on every deopt. The pooled
+  blackhole frame now retains that box together with the six cleared backing
+  capacities: the handoff crosses `DispatchError` and `JitException` as a
+  `Box`, so neither enum is widened by a variant only a deopt reaches, and the
+  same box returns to the frame once the payload has been consumed.
 
 At 65,536 characters these changes move the measured row from 45.6 allocations
 and 7,517 bytes per character to 21.6 and 2,891 (−52.6% and −61.5%). At the

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -17,6 +17,8 @@ cover the condition they diagnose.
 | `MAJIT_CALLEE_CENSUS` | OFF | Reports resolved and unresolved translation callees; remove when every supported callee is classified. |
 | `MAJIT_CALLEE_CENSUS_ROWS` | value | Limits rows printed by `MAJIT_CALLEE_CENSUS`; remove with that census. |
 | `MAJIT_CALLEE_RCA` | OFF | Reports metainterpreter callee-resolution decisions; remove when those decisions are covered by focused tests. |
+| `MAJIT_CL_BRIDGE_MERGE` | OFF | Re-emits a bridge that closes onto its owner loop into that loop's own Cranelift function, so the guard reaches it by a block jump instead of a recovery stub and an indirect call; measured faster on every branching row, but it miscompiles (16 `pyre/check.py` checks separate the two arms), so it stays off until that is found and the route can become the default. |
+| `MAJIT_CL_BRIDGE_MERGE_LOG` | OFF | Prints one line per merge attempt — merged, or the reason it was declined — for the gate above; remove it with that gate. |
 | `MAJIT_CL_NO_CLOSING_JUMP` | OFF | Disables Cranelift's in-code closing jump to exercise external jump dispatch; remove when that fallback no longer needs comparison coverage. |
 | `MAJIT_DESCR_POOL_CENSUS` | OFF | Reports descriptor interning and duplication; remove when descriptor identity is covered by ordinary tests. |
 | `MAJIT_DETERMINISM_TRACE` | OFF | Prints inputs used to diagnose nondeterministic translation output; remove when deterministic output is enforced structurally. |

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5679,6 +5679,21 @@ fn resolve_opref_or_imm(
     use_declared_var_or_panic(builder, opref, "resolve_opref_or_imm")
 }
 
+/// The frame slot each of an attached bridge's inputargs is read from, in
+/// bridge inputarg order — `rebuild_faillocs_from_descr` decoded onto this
+/// guard by `collect_guards`.
+///
+/// An empty `bridge_source_slots` is the plain-identity case, the one
+/// `emit_attached_bridge_dispatch` skips its compaction for: the descr carries
+/// no `rd_locs`, so the k-th entry value is the k-th logical fail arg.
+fn bridge_entry_slots(info: &GuardInfo, arity: usize) -> Vec<usize> {
+    if info.bridge_source_slots.is_empty() {
+        (0..arity).collect()
+    } else {
+        info.bridge_source_slots.clone()
+    }
+}
+
 fn resolve_failarg_opref(
     builder: &mut FunctionBuilder,
     constants: &indexmap::IndexMap<u32, i64>,
@@ -7203,6 +7218,336 @@ fn emit_attached_loop_dispatch(
 ///   1. save result to jf_frame[0]
 ///   2. MOV [ebp + jf_descr], faildescrindex
 ///   3. _call_footer
+/// A bridge whose closing JUMP lands on a LABEL of the loop it attaches to,
+/// merged into that loop's own cranelift function rather than left as a
+/// separate one.
+///
+/// `patch_jump_for_descr` gives the same shape a jump: the guard branches into
+/// the bridge and the bridge's `closing_jump` branches back, both inside one
+/// code blob with the values in registers. Cranelift cannot jump between
+/// functions, so a bridge kept out of line costs two function entries and a
+/// jitframe round trip per crossing. Merging restores the branch.
+///
+/// The wasm backend carries the same construct as `codegen::InlinedBridge`,
+/// with the placement bookkeeping wasm's structured control flow needs; the two
+/// merges share `value_id_end` and the id rebase, and will be unified once this
+/// side is proven.
+struct MergedRegion {
+    /// Per-trace fail index of the owner guard that enters this region.
+    source_fail_index: u32,
+    /// The region's own inputargs, positionally the owner guard's live fail
+    /// args (`bridge_source_slots`).
+    inputargs: Vec<InputArg>,
+    ops: Vec<Op>,
+    /// The constant pool registered for the region's own trace. A pool is
+    /// per-trace (`Backend::set_constants_pool` names the next compile) and its
+    /// keys are in that trace's value numbering, so the merge rebases them with
+    /// the region.
+    constants: majit_ir::ConstMap<majit_ir::Const>,
+    /// Where this region's reference constants start in the merged trace's
+    /// `GcTable`. The rewrite indexes each stream's table from zero, so every
+    /// `LoadFromGcTable` the region carries is shifted onto its own extension of
+    /// the owner's. Zero on a region as recorded, set when it is prepared.
+    gc_table_base: i64,
+}
+
+impl Clone for MergedRegion {
+    fn clone(&self) -> Self {
+        Self {
+            source_fail_index: self.source_fail_index,
+            // `InputArg` is not `Clone`: a copy has to be minted, not shared.
+            inputargs: self
+                .inputargs
+                .iter()
+                .map(InputArg::fresh_value_copy)
+                .collect(),
+            ops: self.ops.clone(),
+            constants: self.constants.clone(),
+            gc_table_base: self.gc_table_base,
+        }
+    }
+}
+
+/// Where one merged region landed in the merged stream.
+struct MergedRegionEntry {
+    source_fail_index: u32,
+    /// Index in the merged `ops` of the region's first operation.
+    ops_start: usize,
+    /// Value ids the region's inputargs occupy after the rebase, in order.
+    inputarg_ids: Vec<u32>,
+}
+
+/// The owner's stream with every region appended to it.
+struct MergedStream {
+    inputargs: Vec<InputArg>,
+    ops: Vec<Op>,
+    constants: majit_ir::ConstMap<majit_ir::Const>,
+    entries: Vec<MergedRegionEntry>,
+}
+
+/// Regions one loop takes before further merges are declined. Each merge
+/// re-emits the owner's function, so the cost of the next one grows with the
+/// stream; the cap bounds both that and the code size a hot loop reaches.
+const MAX_MERGED_REGIONS: usize = 8;
+
+/// Operations the merged stream may reach before further merges are declined.
+const MAX_MERGED_OPS: usize = 4096;
+
+/// Whether `bridge` leaves through a LABEL that `owner` publishes, with the
+/// arity that LABEL was compiled at.
+///
+/// That is what makes the merge worth taking: `do_compile`'s Jump lowering
+/// resolves such a target to a local block and emits a plain `jump`, so the
+/// region's exit becomes a branch. A JUMP naming a LABEL of another loop, or
+/// naming one of these with a different arg count, still lowers as an external
+/// jump — a tail call through the frame — and merging buys nothing.
+fn bridge_closes_onto(owner_ops: &[Op], bridge_ops: &[Op]) -> bool {
+    let label_arity: IndexMap<u32, usize> = owner_ops
+        .iter()
+        .filter(|op| op.opcode == OpCode::Label)
+        .filter_map(|op| op.getdescr().map(|d| (d.index(), op.num_args())))
+        .collect();
+    if label_arity.is_empty() {
+        return false;
+    }
+    bridge_ops.iter().any(|op| {
+        op.opcode == OpCode::Jump
+            && op.getdescr().is_some_and(|d| {
+                label_arity
+                    .get(&d.index())
+                    .is_some_and(|&arity| arity == op.num_args())
+            })
+    })
+}
+
+/// Whether `r` names an ordinary value id — the only kind a merge renumbers.
+///
+/// Everything else passes through a rebase untouched and stays out of the width
+/// the next region is offset by: a constant carries an inline payload and has no
+/// id at all, a `TempVar` id lives in the reserved sentinel strip above
+/// `VALUE_ID_LIMIT`, and a result-less op's `pos` is a *typed* none —
+/// `op_typed(OpRef::NONE.raw(), Void)` builds `VoidOp(u32::MAX)`, which the
+/// `OpRef::None` variant match in `is_none()` does not catch, so the raw is what
+/// has to be tested.
+fn names_a_value_id(r: OpRef) -> bool {
+    !r.is_constant() && r.raw() < OpRef::VALUE_ID_LIMIT
+}
+
+/// One past the highest value id `inputargs` and `ops` name.
+fn value_id_end(inputargs: &[InputArg], ops: &[Op]) -> u32 {
+    let mut end: u32 = 0;
+    let widen = |r: OpRef, end: &mut u32| {
+        if names_a_value_id(r) && r.raw() + 1 > *end {
+            *end = r.raw() + 1;
+        }
+    };
+    for ia in inputargs {
+        if ia.index + 1 > end {
+            end = ia.index + 1;
+        }
+    }
+    for op in ops {
+        widen(op.pos.get(), &mut end);
+        for a in op.getarglist().iter() {
+            widen(a.to_opref(), &mut end);
+        }
+        if let Some(fa) = op.getfailargs() {
+            for a in fa.iter() {
+                widen(a.to_opref(), &mut end);
+            }
+        }
+    }
+    end
+}
+
+/// Move every value id `region` defines or reads up by `offset`, returning the
+/// rebased ops, inputargs and the width of the id range they now occupy.
+///
+/// The owner and each region are separately recorded traces, so both number
+/// their values from zero and their ids overlap. A region is entered with the
+/// owner's live guard values and leaves through the owner's loop header, so an
+/// id it shares with an owner value that is live across the back edge would
+/// overwrite that value for every following iteration. Rebasing onto a disjoint
+/// range is what makes the merged stream's single value namespace sound.
+///
+/// What is and is not renumbered is `names_a_value_id`.
+fn rebase_merged_region(
+    region: &MergedRegion,
+    offset: u32,
+) -> Result<(Vec<InputArg>, Vec<Op>, u32), BackendError> {
+    use majit_ir::operand::Operand;
+
+    let shift = |r: OpRef| -> OpRef {
+        if names_a_value_id(r) {
+            r.with_raw(r.raw() + offset)
+        } else {
+            r
+        }
+    };
+
+    let width = value_id_end(&region.inputargs, &region.ops);
+    // `with_raw` keeps the variant, but readers classify by raw payload, so an
+    // id shifted to or past the limit reads as a constant. Decline instead: the
+    // merged stream is an optimization, and no renumbering is correct once the
+    // region's range no longer fits below the limit.
+    if offset
+        .checked_add(width)
+        .is_none_or(|end| end > OpRef::VALUE_ID_LIMIT)
+    {
+        return Err(BackendError::Unsupported(format!(
+            "cranelift backend: merged region value ids exceed the value-id \
+             space (offset {offset}, width {width})"
+        )));
+    }
+    let inputargs: Vec<InputArg> = region
+        .inputargs
+        .iter()
+        .map(|ia| InputArg::from_type(ia.tp, ia.index + offset))
+        .collect();
+    // `Op::clone` gives the copy its own arg/failarg slots, but the operands in
+    // them keep pointing at the region's original producers, whose `pos` this
+    // must not touch — the region is retained for the next re-emission. So each
+    // moved reference is rebound to a synthetic producer carrying the new id.
+    let ops: Vec<Op> = region.ops.to_vec();
+    for op in &ops {
+        op.pos.set(shift(op.pos.get()));
+        // The rewrite indexed this region's reference constants from zero
+        // against its own table; `prepare_and_merge_regions` appended that table
+        // to the owner's, so the index has to move with it.
+        if op.opcode == OpCode::LoadFromGcTable
+            && region.gc_table_base != 0
+            && let Some(majit_ir::Value::Int(index)) = op.arg(0).const_value()
+        {
+            op.setarg(
+                0,
+                Operand::const_from_value(majit_ir::Value::Int(index + region.gc_table_base)),
+            );
+        }
+        for (i, arg) in op.getarglist().iter().enumerate() {
+            let before = arg.to_opref();
+            let after = shift(before);
+            if after != before {
+                op.setarg(i, Operand::bound_from_opref(after));
+            }
+        }
+        if let Some(mut fail_args) = op.getfailargs() {
+            let mut moved = false;
+            for slot in fail_args.iter_mut() {
+                let before = slot.to_opref();
+                let after = shift(before);
+                if after != before {
+                    *slot = Operand::bound_from_opref(after);
+                    moved = true;
+                }
+            }
+            if moved {
+                op.setfailargs(fail_args);
+            }
+        }
+    }
+    Ok((inputargs, ops, width))
+}
+
+/// Refuse a merge whose region cannot be entered on block parameters.
+///
+/// The out-of-line bridge takes its inputargs out of jitframe slots, so a slot
+/// list that does not line up one-for-one with them still works there — the
+/// loader reads what the recovery stub wrote. A region entered by a branch has
+/// no such indirection: every inputarg must have exactly one live fail arg of
+/// the owner guard behind it. Decline instead of emitting a jump whose arity or
+/// operands the region's entry does not match.
+fn check_region_entry_slots(
+    region_entries: &[MergedRegionEntry],
+    guard_infos: &[GuardInfo],
+) -> Result<(), BackendError> {
+    for entry in region_entries {
+        let arity = entry.inputarg_ids.len();
+        let decline = |why: &str| {
+            Err(BackendError::Unsupported(format!(
+                "cranelift backend: merged region off guard {} {why}",
+                entry.source_fail_index
+            )))
+        };
+        let Some(info) = guard_infos
+            .iter()
+            .find(|info| info.fail_index == entry.source_fail_index)
+        else {
+            return decline("has no guard in the merged stream");
+        };
+        let slots = bridge_entry_slots(info, arity);
+        if slots.len() != arity {
+            return decline(&format!(
+                "reads {} entry value(s) for {arity} inputarg(s)",
+                slots.len()
+            ));
+        }
+        if slots
+            .iter()
+            .any(|&slot| info.fail_arg_refs.get(slot).is_none_or(|r| r.is_none()))
+        {
+            return decline("reads a fail-arg hole");
+        }
+    }
+    Ok(())
+}
+
+/// Append every region to the owner's stream, each rebased off the ids the
+/// owner and the earlier regions already use.
+///
+/// Append-only, as the wasm merge is: a region's ops are the tail of the merged
+/// stream, so the owner's own guards keep the fail indices they were compiled
+/// with and every dispatch cell keyed by one still names the same guard.
+fn merge_regions(
+    inputargs: &[InputArg],
+    ops: &[Op],
+    regions: &[MergedRegion],
+    constants: &majit_ir::ConstMap<majit_ir::Const>,
+) -> Result<MergedStream, BackendError> {
+    let merged_inputargs: Vec<InputArg> =
+        inputargs.iter().map(InputArg::fresh_value_copy).collect();
+    let mut merged_ops: Vec<Op> = ops.to_vec();
+    let mut merged_constants = constants.clone();
+    let mut entries = Vec::with_capacity(regions.len());
+    let mut next_value_id = value_id_end(inputargs, ops);
+    for region in regions {
+        let (region_inputargs, region_ops, width) = rebase_merged_region(region, next_value_id)?;
+        // The pool is keyed by value position for a folded value with no
+        // producing op, so rebasing the region's ids moved its reads off its own
+        // entries. Replay that window at the offset, and drop a key another
+        // trace left inside it; keys outside the window are left alone, because
+        // rewriting them would overwrite the entries the owner's own operations
+        // read.
+        for id in 0..width {
+            match region.constants.get(&id) {
+                Some(c) => {
+                    merged_constants.insert(id + next_value_id, c.clone());
+                }
+                None => {
+                    merged_constants.shift_remove(&(id + next_value_id));
+                }
+            }
+        }
+        next_value_id += width;
+        entries.push(MergedRegionEntry {
+            source_fail_index: region.source_fail_index,
+            ops_start: merged_ops.len(),
+            inputarg_ids: region_inputargs.iter().map(|ia| ia.index).collect(),
+        });
+        // The region's own inputargs deliberately stay out of `merged_inputargs`:
+        // a region is entered on block parameters, so counting them into
+        // `num_inputs` would grow the entry layout every caller of this loop
+        // passes and every `input_types` check made against it. `do_compile`
+        // declares their variables off `MergedRegionEntry::inputarg_ids`.
+        merged_ops.extend(region_ops);
+    }
+    Ok(MergedStream {
+        inputargs: merged_inputargs,
+        ops: merged_ops,
+        constants: merged_constants,
+        entries,
+    })
+}
+
 /// Move every block that only a guard exit can reach out of the trace body.
 ///
 /// `write_pending_failure_recoveries` parity: RPython assembles the whole
@@ -7269,7 +7614,43 @@ fn emit_guard_exit(
     ref_root_base_ofs: i32,
     ptr_type: cranelift_codegen::ir::Type,
     call_conv: cranelift_codegen::isa::CallConv,
+    region_blocks: &IndexMap<u32, Block>,
 ) {
+    // A bridge merged into this function (`MergedRegion`) replaces the whole
+    // exit: `patch_jump_for_descr` rewrites the guard's branch to enter the
+    // bridge, so the failure-recovery stub never runs on a bridge hit, and here
+    // the bridge is in the same function, so its entry values ride block
+    // parameters instead of a jitframe round trip. Everything below —
+    // fail-arg publish, gcmap, write barrier, descr store, the dispatch
+    // cells — is the out-of-line path only.
+    if let Some(&region_block) = region_blocks.get(&info.fail_index) {
+        // `compile_bridge` filtered the bridge's inputargs by
+        // `inputargs_and_holes`, so the region takes the guard's LIVE fail args
+        // in `rd_locs` order — the same list `emit_attached_bridge_dispatch`
+        // compacts the frame slots into for the out-of-line bridge.
+        // `check_region_entry_slots` already refused the merge unless every one
+        // of these slots exists and holds a live fail arg.
+        let arity = builder.block_params(region_block).len();
+        let vals: Vec<CValue> = bridge_entry_slots(info, arity)
+            .iter()
+            .map(|&slot| info.fail_arg_refs[slot])
+            .map(|arg_ref| {
+                resolve_failarg_opref(
+                    builder,
+                    constants,
+                    jf_ptr,
+                    ref_root_slots,
+                    stale_ref_vars,
+                    demoted_failarg_slots,
+                    ref_root_base_ofs,
+                    arg_ref,
+                )
+            })
+            .collect();
+        let args = block_args_to(builder, region_block, &vals);
+        builder.ins().jump(region_block, &args);
+        return;
+    }
     // _push_all_regs_to_frame / save_into_mem parity:
     // store fail_args to jf_frame[slot]
     //
@@ -7536,6 +7917,26 @@ fn emit_guard_exit(
 
 // Compiled loop data
 
+/// Everything `do_compile` needs to emit this loop's function again.
+///
+/// Kept because a bridge that closes back onto the loop is merged into it
+/// (`MergedRegion`), and the merge is append-only: each re-emission replays the
+/// owner's own stream plus every region taken so far.
+struct ReemitInputs {
+    inputargs: Vec<InputArg>,
+    ops: Vec<Op>,
+    /// The pool the owner's own compile was given. Each region's pool is merged
+    /// onto this one by `merge_regions`, never into it.
+    constants: majit_ir::ConstMap<majit_ir::Const>,
+    invalidation_flag_ptr: Option<usize>,
+    /// The compiling driver's one-shot `set_next_frame_value_count_fn`. A
+    /// re-emission is the same trace compiled again, so it has to decode the
+    /// `-live-` marker with the same counter the first emission used rather
+    /// than fall back to the process-global callback.
+    frame_value_count_fn: Option<fn(i32, i32) -> usize>,
+    regions: Vec<MergedRegion>,
+}
+
 struct CompiledLoop {
     trace_id: u64,
     input_types: Vec<Type>,
@@ -7576,12 +7977,35 @@ struct CompiledLoop {
     /// `register_fail_descrs`), because a bridge's `CompiledLoop` is
     /// consumed into `BridgeData` and would otherwise drop the table.
     gc_table: Option<Arc<majit_gc::GcTable>>,
+    /// The stream this loop was emitted from, for a later merge. `None` on a
+    /// trace no merge applies to — a bridge, or a loop whose re-emission has
+    /// been declined.
+    reemit: RefCell<Option<ReemitInputs>>,
+    /// Set once a re-emission carrying one more merged region has been
+    /// installed. Readers reach the live code through `current`.
+    ///
+    /// The superseded link is kept rather than dropped: its code can still be
+    /// running (the merge is installed from the host while a deopt is being
+    /// serviced, but a frame entered earlier returns through the old body), and
+    /// the arena range it occupies is owned by the `CompiledLoopToken` for the
+    /// life of the token either way.
+    superseded_by: OnceLock<Box<CompiledLoop>>,
 }
 
 unsafe impl Send for CompiledLoop {}
 unsafe impl Sync for CompiledLoop {}
 
 impl CompiledLoop {
+    /// The live code for this loop: the last re-emission installed, or this one
+    /// when none has been.
+    fn current(&self) -> &CompiledLoop {
+        let mut cur = self;
+        while let Some(next) = cur.superseded_by.get() {
+            cur = next;
+        }
+        cur
+    }
+
     #[inline]
     fn terminal_exit_layouts_ref(&self) -> &Vec<TerminalExitLayout> {
         unsafe { &*self.terminal_exit_layouts.get() }
@@ -8430,10 +8854,8 @@ fn run_compiled_code_inner(
 struct GuardInfo {
     /// Source operation whose failure layout this metadata describes.
     source_op_index: usize,
-    #[expect(
-        dead_code,
-        reason = "guard metadata keeps the assigned fail index alongside emitted layouts"
-    )]
+    /// This exit's ordinal within the trace, the number a `ResumeGuardDescr`
+    /// is keyed by and the one a merged region names as its `source_fail_index`.
     fail_index: u32,
     can_have_bridge: bool,
     fail_arg_refs: Vec<OpRef>,
@@ -8820,6 +9242,7 @@ impl CraneliftBackend {
             .compiled
             .get()
             .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)
         {
             Some(c) => c,
             None => return,
@@ -8830,6 +9253,7 @@ impl CraneliftBackend {
                 .compiled
                 .get()
                 .and_then(|c| c.downcast_ref::<CompiledLoop>())
+                .map(CompiledLoop::current)
             {
                 for prev_d in &prev_compiled.fail_descrs {
                     if fail_descr_has_bridge(as_fd(prev_d)) {
@@ -9500,6 +9924,210 @@ impl CraneliftBackend {
         deadframe_from_jitframe(exec.jf_gcref, fail_descr.clone(), exec.heap_owner)
     }
 
+    /// Merge a bridge that closes back onto its owner's loop into that loop's
+    /// own function, and install the re-emission.
+    ///
+    /// `patch_jump_for_descr` makes a bridge hit a jump: the guard branches into
+    /// the bridge and `closing_jump` branches back, one code blob, values in
+    /// registers. Cranelift cannot jump between functions, so an out-of-line
+    /// bridge pays two function entries and two jitframe round trips per
+    /// crossing — measured at 5.5ns against dynasm's 0.28ns on a loop taking the
+    /// bridge every seventh iteration. Emitting the bridge inside the owner
+    /// restores the branch.
+    ///
+    /// This is the cranelift half of what the wasm backend does with
+    /// `install_inline_region`; wasm defers the merge behind an entry count
+    /// because its re-emission rebuilds a whole module, while a cranelift
+    /// re-emission is one function.
+    ///
+    /// `Err` names why the merge was declined and leaves the owner exactly as it
+    /// was, for a caller that still has the out-of-line bridge to reach the
+    /// guard through.
+    fn merge_bridge_into_owner(
+        &mut self,
+        original_token: &JitCellToken,
+        source_fail_index: u32,
+        inputargs: &[InputArg],
+        ops: &[Op],
+        constants: majit_ir::ConstMap<majit_ir::Const>,
+    ) -> Result<(), &'static str> {
+        if original_token.is_invalidated() {
+            return Err("owner invalidated");
+        }
+        // A region carrying a CALL_ASSEMBLER would put a call site into the
+        // merged stream that `install_call_assembler_expectations` was never
+        // told about for this caller. Decline rather than re-derive the merged
+        // expectation set: the out-of-line bridge is already correct.
+        if ops.iter().any(|op| {
+            matches!(
+                op.opcode,
+                OpCode::CallAssemblerI
+                    | OpCode::CallAssemblerR
+                    | OpCode::CallAssemblerF
+                    | OpCode::CallAssemblerN
+            )
+        }) {
+            return Err("region calls assembler");
+        }
+        let Some(owner) = original_token
+            .compiled
+            .get()
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)
+        else {
+            return Err("owner not compiled");
+        };
+        // Taken, not borrowed: a re-emission that fails must leave the owner
+        // without retained inputs rather than invite the same failing merge on
+        // the next bridge.
+        let Some(mut seed) = owner.reemit.borrow_mut().take() else {
+            return Err("owner has no retained stream");
+        };
+        let declined = if ops.iter().any(|op| op.opcode == OpCode::Label) {
+            // A region is entered through the block its owner guard branches
+            // to, never through a header of its own. A LABEL inside one would
+            // take over `loop_block`, the preamble split and the entry
+            // `br_table` — all of which belong to the owner loop.
+            Some("region carries a LABEL")
+        } else if seed.regions.len() >= MAX_MERGED_REGIONS {
+            Some("region budget spent")
+        } else if seed.ops.len()
+            + seed.regions.iter().map(|r| r.ops.len()).sum::<usize>()
+            + ops.len()
+            > MAX_MERGED_OPS
+        {
+            Some("op budget spent")
+        } else if !bridge_closes_onto(&seed.ops, ops) {
+            Some("bridge does not close onto the owner")
+        } else {
+            None
+        };
+        if let Some(why) = declined {
+            *owner.reemit.borrow_mut() = Some(seed);
+            return Err(why);
+        }
+        seed.regions.push(MergedRegion {
+            source_fail_index,
+            inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+            ops: ops.to_vec(),
+            constants,
+            gc_table_base: 0,
+        });
+        self.constants = seed.constants.clone();
+        // A re-emission is the same trace, not a new one. Its identity is what
+        // every descr the merged stream re-stamps carries, and what the
+        // metainterp looks this loop up by, so it has to be the owner's.
+        self.next_trace_id = Some(owner.trace_id);
+        self.next_header_pc = Some(owner.header_pc);
+        self.next_frame_value_count_fn = seed.frame_value_count_fn;
+        let compiled = self.do_compile(
+            &seed.inputargs,
+            &seed.ops,
+            seed.invalidation_flag_ptr,
+            None,
+            owner.caller_prefix_layout.as_ref(),
+            &seed.regions,
+        );
+        // `do_compile` consumes all three, but only past the validation it can
+        // fail at; clear them so a declined merge leaves nothing for the next
+        // compile to inherit.
+        self.next_trace_id = None;
+        self.next_header_pc = None;
+        self.next_frame_value_count_fn = None;
+        let Ok(mut compiled) = compiled else {
+            seed.regions.pop();
+            *owner.reemit.borrow_mut() = Some(seed);
+            return Err("merged stream did not compile");
+        };
+        compiled.green_key = original_token.green_key();
+        if register_call_assembler_target(original_token, &compiled, self.attached_descr_ptrs())
+            .is_err()
+            || install_call_assembler_expectations(
+                CallAssemblerCallerId::RootLoop(original_token.number),
+                &seed.ops,
+            )
+            .is_err()
+        {
+            // The owner's own registration still names the superseded body,
+            // which is live and correct; nothing was published for the new one.
+            seed.regions.pop();
+            *owner.reemit.borrow_mut() = Some(seed);
+            return Err("merged stream could not be published");
+        }
+        self.register_fail_descrs(original_token, &compiled.fail_descrs);
+        if let Some(table) = compiled.gc_table.clone() {
+            self.register_gc_table(original_token, table);
+        }
+        {
+            let clt = original_token.compiled_loop_token_expect();
+            for descr in &compiled.fail_descrs {
+                let fd = as_fd(descr);
+                if !(fd.is_resume_guard() || fd.is_resume_guard_copied()) {
+                    continue;
+                }
+                fd.set_rd_loop_token_clt(
+                    std::sync::Arc::clone(&clt) as std::sync::Arc<dyn std::any::Any + Send + Sync>
+                );
+            }
+            clt.asmmemmgr_blocks.lock().extend(
+                compiled
+                    .asm_memory_blocks
+                    .drain(..)
+                    .map(|block| Box::new(block) as Box<dyn std::any::Any + Send>),
+            );
+        }
+        // The re-emission carries the retained stream forward: the next merge
+        // replays the owner plus every region taken so far.
+        *compiled.reemit.borrow_mut() = Some(seed);
+        match owner.superseded_by.set(Box::new(compiled)) {
+            Ok(()) => Ok(()),
+            Err(_) => Err("owner already superseded"),
+        }
+    }
+
+    /// Prepare every region the way `do_compile` prepared the owner, then
+    /// rebase and append them.
+    ///
+    /// A region is prepared in the value and constant namespace it was recorded
+    /// and first compiled in, the same one the standalone bridge used, so the
+    /// rewrite's fresh positions land above that region's own high-water mark
+    /// and are carried onto the owner's range by the single rebase below.
+    ///
+    /// `gcrefs` is the owner's reference-constant table, extended per region;
+    /// each region's `LoadFromGcTable` index is shifted onto its extension.
+    fn prepare_and_merge_regions(
+        &mut self,
+        inputargs: &[InputArg],
+        owner_ops: &[Op],
+        regions: &[MergedRegion],
+        gcrefs: &mut Vec<GcRef>,
+    ) -> Result<MergedStream, BackendError> {
+        let mut prepared = Vec::with_capacity(regions.len());
+        for region in regions {
+            validate_call_assembler_rewrite_prereqs(&region.ops)?;
+            let owner_constants = std::mem::replace(&mut self.constants, region.constants.clone());
+            let (ops, region_gcrefs) = self.prepare_ops_for_compile(
+                &region.inputargs,
+                &region.ops,
+                &self.constants.clone(),
+            );
+            let constants = std::mem::replace(&mut self.constants, owner_constants);
+            prepared.push(MergedRegion {
+                source_fail_index: region.source_fail_index,
+                inputargs: region
+                    .inputargs
+                    .iter()
+                    .map(InputArg::fresh_value_copy)
+                    .collect(),
+                ops,
+                constants,
+                gc_table_base: gcrefs.len() as i64,
+            });
+            gcrefs.extend(region_gcrefs);
+        }
+        merge_regions(inputargs, owner_ops, &prepared, &self.constants)
+    }
+
     fn do_compile(
         &mut self,
         inputargs: &[InputArg],
@@ -9507,11 +10135,49 @@ impl CraneliftBackend {
         invalidation_flag_ptr: Option<usize>,
         source_guard: Option<(u64, u32)>,
         caller_layout: Option<&ExitRecoveryLayout>,
+        regions: &[MergedRegion],
     ) -> Result<CompiledLoop, BackendError> {
+        // Captured before the merge and the GC rewrite shadow them: a
+        // re-emission replays the owner's OWN stream and pool, with every region
+        // appended again from scratch.
+        let reemit = source_guard.is_none().then(|| ReemitInputs {
+            inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+            ops: ops.to_vec(),
+            constants: self.constants.clone(),
+            invalidation_flag_ptr,
+            // Read before the one-shot below consumes it.
+            frame_value_count_fn: self.next_frame_value_count_fn,
+            regions: regions.to_vec(),
+        });
         validate_call_assembler_rewrite_prereqs(ops)?;
-        let (prepared_ops, gcrefs) =
+        let (owner_prepared, mut gcrefs) =
             self.prepare_ops_for_compile(inputargs, ops, &self.constants.clone());
-        let ops = prepared_ops.as_slice();
+        // Every region is appended already prepared, and only then: the rewrite
+        // is what fixes a stream's op count — it inserts a `LoadFromGcTable`
+        // ahead of the op whose constant it replaces, and expands a nursery
+        // allocation in place — so preparing after the append would leave every
+        // `MergedRegionEntry::ops_start` naming an op the rewrite had moved.
+        // Everything downstream sees one trace, which is what the OpRef
+        // validation and the guard collection need.
+        let merged = if regions.is_empty() {
+            None
+        } else {
+            Some(self.prepare_and_merge_regions(
+                inputargs,
+                &owner_prepared,
+                regions,
+                &mut gcrefs,
+            )?)
+        };
+        let (inputargs, ops) = match merged.as_ref() {
+            Some(m) => (m.inputargs.as_slice(), m.ops.as_slice()),
+            None => (inputargs, owner_prepared.as_slice()),
+        };
+        if let Some(m) = merged.as_ref() {
+            self.constants = m.constants.clone();
+        }
+        let region_entries: &[MergedRegionEntry] =
+            merged.as_ref().map_or(&[], |m| m.entries.as_slice());
         // assembler.py:793-824 parity: build the per-loop gc_table from
         // the rewrite's reference-constant list. Its base address is baked
         // by the `LoadFromGcTable` genop; the strong `Arc` is moved into
@@ -10171,6 +10837,18 @@ impl CraneliftBackend {
             var_types.insert(ia.index, cl_types::I64);
             declared_vars.insert(ia.index);
         }
+        // A merged region's inputargs are bound by the branch its owner guard
+        // takes, not by the entry prologue, so they are declared here rather
+        // than joining `inputargs`. I64 for the same reason the loop above
+        // declares its own: a trace entry carries every value as a raw 64-bit
+        // word, and this must run before the op-argument loop below, which
+        // would otherwise type them off their OpRef variant.
+        for entry in region_entries {
+            for &id in &entry.inputarg_ids {
+                var_types.insert(id, cl_types::I64);
+                declared_vars.insert(id);
+            }
+        }
         // Declare variables for op results
         for (op_idx, op) in ops.iter().enumerate() {
             if op.result_type() != Type::Void {
@@ -10458,6 +11136,27 @@ impl CraneliftBackend {
         };
 
         let mut guard_idx: usize = 0;
+        // One entry block per merged region, keyed by the fail index of the
+        // owner guard that enters it. `emit_guard_exit` branches here instead
+        // of publishing an exit; the block's parameters carry the guard's live
+        // fail args, which is the whole point of merging — the out-of-line
+        // bridge takes the same values through jitframe slots.
+        let region_blocks: IndexMap<u32, Block> = region_entries
+            .iter()
+            .map(|entry| {
+                let block = builder.create_block();
+                for _ in 0..entry.inputarg_ids.len() {
+                    builder.append_block_param(block, cl_types::I64);
+                }
+                // A region runs only when its guard fails, which is why the
+                // guard had a bridge compiled for it at all. It is colder than
+                // the body and warmer than a deadframe exit; cranelift has one
+                // bit, and the body is what must stay contiguous.
+                builder.set_cold_block(block);
+                (entry.source_fail_index, block)
+            })
+            .collect();
+        check_region_entry_slots(region_entries, &guard_infos)?;
         let mut last_ovf_flag: Option<CValue> = None;
         let _nursery_inline_count: usize = 0; // reserved for future bridge inline support
 
@@ -10649,8 +11348,29 @@ impl CraneliftBackend {
             // lowers to below — lands in that op's span, and the emitted bytes
             // are unaffected either way. Only the dump reads the mapping back,
             // so the regions are recorded only when it is asked for.
+            //
+            // Set before the region entry below for the same reason it is set
+            // before the LABEL plumbing: the block a merged region opens is
+            // this op's own code, so it belongs in this op's span.
             if dump_offsets {
                 builder.set_srcloc(cranelift_codegen::ir::SourceLoc::new(op_idx as u32));
+            }
+            // A merged region's ops are the tail of the stream, so the walk
+            // reaches them after the owner's own JUMP has terminated its block.
+            // Open the region's block here and bind its inputargs from the
+            // parameters its entering guard passed.
+            if let Some(entry) = region_entries
+                .iter()
+                .find(|entry| entry.ops_start == op_idx)
+            {
+                let block = region_blocks[&entry.source_fail_index];
+                builder.switch_to_block(block);
+                builder.seal_block(block);
+                for (i, &value_id) in entry.inputarg_ids.iter().enumerate() {
+                    let param = builder.block_params(block)[i];
+                    builder.def_var(var(value_id), param);
+                }
+                preamble_phase = false;
             }
             if let Some((_, label_block)) = label_blocks
                 .iter()
@@ -11229,6 +11949,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11264,6 +11985,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11316,6 +12038,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11370,6 +12093,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11416,6 +12140,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11469,6 +12194,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11531,6 +12257,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11569,6 +12296,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11618,6 +12346,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11723,6 +12452,7 @@ impl CraneliftBackend {
                             ref_root_base_ofs,
                             ptr_type,
                             call_conv,
+                            &region_blocks,
                         );
 
                         builder.switch_to_block(cont_block);
@@ -11763,6 +12493,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11786,6 +12517,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     // Create a continuation block for subsequent ops (dead code).
@@ -11840,6 +12572,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -11951,6 +12684,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -12116,6 +12850,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
 
                     builder.switch_to_block(cont_block);
@@ -14499,6 +15234,7 @@ impl CraneliftBackend {
                             ref_root_base_ofs,
                             ptr_type,
                             call_conv,
+                            &region_blocks,
                         );
                     }
                 }
@@ -14518,6 +15254,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
                 }
 
@@ -14674,6 +15411,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
                     builder.switch_to_block(cont_block);
                     builder.seal_block(cont_block);
@@ -14707,6 +15445,7 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                         ptr_type,
                         call_conv,
+                        &region_blocks,
                     );
                     builder.switch_to_block(cont_block);
                     builder.seal_block(cont_block);
@@ -15795,6 +16534,8 @@ impl CraneliftBackend {
             label_block_id += 1;
         }
         Ok(CompiledLoop {
+            reemit: RefCell::new(reemit),
+            superseded_by: OnceLock::new(),
             trace_id,
             input_types: trace_info.input_types.clone(),
             header_pc,
@@ -16930,7 +17671,7 @@ impl majit_backend::Backend for CraneliftBackend {
         // Pass the address of the invalidation flag so GUARD_NOT_INVALIDATED
         // can load from it at runtime.
         let flag_ptr = Arc::as_ptr(&token.invalidated) as *const AtomicBool as usize;
-        let mut compiled = self.do_compile(inputargs, ops, Some(flag_ptr), None, None)?;
+        let mut compiled = self.do_compile(inputargs, ops, Some(flag_ptr), None, None, &[])?;
         compiled.green_key = token.green_key();
         let info = AsmInfo {
             code_addr: compiled.code_ptr as usize,
@@ -17059,6 +17800,9 @@ impl majit_backend::Backend for CraneliftBackend {
         }
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
+        // `do_compile` takes the pool, so the copy the merge needs has to be
+        // made before the out-of-line compile below consumes it.
+        let bridge_constants = self.constants.clone();
         let invalidated_arc = original_token.mint_bridge_invalidation_flag();
         let flag_ptr =
             Arc::as_ptr(&invalidated_arc) as *const std::sync::atomic::AtomicBool as usize;
@@ -17066,6 +17810,7 @@ impl majit_backend::Backend for CraneliftBackend {
             .compiled
             .get()
             .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)
             .ok_or_else(|| {
                 BackendError::CompilationFailed("original token has no compiled loop".to_string())
             })?;
@@ -17115,6 +17860,7 @@ impl majit_backend::Backend for CraneliftBackend {
             Some(flag_ptr),
             Some((source_trace_id, fail_descr.fail_index_per_trace())),
             caller_layout.as_ref(),
+            &[],
         );
         let mut compiled = compiled?;
         // Same invariant as the loop path above: skipping would free the arena
@@ -17247,6 +17993,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     .compiled
                     .get()
                     .and_then(|c| c.downcast_ref::<CompiledLoop>())
+                    .map(CompiledLoop::current)
                     && let Some(prev_descr) = find_fail_descr_in_fail_descrs(
                         &prev_compiled.fail_descrs,
                         source_trace_id,
@@ -17286,6 +18033,30 @@ impl majit_backend::Backend for CraneliftBackend {
             }
         }
 
+        // The out-of-line bridge above is attached and correct; this is the
+        // faster route to the same guard when the bridge closes back onto the
+        // loop it came from. A declined merge leaves it as the only route.
+        if std::env::var_os("MAJIT_CL_NO_BRIDGE_MERGE").is_none() {
+            let fail_index = fail_descr.fail_index_per_trace();
+            let merged = self.merge_bridge_into_owner(
+                original_token,
+                fail_index,
+                inputargs,
+                ops,
+                bridge_constants,
+            );
+            if std::env::var_os("MAJIT_CL_BRIDGE_MERGE_LOG").is_some() {
+                let outcome = match merged {
+                    Ok(()) => "merged".to_string(),
+                    Err(why) => format!("declined: {why}"),
+                };
+                eprintln!(
+                    "[cl-merge] loop {} guard {fail_index}: {outcome}",
+                    original_token.number
+                );
+            }
+        }
+
         Ok(info)
     }
 
@@ -17303,7 +18074,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>());
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current);
         if let Some(compiled) = compiled {
             for (i, &hash) in hashes.iter().enumerate() {
                 if let Some(descr) = compiled.fail_descrs.get(i) {
@@ -17340,7 +18112,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>());
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current);
         if let Some(compiled) = compiled {
             // Use recursive search matching compiled_bridge_fail_descr_layouts.
             let source_descr = find_fail_descr_in_fail_descrs(
@@ -17371,11 +18144,13 @@ impl majit_backend::Backend for CraneliftBackend {
         let old_compiled = old_token
             .compiled
             .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>());
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current);
         let new_compiled = new_token
             .compiled
             .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>());
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current);
         let (Some(old), Some(new)) = (old_compiled, new_compiled) else {
             return;
         };
@@ -17429,7 +18204,8 @@ impl majit_backend::Backend for CraneliftBackend {
             .get()
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
-            .expect("compiled data is not CompiledLoop");
+            .expect("compiled data is not CompiledLoop")
+            .current();
 
         Self::execute_with_inputs(compiled, FrameInputs::Values(args))
     }
@@ -17445,7 +18221,8 @@ impl majit_backend::Backend for CraneliftBackend {
             .get()
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
-            .expect("compiled data is not CompiledLoop");
+            .expect("compiled data is not CompiledLoop")
+            .current();
 
         // `llmodel.py:306-315` unwraps each argument at the store into the
         // frame slot, so the values go from the caller's list to the frame in
@@ -17464,7 +18241,8 @@ impl majit_backend::Backend for CraneliftBackend {
             .get()
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
-            .expect("compiled data is not CompiledLoop");
+            .expect("compiled data is not CompiledLoop")
+            .current();
 
         Self::execute_with_inputs(compiled, FrameInputs::Ints(args))
     }
@@ -17479,7 +18257,8 @@ impl majit_backend::Backend for CraneliftBackend {
             .get()
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
-            .expect("compiled data is not CompiledLoop");
+            .expect("compiled data is not CompiledLoop")
+            .current();
 
         // llmodel.py `execute_token` parity (raw-output variant).
         // PyPy's `execute_token` performs one `func(ll_frame, ...)` call
@@ -17744,7 +18523,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         Some(build_per_trace_layouts(
             &compiled.fail_descrs,
             compiled.trace_id,
@@ -17760,7 +18540,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let original_compiled = original_token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         // Use recursive search to find fail_descrs nested inside bridges.
         let source_descr = find_fail_descr_in_fail_descrs(
             &original_compiled.fail_descrs,
@@ -17783,7 +18564,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         if compiled.trace_id == trace_id {
             return Some(build_per_trace_layouts(
                 &compiled.fail_descrs,
@@ -17800,7 +18582,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         Some(compiled.terminal_exit_layouts_ref().clone())
     }
 
@@ -17813,7 +18596,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let original_compiled = original_token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         let source_descr = original_compiled.fail_descrs.iter().find(|descr| {
             let fd = as_fd(descr);
             fd.fail_index() == source_fail_index && fd.trace_id() == source_trace_id
@@ -17831,7 +18615,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         if compiled.trace_id == trace_id {
             return Some(compiled.terminal_exit_layouts_ref().clone());
         }
@@ -17846,7 +18631,8 @@ impl majit_backend::Backend for CraneliftBackend {
         let compiled = token
             .compiled
             .get()
-            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())?;
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)?;
         if compiled.trace_id == trace_id {
             return Some(CompiledTraceInfo {
                 trace_id: compiled.trace_id,
@@ -17873,6 +18659,7 @@ impl majit_backend::Backend for CraneliftBackend {
             .compiled
             .get()
             .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)
         else {
             return false;
         };
@@ -19666,6 +20453,122 @@ mod tests {
         let moved = backend.get_ref_value(&frame, 0);
         assert_ne!(moved, root);
         assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xD30F_0004);
+    }
+
+    /// A bridge whose JUMP closes back onto its owner's LABEL is merged into
+    /// the owner's own function (`merge_bridge_into_owner`), so the guard
+    /// branches into it instead of publishing a jitframe and dispatching
+    /// through the bridge cache — `patch_jump_for_descr`'s effect.
+    ///
+    /// The region carries a guard of its own, so this also covers a merged
+    /// guard taking a fail index past every one the owner already owns, and a
+    /// constant-pool window rebased onto the owner's pool.
+    #[test]
+    fn bridge_closing_onto_its_owner_merges_into_the_loop() {
+        let mut backend = CraneliftBackend::new();
+        let loop_descr = make_label_descr(1_500_290);
+        let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
+
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        guard.setfailargs(smallvec::smallvec![
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+        ]);
+        let loop_ops = vec![
+            mk_op_with_descr(
+                OpCode::Label,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+                OpRef::NONE.raw(),
+                loop_descr.clone(),
+            ),
+            // i > 0
+            mk_op(
+                OpCode::IntGt,
+                &[OpRef::input_arg_int(0), OpRef::int_op(100)],
+                2,
+            ),
+            guard,
+            // i - 1
+            mk_op(
+                OpCode::IntSub,
+                &[OpRef::input_arg_int(0), OpRef::int_op(101)],
+                3,
+            ),
+            // s + 10
+            mk_op(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(1), OpRef::int_op(102)],
+                4,
+            ),
+            mk_op_with_descr(
+                OpCode::Jump,
+                &[OpRef::int_op(3), OpRef::int_op(4)],
+                OpRef::NONE.raw(),
+                loop_descr.clone(),
+            ),
+        ];
+        let mut loop_constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+        loop_constants.insert(100, 0);
+        loop_constants.insert(101, 1);
+        loop_constants.insert(102, 10);
+        backend.set_constants(loop_constants);
+
+        let token = JitCellToken::new(1_500_291);
+        backend.compile_loop(&inputargs, &loop_ops, &token).unwrap();
+
+        // i counts 3, 2, 1 down to 0 while s takes 10 per iteration; the guard
+        // fails on i == 0 with s == 30.
+        let failed = backend.execute_token(&token, &[Value::Int(3), Value::Int(0)]);
+        assert_eq!(backend.get_int_value(&failed, 0), 0);
+        assert_eq!(backend.get_int_value(&failed, 1), 30);
+        let guard_descr =
+            get_latest_descr_from_deadframe(&failed).expect("guard should produce a descr");
+
+        // s + 100, taken while it stays under 500, then back through the LABEL.
+        let bridge_guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
+        bridge_guard.setfailargs(smallvec::smallvec![
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::int_op(2)),
+        ]);
+        let bridge_ops = vec![
+            mk_op(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(1), OpRef::int_op(110)],
+                2,
+            ),
+            mk_op(OpCode::IntLt, &[OpRef::int_op(2), OpRef::int_op(111)], 3),
+            bridge_guard,
+            mk_op_with_descr(
+                OpCode::Jump,
+                &[OpRef::input_arg_int(0), OpRef::int_op(2)],
+                OpRef::NONE.raw(),
+                loop_descr,
+            ),
+        ];
+        let mut bridge_constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+        bridge_constants.insert(110, 100);
+        bridge_constants.insert(111, 500);
+        backend.set_constants(bridge_constants);
+        backend
+            .compile_bridge(guard_descr, &inputargs, &bridge_ops, &token, &[], None)
+            .unwrap();
+
+        let owner = token
+            .compiled
+            .get()
+            .and_then(|c| c.downcast_ref::<CompiledLoop>())
+            .expect("loop should be compiled");
+        assert!(
+            owner.superseded_by.get().is_some(),
+            "a bridge closing onto its owner's LABEL should have been merged"
+        );
+
+        backend.set_constants(indexmap::IndexMap::new());
+        // 30 -> 130 -> 230 -> 330 -> 430 -> 530, where the region's own guard
+        // fails and publishes its fail args.
+        let frame = backend.execute_token(&token, &[Value::Int(3), Value::Int(0)]);
+        assert_eq!(backend.get_int_value(&frame, 0), 0);
+        assert_eq!(backend.get_int_value(&frame, 1), 530);
     }
 
     /// `demoted_failarg_slots` is trace-global while `loop_phi_keep` is per

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -13,7 +13,7 @@ use cranelift_codegen::Context;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::types as cl_types;
 use cranelift_codegen::ir::{
-    AbiParam, BlockArg, Function, InstBuilder, MemFlagsData, Signature, StackSlotData,
+    AbiParam, Block, BlockArg, Function, InstBuilder, MemFlagsData, Signature, StackSlotData,
     StackSlotKind,
 };
 use cranelift_codegen::settings::{self, Configurable};
@@ -7203,6 +7203,61 @@ fn emit_attached_loop_dispatch(
 ///   1. save result to jf_frame[0]
 ///   2. MOV [ebp + jf_descr], faildescrindex
 ///   3. _call_footer
+/// Move every block that only a guard exit can reach out of the trace body.
+///
+/// `write_pending_failure_recoveries` parity: RPython assembles the whole
+/// trace, collecting each guard's token in `pending_guard_tokens`, and only
+/// then emits the recovery stubs, so no failure-recovery instruction is ever
+/// laid out between two body instructions.
+///
+/// Cranelift's coldness is not transitive -- `Function::is_effectively_cold`
+/// reads the flag on the block itself and nothing else -- while a guard exit
+/// here is a chain of blocks: `emit_guard_exit` is entered on the one block
+/// this backend marks, and the write-barrier arm, the attached-bridge
+/// dispatch, the closing-jump dispatch and the deadframe return that follow it
+/// are all created fresh with no mark.  Those unmarked blocks were laid out
+/// inside the body's range: the three-guard integer loop in
+/// `pyre/bench/raise_catch_loop.py` carried ~75 instructions of exit code
+/// interleaved with its ~31 body instructions, and each iteration branched
+/// over them.
+///
+/// A block whose predecessors are all cold cannot be reached without first
+/// running cold code, so it is cold too.  Run that to a fixpoint.  Coldness is
+/// a layout and register-allocation hint only, so this changes placement and
+/// spill preference, never behaviour.
+fn propagate_cold_blocks(func: &mut Function) {
+    let cfg = cranelift_codegen::flowgraph::ControlFlowGraph::with_function(func);
+    let entry = func.layout.entry_block();
+    let blocks: Vec<Block> = func.layout.blocks().collect();
+    loop {
+        let mut changed = false;
+        for &block in &blocks {
+            if Some(block) == entry || func.layout.is_cold(block) {
+                continue;
+            }
+            // No predecessor at all means unreachable, not cold: leave it to
+            // the layout pass rather than claim a verdict about a block
+            // nothing branches to.
+            let mut reached = false;
+            let mut only_from_cold = true;
+            for pred in cfg.pred_iter(block) {
+                reached = true;
+                if !func.layout.is_cold(pred.block) {
+                    only_from_cold = false;
+                    break;
+                }
+            }
+            if reached && only_from_cold {
+                func.layout.set_cold(block);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
 fn emit_guard_exit(
     builder: &mut FunctionBuilder,
     constants: &indexmap::IndexMap<u32, i64>,
@@ -15462,6 +15517,7 @@ impl CraneliftBackend {
         }
         builder.finalize(frontend_config);
         self.func_ctx = func_ctx;
+        propagate_cold_blocks(&mut func);
 
         // Compile
         let mut ctx = Context::for_function(func);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -9121,6 +9121,11 @@ pub struct CraneliftBackend {
     /// `Backend::set_next_frame_value_count_fn` — the compiling driver's
     /// `-live-` decoder for the `rd_numb` reads below.
     next_frame_value_count_fn: Option<fn(i32, i32) -> usize>,
+    /// Whether a bridge that closes onto its owner is re-emitted into the
+    /// owner's own function (`MAJIT_CL_BRIDGE_MERGE`). Read once here rather
+    /// than per compile so a test can drive the route without an environment
+    /// the rest of the process shares.
+    bridge_merge: bool,
     registered_call_assembler_tokens: IndexSet<u64>,
     registered_call_assembler_bridge_traces: IndexSet<u64>,
     /// llmodel.py: self.vtable_offset — byte offset for vtable in objects.
@@ -9379,6 +9384,7 @@ impl CraneliftBackend {
             next_trace_id: None,
             next_header_pc: None,
             next_frame_value_count_fn: None,
+            bridge_merge: std::env::var_os("MAJIT_CL_BRIDGE_MERGE").is_some(),
             registered_call_assembler_tokens: IndexSet::new(),
             registered_call_assembler_bridge_traces: IndexSet::new(),
             // llmodel.py:64-69: vtable_offset is None when gcremovetypeptr is
@@ -18036,7 +18042,15 @@ impl majit_backend::Backend for CraneliftBackend {
         // The out-of-line bridge above is attached and correct; this is the
         // faster route to the same guard when the bridge closes back onto the
         // loop it came from. A declined merge leaves it as the only route.
-        if std::env::var_os("MAJIT_CL_NO_BRIDGE_MERGE").is_none() {
+        //
+        // Off by default: the merged stream miscompiles. `synth/dict_set`,
+        // `synth/nested_break_not_hot` and `synth/loops_comprehension` fault,
+        // and `synth/exception_escape_hot_callee_tb_node_once` reaches the
+        // collector with an invalid type id, each of them only once a merge has
+        // fired and none of them with this gate unset. Sixteen of the
+        // cranelift suite's checks separate the two arms, so the route stays
+        // opt-in until that is understood.
+        if self.bridge_merge {
             let fail_index = fail_descr.fail_index_per_trace();
             let merged = self.merge_bridge_into_owner(
                 original_token,
@@ -20466,6 +20480,9 @@ mod tests {
     #[test]
     fn bridge_closing_onto_its_owner_merges_into_the_loop() {
         let mut backend = CraneliftBackend::new();
+        // The route is opt-in while it miscompiles; this test is what drives
+        // it, so it asks for it here instead of through the environment.
+        backend.bridge_merge = true;
         let loop_descr = make_label_descr(1_500_290);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -30,6 +30,32 @@ use crate::resoperation::{OpRc, OpRef};
 use crate::value::{Const, GcRef, InputArgRc, Type, Value};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Allocation-free identity source for the small-`ConstInt` arm below.
+///
+/// RPython's opencoder writes small integers directly into the byte stream and
+/// only mints the `ConstInt` object when an iterator decodes the operation. The
+/// legacy structured recorder has to expose an `Operand` immediately, but it
+/// need not ask the process allocator for the overwhelmingly common small-int
+/// object. The high word is an object-identity token; the low word is the
+/// sign-preserving `i32` payload. A clone keeps the token, while a fresh mint
+/// gets a new one, preserving `AbstractValue` identity and hashing.
+static NEXT_SMALL_INT_ID: AtomicU32 = AtomicU32::new(1);
+
+#[inline]
+fn fresh_small_int(value: i64) -> Option<u64> {
+    let value = i32::try_from(value).ok()?;
+    let id = NEXT_SMALL_INT_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+        .unwrap_or_else(|_| panic!("small ConstInt identity space exhausted"));
+    Some((u64::from(id) << 32) | u64::from(value as u32))
+}
+
+#[inline]
+fn small_int_value(encoded: u64) -> i64 {
+    (encoded as u32 as i32) as i64
+}
 
 /// An operand stored in `Op.args` / `Op.fail_args`.
 ///
@@ -45,6 +71,11 @@ pub enum Operand {
     Op(OpRc),
     /// An input-arg producer (`resoperation.py` `AbstractInputArg`).
     InputArg(InputArgRc),
+    /// A freshly-minted `ConstInt` whose value fits in the opencoder's common
+    /// machine-int band. `encoded = identity:u32 | value:i32`; this has the
+    /// same one-word payload as an `Rc`, so it does not enlarge `Operand` or
+    /// the three inline operand slots in every [`Op`](crate::resoperation::Op).
+    SmallInt(u64),
     /// A constant (`history.py/268/314` `ConstInt`/`ConstFloat`/
     /// `ConstPtr`). The value lives in an `Rc<Cell<Value>>`: the `Cell` lets
     /// the GC root walker forward an inline `ConstPtr` `GcRef` in place
@@ -63,6 +94,16 @@ pub enum Operand {
 }
 
 impl Operand {
+    #[inline]
+    fn fresh_const_value(value: Value) -> Operand {
+        if let Value::Int(value) = value
+            && let Some(encoded) = fresh_small_int(value)
+        {
+            return Operand::SmallInt(encoded);
+        }
+        Operand::Const(Rc::new(Cell::new(value)))
+    }
+
     /// Wrap a bound op as `Operand::Op` (`Rc::clone`, cheap). The successor
     /// (`resoperation.py:250`) — no `box_cache` memoization, the `Rc`
     /// itself IS the stable identity.
@@ -80,13 +121,13 @@ impl Operand {
     /// `ConstInt(value)` object construction; identity starts here and is
     /// shared by every read of the slot).
     pub fn const_(value: Const) -> Operand {
-        Operand::Const(Rc::new(Cell::new(value.to_value())))
+        Self::fresh_const_value(value.to_value())
     }
 
     /// A constant operand straight from a [`Value`] — the successor to
     /// a fresh `Rc<Cell<Value>>` const identity (`history.py` `ConstInt`).
     pub fn const_from_value(value: Value) -> Operand {
-        Operand::Const(Rc::new(Cell::new(value)))
+        Self::fresh_const_value(value)
     }
 
     /// The absent-slot sentinel.
@@ -107,7 +148,7 @@ impl Operand {
     pub fn from_opref(r: OpRef) -> Operand {
         match r {
             OpRef::None => Operand::None,
-            OpRef::ConstInt(v) => Operand::Const(Rc::new(Cell::new(Value::Int(v)))),
+            OpRef::ConstInt(v) => Self::fresh_const_value(Value::Int(v)),
             OpRef::ConstFloat(v) => Operand::Const(Rc::new(Cell::new(Value::Float(v)))),
             OpRef::ConstPtr(v) => Operand::Const(Rc::new(Cell::new(Value::Ref(v)))),
             _ => panic!(
@@ -168,6 +209,7 @@ impl Operand {
             Operand::None => OpRef::NONE,
             Operand::Op(op) => op.pos.get(),
             Operand::InputArg(ia) => OpRef::input_arg_typed(ia.index, ia.tp),
+            Operand::SmallInt(encoded) => OpRef::const_int(small_int_value(*encoded)),
             // Re-encodes from the live `Cell` value, so a GC-moved `ConstPtr`
             // reads back at its post-move address (forwarding.rs parity).
             Operand::Const(cell) => match cell.get() {
@@ -185,7 +227,7 @@ impl Operand {
         match self {
             Operand::Op(op) => Some(op.pos.get().raw()),
             Operand::InputArg(ia) => Some(ia.index),
-            Operand::Const(_) | Operand::None => None,
+            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => None,
         }
     }
 
@@ -194,6 +236,7 @@ impl Operand {
         match self {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
+            Operand::SmallInt(_) => Type::Int,
             Operand::Const(cell) => cell.get().get_type(),
             Operand::None => Type::Void,
         }
@@ -203,6 +246,7 @@ impl Operand {
     /// `None` for non-`Const`.
     pub fn const_value(&self) -> Option<Value> {
         match self {
+            Operand::SmallInt(encoded) => Some(Value::Int(small_int_value(*encoded))),
             Operand::Const(cell) => Some(cell.get()),
             _ => None,
         }
@@ -215,6 +259,7 @@ impl Operand {
     /// `history.py` concrete-value read.
     pub fn get_value(&self) -> Option<Value> {
         match self {
+            Operand::SmallInt(encoded) => Some(Value::Int(small_int_value(*encoded))),
             Operand::Const(cell) => Some(cell.get()),
             Operand::Op(op) => op.get_value(),
             Operand::InputArg(ia) => ia.get_value(),
@@ -226,6 +271,7 @@ impl Operand {
     /// parity).
     pub fn const_int(&self) -> Option<i64> {
         match self {
+            Operand::SmallInt(encoded) => Some(small_int_value(*encoded)),
             Operand::Const(cell) => match cell.get() {
                 Value::Int(v) => Some(v),
                 _ => None,
@@ -236,7 +282,7 @@ impl Operand {
 
     /// `resoperation.py is_constant`.
     pub fn is_constant(&self) -> bool {
-        matches!(self, Operand::Const(_))
+        matches!(self, Operand::SmallInt(_) | Operand::Const(_))
     }
 
     pub fn is_inputarg(&self) -> bool {
@@ -269,7 +315,7 @@ impl Operand {
         match (self, other) {
             (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
             (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
-            (Operand::Const(a), Operand::Const(b)) => a.get() == b.get(),
+            (a, b) if a.is_constant() && b.is_constant() => a.const_value() == b.const_value(),
             (Operand::None, Operand::None) => true,
             _ => false,
         }
@@ -291,7 +337,7 @@ impl Operand {
             let forwarded = match &cur {
                 Operand::Op(op) => op.get_forwarded(),
                 Operand::InputArg(ia) => ia.get_forwarded(),
-                Operand::Const(_) | Operand::None => return cur,
+                Operand::SmallInt(_) | Operand::Const(_) | Operand::None => return cur,
             };
             match forwarded {
                 Forwarded::None | Forwarded::Info(_) => return cur,
@@ -337,7 +383,7 @@ impl Operand {
         match self {
             Operand::Op(op) => f(&**op),
             Operand::InputArg(ia) => f(&**ia),
-            Operand::Const(_) | Operand::None => default,
+            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => default,
         }
     }
 
@@ -348,7 +394,7 @@ impl Operand {
         match self {
             Operand::Op(op) => f(&**op),
             Operand::InputArg(ia) => f(&**ia),
-            Operand::Const(_) | Operand::None => panic!(
+            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => panic!(
                 "Operand::{what} on a non-producer operand — only a bound \
                  Op/InputArg carries a _forwarded slot (box identity precondition)"
             ),
@@ -486,7 +532,7 @@ impl Operand {
                     cell.set(v);
                 }
             }
-            Operand::None | Operand::Op(_) | Operand::InputArg(_) => {}
+            Operand::None | Operand::Op(_) | Operand::InputArg(_) | Operand::SmallInt(_) => {}
         }
     }
 }
@@ -506,6 +552,7 @@ impl PartialEq for Operand {
             (Operand::None, Operand::None) => true,
             (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
             (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
+            (Operand::SmallInt(a), Operand::SmallInt(b)) => a == b,
             (Operand::Const(a), Operand::Const(b)) => Rc::ptr_eq(a, b),
             _ => false,
         }
@@ -530,8 +577,12 @@ impl std::hash::Hash for Operand {
                 2u8.hash(state);
                 (Rc::as_ptr(ia) as *const () as usize).hash(state);
             }
-            Operand::Const(cell) => {
+            Operand::SmallInt(encoded) => {
                 3u8.hash(state);
+                encoded.hash(state);
+            }
+            Operand::Const(cell) => {
+                4u8.hash(state);
                 (Rc::as_ptr(cell) as usize).hash(state);
             }
         }
@@ -857,5 +908,32 @@ mod tests {
         // Const has no _forwarded slot -> readers return None (no panic).
         assert!(Operand::const_(Const::Int(0)).ptr_info().is_none());
         assert!(Operand::none().int_bound().is_none());
+    }
+
+    /// The structured-recorder adapter keeps RPython ConstInt object identity
+    /// without allocating the small values that opencoder.py writes inline.
+    #[test]
+    fn small_int_is_inline_but_keeps_fresh_object_identity() {
+        let first = Operand::const_(Const::Int(42));
+        let second = Operand::const_(Const::Int(42));
+        assert!(matches!(first, Operand::SmallInt(_)));
+        assert!(matches!(second, Operand::SmallInt(_)));
+        assert_ne!(
+            first, second,
+            "fresh ConstInt objects have distinct identity"
+        );
+        assert_eq!(first, first.clone(), "cloning preserves ConstInt identity");
+        assert!(first.same_box(&second), "ConstInt.same_box compares values");
+
+        let edge = Operand::const_(Const::Int(i32::MAX as i64));
+        let outside = Operand::const_(Const::Int(i32::MAX as i64 + 1));
+        assert!(matches!(edge, Operand::SmallInt(_)));
+        assert!(matches!(outside, Operand::Const(_)));
+
+        // SmallInt deliberately replaces an Rc-sized payload. Pin this on the
+        // two 64-bit production hosts so adding it cannot silently grow the
+        // three inline Operand slots embedded in every Op.
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(std::mem::size_of::<Operand>(), 16);
     }
 }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -3745,11 +3745,16 @@ mod tests {
     fn ordinary_op_does_not_embed_guard_failarg_inline_storage() {
         // GuardResOp owns `_fail_args` upstream. A previous SmallVec<[Operand;
         // 3]> in the unified Rust Op made every ordinary operation reserve
-        // three Operand slots; keep the common allocation below that old
-        // 280-byte payload on 64-bit targets.
+        // three Operand slots: that field measures 72 bytes against the Vec
+        // header's 32, so Op was 280 and is 240. Bound it at what the change
+        // reached, not merely under the old size, or half a regression passes.
         #[cfg(target_pointer_width = "64")]
         {
-            assert!(std::mem::size_of::<Op>() < 280);
+            assert!(
+                std::mem::size_of::<Op>() <= 240,
+                "Op grew to {} bytes",
+                std::mem::size_of::<Op>()
+            );
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -2947,7 +2947,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // `register_dispatch_jitcode`, so an absent callback is
                 // legitimate and keeps the previous fallback behaviour.
                 let storage = storage?;
-                let rd_numb = storage.rd_numb.as_slice();
+                let rd_numb = storage.rd_numb.as_ref();
                 let rd_consts = storage.rd_consts();
                 let __fvc = majit_ir::resumedata::get_frame_value_count_fn();
                 let __fvc_ref: ::std::option::Option<&dyn Fn(i32, i32) -> usize> =

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
@@ -220,6 +220,18 @@ fn is_aux_builder_method(name: &str) -> bool {
         )
 }
 
+/// Rewrites one builder call's register literals, in argument order.
+///
+/// The pass works on tokens, so a register operand and an ordinary integer
+/// constant are both `Lit::Int` and nothing in the syntax tells them apart.
+/// What separates them is that `remaining` is seeded with exactly this op's
+/// reads and writes and each match spends one: by the time a constant is
+/// visited, the registers it could collide with are already spent. That holds
+/// only because **every builder method lists its register operands before its
+/// constants**. A method taking a constant first would let it consume the slot
+/// and leave the real register literal unrewritten — with the counts still
+/// balancing, so nothing here would report it. Keep new builder methods
+/// registers-first.
 struct LiteralRegisterRewriter<'a> {
     mapping: &'a HashMap<Register, Register>,
     remaining: HashMap<Register, usize>,

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -701,6 +701,25 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
         } else {
             inputargs.iter().map(|arg| arg.tp).collect()
         };
+        // Both resume-layout consumers below decode the same guard-owned
+        // `rd_numb`. RPython keeps one numbering stream on the descr and its
+        // consumers walk that shared data; decoding it twice here duplicated
+        // every vable, vref and frame vector solely to project two Rust layout
+        // views. Decode once and let both projections borrow the result.
+        let decoded_numbering = if let (Some(rd_numb_bytes), Some(rd_consts_data)) =
+            (op.resolved_rd_numb(), op.resolved_rd_consts())
+        {
+            let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
+            Some(majit_ir::resumedata::rebuild_from_numbering(
+                &rd_numb_bytes,
+                &rd_consts_data,
+                &exit_types,
+                fvc_ref,
+                num_virtuals,
+            ))
+        } else {
+            None
+        };
         let resume_layout;
         let storage = if is_guard {
             let mut builder = ResumeDataVirtualAdder::new();
@@ -714,18 +733,10 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             // `resolved_rd_*` chases `descr.prev` (compile.py:849
             // ResumeGuardCopiedDescr.get_resumestorage) so a shared guard
             // reads the donor's resume data without an owned copy.
-            if let (Some(rd_numb_bytes), Some(rd_consts_data)) =
-                (op.resolved_rd_numb(), op.resolved_rd_consts())
+            if let Some((_num_failargs, vable_values, _vref_values, frames)) =
+                decoded_numbering.as_ref()
             {
-                use majit_ir::resumedata::{RebuiltValue, rebuild_from_numbering};
-                let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
-                let (_num_failargs, vable_values, _vref_values, frames) = rebuild_from_numbering(
-                    &rd_numb_bytes,
-                    &rd_consts_data,
-                    &exit_types,
-                    fvc_ref,
-                    num_virtuals,
-                );
+                use majit_ir::resumedata::RebuiltValue;
                 let vable_array = vable_values
                     .iter()
                     .map(|val| match val {
@@ -817,23 +828,15 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
         // ResumeGuardCopiedDescr whose `prev` points at the donor;
         // the `resolved_rd_*` helpers chase that descr-side pointer
         // (compile.py get_resumestorage).
-        let recovery_layout = if op.resolved_rd_numb().is_some() {
+        let recovery_layout = if decoded_numbering.is_some() {
             // Consumer switchover path: rd_numb contains the full frame encoding.
             // Build recovery_layout from rd_numb + rd_virtuals.
             use majit_backend::{ExitRecoveryLayout, ExitValueSourceLayout};
             let (num_failargs, vable_layout, vref_layout, frames_layout) =
-                if let (Some(rd_numb_bytes), Some(rd_consts_data)) =
-                    (op.resolved_rd_numb(), op.resolved_rd_consts())
+                if let Some((num_failargs, vable_values, vref_values, frames)) =
+                    decoded_numbering.as_ref()
                 {
-                    use majit_ir::resumedata::{RebuiltValue, rebuild_from_numbering};
-                    let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len());
-                    let (num_failargs, vable_values, vref_values, frames) = rebuild_from_numbering(
-                        &rd_numb_bytes,
-                        &rd_consts_data,
-                        &exit_types,
-                        fvc_ref,
-                        num_virtuals,
-                    );
+                    use majit_ir::resumedata::RebuiltValue;
                     debug_assert!(
                         vref_values.len() & 1 == 0,
                         "vref_values length must be even, got {}",
@@ -848,7 +851,7 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                         RebuiltValue::Unassigned => ExitValueSourceLayout::Uninitialized,
                     };
                     (
-                        num_failargs,
+                        *num_failargs,
                         vable_values.iter().map(to_exit_source).collect::<Vec<_>>(),
                         vref_values.iter().map(to_exit_source).collect::<Vec<_>>(),
                         frames

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -801,17 +801,11 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             // ResumeGuardCopiedDescr).
             let storage_for_guard = op.resolved_rd_numb().map(|numb| {
                 crate::resume::ResumeStorage::with_shared_consts(
-                    numb.to_vec(),
+                    numb,
                     op.resolved_rd_consts()
                         .unwrap_or_else(|| majit_ir::SharedConstPool::new(Vec::new())),
-                    op.resolved_rd_virtuals()
-                        .as_deref()
-                        .map(<[std::rc::Rc<majit_ir::RdVirtualInfo>]>::to_vec)
-                        .unwrap_or_default(),
-                    op.resolved_rd_pendingfields()
-                        .as_deref()
-                        .map(<[majit_ir::GuardPendingFieldEntry]>::to_vec)
-                        .unwrap_or_default(),
+                    op.resolved_rd_virtuals(),
+                    op.resolved_rd_pendingfields(),
                 )
             });
             result.insert(fail_index, layout);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -803,9 +803,9 @@ fn convert_rd_virtuals_for_storage(
 ) -> Vec<crate::resume::VirtualInfo> {
     let rd_consts = storage.rd_consts();
     let count = raw_value_count as i32;
-    let num_virtuals = storage.rd_virtuals.len();
+    let num_virtuals = storage.rd_virtuals().len();
     storage
-        .rd_virtuals
+        .rd_virtuals()
         .iter()
         .map(|rd| crate::resume::rd_virtual_to_virtual_info(rd, rd_consts, count, num_virtuals))
         .collect()
@@ -5250,7 +5250,7 @@ impl<S: JitState> JitDriver<S> {
             )
             .and_then(|layout| layout.storage)
             .is_some_and(|storage| {
-                !storage.rd_pendingfields.is_empty() && storage.rd_virtuals.len() > 1
+                !storage.rd_pendingfields().is_empty() && storage.rd_virtuals().len() > 1
             })
     }
 
@@ -6420,7 +6420,7 @@ impl<S: JitState> JitDriver<S> {
             // Arc so blackhole resume observes the guard-owned pool
             // the GC walker updates (no per-call Vec clone).
             if let Some(storage) = exit_layout.storage.as_deref() {
-                let rd_numb = storage.rd_numb.as_slice();
+                let rd_numb = storage.rd_numb.as_ref();
                 let rd_consts_slice: &[Const] = storage.rd_consts();
 
                 // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
@@ -6512,7 +6512,7 @@ impl<S: JitState> JitDriver<S> {
                     &raw_values,
                     Some(&exit_layout.exit_types),
                     rd_virtuals_slice,
-                    Some(&storage.rd_pendingfields), // rd_guard_pendingfields
+                    Some(storage.rd_pendingfields()), // rd_guard_pendingfields
                     Some(
                         &self.meta_interp().staticdata.virtualref_info
                             as &dyn crate::resume::VRefInfo,
@@ -9120,7 +9120,7 @@ impl<S: JitState> JitDriver<S> {
             if execute_replay
                 && replay_allocator.is_none()
                 && retrace.storage.as_deref().is_some_and(|storage| {
-                    !storage.rd_pendingfields.is_empty() || !storage.rd_virtuals.is_empty()
+                    !storage.rd_pendingfields().is_empty() || !storage.rd_virtuals().is_empty()
                 })
             {
                 ctx.mark_bridge_replay_incomplete();
@@ -9129,7 +9129,7 @@ impl<S: JitState> JitDriver<S> {
                 sym,
                 ctx,
                 bfm,
-                retrace.storage.as_deref().map(|s| s.rd_virtuals.as_slice()),
+                retrace.storage.as_deref().map(|s| s.rd_virtuals()),
                 &raw_values,
                 &retrace.fail_types,
                 replay_allocator,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1828,6 +1828,11 @@ pub struct JitDriver<S: JitState> {
     /// for buffers whose contents never move at all. `None` is the window
     /// between the two, which is what a nested entry finds.
     entry_scratch: Option<Box<EntryScratch>>,
+    /// Machine-word projection of one guard exit's typed deadframe values.
+    /// Kept separate from `entry_scratch`: bridge tracing can re-enter this
+    /// driver while the outer guard is still consuming these words, and that
+    /// nested entry should still be able to reuse the ordinary entry buffers.
+    exit_raw_scratch: Option<Vec<i64>>,
 }
 
 /// Per-entry scratch owned by [`JitDriver`]; see [`JitDriver::entry_scratch`].
@@ -2043,6 +2048,7 @@ impl<S: JitState> JitDriver<S> {
             portal_jd_index: None,
             state_field_fvc: None,
             entry_scratch: Some(Box::default()),
+            exit_raw_scratch: Some(Vec::new()),
             #[expect(
                 clippy::arc_with_non_send_sync,
                 reason = "Arc preserves shared JitCode/descriptor identity across compiled artifacts; the non-Send translator payload is confined to the single-threaded build phase and is never transferred between threads"
@@ -6185,9 +6191,9 @@ impl<S: JitState> JitDriver<S> {
                 live_values,
                 selected_dispatch_key,
             );
-            // The compiled body has run and nothing below reads the entry
-            // arguments, so the buffers go back before the first exit past
-            // this point.
+            // The compiled body no longer reads its entry arguments. Return
+            // these buffers before any guard-resume path can re-enter the
+            // driver to trace a bridge.
             self.entry_scratch_out(scratch);
             let mut result = result;
             if portal_rca {
@@ -6290,10 +6296,13 @@ impl<S: JitState> JitDriver<S> {
                 .exit_layout
                 .take()
                 .expect("a guard exit carries its exit layout");
-            // Projected here rather than carried on the result: only this arm
-            // and the detailed run below read machine words, and building the
-            // list on every entry charged the finish exit for both.
-            let raw_values = crate::compile::raw_exit_values(&result.typed_values);
+            // `warmstate.py execute_assembler` reads fail values from the
+            // deadframe in place. Pyre projects its typed exit buffer back to
+            // machine words for the resume helpers; reuse the entry scratch's
+            // raw buffer instead of spilling a fresh `ExitRawValues` whenever
+            // this guard has more than its inline width.
+            let mut raw_values = self.take_exit_raw_scratch();
+            raw_values.extend(result.typed_values.iter().map(Value::as_raw_i64));
             let descr_arc = result
                 .descr_arc
                 .take()
@@ -6401,6 +6410,7 @@ impl<S: JitState> JitDriver<S> {
                         green_key, trace_id, fail_index, pc,
                     );
                 }
+                self.exit_raw_scratch_out(raw_values);
                 return Some(pc);
             }
 
@@ -6875,6 +6885,7 @@ impl<S: JitState> JitDriver<S> {
                                 );
                             }
                         }
+                        self.exit_raw_scratch_out(raw_values);
                         return Some(pc);
                     }
                 }
@@ -6889,6 +6900,7 @@ impl<S: JitState> JitDriver<S> {
             self.meta.invalidate_loop(green_key);
             self.meta.remove_compiled_loop(green_key);
             self.meta.warm_state_mut().abort_tracing(green_key, true);
+            self.exit_raw_scratch_out(raw_values);
             return Some(guard_resume_pc);
         }
 
@@ -7206,6 +7218,16 @@ impl<S: JitState> JitDriver<S> {
     /// Return the buffers [`Self::take_entry_scratch`] handed out.
     fn entry_scratch_out(&mut self, scratch: Box<EntryScratch>) {
         self.entry_scratch = Some(scratch);
+    }
+
+    fn take_exit_raw_scratch(&mut self) -> Vec<i64> {
+        let mut raw = self.exit_raw_scratch.take().unwrap_or_default();
+        raw.clear();
+        raw
+    }
+
+    fn exit_raw_scratch_out(&mut self, raw: Vec<i64>) {
+        self.exit_raw_scratch = Some(raw);
     }
 
     /// The driver's static data, resolved once and then shared.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -799,14 +799,20 @@ fn snapshot_map_from_trace_snapshots(
     SnapshotFramePcs,
 ) {
     let _ = constants; // legacy idx-Const pool no longer populated here; see SnapshotTagged::Const arm
-    let mut box_map = Vec::new();
-    let mut size_map = Vec::new();
-    let mut vable_map = Vec::new();
-    let mut vref_map = Vec::new();
+    // Recorder snapshot ids below come directly from `enumerate`, so all five
+    // maps are dense and have the final length in hand. RPython's opencoder
+    // also appends its snapshot payloads to flat buffers; repeatedly growing a
+    // sparse Rust adapter here only adds allocator traffic while preserving no
+    // extra semantics.
+    let snapshot_count = trace_snapshots.len();
+    let mut box_map = Vec::with_capacity(snapshot_count);
+    let mut size_map = Vec::with_capacity(snapshot_count);
+    let mut vable_map = Vec::with_capacity(snapshot_count);
+    let mut vref_map = Vec::with_capacity(snapshot_count);
     // Not `pc_map`: that name belongs to the `-live-` marker table keyed by
     // Python pc (`pc_map[py_pc]`, `pyre-jit/src/jit/codewriter.rs`). This is
     // keyed by snapshot id and holds one `(jitcode_index, pc, py_pc)` per frame.
-    let mut frame_pcs_map = Vec::new();
+    let mut frame_pcs_map = Vec::with_capacity(snapshot_count);
     // opencoder.py _encode: trace snapshot recorder only emits Box
     // (live deadframe slot) and Const (compile-time pool) payloads.
     // TAGVIRTUAL belongs to resume numbering (resume.py:_number_boxes)
@@ -844,7 +850,7 @@ fn snapshot_map_from_trace_snapshots(
             }
         }
     };
-    for (id, snap) in trace_snapshots.iter().enumerate() {
+    for snap in trace_snapshots {
         let boxes: Vec<SnapshotBox> = snap
             .frames
             .iter()
@@ -862,12 +868,11 @@ fn snapshot_map_from_trace_snapshots(
             .iter()
             .map(|f| (f.jitcode_index as i32, f.pc as i32, f.py_pc as i32))
             .collect();
-        let id = id as i32;
-        snapshot_insert(&mut box_map, id, boxes);
-        snapshot_insert(&mut size_map, id, frame_sizes);
-        snapshot_insert(&mut vable_map, id, vable_boxes);
-        snapshot_insert(&mut vref_map, id, vref_boxes);
-        snapshot_insert(&mut frame_pcs_map, id, frame_pcs);
+        box_map.push(Some(boxes));
+        size_map.push(Some(frame_sizes));
+        vable_map.push(Some(vable_boxes));
+        vref_map.push(Some(vref_boxes));
+        frame_pcs_map.push(Some(frame_pcs));
     }
     (box_map, size_map, vable_map, vref_map, frame_pcs_map)
 }
@@ -1930,6 +1935,11 @@ pub struct MetaInterp<M: Clone> {
     /// `popframe` (pyjitpl.py).  Initialized as empty by
     /// `initialize_state_from_start` and `rebuild_state_after_failure`.
     pub framestack: crate::pyjitpl::MIFrameStack,
+    /// pyjitpl.py `MetaInterp.free_frames_list` — popped frames whose
+    /// register storage can be reset by `MIFrame.setup` and reused by the next
+    /// inlined call. The list belongs to one MetaInterp exactly as upstream's
+    /// does; it is neither process-global nor thread-local.
+    pub free_frames_list: Vec<crate::pyjitpl::MIFrame>,
 
     /// pyjitpl.py `MetaInterp.portal_call_depth = 0` (class
     /// attribute, instance-mutated).  Counts the nesting depth of
@@ -3488,6 +3498,7 @@ impl<M: Clone> MetaInterp<M> {
             issubclass: Some(default_issubclass),
             staticdata: std::sync::Arc::new(MetaInterpStaticData::new()),
             framestack: crate::pyjitpl::MIFrameStack::empty(),
+            free_frames_list: Vec::new(),
             portal_call_depth: 0,
             call_ids: Vec::new(),
             current_call_id: 0,
@@ -13855,38 +13866,17 @@ impl<M: Clone> MetaInterp<M> {
                 }
             }
         }
-        // compile.py: BridgeCompileData is built from the original
-        // history trace/runtime boxes. The explicit Rust TraceIterator
-        // preparation below mirrors unroll.py:187 `trace = trace.get_iter()`
-        // and must happen after this payload is formed.
+        // compile.py: BridgeCompileData carries the trace/runtime boxes into
+        // `UnrollOptimizer.optimize_bridge`, whose first operation is
+        // unroll.py:187 `trace = trace.get_iter()`.  In the Rust port the
+        // CompileData dispatch is flattened into this method (compile.rs
+        // `CompileData`), so build its short-lived view over that iterator's
+        // canonical `Rc<Op>` objects.  Building a separate `TreeLoop` from
+        // `bridge_ops.to_vec()` here used to allocate one throw-away `Rc<Op>`
+        // for every recorded operation, immediately before TraceIterator
+        // allocated the real fresh objects consumed by the optimizer.
         let bridge_runtime_boxes: Vec<OpRef> =
             Self::closing_jump_runtime_boxes(bridge_ops, bridge_inputargs);
-        let bridge_trace_data = TreeLoop::with_snapshots(
-            bridge_inputargs
-                .iter()
-                .map(InputArg::fresh_value_copy)
-                .collect(),
-            bridge_ops.to_vec(),
-            Vec::new(),
-        );
-        let bridge_resumestorage = pending_bridge_rd
-            .as_ref()
-            .map(|pending| pending.storage.as_ref());
-        let (bridge_inline_short_preamble, bridge_call_pure_results, bridge_runtime_boxes) = {
-            let bridge_data = compile::BridgeCompileData::new(
-                &bridge_trace_data,
-                &bridge_runtime_boxes,
-                bridge_resumestorage,
-                &call_pure_results,
-                inline_short_preamble,
-                self.warm_state.get_enable_opts(),
-            );
-            (
-                bridge_data.inline_short_preamble,
-                bridge_data.call_pure_results.clone(),
-                bridge_data.runtime_boxes.to_vec(),
-            )
-        };
         // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
         // ResOperation objects in a disjoint OpRef namespace
         // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
@@ -13902,19 +13892,62 @@ impl<M: Clone> MetaInterp<M> {
             bridge_runtime_boxes,
             bridge_inputarg_base,
         );
-        let bridge_inputarg_types: Vec<majit_ir::OpRef> = prepared
-            .inputargs
+        let PreparedBridgeTrace {
+            ops: prepared_ops,
+            inputargs: prepared_inputargs,
+            snapshot_boxes,
+            snapshot_frame_sizes,
+            snapshot_vable_boxes,
+            snapshot_vref_boxes,
+            snapshot_frame_pcs,
+            pending_bridge_rd,
+            runtime_boxes: prepared_runtime_boxes,
+        } = prepared;
+        // `TreeLoop::from_oprc` preserves the TraceIterator identities rather
+        // than wrapping a second copy of every operation.  The inputargs on
+        // this CompileData-only view remain the original pre-iterator boxes,
+        // matching BridgeCompileData.__init__; optimizer consumers below use
+        // `prepared_inputargs`, matching `trace.get_iter().inputargs`.
+        let bridge_trace_data = TreeLoop::from_oprc(
+            bridge_inputargs
+                .iter()
+                .map(|arg| std::rc::Rc::new(arg.fresh_value_copy()))
+                .collect(),
+            prepared_ops,
+            Vec::new(),
+        );
+        let bridge_resumestorage = pending_bridge_rd
+            .as_ref()
+            .map(|pending| pending.storage.as_ref());
+        let (bridge_inline_short_preamble, bridge_call_pure_results) = {
+            let bridge_data = compile::BridgeCompileData::new(
+                &bridge_trace_data,
+                &prepared_runtime_boxes,
+                bridge_resumestorage,
+                &call_pure_results,
+                inline_short_preamble,
+                self.warm_state.get_enable_opts(),
+            );
+            // The flattened dispatch consumes this slice below rather than
+            // through BridgeCompileData::optimize, but constructing the
+            // payload still validates that both views name the same boxes.
+            debug_assert_eq!(bridge_data.runtime_boxes, prepared_runtime_boxes);
+            (
+                bridge_data.inline_short_preamble,
+                bridge_data.call_pure_results.clone(),
+            )
+        };
+        let bridge_inputarg_types: Vec<majit_ir::OpRef> = prepared_inputargs
             .iter()
             .enumerate()
             .map(|(i, ia)| majit_ir::OpRef::input_arg_typed(i as u32, ia.tp))
             .collect();
-        let bridge_inputargs = prepared.inputargs.as_slice();
-        let bridge_ops = prepared.ops.as_slice();
-        let pending_bridge_rd = prepared.pending_bridge_rd;
+        let bridge_inputargs = prepared_inputargs.as_slice();
+        let bridge_ops = bridge_trace_data.ops.as_slice();
         // unroll.py:187 `trace = trace.get_iter()` rewrote the runtime boxes
         // into the fresh-iterator namespace; consume the translated list so
         // optimize_bridge's generate_guards reads them in the re-minted space.
-        let bridge_runtime_boxes = prepared.runtime_boxes.as_slice();
+        let bridge_runtime_boxes = prepared_runtime_boxes.as_slice();
 
         let mut optimizer = self.make_optimizer();
         optimizer.all_descrs = self.staticdata.all_descrs().lock().clone();
@@ -13929,11 +13962,11 @@ impl<M: Clone> MetaInterp<M> {
         // in the typed OpRef variant tag (`OpRef::input_arg_typed`); the
         // legacy `constant_types.insert(arg.index, arg.tp)` writes were
         // redundant with `opref_type`'s priority-0 variant-tag read.
-        optimizer.snapshot_boxes = prepared.snapshot_boxes;
-        optimizer.snapshot_frame_sizes = prepared.snapshot_frame_sizes;
-        optimizer.snapshot_vable_boxes = prepared.snapshot_vable_boxes;
-        optimizer.snapshot_vref_boxes = prepared.snapshot_vref_boxes;
-        optimizer.snapshot_frame_pcs = prepared.snapshot_frame_pcs;
+        optimizer.snapshot_boxes = snapshot_boxes;
+        optimizer.snapshot_frame_sizes = snapshot_frame_sizes;
+        optimizer.snapshot_vable_boxes = snapshot_vable_boxes;
+        optimizer.snapshot_vref_boxes = snapshot_vref_boxes;
+        optimizer.snapshot_frame_pcs = snapshot_frame_pcs;
         // Store bridge inputarg types so export_state can mint typed
         // `renamed_inputargs` OpRefs that carry their type intrinsically
         // (history.py:220 InputArg{Int,Ref,Float}.type Box parity).
@@ -16274,7 +16307,12 @@ impl<M: Clone> MetaInterp<M> {
         let raw = (greenkey.as_ref().map_or(0, |(key, _)| *key) as usize, 0);
         let _ = self.enter_inline_frame(raw);
         // pyjitpl.py: reuse / allocate MIFrame, push onto framestack.
-        let frame = crate::pyjitpl::MIFrame::setup(jitcode, 0, greenkey, self.tracing.as_mut());
+        let frame = if let Some(mut frame) = self.free_frames_list.pop() {
+            frame.setup_reused(jitcode, 0, greenkey, self.tracing.as_mut());
+            frame
+        } else {
+            crate::pyjitpl::MIFrame::setup(jitcode, 0, greenkey, self.tracing.as_mut())
+        };
         self.framestack.push(frame);
         self.framestack.len() - 1
     }
@@ -16347,9 +16385,8 @@ impl<M: Clone> MetaInterp<M> {
             }
             // pyjitpl.py: frame.cleanup_registers().
             frame.cleanup_registers();
-            // pyjitpl.py:2477: self.free_frames_list.append(frame) is
-            // an RPython memory-reuse optimization; pyre relies on the
-            // Rust drop to release register banks.
+            // pyjitpl.py:2477: self.free_frames_list.append(frame).
+            self.free_frames_list.push(frame);
         }
         // Mirror the TraceCtx inline-depth counter so trace recorder
         // bookkeeping stays balanced with the framestack pop.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -13071,7 +13071,7 @@ impl<M: Clone> MetaInterp<M> {
         fail_index: u32,
     ) -> Option<Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>> {
         let storage = self.get_resume_storage(green_key, trace_id, fail_index)?;
-        Some(storage.rd_virtuals.clone())
+        Some(storage.rd_virtuals().to_vec())
     }
 
     /// resume.py _prepare parity: get rd_pendingfields for a guard.
@@ -13082,7 +13082,7 @@ impl<M: Clone> MetaInterp<M> {
         fail_index: u32,
     ) -> Option<Vec<majit_ir::GuardPendingFieldEntry>> {
         let storage = self.get_resume_storage(green_key, trace_id, fail_index)?;
-        Some(storage.rd_pendingfields.clone())
+        Some(storage.rd_pendingfields().to_vec())
     }
 
     /// compile.py ResumeFromInterpDescr.compile_and_attach parity.
@@ -14692,7 +14692,7 @@ impl<M: Clone> MetaInterp<M> {
         // forced virtuals fell back to NullAllocator entries and pending
         // heap writes were dropped on async forcing.
         let storage = exit_layout.storage.as_deref();
-        let rd_numb = storage.map(|s| s.rd_numb.as_slice()).unwrap_or(&[]);
+        let rd_numb = storage.map(|s| s.rd_numb.as_ref()).unwrap_or(&[]);
         let empty_consts: [Const; 0] = [];
         let rd_consts: &[Const] = storage.map(|s| s.rd_consts()).unwrap_or(&empty_consts);
         // resume.py _prepare(storage) parity: materialize rd_virtuals
@@ -14706,8 +14706,8 @@ impl<M: Clone> MetaInterp<M> {
             fail_values.len() as i32
         };
         let rd_virtuals = storage.map(|s| {
-            let num_virtuals = s.rd_virtuals.len();
-            s.rd_virtuals
+            let num_virtuals = s.rd_virtuals().len();
+            s.rd_virtuals()
                 .iter()
                 .map(|rd| {
                     crate::resume::rd_virtual_to_virtual_info(
@@ -14735,7 +14735,7 @@ impl<M: Clone> MetaInterp<M> {
                 fail_values,
                 Some(deadframe_types),
                 rd_virtuals.as_deref(),
-                storage.map(|s| s.rd_pendingfields.as_slice()),
+                storage.map(|s| s.rd_pendingfields()),
                 Some(&self.staticdata.virtualref_info as &dyn crate::resume::VRefInfo),
                 vinfo.map(|v| v.as_ref() as &dyn crate::resume::VirtualizableInfo),
                 None, // ginfo — pyre has no greenfield mechanism
@@ -24415,7 +24415,7 @@ mod tests {
         let storage = meta
             .get_resume_storage(green_key, trace_id, fail_index)
             .expect("storage should be present");
-        assert_eq!(storage.rd_numb, vec![7, 8, 9]);
+        assert_eq!(storage.rd_numb.as_ref(), &[7, 8, 9]);
         assert_eq!(storage.rd_consts_snapshot(), vec![majit_ir::Const::Int(11)]);
         assert_eq!(
             meta.get_recovery_slot_types(green_key, trace_id, fail_index),
@@ -25099,9 +25099,9 @@ mod tests {
             .storage
             .as_ref()
             .expect("retrace storage should be present");
-        assert_eq!(storage.rd_numb, expected_rd_numb);
+        assert_eq!(storage.rd_numb.as_ref(), expected_rd_numb.as_slice());
         assert!(storage.rd_consts().is_empty());
-        assert!(storage.rd_virtuals.is_empty());
+        assert!(storage.rd_virtuals().is_empty());
         assert_eq!(meta.pending_frontend_boxes_ref(), Some([42].as_slice()));
         assert_eq!(
             meta.pending_frontend_box_types.as_deref(),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2638,7 +2638,7 @@ where
     /// snapshot, if any, so a `sym`-holding caller can restore it (this
     /// method has no `sym` in scope).
     fn pop_exception_frame(&mut self, ctx: &mut TraceCtx) -> Option<Vec<(OpRef, i64)>> {
-        if let Some(frame) = self.frames.pop() {
+        if let Some(mut frame) = self.frames.pop() {
             if frame.inline_frame {
                 ctx.pop_inline_frame();
             }
@@ -2650,7 +2650,9 @@ where
                 let jd_box = ctx.const_int(frame.portal_jd as i64);
                 ctx.record_op(OpCode::LeavePortalFrame, &[jd_box]);
             }
-            frame.portal_scalar_state
+            let portal_scalar_state = frame.portal_scalar_state.take();
+            self.frames.recycle_frame(frame);
+            portal_scalar_state
         } else {
             None
         }
@@ -3263,7 +3265,7 @@ where
         // pc-aligned portal runtimes (dispatch.rs test fixtures) wire
         // `portal_jitcode`; enter their portal at `green_pc` as before.
         if let Some(portal) = runtime.portal_jitcode(jd_index) {
-            let mut portal_frame = MIFrame::setup(portal, green_pc, None, Some(ctx));
+            let mut portal_frame = self.frames.take_frame(portal, green_pc, None, Some(ctx));
             portal_frame.code_cursor = green_pc;
             ctx.push_inline_frame((jd_index, green_pc), u32::MAX);
             // pyjitpl.py newframe -> enter_portal_frame(jd_no, unique_id)
@@ -3625,7 +3627,7 @@ where
             frame.finished()
         };
         if finished {
-            let finished_frame = self.frames.pop().expect("finished frame stack was empty");
+            let mut finished_frame = self.frames.pop().expect("finished frame stack was empty");
             if finished_frame.inline_frame {
                 ctx.pop_inline_frame();
             }
@@ -3640,7 +3642,7 @@ where
             }
             // [FR] Restore the caller's sym scalar/fixed-array state that this
             // inline recursive-portal frame overwrote.
-            if let Some(snapshot) = finished_frame.portal_scalar_state.clone() {
+            if let Some(snapshot) = finished_frame.portal_scalar_state.take() {
                 sym.restore_inline_scalar_state(snapshot);
             }
             if let Some(parent) = self.frames.frames.last_mut()
@@ -3675,6 +3677,7 @@ where
                     }
                 }
             }
+            self.frames.recycle_frame(finished_frame);
             return TraceAction::Continue;
         }
 
@@ -6336,13 +6339,14 @@ where
                         //     but DO NOT wire the return (do_recursive_call's job)
                         //     and DO NOT record LEAVE_PORTAL_FRAME yet
                         //     (leave_portal_frame=False).
-                        let popped = self.frames.pop().expect("recursive-cut: framestack < 2");
+                        let mut popped = self.frames.pop().expect("recursive-cut: framestack < 2");
                         if popped.inline_frame {
                             ctx.pop_inline_frame();
                         }
-                        if let Some(snapshot) = popped.portal_scalar_state.clone() {
+                        if let Some(snapshot) = popped.portal_scalar_state.take() {
                             sym.restore_inline_scalar_state(snapshot);
                         }
+                        self.frames.recycle_frame(popped);
                         // (3) do_recursive_call(assembler_call=True) on the caller
                         //     (now current): reuse the existing 8-step
                         //     CALL_ASSEMBLER recorder. `set_int_reg(result_dst)`
@@ -6972,7 +6976,7 @@ where
                     .unwrap_or_else(|| {
                         panic!("BC_INLINE_CALL: descrs[{sub_idx}] is not a JitCode entry")
                     });
-                let mut sub_frame = MIFrame::setup(sub_jitcode, 0, None, Some(ctx));
+                let mut sub_frame = self.frames.take_frame(sub_jitcode, 0, None, Some(ctx));
                 ctx.push_inline_frame((sub_idx, pc), u32::MAX);
                 sub_frame.inline_frame = true;
                 for (kind, caller_src, callee_dst) in arg_triples {
@@ -9387,7 +9391,7 @@ where
             // crashing the process.
             return TraceAction::Abort;
         };
-        let mut sub_frame = MIFrame::setup(sub_jitcode, 0, None, Some(ctx));
+        let mut sub_frame = self.frames.take_frame(sub_jitcode, 0, None, Some(ctx));
         ctx.push_inline_frame((sub_idx, pc), u32::MAX);
         sub_frame.inline_frame = true;
 

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -223,6 +223,61 @@ impl MIFrame {
         frame
     }
 
+    /// `pyjitpl.py MIFrame.setup` on an object taken from
+    /// `MetaInterp.free_frames_list`.
+    ///
+    /// RPython reuses the `MIFrame` object and replaces its register lists.
+    /// Rust can preserve the lists' backing capacity while spelling the same
+    /// reset: every logical slot is cleared, the lists are resized for the new
+    /// JitCode, constants are recopied, and all per-call bookkeeping returns
+    /// to the values established by `setup`. This is allocator-equivalent to
+    /// RPython's nursery list replacement without changing frame identity or
+    /// retaining a live box across calls.
+    pub fn setup_reused(
+        &mut self,
+        jitcode: Arc<JitCode>,
+        pc: usize,
+        greenkey: Option<super::PortalGreenKey>,
+        ctx: Option<&mut crate::trace_ctx::TraceCtx>,
+    ) {
+        let regs_and_consts_i = jitcode.num_regs_and_consts_i();
+        let regs_and_consts_r = jitcode.num_regs_and_consts_r();
+        let regs_and_consts_f = jitcode.num_regs_and_consts_f();
+
+        self.jitcode = jitcode;
+        self.pc = pc;
+        self.code_cursor = 0;
+        self.last_opcode_position = pc;
+        self.int_regs.resize(regs_and_consts_i, None);
+        self.int_regs.fill(None);
+        self.int_values.resize(regs_and_consts_i, None);
+        self.int_values.fill(None);
+        self.ref_regs.resize(regs_and_consts_r, None);
+        self.ref_regs.fill(None);
+        self.ref_values.resize(regs_and_consts_r, None);
+        self.ref_values.fill(None);
+        self.float_regs.resize(regs_and_consts_f, None);
+        self.float_regs.fill(None);
+        self.float_values.resize(regs_and_consts_f, None);
+        self.float_values.fill(None);
+        self.inline_frame = false;
+        self.portal_scalar_state = None;
+        self.portal_entered = false;
+        self.portal_jd = 0;
+        self.return_i = None;
+        self.return_r = None;
+        self.return_f = None;
+        self.greenkey = greenkey;
+        self._result_argcode = b'v';
+        self.result_arg_index = None;
+        self.pushed_box = None;
+        self.parent_snapshot = -1;
+        self.unroll_iterations = 1;
+        if let Some(ctx) = ctx {
+            self.copy_constants(ctx);
+        }
+    }
+
     pub fn next_u8(&mut self) -> u8 {
         read_u8(&self.jitcode.code, &mut self.code_cursor)
     }
@@ -1190,6 +1245,12 @@ impl MIFrame {
 #[derive(Default)]
 pub struct MIFrameStack {
     pub frames: Vec<MIFrame>,
+    /// `pyjitpl.py MetaInterp.free_frames_list` for the generated
+    /// `JitCodeMachine` adapter.  The machine borrows this wrapper instead of
+    /// the whole `MetaInterp`, so the wrapper must carry the paired free list
+    /// alongside the live `framestack`; they still have one owner and one
+    /// lifetime, just as the two upstream `MetaInterp` attributes do.
+    free_frames: Vec<MIFrame>,
 }
 
 impl MIFrameStack {
@@ -1197,7 +1258,10 @@ impl MIFrameStack {
     /// `MetaInterp.initialize_state_from_start` (pyjitpl.py) and
     /// `rebuild_state_after_failure` (pyjitpl.py).
     pub fn empty() -> Self {
-        Self { frames: Vec::new() }
+        Self {
+            frames: Vec::new(),
+            free_frames: Vec::new(),
+        }
     }
 
     /// Build a stack pre-seeded with one root frame.  Pyre's
@@ -1205,7 +1269,10 @@ impl MIFrameStack {
     /// constructor mirrors `MIFrameStack::new(root)` from before the
     /// `Arc<JitCode>` migration.
     pub fn new(root: MIFrame) -> Self {
-        Self { frames: vec![root] }
+        Self {
+            frames: vec![root],
+            free_frames: Vec::new(),
+        }
     }
 
     pub fn current_mut(&mut self) -> &mut MIFrame {
@@ -1218,6 +1285,30 @@ impl MIFrameStack {
 
     pub fn pop(&mut self) -> Option<MIFrame> {
         self.frames.pop()
+    }
+
+    /// `pyjitpl.py MetaInterp.newframe`: take a cleaned MIFrame from
+    /// `free_frames_list` when possible, then run `MIFrame.setup` on it.
+    pub fn take_frame(
+        &mut self,
+        jitcode: Arc<JitCode>,
+        pc: usize,
+        greenkey: Option<super::PortalGreenKey>,
+        ctx: Option<&mut crate::trace_ctx::TraceCtx>,
+    ) -> MIFrame {
+        if let Some(mut frame) = self.free_frames.pop() {
+            frame.setup_reused(jitcode, pc, greenkey, ctx);
+            frame
+        } else {
+            MIFrame::setup(jitcode, pc, greenkey, ctx)
+        }
+    }
+
+    /// `pyjitpl.py MetaInterp.popframe`: clear live references before
+    /// returning the frame object to `free_frames_list`.
+    pub fn recycle_frame(&mut self, mut frame: MIFrame) {
+        frame.cleanup_registers();
+        self.free_frames.push(frame);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1275,6 +1366,42 @@ mod tests {
         assert_eq!(frame.ref_values[1], Some(201));
         assert_eq!(frame.float_regs[0], Some(OpRef::float_op(30)));
         assert_eq!(frame.float_values[0], Some(300));
+    }
+
+    #[test]
+    fn frame_stack_reuses_cleaned_register_storage() {
+        // pyjitpl.py `MetaInterp.newframe` / `popframe`: a popped MIFrame is
+        // cleaned, appended to `free_frames_list`, and selected for the next
+        // call.  The generated-machine adapter must preserve that lifecycle
+        // without leaking any per-call state into the reused frame.
+        let jitcode = make_jitcode_with_regs(2, 2, 1);
+        let mut stack = MIFrameStack::empty();
+        let mut frame = stack.take_frame(jitcode.clone(), 7, None, None);
+        let int_storage = frame.int_regs.as_ptr();
+        let ref_storage = frame.ref_regs.as_ptr();
+        let float_storage = frame.float_regs.as_ptr();
+        frame.int_regs[0] = Some(OpRef::int_op(11));
+        frame.ref_regs[0] = Some(OpRef::ref_op(12));
+        frame.float_regs[0] = Some(OpRef::float_op(13));
+        frame.inline_frame = true;
+        frame.return_i = Some(1);
+        frame.pushed_box = Some(OpRef::ref_op(14));
+
+        stack.recycle_frame(frame);
+        assert_eq!(stack.free_frames.len(), 1);
+
+        let frame = stack.take_frame(jitcode, 3, None, None);
+        assert_eq!(stack.free_frames.len(), 0);
+        assert_eq!(frame.int_regs.as_ptr(), int_storage);
+        assert_eq!(frame.ref_regs.as_ptr(), ref_storage);
+        assert_eq!(frame.float_regs.as_ptr(), float_storage);
+        assert!(frame.int_regs.iter().all(Option::is_none));
+        assert!(frame.ref_regs.iter().all(Option::is_none));
+        assert!(frame.float_regs.iter().all(Option::is_none));
+        assert!(!frame.inline_frame);
+        assert_eq!(frame.return_i, None);
+        assert_eq!(frame.pushed_box, None);
+        assert_eq!(frame.pc, 3);
     }
 
     /// `MIFrame::get_list_of_active_boxes` (non-in_a_call

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -582,6 +582,52 @@ const ENCODED_UNAVAILABLE: i64 = -3;
 const INLINE_TAGGED_MIN: i64 = -(1_i64 << 61);
 const INLINE_TAGGED_MAX: i64 = (1_i64 << 61) - 1;
 
+/// RPython's nullable `rd_virtuals` / `rd_pendingfields` arrays with a slice
+/// surface.  The overwhelmingly common null case occupies only the enum and
+/// performs no allocation; a populated array shares the guard descr's exact
+/// backing storage.  `Deref<[T]>` deliberately preserves the field operations
+/// used by generated JIT code (`len`, `iter`, indexing).
+pub enum SharedResumeSlice<T> {
+    Empty,
+    Shared(Arc<[T]>),
+}
+
+impl<T> SharedResumeSlice<T> {
+    pub fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Empty => &[],
+            Self::Shared(values) => values,
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for SharedResumeSlice<T> {
+    fn from(values: Vec<T>) -> Self {
+        if values.is_empty() {
+            Self::Empty
+        } else {
+            Self::Shared(Arc::from(values))
+        }
+    }
+}
+
+impl<T> From<Option<Arc<[T]>>> for SharedResumeSlice<T> {
+    fn from(values: Option<Arc<[T]>>) -> Self {
+        match values {
+            Some(values) if !values.is_empty() => Self::Shared(values),
+            _ => Self::Empty,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for SharedResumeSlice<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
 /// compile.py `ResumeGuardDescr` storage.
 ///
 /// Canonical, guard-owned resume payload (`storage.rd_numb/rd_consts/
@@ -599,7 +645,7 @@ const INLINE_TAGGED_MAX: i64 = (1_i64 << 61) - 1;
 pub struct ResumeStorage {
     /// resume.py:466 `storage.rd_numb` — packed byte stream (NUMBERING
     /// lltype equivalent). Immutable once installed.
-    pub rd_numb: Vec<u8>,
+    pub rd_numb: Arc<[u8]>,
     /// resume.py:467 `storage.rd_consts` — shared constant pool.
     ///
     /// Interior mutability: the minor-collection root walker visits
@@ -610,10 +656,10 @@ pub struct ResumeStorage {
     pub rd_consts: Arc<majit_ir::SharedConstPool>,
     /// compile.py:858 `storage.rd_virtuals` — live `RdVirtualInfo`
     /// entries describing virtual objects to materialize on resume.
-    pub rd_virtuals: Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
+    pub rd_virtuals: SharedResumeSlice<std::rc::Rc<majit_ir::RdVirtualInfo>>,
     /// resume.py:468 `storage.rd_pendingfields` — pending field writes
     /// replayed during blackhole resume.
-    pub rd_pendingfields: Vec<majit_ir::GuardPendingFieldEntry>,
+    pub rd_pendingfields: SharedResumeSlice<majit_ir::GuardPendingFieldEntry>,
 }
 
 impl ResumeStorage {
@@ -631,12 +677,12 @@ impl ResumeStorage {
     /// `_DoneWithThisFrameDescr` family / `ExitFrameWithExceptionDescrRef`),
     /// matching the `_attrs_`-only-on-`AbstractResumeGuardDescr` contract.
     pub fn from_fail_descr(descr: &dyn majit_ir::FailDescr) -> Option<Self> {
-        let rd_numb = descr.rd_numb()?.to_vec();
+        let rd_numb = descr.rd_numb_arc()?;
         Some(Self {
             rd_numb,
             rd_consts: descr.rd_consts_arc()?,
-            rd_virtuals: descr.rd_virtuals().unwrap_or(&[]).to_vec(),
-            rd_pendingfields: descr.rd_pendingfields().unwrap_or(&[]).to_vec(),
+            rd_virtuals: descr.rd_virtuals_arc().into(),
+            rd_pendingfields: descr.rd_pendingfields_arc().into(),
         })
     }
 }
@@ -653,8 +699,8 @@ impl std::fmt::Debug for ResumeStorage {
         f.debug_struct("ResumeStorage")
             .field("rd_numb_len", &self.rd_numb.len())
             .field("rd_consts_len", &consts_len)
-            .field("rd_virtuals_len", &self.rd_virtuals.len())
-            .field("rd_pendingfields_len", &self.rd_pendingfields.len())
+            .field("rd_virtuals_len", &self.rd_virtuals().len())
+            .field("rd_pendingfields_len", &self.rd_pendingfields().len())
             .finish()
     }
 }
@@ -667,10 +713,10 @@ impl ResumeStorage {
         rd_pendingfields: Vec<majit_ir::GuardPendingFieldEntry>,
     ) -> Arc<Self> {
         Arc::new(ResumeStorage {
-            rd_numb,
+            rd_numb: Arc::from(rd_numb),
             rd_consts: majit_ir::SharedConstPool::new(rd_consts),
-            rd_virtuals,
-            rd_pendingfields,
+            rd_virtuals: rd_virtuals.into(),
+            rd_pendingfields: rd_pendingfields.into(),
         })
     }
 
@@ -692,17 +738,30 @@ impl ResumeStorage {
         self.rd_consts.as_slice()
     }
 
+    /// `resume.py ResumeDataReader._prepare_virtuals`: `None` is the
+    /// allocation-free common case; readers see the same empty slice they
+    /// previously obtained from an empty `Vec`.
+    pub fn rd_virtuals(&self) -> &[std::rc::Rc<majit_ir::RdVirtualInfo>] {
+        self.rd_virtuals.as_slice()
+    }
+
+    /// `resume.py ResumeDataReader._prepare_pendingfields`: upstream uses a
+    /// null pointer when there are no deferred writes.
+    pub fn rd_pendingfields(&self) -> &[majit_ir::GuardPendingFieldEntry] {
+        self.rd_pendingfields.as_slice()
+    }
+
     pub fn with_shared_consts(
-        rd_numb: Vec<u8>,
+        rd_numb: Arc<[u8]>,
         rd_consts: Arc<majit_ir::SharedConstPool>,
-        rd_virtuals: Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
-        rd_pendingfields: Vec<majit_ir::GuardPendingFieldEntry>,
+        rd_virtuals: Option<Arc<[std::rc::Rc<majit_ir::RdVirtualInfo>]>>,
+        rd_pendingfields: Option<Arc<[majit_ir::GuardPendingFieldEntry]>>,
     ) -> Arc<Self> {
         Arc::new(ResumeStorage {
             rd_numb,
             rd_consts,
-            rd_virtuals,
-            rd_pendingfields,
+            rd_virtuals: rd_virtuals.into(),
+            rd_pendingfields: rd_pendingfields.into(),
         })
     }
 }

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -1276,13 +1276,13 @@ pub fn replay_pending_fields(
     if __diag {
         eprintln!(
             "[replay] storage=Some pendingfields={} rd_virtuals={} num_failargs={}",
-            storage.rd_pendingfields.len(),
-            storage.rd_virtuals.len(),
+            storage.rd_pendingfields().len(),
+            storage.rd_virtuals().len(),
             resume_data.num_failargs,
         );
     }
-    let num_virtuals = storage.rd_virtuals.len();
-    for pending in &storage.rd_pendingfields {
+    let num_virtuals = storage.rd_virtuals().len();
+    for pending in storage.rd_pendingfields() {
         let Some(descr) = pending.descr.as_ref() else {
             if __diag {
                 eprintln!(

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2340,6 +2340,7 @@ impl TraceCtx {
                 .map(|a| match a {
                     Operand::Op(o) => format!("{:?}", o.pos.get()),
                     Operand::InputArg(ia) => format!("IA{}", ia.index),
+                    Operand::SmallInt(_) => format!("C{:?}", a.const_value().unwrap()),
                     Operand::Const(c) => format!("C{:?}", c.get()),
                     Operand::None => "_".to_string(),
                 })

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -9025,7 +9025,7 @@ fn prepare_bridge_pending_fields(
         return pending_ref_array_writes;
     };
     let target_descr = crate::descr::ec_sys_exc_value_descr();
-    for pending in &storage.rd_pendingfields {
+    for pending in storage.rd_pendingfields() {
         let Some(descr) = pending.descr.as_ref() else {
             continue;
         };
@@ -11629,7 +11629,7 @@ impl JitState for PyreJitState {
         // MetaInterp::initialize_virtualizable(), not carried as reds.
         _meta.trace_extra_reds = 1;
         let storage = storage?;
-        let rd_numb = storage.rd_numb.as_slice();
+        let rd_numb = storage.rd_numb.as_ref();
         // resume.py `self.consts = storage.rd_consts` — borrow
         // the shared pool; `ResumeDataResult` carries the Arc handle
         // so downstream virtual materialization reads the same pool

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -13676,7 +13676,7 @@ pub(crate) fn decode_and_restore_guard_failure(
     // from the guard-owned shared Arc instead of a per-guard Vec copy.
     let (typed, mut pending_virtuals_cache) = {
         let storage = exit_layout.storage.as_deref();
-        let rd_numb = storage.map(|s| s.rd_numb.as_slice()).unwrap_or(&[]);
+        let rd_numb = storage.map(|s| s.rd_numb.as_ref()).unwrap_or(&[]);
         let empty_consts: Vec<majit_ir::Const> = Vec::new();
         let rd_consts: &[majit_ir::Const] = storage.map(|s| s.rd_consts()).unwrap_or(&empty_consts);
         if rd_numb.is_empty() {
@@ -13738,7 +13738,7 @@ pub(crate) fn decode_and_restore_guard_failure(
         // in the vable `last_instr` field.
         build_resumed_frames(
             raw_values,
-            storage.rd_numb.as_slice(),
+            storage.rd_numb.as_ref(),
             storage.rd_consts(),
             exit_layout,
             ResumeVableMode::GuardFailureSync,


### PR DESCRIPTION
Eight commits on `main`, in two independent strands plus three regex-row
follow-ups.

## Cranelift: guard-exit layout, and a loop-closing bridge merge

`cranelift: mark every block only a guard exit can reach cold` — `set_cold_block`
was applied to the block a guard exit starts at and to nothing after it, and
cranelift's coldness is not transitive (`Function::is_effectively_cold` reads
the flag on the block itself plus an unconditional trap). The write-barrier arm,
the bridge dispatch, the closing-jump dispatch and the deadframe return were
laid out inside the trace body. Coldness is now propagated to a fixpoint after
`builder.finalize`, which is where `write_pending_failure_recoveries` puts the
recovery stubs upstream. On `pyre/bench/raise_catch_loop.py` the loop function
goes from 33 cold blocks of 249 to 92. Layout hint only; nothing about behaviour
changes.

`cranelift: merge a loop-closing bridge into the loop's own function` — a bridge
whose closing JUMP lands on a LABEL of the loop it attaches to is retained as a
`MergedRegion`, appended to that loop's stream, and the loop re-emitted with the
region as a block the failing guard branches into (`patch_jump_for_descr`'s
shape, where a bridge hit never runs the failure-recovery stub).

**It is fast, and it miscompiles.** Interleaved on one binary, min per round:
`raise_catch_loop` 1.71s merged / 2.80s not / 2.00s dynasm; a raise-free
`if i % 7` loop 1.56s / 2.47s / 1.74s. But `pyre/check.py --backend cranelift`
against that same binary reports 18 failures with the route on and 2 with it
off, so **16 checks separate the arms** — `dict_set.py` and
`nested_break_not_hot.py` SIGSEGV, `loops_comprehension.py` SIGBUS, each only
once a merge has fired. The frame-too-small hypothesis is refuted (the merged
loop allocates a *deeper* frame, 36 words against 32, and faults inside it);
`exception_escape_hot_callee_tb_node_once` reaches the collector with an invalid
type id, so the fault is a store through a wrong pointer.

So the third commit makes it **opt-in behind `MAJIT_CL_BRIDGE_MERGE`** (off by
default), read once into a backend field so
`bridge_closing_onto_its_owner_merges_into_the_loop` keeps driving the route
without an environment the rest of the process shares. The suspected cause is
recorded in the commit: `prepare_and_merge_regions` runs the GC rewrite per
region in its own namespace, and `merge_regions` replays only the window
`0..value_id_end(region)`, so a rewriter-minted constant at or above that width
is never replayed.

## Metainterp: sharing a guard's resume arrays

`ResumeStorage` holds `Arc<[u8]>` for `rd_numb` and a `SharedResumeSlice` for
`rd_virtuals` / `rd_pendingfields`, so `from_fail_descr` borrows the guard
descr's arrays instead of copying all three at every guard failure.
`SharedResumeSlice` keeps the nullable upstream shape — the empty case, which is
the common one, allocates nothing and reaches its readers as the same empty
slice an empty `Vec` gave them.

An earlier draft of that commit also pooled `ConstPtr` boxes per address in
`Trace`, reading `opencoder.py Trace._refs_dict` as one canonical box per
address. **That is not what `_refs_dict` is**: it interns the *encoded* ref
pool, and the decode side mints a box per read (`_untag`:
`ConstPtr(self.trace._refs[v])`), so two occurrences of one address stay
distinct under `is`. pyre models that with `Rc::ptr_eq`, and sharing the box
made previously-distinct constants compare equal, which moved CSE —
`synth/exception_bridge_traceback_head` to `loops_compiled 1 -> 2`, and
`synth/nested_loop_gate_switch` to `bridges_compiled 6 -> 7`, on all three
backends. Only the resume-array sharing, which carries no box identity, is kept.

## Regex row

`ir, regex: pin the Op size gate at the 240 bytes it reached`,
`macros: state the builder-argument order the JitCode register rewriter depends
on`, and `regex: re-measure the and/or row against a freshly translated
RPython`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in optimization that can improve execution of selected loop branches.
  * Added optional diagnostic logging for optimization decisions.

* **Performance**
  * Reduced memory allocation and copying during execution, tracing, and recovery.
  * Improved reuse of runtime frames and temporary buffers.

* **Bug Fixes**
  * Improved reliability when resuming execution and handling nested tracing scenarios.
  * Corrected diagnostic output for compact integer values.

* **Documentation**
  * Updated performance measurements, memory usage figures, and configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->