### PR TITLE
jit, majit, interp: the portal metatrace walk's residual bindings, the vable identity stamp, and the scoped-call result retyping

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -49,7 +49,7 @@ cover the condition they diagnose.
 | `MAJIT_TRACE_CALL_DIAG` | OFF | Reports calls emitted by the native backend; remove when call lowering has sufficient trace-level coverage. |
 | `MAJIT_TRACE_OPS_DIAG` | OFF | Reports operations executed by the native backend; remove when operation lowering has sufficient trace-level coverage. |
 | `MAJIT_VABLE_IDX_PROBE` | OFF | Reports whether virtualizable array indices are constant; remove when supported index shapes are covered by ordinary tests. |
-| `MAJIT_VABLE_READ_PROBE` | OFF | Prints every exit of the virtualizable ref read, with the vable identity and the reading register, because a `getarrayitem_vable_r` that answers `(opref, None)` panics later in `read_ref_reg` naming none of the four exits that produce it; remove when the concrete-less exits are separated by focused tests. |
+| `MAJIT_VABLE_READ_PROBE` | OFF | Prints every exit of the virtualizable ref read, with the vable identity and the reading register, because a `getarrayitem_vable_r` that answers `(opref, None)` panics later in `read_ref_reg` naming none of the four exits that produce it; also names which cause made a vable descriptor lookup decline, since "no vinfo bound" and "index past the declared list" abort the walk identically and call for opposite fixes; remove when the concrete-less exits are separated by focused tests. |
 
 ### `MAJIT_BH_DEBUG`
 

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -386,7 +386,7 @@ cover the condition they diagnose.
 
 - Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
 - Accessor: `pcseq_enabled()`
-- What it does: **UNRECORDED** — no doc comment at the read site.
+- What it does: Prints the control-flow decisions a walk of the portal jitcode makes: the interpreter pc every `jit_merge_point` visit carries, and — for the root jitcode frame alone — every `switch`, every `goto_if_not`, and every `loop_header`. A walk that records without ever closing gives the same reading at the top (`seen_loop_header_for_jdindex` stays -1 at every merge point) whether the `loop_header` op was never reached or was reached and declined, and the two call for opposite fixes; the branch lines name which edge diverted the walk.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
 ### `MAJIT_PORTAL_INLINE`

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -49,6 +49,7 @@ cover the condition they diagnose.
 | `MAJIT_TRACE_CALL_DIAG` | OFF | Reports calls emitted by the native backend; remove when call lowering has sufficient trace-level coverage. |
 | `MAJIT_TRACE_OPS_DIAG` | OFF | Reports operations executed by the native backend; remove when operation lowering has sufficient trace-level coverage. |
 | `MAJIT_VABLE_IDX_PROBE` | OFF | Reports whether virtualizable array indices are constant; remove when supported index shapes are covered by ordinary tests. |
+| `MAJIT_VABLE_READ_PROBE` | OFF | Prints every exit of the virtualizable ref read, with the vable identity and the reading register, because a `getarrayitem_vable_r` that answers `(opref, None)` panics later in `read_ref_reg` naming none of the four exits that produce it; remove when the concrete-less exits are separated by focused tests. |
 
 ### `MAJIT_BH_DEBUG`
 

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -474,6 +474,21 @@ pub fn vable_idx_probe_enabled() -> bool {
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_VABLE_IDX_PROBE").is_some())
 }
 
+/// Which exit of `TraceCtx::vable_getarrayitem_ref_checked` answered, and
+/// whether it carried a concrete.
+///
+/// A `getarrayitem_vable_r` that returns `(opref, None)` leaves the reading
+/// register concrete-less, and the next opcode that demands the value —
+/// `ref_return` in the three-op `load_local_value` jitcode — panics in
+/// `read_ref_reg` with "jitcode concrete ref register was uninitialized".
+/// Four different exits produce that `None`, and the panic names none of
+/// them, so the probe prints on every exit including the answering ones:
+/// silence on an exit must mean "not reached", never "reached and fine".
+pub fn vable_read_probe_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_VABLE_READ_PROBE").is_some())
+}
+
 pub fn mptrace_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_MPTRACE").is_some())

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -494,6 +494,18 @@ pub fn mptrace_enabled() -> bool {
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_MPTRACE").is_some())
 }
 
+/// Prints the control-flow decisions a walk of the portal jitcode makes: the
+/// interpreter pc every `jit_merge_point` visit carries, and — for the root
+/// jitcode frame alone — every `switch`, every `goto_if_not`, and every
+/// `loop_header`.
+///
+/// A walk that records without ever closing gives the same reading at the top
+/// (`seen_loop_header_for_jdindex` stays -1 at every merge point) whether the
+/// `loop_header` op was never reached or was reached and declined, and the two
+/// call for opposite fixes. The branch lines name which edge diverted the walk,
+/// so the answer is the sequence itself rather than an inference from its
+/// absence. Restricted to the root frame because the ops in question are the
+/// portal's own; an inlined callee's branches would bury them.
 pub fn pcseq_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_PCSEQ").is_some())

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -14197,18 +14197,19 @@ impl<M: Clone> MetaInterp<M> {
         }
         // compile.py: BridgeCompileData carries the trace/runtime boxes into
         // `UnrollOptimizer.optimize_bridge`, whose first operation is
-        // unroll.py:187 `trace = trace.get_iter()`.  In the Rust port the
-        // CompileData dispatch is flattened into this method (compile.rs
-        // `CompileData`), so build its short-lived view over that iterator's
-        // canonical `Rc<Op>` objects.  Building a separate `TreeLoop` from
+        // `trace = trace.get_iter()`.  In the Rust port the CompileData
+        // dispatch is flattened into this method (compile.rs `CompileData`),
+        // so build its short-lived view over that iterator's canonical
+        // `Rc<Op>` objects.  Building a separate `TreeLoop` from
         // `bridge_ops.to_vec()` here used to allocate one throw-away `Rc<Op>`
         // for every recorded operation, immediately before TraceIterator
         // allocated the real fresh objects consumed by the optimizer.
         let bridge_runtime_boxes: Vec<OpRef> =
             Self::closing_jump_runtime_boxes(bridge_ops, bridge_inputargs);
-        // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
-        // ResOperation objects in a disjoint OpRef namespace
-        // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
+        // `UnrollOptimizer.optimize_bridge`'s `trace = trace.get_iter()`: mint
+        // fresh InputArg / ResOperation objects in a disjoint OpRef namespace
+        // (`TraceIterator.__init__`, `opencoder.py`:
+        // `self.inputargs = [rop.inputarg_from_tp(arg.type) for ...]`).
         let prepared = prepare_bridge_trace_for_optimizer(
             bridge_ops,
             bridge_inputargs,
@@ -16715,7 +16716,7 @@ impl<M: Clone> MetaInterp<M> {
             }
             // pyjitpl.py: frame.cleanup_registers().
             frame.cleanup_registers();
-            // pyjitpl.py:2477: self.free_frames_list.append(frame).
+            // `MetaInterp.popframe`'s `self.free_frames_list.append(frame)`.
             self.free_frames_list.push(frame);
         }
         // Mirror the TraceCtx inline-depth counter so trace recorder

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4462,6 +4462,18 @@ impl<M: Clone> MetaInterp<M> {
         // pyjitpl.py:3330: virtualizable_boxes.append(virtualizable_box)
         // is folded inside init_virtualizable_boxes (it pushes vable_ref
         // at the end of the list).
+        if crate::vable_read_probe_enabled() {
+            eprintln!(
+                "[vable-read-probe] init virtualizable_box={virtualizable_box:?} \
+                 virtualizable_value={virtualizable_value:?} num_greens={num_green_args} \
+                 num_reds={num_reds} index_of_virtualizable={index_of_virtualizable} \
+                 identity_ref_bank_index={:?} identity_index={identity_index:?} \
+                 box_ref_index={box_ref_index} num_static={num_static} \
+                 array_lengths={array_lengths:?} has_expanded_tail={has_expanded_tail} \
+                 live_values={:?}",
+                info.identity_ref_bank_index, live_values,
+            );
+        }
         ctx.init_virtualizable_boxes(
             info,
             virtualizable_box,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5074,6 +5074,19 @@ where
                     let (vable_reg, array_idx, index_reg, dest) = frame.read_vable_getarrayitem();
                     (opcode_pc, vable_reg, array_idx, index_reg, dest)
                 };
+                if crate::vable_read_probe_enabled() {
+                    let depth = self.frames.len();
+                    let frame = self.frames.current_mut();
+                    eprintln!(
+                        "[vable-read-probe] reg jitcode={} depth={} vable_reg={} \
+                         reg_opref={:?} reg_value={:?}",
+                        frame.jitcode.name,
+                        depth,
+                        vable_reg,
+                        frame.ref_regs[vable_reg],
+                        frame.ref_values[vable_reg].map(|v| format!("0x{v:x}")),
+                    );
+                }
                 let Some((vable_opref, fdescr, adescr)) =
                     self.vable_array_descrs(ctx, vable_reg, array_idx)
                 else {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2315,6 +2315,29 @@ where
         );
     }
 
+    /// Print one control-flow edge of the root jitcode frame under
+    /// `MAJIT_PCSEQ` (see `crate::pcseq_enabled`).
+    ///
+    /// `value` is the concrete word the edge was decided on and `target` the
+    /// cursor it moves to, so a run's lines read as the walk's own path
+    /// through the portal.  Silent for an inlined callee: the ops this exists
+    /// to follow are the portal's, and the callees run orders of magnitude
+    /// more of them.
+    fn pcseq_branch(&mut self, kind: &str, opcode_pc: usize, value: i64, target: Option<usize>) {
+        if !crate::pcseq_enabled() || self.frames.len() != 1 {
+            return;
+        }
+        let name = &self.frames.current_mut().jitcode.name;
+        match target {
+            Some(t) => {
+                eprintln!("@@@PCSEQ {kind} jitcode={name} pc={opcode_pc} value={value} -> {t}")
+            }
+            None => eprintln!(
+                "@@@PCSEQ {kind} jitcode={name} pc={opcode_pc} value={value} -> fallthrough"
+            ),
+        }
+    }
+
     /// pyjitpl.py: vable array descriptor lookup.  Converts a bytecode
     /// array index to the cached `(arrayfielddescr, arraydescr)` pair
     /// from `VirtualizableInfo` and pairs it with the box operand
@@ -5545,6 +5568,12 @@ where
                     )
                 };
                 let (cond, cond_value) = self.read_int_reg(cond_idx);
+                self.pcseq_branch(
+                    "goto_if_not",
+                    opcode_pc,
+                    cond_value,
+                    (cond_value == 0).then_some(target),
+                );
                 self.goto_if_not(ctx, sym, opcode_pc, cond, cond_value, target, true);
             }
             // pyjitpl.py opimpl_goto_if_not_int_is_true(box, target):
@@ -5741,7 +5770,9 @@ where
                     .unwrap_or_else(|| panic!("BC_SWITCH descrs[{descr_idx}] is not a BhDescr"))
                     .clone();
                 let (value_box, concrete_value) = self.read_int_reg(value_idx);
-                if let Some(target) = descr.switch_lookup(concrete_value) {
+                let hit = descr.switch_lookup(concrete_value);
+                self.pcseq_branch("switch", opcode_pc, concrete_value, hit);
+                if let Some(target) = hit {
                     let const_ref = ctx.const_int(concrete_value);
                     self.record_state_guard(
                         ctx,
@@ -7000,6 +7031,13 @@ where
                 // setter; the close happens in BC_JIT_MERGE_POINT after
                 // the assert/reset on the next iteration.
                 self.seen_loop_header_for_jdindex = jdindex as i32;
+                if crate::pcseq_enabled() {
+                    eprintln!(
+                        "@@@PCSEQ loop_header jdindex={jdindex} num_ops={} depth={}",
+                        ctx.num_ops(),
+                        self.frames.len(),
+                    );
+                }
             }
             jitcode::insns::BC_JUMP => {
                 let target = self.frames.current_mut().next_u16() as usize;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7913,6 +7913,21 @@ where
                     // writes the call result into the frame *before*
                     // vable_after_residual_call fires GUARD_NOT_FORCED
                     // (see legacy BC_CALL_MAY_FORCE_INT arm for rationale).
+                    // `pyjitpl.py execute_and_record_varargs` runs the call
+                    // through `executor.execute_varargs` and hands the result
+                    // to `history.record_nospec`, so the recorded op carries
+                    // the executed value on its own frontend slot -- every
+                    // later `getvalue()` of that box answers it.  Writing the
+                    // value into the destination register alone leaves
+                    // `concrete_of_opref` answering `None` for the box, and
+                    // the two readers then disagree: `_nonstandard_virtualizable`
+                    // asks the box, so a residual that returns the standard
+                    // virtualizable (the portal's `reload_top_root`) loses its
+                    // PTR_EQ against `virtualizable_boxes[-1]` and every later
+                    // vable access on that register takes the nonstandard leg.
+                    // The full-body walker already stamps its own residual
+                    // results this way (`jitcode_dispatch/residual_call.rs`).
+                    ctx.set_opref_concrete(traced, majit_ir::Value::Int(concrete));
                     self.set_int_reg(dst, Some(traced), Some(concrete));
                     if is_forces
                         && matches!(
@@ -8188,6 +8203,24 @@ where
                         }
                         _ => traced,
                     };
+                    // `pyjitpl.py execute_and_record_varargs` runs the call
+                    // through `executor.execute_varargs` and hands the result
+                    // to `history.record_nospec`, so the recorded op carries
+                    // the executed value on its own frontend slot -- every
+                    // later `getvalue()` of that box answers it.  Writing the
+                    // value into the destination register alone leaves
+                    // `concrete_of_opref` answering `None` for the box, and
+                    // the two readers then disagree: `_nonstandard_virtualizable`
+                    // asks the box, so a residual that returns the standard
+                    // virtualizable (the portal's `reload_top_root`) loses its
+                    // PTR_EQ against `virtualizable_boxes[-1]` and every later
+                    // vable access on that register takes the nonstandard leg.
+                    // The full-body walker already stamps its own residual
+                    // results this way (`jitcode_dispatch/residual_call.rs`).
+                    ctx.set_opref_concrete(
+                        traced,
+                        majit_ir::Value::Ref(majit_ir::GcRef(concrete as usize)),
+                    );
                     self.set_ref_reg(dst, Some(traced), Some(concrete));
                     if is_forces
                         && matches!(
@@ -8446,6 +8479,21 @@ where
                         }
                         _ => traced,
                     };
+                    // `pyjitpl.py execute_and_record_varargs` runs the call
+                    // through `executor.execute_varargs` and hands the result
+                    // to `history.record_nospec`, so the recorded op carries
+                    // the executed value on its own frontend slot -- every
+                    // later `getvalue()` of that box answers it.  Writing the
+                    // value into the destination register alone leaves
+                    // `concrete_of_opref` answering `None` for the box, and
+                    // the two readers then disagree: `_nonstandard_virtualizable`
+                    // asks the box, so a residual that returns the standard
+                    // virtualizable (the portal's `reload_top_root`) loses its
+                    // PTR_EQ against `virtualizable_boxes[-1]` and every later
+                    // vable access on that register takes the nonstandard leg.
+                    // The full-body walker already stamps its own residual
+                    // results this way (`jitcode_dispatch/residual_call.rs`).
+                    ctx.set_opref_concrete(traced, majit_ir::Value::Float(concrete));
                     self.set_float_reg(dst, Some(traced), Some(concrete.to_bits() as i64));
                     if is_forces
                         && matches!(

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2274,9 +2274,45 @@ where
         field_idx: usize,
     ) -> Option<(OpRef, majit_ir::DescrRef)> {
         let vable_opref = self.resolve_vable_box(vable_reg);
-        let info = ctx.virtualizable_info()?;
-        let descr = info.static_field_descrs().get(field_idx)?.clone();
-        Some((vable_opref, descr))
+        let descr = ctx
+            .virtualizable_info()
+            .and_then(|info| info.static_field_descrs().get(field_idx).cloned());
+        match descr {
+            Some(descr) => Some((vable_opref, descr)),
+            None => {
+                let declared = ctx
+                    .virtualizable_info()
+                    .map(|info| info.static_field_descrs().len());
+                self.report_absent_vable_descr("static field", field_idx, declared);
+                None
+            }
+        }
+    }
+
+    /// Name the reason a vable descriptor lookup declined, under
+    /// `MAJIT_VABLE_READ_PROBE`.
+    ///
+    /// Both causes — no `VirtualizableInfo` bound to the trace at all, and an
+    /// index past the declared list — return `None` here and abort the walk
+    /// identically, and the abort is reported by jitcode and cursor alone.
+    /// Without this the two are indistinguishable from outside, and they call
+    /// for opposite fixes: the first is a trace that was started without
+    /// `initialize_virtualizable`, the second a codewriter index that does not
+    /// match the runtime declaration.
+    fn report_absent_vable_descr(&mut self, kind: &str, index: usize, declared: Option<usize>) {
+        if !crate::vable_read_probe_enabled() {
+            return;
+        }
+        let depth = self.frames.len();
+        let frame = self.frames.current_mut();
+        let cause = match declared {
+            None => "no vinfo bound to the trace".to_owned(),
+            Some(n) => format!("declared {n}"),
+        };
+        eprintln!(
+            "[vable-read-probe] no {kind} descr jitcode={} depth={} cursor={} index={index} {cause}",
+            frame.jitcode.name, depth, frame.code_cursor,
+        );
     }
 
     /// pyjitpl.py: vable array descriptor lookup.  Converts a bytecode
@@ -2290,10 +2326,21 @@ where
         array_idx: usize,
     ) -> Option<(OpRef, majit_ir::DescrRef, majit_ir::DescrRef)> {
         let vable_opref = self.resolve_vable_box(vable_reg);
-        let info = ctx.virtualizable_info()?;
-        let fdescr = info.array_field_descrs().get(array_idx)?.clone();
-        let adescr = info.array_descrs.get(array_idx)?.clone();
-        Some((vable_opref, fdescr, adescr))
+        let pair = ctx.virtualizable_info().and_then(|info| {
+            let fdescr = info.array_field_descrs().get(array_idx)?.clone();
+            let adescr = info.array_descrs.get(array_idx)?.clone();
+            Some((fdescr, adescr))
+        });
+        match pair {
+            Some((fdescr, adescr)) => Some((vable_opref, fdescr, adescr)),
+            None => {
+                let declared = ctx
+                    .virtualizable_info()
+                    .map(|info| info.array_field_descrs().len());
+                self.report_absent_vable_descr("array", array_idx, declared);
+                None
+            }
+        }
     }
 
     /// Resolve a `d`-argcode descr index against the current frame's

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -5394,10 +5394,17 @@ impl TraceCtx {
         if crate::vable_read_probe_enabled() {
             eprintln!(
                 "[vable-read-probe] enter pc={pc} nonstandard={nonstandard} \
-                 index_value={index_runtime_value} vable_concrete={} boxes={:?} lengths={:?}",
+                 index_value={index_runtime_value} vable_concrete={} boxes={:?} lengths={:?} \
+                 vable_opref={vable_opref:?} standard_box={:?} hc_nonstandard={} \
+                 heap_ptr=0x{:x} shadow_concrete={:?}",
                 concrete.is_some(),
                 self.virtualizable_boxes.as_ref().map(Vec::len),
                 self.virtualizable_array_lengths.as_deref(),
+                self.standard_virtualizable_box(),
+                self.heap_cache
+                    .is_known_nonstandard_virtualizable(vable_opref),
+                self.diag_virtualizable_heap_ptr(),
+                self.standard_virtualizable_concrete(),
             );
         }
         if nonstandard {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -5391,6 +5391,15 @@ impl TraceCtx {
         adescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
+        if crate::vable_read_probe_enabled() {
+            eprintln!(
+                "[vable-read-probe] enter pc={pc} nonstandard={nonstandard} \
+                 index_value={index_runtime_value} vable_concrete={} boxes={:?} lengths={:?}",
+                concrete.is_some(),
+                self.virtualizable_boxes.as_ref().map(Vec::len),
+                self.virtualizable_array_lengths.as_deref(),
+            );
+        }
         if nonstandard {
             let fwd = self.nonstandard_vable_element_concrete(
                 vable_opref,
@@ -5400,16 +5409,28 @@ impl TraceCtx {
             );
             let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             let item = self.vable_getarrayitem_ref_descr(array_opref, index, adescr);
+            if crate::vable_read_probe_enabled() {
+                eprintln!(
+                    "[vable-read-probe] exit=nonstandard concrete={}",
+                    fwd.is_some()
+                );
+            }
             if let Some(v) = fwd {
                 self.set_opref_concrete(item, v);
                 return (item, Some(v));
             }
             return (item, None);
         }
-        if let Some(flat_idx) =
-            self.get_arrayitem_vable_index(pc, index, index_runtime_value, &fdescr)
-            && let Some((op, value)) = self.virtualizable_entry_at(flat_idx)
-        {
+        let flat_idx = self.get_arrayitem_vable_index(pc, index, index_runtime_value, &fdescr);
+        let entry = flat_idx.and_then(|flat_idx| self.virtualizable_entry_at(flat_idx));
+        if crate::vable_read_probe_enabled() {
+            eprintln!(
+                "[vable-read-probe] exit=standard flat_idx={flat_idx:?} entry={} concrete={}",
+                entry.is_some(),
+                entry.is_some_and(|(_, value)| concrete_shadow_value(value).is_some()),
+            );
+        }
+        if let Some((op, value)) = entry {
             return (op, concrete_shadow_value(value));
         }
         // `stamp_vable_array_base` supplies the concrete after the record, so
@@ -5423,14 +5444,22 @@ impl TraceCtx {
             0,
         );
         self.stamp_vable_array_base(array_opref, concrete, &fdescr);
-        if let Ok(item_index) = usize::try_from(index_runtime_value) {
+        let result = if let Ok(item_index) = usize::try_from(index_runtime_value) {
             self.vable_getarrayitem_ref_vable(array_opref, &fdescr, item_index, adescr)
         } else {
             (
                 self.vable_getarrayitem_ref_descr(array_opref, index, adescr),
                 None,
             )
+        };
+        if crate::vable_read_probe_enabled() {
+            eprintln!(
+                "[vable-read-probe] exit=fallback base_concrete={} concrete={}",
+                concrete.is_some(),
+                result.1.is_some(),
+            );
         }
+        result
     }
 
     /// Standard virtualizable array item read (float).

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -23042,24 +23042,39 @@ fn trait_assoc_projection_target<'a>(
     let mut cur: &serde_json::Value = value;
     let mut resolved: Option<&'a serde_json::Value> = None;
     for _ in 0..4 {
-        let Some(arr) = cur
-            .as_object()
-            .and_then(|o| o.get("TraitType"))
-            .and_then(serde_json::Value::as_array)
-        else {
+        let Some(arr) = trait_type_projection_args(cur) else {
             break;
         };
-        if arr.len() != 2 {
-            break;
-        }
         let next = resolve_trait_assoc_type_value(&arr[0], &arr[1], llbc)?;
         resolved = Some(next);
         cur = next;
+    }
+    // Hand back only a value that is no longer a projection.  The caller
+    // resolves the answer by recursing into `tyref_to_value_type`, which
+    // enters this walk again with a fresh hop budget, so returning a
+    // still-unresolved projection would make the four-hop cap local rather
+    // than total: an `A::X = B::Y`, `B::Y = A::X` binding would then recurse
+    // without bound.  Declining here caps the whole resolution at four hops
+    // and leaves such a chain typed `Ref`, which is what it was before this
+    // walk existed.
+    if trait_type_projection_args(cur).is_some() {
+        return None;
     }
     // The binding is an ordinary type reference: it may be inline, hash
     // consed or a dedup id, and `TyRef`'s own deserializer is what knows
     // the three shapes apart.
     serde_json::from_value::<TyRef>(resolved?.clone()).ok()
+}
+
+/// The `[traitref, assoc]` pair of an unresolved `Self::Assoc` projection,
+/// or `None` when the value is any other type shape.
+fn trait_type_projection_args(value: &serde_json::Value) -> Option<&[serde_json::Value]> {
+    value
+        .as_object()
+        .and_then(|o| o.get("TraitType"))
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+        .filter(|arr| arr.len() == 2)
 }
 
 /// The type value the trait's unique impl binds to `assoc` — the shared

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -20622,6 +20622,25 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
             }
         }
     }
+    // A trait associated-type projection (`Self::Truth`) has no
+    // representation of its own — it is whatever the selected impl binds
+    // it to.  The decl-level type cannot name that, but with exactly ONE
+    // impl of the trait in this LLBC the binding is recoverable, which is
+    // the same walk `charon_type_value_to_ast_string` already performs for
+    // the rendered form (`resolve_trait_assoc_type_value`).
+    //
+    // Resolving it HERE is what keeps one projection in one register bank
+    // across the whole program.  A *required* trait method is lowered from
+    // the impl, where `Self` is concrete and the projection is already the
+    // bound type; a *provided* default body with no override is lowered
+    // from the trait, where it is not.  Without this arm the two spellings
+    // of the same value disagree on its bank — a caller reaches
+    // `concrete_truth_as_bool(_, truth)` wanting `i` and
+    // `record_branch_guard(_, truth, ..)` wanting `r`, and no kind for the
+    // caller's variable satisfies both.
+    if let Some(resolved) = trait_assoc_projection_target(value, llbc) {
+        return tyref_to_value_type(&resolved, llbc);
+    }
     // RPython `history.getkind` classifies `Ptr(FuncType)` through the raw
     // pointer arm, hence as `int`.  Charon's equivalent is a top-level
     // `FnPtr`: it is the machine address that `FunctionReprBase.call` feeds
@@ -23008,6 +23027,51 @@ fn resolve_trait_assoc_type(
     llbc: &Llbc,
     depth: usize,
 ) -> Option<String> {
+    let value = resolve_trait_assoc_type_value(traitref, assoc, llbc)?;
+    Some(charon_type_value_to_ast_string(value, llbc, depth + 1))
+}
+
+/// Peel a trait associated-type projection to the type the trait's unique
+/// impl binds it to, following a chain of projections but stopping at a
+/// small bound so a self-referential binding cannot spin.  `None` when the
+/// value is not a projection, or when the walk cannot resolve one.
+fn trait_assoc_projection_target<'a>(
+    value: &'a serde_json::Value,
+    llbc: &'a Llbc,
+) -> Option<TyRef> {
+    let mut cur: &serde_json::Value = value;
+    let mut resolved: Option<&'a serde_json::Value> = None;
+    for _ in 0..4 {
+        let Some(arr) = cur
+            .as_object()
+            .and_then(|o| o.get("TraitType"))
+            .and_then(serde_json::Value::as_array)
+        else {
+            break;
+        };
+        if arr.len() != 2 {
+            break;
+        }
+        let next = resolve_trait_assoc_type_value(&arr[0], &arr[1], llbc)?;
+        resolved = Some(next);
+        cur = next;
+    }
+    // The binding is an ordinary type reference: it may be inline, hash
+    // consed or a dedup id, and `TyRef`'s own deserializer is what knows
+    // the three shapes apart.
+    serde_json::from_value::<TyRef>(resolved?.clone()).ok()
+}
+
+/// The type value the trait's unique impl binds to `assoc` — the shared
+/// half of [`resolve_trait_assoc_type`], kept separate so a caller that
+/// needs the register bank rather than the rendered name
+/// ([`tyref_to_value_type`]) reads the same binding through the same
+/// uniqueness rule instead of re-deriving it.
+fn resolve_trait_assoc_type_value<'a>(
+    traitref: &serde_json::Value,
+    assoc: &serde_json::Value,
+    llbc: &'a Llbc,
+) -> Option<&'a serde_json::Value> {
     let trait_id = traitref_decl_id(traitref, llbc, 0)?;
     let mut unique: Option<&serde_json::Value> = None;
     for ti in llbc.trait_impls_raw() {
@@ -23032,8 +23096,7 @@ fn resolve_trait_assoc_type(
             continue;
         };
         if kind.len() == 2 && &kind[1] == assoc {
-            let value = entry.get("skip_binder")?.get("value")?;
-            return Some(charon_type_value_to_ast_string(value, llbc, depth + 1));
+            return entry.get("skip_binder")?.get("value");
         }
     }
     None

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1536,9 +1536,10 @@ fn rewire_one_call_site(
         // what the rtyper colours and what flows on to `returnblock`.
         //
         // Leaving it `Ref` is not a cosmetic mislabel; it is the whole
-        // disagreement `call.py:230` ("the call result must have the same
-        // concretetype as FUNC.RESULT") exists to prevent, and it lands on
-        // BOTH sides of this graph:
+        // disagreement `CallControl.getcalldescr` (`call.py`) exists to
+        // prevent — it refuses a call whose `op.result.concretetype`
+        // differs from its `FUNC.RESULT` — and it lands on BOTH sides of
+        // this graph:
         //
         //   - inside, the call emits `inline_call_r_r` while the callee's
         //     transformed CFG `int_return`s, and the metainterp's

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1525,6 +1525,35 @@ fn rewire_one_call_site(
                  switches would read garbage"
             ));
         }
+        // The forward needs no CFG rewrite — but it does need the same
+        // retyping the diamond arm performs, and for the same reason.
+        // `front::mir` types every aggregate `Ref`, so the call declares
+        // the `Result` shell; once the callee is transformed it hands
+        // back `T` and the raise travels the exception edge, so the value
+        // crossing this link is the payload.  Narrow the call's declared
+        // result to `T` exactly as the diamond's `collapse_pos0_read` arm
+        // does (`narrow_call_result_ty` below), so the payload's kind is
+        // what the rtyper colours and what flows on to `returnblock`.
+        //
+        // Leaving it `Ref` is not a cosmetic mislabel; it is the whole
+        // disagreement `call.py:230` ("the call result must have the same
+        // concretetype as FUNC.RESULT") exists to prevent, and it lands on
+        // BOTH sides of this graph:
+        //
+        //   - inside, the call emits `inline_call_r_r` while the callee's
+        //     transformed CFG `int_return`s, and the metainterp's
+        //     `typed_return_without_caller_destination` fires because the
+        //     caller encoded NO_RETURN_REG in the int bank;
+        //   - outside, this graph's own returnblock inherits the `Ref` and
+        //     `graph_result_kind` reports `r` (`codewriter.rs`
+        //     `result_type = declared_kind.unwrap_or(cfg_kind)`), so every
+        //     `?`-site calling it — whose diamond DID narrow to `T` —
+        //     emits `_i` against an `r` calldescr.
+        //
+        // A wrapper whose every return is such a forward (`is_true`) is the
+        // shape that shows both at once, which is why the two mismatch
+        // classes are one defect and not two.
+        narrow_call_result_ty(graph, a, r, payload_ty.clone());
         return Ok(SiteOutcome::TailForward);
     }
     let (b, r_b) =

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1992,6 +1992,23 @@ fn catch_and_rewrap(
         Some(ExitSwitch::LastException),
         vec![Link::new_mixed(value_args, n_id, None), exc_link],
     );
+    // The normal arm above wrapped `r` in a fresh `Ok` shell, which is a
+    // statement about what `r` now IS: the raw payload the transformed
+    // callee returns, not the `Result` it returned before.  Retype the call
+    // to match, the same narrowing the diamond and tail-forward arms perform
+    // (`narrow_call_result_ty`).  Without it the call keeps the shell's
+    // `Ref`, so a callee that `int_return`s is invoked through
+    // `inline_call_*_r` and the returned value has no destination in the int
+    // bank — and the `Ok` shell built here would be handed the register the
+    // caller never wrote.
+    //
+    // Gated on `has_r` for the same reason the shells are: when the result
+    // does not flow along the original exit there is no payload to speak of
+    // and nothing consumes the call's type.  Placed last, after this rule's
+    // final mutation, so a decline still leaves the graph untouched.
+    if has_r {
+        narrow_call_result_ty(graph, a, r, payload_ty.clone());
+    }
     Ok(())
 }
 

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1633,6 +1633,20 @@ fn analyze_pipeline_from_module_paths(
                 // concrete override at the same classdef/MRO decision point
                 // as the exception-handler pair above.
                 "load_super_attr_with",
+                // `ControlFlowOpcodeHandler::close_loop`'s default asks
+                // `close_loop_args`, whose own default answers `None`, and
+                // reports `StepResult::Continue`.  `PyFrame` overrides it to
+                // report `CloseLoop` unconditionally — that report is the
+                // back edge, and the portal turns it into the `loop_header`
+                // op `jtransform.py` rewrites `can_enter_jit` into.  Left on
+                // the default, a walk of the portal reads `Continue` at every
+                // back edge, never reaches `loop_header`, and so leaves
+                // `seen_loop_header_for_jdindex` at -1 for the whole walk:
+                // every `jit_merge_point` is a no-op and no trace can close.
+                // The override is three statements over a `Vec` and a struct
+                // literal, so it carries none of the objspace surface the
+                // staging above is about.
+                "close_loop",
             ];
             let devirt: Option<(&str, &front::semantic::SemanticFunction)> =
                 if is_default && DEFAULT_SHADOW_DEVIRT_SCOPE.contains(&method.name.as_str()) {

--- a/majit/majit-translate/tests/test_residual_dunder_arg_slots.rs
+++ b/majit/majit-translate/tests/test_residual_dunder_arg_slots.rs
@@ -1,0 +1,119 @@
+//! A residual call's argument must fit one machine word: production-LLBC
+//! regression for the `descroperation` override gates.
+//!
+//! `jit_fnaddr.rs` states the ABI — one word per argument slot, classified
+//! `'i'`/`'r'`/`'f'` — so a `&str` parameter is undescribable: it is two
+//! words, and the callee would read the second out of whatever the caller
+//! happened to leave there.  Each gate below is `dont_look_inside`, so every
+//! one of them IS a residual call, and each used to take the forward and
+//! reflected dunder NAMES.  They take a fieldless-enum discriminant instead
+//! and recover the names inside the residual.
+//!
+//! The publication side is already checked by the compiler: `jit_fnaddr`'s
+//! helpers take the function itself, so `ResidualSlot` rejects a fat pointer
+//! before an address can be taken.  What nothing checks is the signature the
+//! front actually lowers, which is what this file covers.  `ValueType::Str`
+//! is the exact shape that cannot be published, so it — not the argument
+//! count — is what these assert on: swapping two `&str`s for one enum also
+//! changes the count, but restoring a single `&str` would not.
+
+use majit_charon_reader::Llbc;
+use majit_translate::front::mir::lower_function_with_static_addrs;
+use majit_translate::model::{OpKind, ValueType};
+use majit_translate::{ErrorCarrierSpec, HostStaticAddrs};
+use std::sync::OnceLock;
+
+const INTERP: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc",
+);
+
+/// Shared parse — the corpus is several GB resident, so one parse behind a
+/// `OnceLock` is what keeps concurrent tests off the runner's swap.
+fn interp() -> &'static Llbc {
+    static L: OnceLock<Llbc> = OnceLock::new();
+    L.get_or_init(|| Llbc::load(INTERP).expect("load pyre-interpreter.ullbc"))
+}
+
+/// Every parameter of `name`, as the front banks it.
+fn parameter_banks(name: &str) -> Vec<(String, ValueType)> {
+    let graph = lower_function_with_static_addrs(
+        interp(),
+        name,
+        HostStaticAddrs {
+            error_carrier: ErrorCarrierSpec {
+                carrier_path: "pyre_interpreter::error::PyError",
+                carrier_wrappers: &[],
+                to_exc_object: Some(&["pyre_interpreter", "error", "pyerror_to_exc_object"]),
+                from_exc_object: Some(("PyError", "from_exc_object")),
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|e| panic!("lower {name}: {e:?}"));
+    graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .filter_map(|op| match &op.kind {
+            OpKind::Input { name, ty, .. } => Some((name.clone(), ty.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn no_override_gate_takes_a_fat_pointer() {
+    for gate in [
+        "needs_numeric_binop_dispatch",
+        "needs_seq_binop_dispatch",
+        "needs_bytes_binop_dispatch",
+        "needs_numeric_unaryop_dispatch",
+        "needs_set_binop_dispatch",
+    ] {
+        let banks = parameter_banks(&format!(
+            "pyre_interpreter::objspace::descroperation::{gate}"
+        ));
+        assert!(
+            !banks.is_empty(),
+            "{gate} lowered with no parameters at all"
+        );
+        let fat: Vec<_> = banks
+            .iter()
+            .filter(|(_, ty)| *ty == ValueType::Str)
+            .collect();
+        assert!(
+            fat.is_empty(),
+            "{gate} is `dont_look_inside`, so it is a residual call, and a \
+             residual argument gets ONE machine word.  A `&str` is two, so \
+             this parameter cannot be published through `jit_fnaddr` and the \
+             traced caller is left holding an unbound symbolic residual: \
+             {fat:?}"
+        );
+    }
+}
+
+#[test]
+fn the_dunder_discriminant_is_banked_as_an_integer() {
+    // The names live behind `BinopDunder` / `UnaryDunder`, which the front
+    // models as the discriminant integer (`tyref_is_fieldless_enum_free`).
+    // `SeqBase`'s `base` is the same shape and predates them.
+    for (gate, param) in [
+        ("needs_numeric_binop_dispatch", "op"),
+        ("needs_seq_binop_dispatch", "op"),
+        ("needs_seq_binop_dispatch", "base"),
+        ("needs_bytes_binop_dispatch", "op"),
+        ("needs_numeric_unaryop_dispatch", "op"),
+    ] {
+        let banks = parameter_banks(&format!(
+            "pyre_interpreter::objspace::descroperation::{gate}"
+        ));
+        let found = banks.iter().find(|(name, _)| name == param);
+        assert_eq!(
+            found.map(|(_, ty)| ty),
+            Some(&ValueType::Int),
+            "{gate}'s `{param}` is a fieldless enum, which banks as its \
+             discriminant integer.  Parameters: {banks:?}"
+        );
+    }
+}

--- a/majit/majit-translate/tests/test_residual_dunder_arg_slots.rs
+++ b/majit/majit-translate/tests/test_residual_dunder_arg_slots.rs
@@ -11,11 +11,15 @@
 //!
 //! The publication side is already checked by the compiler: `jit_fnaddr`'s
 //! helpers take the function itself, so `ResidualSlot` rejects a fat pointer
-//! before an address can be taken.  What nothing checks is the signature the
-//! front actually lowers, which is what this file covers.  `ValueType::Str`
-//! is the exact shape that cannot be published, so it — not the argument
-//! count — is what these assert on: swapping two `&str`s for one enum also
-//! changes the count, but restoring a single `&str` would not.
+//! before an address can be taken.  That bound is the ONLY check: the front
+//! collapses `ValueType::Str` to `Type::Ref` and `type_to_argclass` gives a
+//! `Ref` one slot, so a `&str` argument is described as one word and its
+//! length half is never passed.  Restoring a `&str` here therefore produces
+//! no front-side error — the gate simply loses its row and every traced
+//! caller is left holding an unbound symbolic residual.  `ValueType::Str` is
+//! that exact shape, so it — not the argument count — is what these assert
+//! on: swapping two `&str`s for one enum also changes the count, but
+//! restoring a single `&str` would not.
 
 use majit_charon_reader::Llbc;
 use majit_translate::front::mir::lower_function_with_static_addrs;
@@ -70,6 +74,8 @@ fn no_override_gate_takes_a_fat_pointer() {
         "needs_bytes_binop_dispatch",
         "needs_numeric_unaryop_dispatch",
         "needs_set_binop_dispatch",
+        "sequence_numeric_slot_is_null",
+        "seq_repeat_override",
     ] {
         let banks = parameter_banks(&format!(
             "pyre_interpreter::objspace::descroperation::{gate}"
@@ -95,15 +101,18 @@ fn no_override_gate_takes_a_fat_pointer() {
 
 #[test]
 fn the_dunder_discriminant_is_banked_as_an_integer() {
-    // The names live behind `BinopDunder` / `UnaryDunder`, which the front
-    // models as the discriminant integer (`tyref_is_fieldless_enum_free`).
-    // `SeqBase`'s `base` is the same shape and predates them.
+    // The names live behind `BinopDunder` / `UnaryDunder` / `RepeatDunder`,
+    // which the front models as the discriminant integer
+    // (`tyref_is_fieldless_enum_free`).  `SeqBase`'s `base` is the same shape
+    // and predates them.
     for (gate, param) in [
         ("needs_numeric_binop_dispatch", "op"),
         ("needs_seq_binop_dispatch", "op"),
         ("needs_seq_binop_dispatch", "base"),
         ("needs_bytes_binop_dispatch", "op"),
         ("needs_numeric_unaryop_dispatch", "op"),
+        ("sequence_numeric_slot_is_null", "op"),
+        ("seq_repeat_override", "dunders"),
     ] {
         let banks = parameter_banks(&format!(
             "pyre_interpreter::objspace::descroperation::{gate}"

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -146,6 +146,52 @@ fn a_tail_forwarding_wrapper_retypes_its_calls_to_the_payload() {
     );
 }
 
+/// The catch-and-rewrap fallback rebuilds the shell from the call's result,
+/// which means that result IS the payload — so the call has to be retyped
+/// like the diamond and tail-forward arms do.
+///
+/// `int_w` is `Result<i64, PyError>`; its consumers here match on the shell
+/// by hand rather than through `?`, so the site takes `catch_and_rewrap`.
+/// Left `Ref`, the call is emitted as `inline_call_*_r` against a callee that
+/// `int_return`s (the returned value then has no destination in the int
+/// bank), and the `Ok` shell the rewrite builds is handed a register the
+/// caller never wrote.
+#[test]
+fn a_rewrapped_call_site_retypes_its_call_to_the_payload() {
+    for name in [
+        "pyre_interpreter::baseobjspace::_check_len_result",
+        "pyre_interpreter::baseobjspace::getindex_w_index",
+        "pyre_interpreter::baseobjspace::index_int_w_preserve_negative",
+    ] {
+        let graph = lower_function(interp(), name).expect("lower");
+        let mut seen = 0usize;
+        for block in &graph.blocks {
+            for op in &block.operations {
+                let OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    result_ty,
+                    ..
+                } = &op.kind
+                else {
+                    continue;
+                };
+                if segments.last().map(String::as_str) != Some("int_w") {
+                    continue;
+                }
+                seen += 1;
+                assert_eq!(
+                    *result_ty,
+                    majit_translate::model::ValueType::Int,
+                    "{name}: the rewrap rebuilds `Ok(r)` from the call result, so \
+                     the call declares int_w's `i64` payload -- not the `Result` \
+                     shell (`Ref`, which is what this reads before the retype)"
+                );
+            }
+        }
+        assert!(seen >= 1, "{name} calls int_w");
+    }
+}
+
 #[test]
 fn pop_value_lowers_to_raise_links() {
     let llbc = interp();

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -91,6 +91,61 @@ fn unit_result_callee_declares_void_return() {
     );
 }
 
+/// A wrapper whose every return is `return f(...)` — no `Ok`/`Err` shell of
+/// its own — must still retype those calls to the payload.
+///
+/// `is_true` is that shape: `if …  { return is_true_slot(obj); }
+/// is_true_lookup(obj)`.  Both callees are scoped `Result<bool, PyError>`
+/// graphs the exception-link lowering transforms into plain `bool` returns,
+/// so the value each call hands back is the payload — but `front::mir` types
+/// every aggregate `Ref`, and a tail forward has no `__pos_0` read for the
+/// diamond arm's `collapse_pos0_read` to narrow through.  Left `Ref`, the
+/// disagreement lands on both sides of this graph: the calls emit
+/// `inline_call_r_r` against callees that `int_return`, and the returnblock
+/// inherits the `Ref` so `graph_result_kind` reports `r` to every `?`-site
+/// caller whose own diamond narrowed to `bool`.
+///
+/// Assert the call ops themselves, not the return kind: the returnblock's
+/// `ConcreteType` is coloured later by the rtyper, so this pass's output is
+/// the declared `result_ty` on the two `Call`s.
+#[test]
+fn a_tail_forwarding_wrapper_retypes_its_calls_to_the_payload() {
+    let graph =
+        lower_function(interp(), "pyre_interpreter::baseobjspace::is_true").expect("lower is_true");
+    let mut forwarded = 0usize;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::Call {
+                target, result_ty, ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            let CallTarget::FunctionPath { segments } = target else {
+                continue;
+            };
+            let Some(leaf) = segments.last() else {
+                continue;
+            };
+            if leaf != "is_true_slot" && leaf != "is_true_lookup" {
+                continue;
+            }
+            forwarded += 1;
+            assert_eq!(
+                *result_ty,
+                majit_translate::model::ValueType::Bool,
+                "{leaf}: a tail-forwarded scoped callee hands back its `bool` \
+                 payload, so the call must declare it -- not the `Result` shell \
+                 (`Ref`, which is what this reads before the retype)"
+            );
+        }
+    }
+    assert_eq!(
+        forwarded, 2,
+        "is_true tail-forwards both is_true_slot and is_true_lookup"
+    );
+}
+
 #[test]
 fn pop_value_lowers_to_raise_links() {
     let llbc = interp();

--- a/majit/majit-translate/tests/test_trait_assoc_type_bank.rs
+++ b/majit/majit-translate/tests/test_trait_assoc_type_bank.rs
@@ -1,0 +1,110 @@
+//! A trait associated-type projection must reach the SAME register bank
+//! wherever it is spelled: production-LLBC regression for
+//! `front::mir`'s unique-impl resolution of `TraitType`.
+//!
+//! `<Self as TruthOpcodeHandler>::Truth` is spelled two ways in the
+//! interpreter.  A *required* method (`truth_value`,
+//! `concrete_truth_as_bool`) is lowered from `impl BranchOpcodeHandler for
+//! PyFrame`, where `Self` is concrete and the projection is already `bool`.
+//! A generic caller (`opcode_pop_jump_if<H>`) and a *provided* default body
+//! (`record_branch_guard`) are lowered from the trait, where it is not.
+//! Without the resolution the two disagree on the bank of one value, and no
+//! kind for the caller's variable satisfies both callees.
+
+use majit_charon_reader::Llbc;
+use majit_translate::front::mir::lower_function_with_static_addrs;
+use majit_translate::model::{CallTarget, OpKind, ValueType};
+use majit_translate::{ErrorCarrierSpec, HostStaticAddrs};
+use std::sync::OnceLock;
+
+const INTERP: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc",
+);
+
+/// Shared parse — see the same note on `test_result_exc_lowering.rs`: the
+/// corpus is several GB resident, so one parse behind a `OnceLock` is what
+/// keeps concurrent tests off the runner's swap.
+fn interp() -> &'static Llbc {
+    static L: OnceLock<Llbc> = OnceLock::new();
+    L.get_or_init(|| Llbc::load(INTERP).expect("load pyre-interpreter.ullbc"))
+}
+
+fn lower(name: &str) -> majit_translate::model::FunctionGraph {
+    lower_function_with_static_addrs(
+        interp(),
+        name,
+        HostStaticAddrs {
+            error_carrier: ErrorCarrierSpec {
+                carrier_path: "pyre_interpreter::error::PyError",
+                carrier_wrappers: &[],
+                to_exc_object: Some(&["pyre_interpreter", "error", "pyerror_to_exc_object"]),
+                from_exc_object: Some(("PyError", "from_exc_object")),
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|e| panic!("lower {name}: {e:?}"))
+}
+
+#[test]
+fn a_generic_caller_types_an_assoc_type_result_through_the_unique_impl() {
+    let graph = lower("pyre_interpreter::pyopcode::opcode_pop_jump_if");
+    let mut seen = 0usize;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::Call {
+                target, result_ty, ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            let CallTarget::FunctionPath { segments } = target else {
+                continue;
+            };
+            if segments.last().map(String::as_str) != Some("truth_value") {
+                continue;
+            }
+            seen += 1;
+            assert_eq!(
+                *result_ty,
+                ValueType::Bool,
+                "`truth_value` hands back `Self::Truth`, which the trait's only \
+                 impl binds to `bool`.  Left unresolved it reads `Ref(None)` and \
+                 the caller emits `inline_call_*_r` against a callee that \
+                 `int_return`s"
+            );
+        }
+    }
+    assert_eq!(seen, 1, "opcode_pop_jump_if calls truth_value once");
+}
+
+#[test]
+fn the_same_projection_resolves_in_a_provided_default_body() {
+    // `opcode_unary_not` is the second caller of the same projection, and
+    // `record_branch_guard` is the provided body that reaches it from the
+    // trait side rather than from the impl.
+    let graph = lower("pyre_interpreter::pyopcode::opcode_unary_not");
+    let mut seen = 0usize;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::Call {
+                target, result_ty, ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            let CallTarget::FunctionPath { segments } = target else {
+                continue;
+            };
+            if segments.last().map(String::as_str) != Some("truth_value") {
+                continue;
+            }
+            seen += 1;
+            assert_eq!(*result_ty, ValueType::Bool);
+        }
+    }
+    assert_eq!(seen, 1, "opcode_unary_not calls truth_value once");
+    // The provided default body lowers at all and keeps its own call.
+    lower("pyre_interpreter::pyopcode::BranchOpcodeHandler::record_branch_guard");
+}

--- a/majit/majit-translate/tests/test_trait_assoc_type_bank.rs
+++ b/majit/majit-translate/tests/test_trait_assoc_type_bank.rs
@@ -105,6 +105,35 @@ fn the_same_projection_resolves_in_a_provided_default_body() {
         }
     }
     assert_eq!(seen, 1, "opcode_unary_not calls truth_value once");
-    // The provided default body lowers at all and keeps its own call.
-    lower("pyre_interpreter::pyopcode::BranchOpcodeHandler::record_branch_guard");
+}
+
+#[test]
+fn a_provided_default_body_banks_its_projection_typed_parameter() {
+    // `record_branch_guard` does not CALL `truth_value` — it receives the
+    // projection as a parameter (`truth: Self::Truth`) and forwards it to
+    // `guard_truth_value`.  So the assertion for this side is on the
+    // parameter's own bank: `truth` is the caller's variable that had no kind
+    // satisfying both callees, and this is the lowering that gave it `Ref`.
+    let graph = lower("pyre_interpreter::pyopcode::BranchOpcodeHandler::record_branch_guard");
+    let mut seen = 0usize;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::Input { name, ty, .. } = &op.kind else {
+                continue;
+            };
+            if name != "truth" {
+                continue;
+            }
+            seen += 1;
+            assert_eq!(
+                *ty,
+                ValueType::Bool,
+                "`truth: Self::Truth` is the trait's only impl's `bool`.  Left \
+                 unresolved it banks as a GC reference while \
+                 `concrete_truth_as_bool` wants the int bank, and no kind for \
+                 the caller's variable satisfies both"
+            );
+        }
+    }
+    assert_eq!(seen, 1, "record_branch_guard declares `truth` once");
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -269,6 +269,27 @@ impl FrameAnchor {
         }
     }
 
+    /// Read the anchored frame back out of its shadow-stack slot.
+    ///
+    /// Opaque to the tracer for the same reason `new` is, arrived at
+    /// differently: `new`'s aggregate return keeps it out of inlining on its
+    /// own, while this one returns a single word and would otherwise be
+    /// inlined. An inlined body is wrong here. `front::mir` aliases an
+    /// `Rvalue::Ref` over a bare local to that local's own Variable without
+    /// emitting an address-of, so `&self` arrives as the one-word anchor's
+    /// VALUE — the depth — and the inlined body's `getfield_gc_i` on
+    /// `FrameAnchor.depth` reads that depth as an address. A walk of
+    /// `push_anchored` faulted on exactly that, at the depth itself
+    /// (`KERN_INVALID_ADDRESS at 0x9`, offset 0 of a one-field struct).
+    /// `frame_anchor_live_method_jit_abi` is the spelling that reconstructs
+    /// the anchor from the word, and it is only reachable while this stays a
+    /// residual.
+    ///
+    /// No effect information is lost by closing it: the whole body is a call
+    /// to `frame_anchor_live`, which is `dont_look_inside` already, so the
+    /// wrapper's graph could never have told the optimizer more than its
+    /// callee's does.
+    #[majit_macros::dont_look_inside]
     pub fn live(&self) -> *mut PyFrame {
         frame_anchor_live(self.depth)
     }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -55,6 +55,15 @@ impl<T: rustpython_compiler_core::bytecode::OpArgType> ResidualSlot
 {
 }
 
+/// The dunder-pair and builtin-base discriminants the override gates in
+/// `descroperation` take.  Each is a fieldless enum, which the front models
+/// as its discriminant integer (`tyref_is_fieldless_enum_free`), so it fills
+/// exactly one argument slot — the reason those gates carry a discriminant
+/// rather than the `&str` names themselves.
+impl ResidualSlot for crate::objspace::descroperation::BinopDunder {}
+impl ResidualSlot for crate::objspace::descroperation::UnaryDunder {}
+impl ResidualSlot for crate::objspace::descroperation::SeqBase {}
+
 impl<T> ResidualSlot for &T {}
 impl<T> ResidualSlot for &mut T {}
 impl<T> ResidualSlot for *const T {}
@@ -289,6 +298,15 @@ fn upa3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
 }
 
 #[inline]
+fn up3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
+    entries: &mut Vec<(&'static str, i64)>,
+    full_path: &'static str,
+    f: unsafe fn(A1, A2, A3) -> R,
+) {
+    push_raw_fnaddr(entries, full_path, f as *const ());
+}
+
+#[inline]
 fn cp3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
     entries: &mut Vec<(&'static str, i64)>,
     full_path: &'static str,
@@ -328,6 +346,15 @@ fn upa4<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, A4: ResidualSlot, 
 ) {
     push_raw_fnaddr(entries, module_path, f as *const ());
     push_raw_fnaddr(entries, root_path, f as *const ());
+}
+
+#[inline]
+fn up4<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, A4: ResidualSlot, R: ResidualRet>(
+    entries: &mut Vec<(&'static str, i64)>,
+    full_path: &'static str,
+    f: unsafe fn(A1, A2, A3, A4) -> R,
+) {
+    push_raw_fnaddr(entries, full_path, f as *const ());
 }
 
 #[inline]
@@ -2267,6 +2294,35 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         &mut entries,
         "pyre_interpreter::objspace::descroperation::compare_slot",
         crate::objspace::descroperation::compare_slot_jit_abi,
+    );
+    // `binop_impl`'s builtin-fast-path override gates.  Each is
+    // `dont_look_inside` so the type-static and typeobject-registry loads stay
+    // out of the traced arithmetic graph, which makes every one of them a
+    // residual call the walk has to bind.
+    up3(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::needs_numeric_binop_dispatch",
+        crate::objspace::descroperation::needs_numeric_binop_dispatch,
+    );
+    up3(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::needs_bytes_binop_dispatch",
+        crate::objspace::descroperation::needs_bytes_binop_dispatch,
+    );
+    up4(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::needs_seq_binop_dispatch",
+        crate::objspace::descroperation::needs_seq_binop_dispatch,
+    );
+    up2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::needs_set_binop_dispatch",
+        crate::objspace::descroperation::needs_set_binop_dispatch,
+    );
+    up2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::needs_numeric_unaryop_dispatch",
+        crate::objspace::descroperation::needs_numeric_unaryop_dispatch,
     );
     // Truncated `_divrem` projections used by Rust operator shims.
     cp2(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -63,6 +63,7 @@ impl<T: rustpython_compiler_core::bytecode::OpArgType> ResidualSlot
 impl ResidualSlot for crate::objspace::descroperation::BinopDunder {}
 impl ResidualSlot for crate::objspace::descroperation::UnaryDunder {}
 impl ResidualSlot for crate::objspace::descroperation::SeqBase {}
+impl ResidualSlot for crate::objspace::descroperation::RepeatDunder {}
 
 impl<T> ResidualSlot for &T {}
 impl<T> ResidualSlot for &mut T {}
@@ -2323,6 +2324,19 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         &mut entries,
         "pyre_interpreter::objspace::descroperation::needs_numeric_unaryop_dispatch",
         crate::objspace::descroperation::needs_numeric_unaryop_dispatch,
+    );
+    // The two gates `binop_impl`'s sequence branches reach past the ones
+    // above.  Each also carried its dunder names as text and so had no row
+    // until it took a discriminant.
+    up2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::sequence_numeric_slot_is_null",
+        crate::objspace::descroperation::sequence_numeric_slot_is_null,
+    );
+    up2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::seq_repeat_override",
+        crate::objspace::descroperation::seq_repeat_override,
     );
     // Truncated `_divrem` projections used by Rust operator shims.
     cp2(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3203,6 +3203,14 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         "majit_ir::eval_breaker_word::take_memory_error",
         majit_ir::eval_breaker_word::take_memory_error_jit_abi,
     );
+    // The portal's prologue arms this bit before the dispatch loop, so it is
+    // the first residual an `ENTRY=start` walk of `eval_loop_jit` meets.
+    let eval_breaker_set_gc_interp: fn() = majit_ir::eval_breaker_word::set_gc_interp;
+    p0(
+        &mut entries,
+        "majit_ir::eval_breaker_word::set_gc_interp",
+        eval_breaker_set_gc_interp,
+    );
     let gc_safepoint_poll: fn() = majit_gc::gc_sync::safepoint_poll;
     p0(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -289,6 +289,15 @@ fn upa3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
 }
 
 #[inline]
+fn cp3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
+    entries: &mut Vec<(&'static str, i64)>,
+    full_path: &'static str,
+    f: extern "C" fn(A1, A2, A3) -> R,
+) {
+    push_raw_fnaddr(entries, full_path, f as *const ());
+}
+
+#[inline]
 fn cpa3<A1: ResidualSlot, A2: ResidualSlot, A3: ResidualSlot, R: ResidualRet>(
     entries: &mut Vec<(&'static str, i64)>,
     module_path: &'static str,
@@ -2244,6 +2253,20 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         &mut entries,
         "pyre_interpreter::pycode::w_code_const",
         crate::pycode::w_code_const,
+    );
+    // `compare` residualizes its `compare_slot` tail: the slot body reads two
+    // `&[u8]` through `core::slice::cmp`, which has no LLBC, so the source lift
+    // fails and the whole callee becomes a residual. What was missing is only
+    // the address — the callee keeps its graph, and with it a real EffectInfo,
+    // so it must NOT be given `dont_look_inside` (a graphless callee gets an
+    // empty rather than a top EffectInfo, and the heap optimizer would then
+    // keep cached fields across a comparison that can run user `__eq__`).
+    // The published address is the word-ABI bridge, not `compare_slot` itself;
+    // see `compare_slot_jit_abi` for why the raw signature cannot be a row.
+    cp3(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::compare_slot",
+        crate::objspace::descroperation::compare_slot_jit_abi,
     );
     // Truncated `_divrem` projections used by Rust operator shims.
     cp2(

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3099,6 +3099,26 @@ impl UnaryDunder {
     }
 }
 
+/// The set of special-method names a repeat gate tests, carried as a word for
+/// the same reason as [`BinopDunder`] — a `&[&str]` is a slice, so it fills two
+/// argument slots and leaves the gate unpublishable.
+#[derive(Clone, Copy)]
+pub(crate) enum RepeatDunder {
+    /// `__mul__` and its reflected counterpart, the pair a binary repeat tests.
+    MulPair,
+    /// `__imul__` alone; an in-place repeat has no reflected form.
+    IMul,
+}
+
+impl RepeatDunder {
+    fn names(self) -> &'static [&'static str] {
+        match self {
+            Self::MulPair => &["__mul__", "__rmul__"],
+            Self::IMul => &["__imul__"],
+        }
+    }
+}
+
 /// Builtin sequence base selected by [`needs_seq_binop_dispatch`].  The
 /// caller passes this discriminant instead of a `&STR_TYPE`/… static so
 /// the type-static load stays inside the residual helper, off the traced
@@ -3192,7 +3212,7 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
 /// base type statics are loaded here, and a traced caller would otherwise
 /// carry an unresolvable `LoadStatic`.
 #[majit_macros::dont_look_inside]
-unsafe fn sequence_numeric_slot_is_null(obj: PyObjectRef, dunder: &str) -> bool {
+pub(crate) unsafe fn sequence_numeric_slot_is_null(obj: PyObjectRef, op: BinopDunder) -> bool {
     let tp: *const pyre_object::PyType = if is_str(obj) {
         &pyre_object::STR_TYPE
     } else if is_list(obj) {
@@ -3209,7 +3229,7 @@ unsafe fn sequence_numeric_slot_is_null(obj: PyObjectRef, dunder: &str) -> bool 
     let Some(t) = crate::typedef::gettypefor(tp) else {
         return false;
     };
-    !dunder_overridden(obj, dunder, t.as_ptr())
+    !dunder_overridden(obj, op.names().0, t.as_ptr())
 }
 
 /// `needs_seq_binop_dispatch` for the `sq_repeat` branches of [`mul`], where
@@ -3227,7 +3247,7 @@ unsafe fn sequence_numeric_slot_is_null(obj: PyObjectRef, dunder: &str) -> bool 
 /// traced caller emits a residual call rather than an unresolvable
 /// `LoadStatic`.
 #[majit_macros::dont_look_inside]
-pub(crate) unsafe fn seq_repeat_override(obj: PyObjectRef, dunders: &[&str]) -> bool {
+pub(crate) unsafe fn seq_repeat_override(obj: PyObjectRef, dunders: RepeatDunder) -> bool {
     if pyre_object::is_exact_builtin_instance(obj) {
         return false;
     }
@@ -3262,6 +3282,7 @@ pub(crate) unsafe fn seq_repeat_override(obj: PyObjectRef, dunders: &[&str]) -> 
         return false;
     };
     dunders
+        .names()
         .iter()
         .any(|dunder| dunder_overridden(obj, dunder, t))
 }
@@ -3471,7 +3492,7 @@ pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         // are `PyNumber_Add`'s `sq_concat` fall-through and already reach
         // `__radd__` before refusing.
         if numeric_override
-            && !sequence_numeric_slot_is_null(a, "__add__")
+            && !sequence_numeric_slot_is_null(a, BinopDunder::Add)
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
         {
@@ -3690,7 +3711,7 @@ pub(crate) fn mul_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         // As in [`binop_add_impl`]: a sequence operand carries no
         // `nb_multiply`, so only the other operand's runs here.
         if numeric_override
-            && !sequence_numeric_slot_is_null(a, "__mul__")
+            && !sequence_numeric_slot_is_null(a, BinopDunder::Mul)
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
@@ -3714,8 +3735,8 @@ pub(crate) fn mul_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         // sequences.  A sequence subclass that overrides `__mul__`/`__rmul__`
         // must reach its override first — `LM([1]) * 2` is `LM.__mul__`, not a
         // list repetition — the same gate the concat branches of `add` apply.
-        if (seq_repeat_override(a, &["__mul__", "__rmul__"])
-            || seq_repeat_override(b, &["__mul__", "__rmul__"]))
+        if (seq_repeat_override(a, RepeatDunder::MulPair)
+            || seq_repeat_override(b, RepeatDunder::MulPair))
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
@@ -3727,8 +3748,8 @@ pub(crate) fn mul_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         // is the only operand offered and answers first.  The repeat runs at
         // the tail of this function when it declines.
         let count_answers_first = numeric_override
-            && (sequence_numeric_slot_is_null(a, "__mul__")
-                || sequence_numeric_slot_is_null(b, "__mul__"));
+            && (sequence_numeric_slot_is_null(a, BinopDunder::Mul)
+                || sequence_numeric_slot_is_null(b, BinopDunder::Mul));
         if !count_answers_first {
             if is_str(a) && is_int_or_long(b) {
                 return str_repeat(a, b);

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5679,6 +5679,50 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
     }
 }
 
+/// The `CompareOp` a jitcode integer operand names.
+///
+/// A fieldless enum argument is lowered as its discriminant, so the decode
+/// has to read the discriminant rather than a hand-written table that happens
+/// to agree with today's declaration order — a variant inserted in the middle
+/// would renumber every later one and the table would keep answering the old
+/// meaning. Searching [`CompareOp::ALL`] by `op as i64` asks the compiler for
+/// the number it actually assigned, so the two sides cannot drift.
+fn compare_op_from_discriminant(value: i64) -> Option<CompareOp> {
+    CompareOp::ALL
+        .iter()
+        .copied()
+        .find(|op| *op as i64 == value)
+}
+
+/// One-word residual-call ABI for [`compare_slot`].
+///
+/// `compare_slot` itself is `(PyObjectRef, PyObjectRef, CompareOp) -> PyResult`,
+/// and neither end of that signature fits the residual-call ABI: `PyError` is
+/// far wider than a register so `Result<PyObjectRef, PyError>` returns through
+/// an sret pointer, and `CompareOp` is not a `ResidualSlot`. Publishing the
+/// raw address would pass one register where the callee reads a hidden return
+/// slot. `jit_fnaddr.rs`'s publication helpers reject both by their bounds.
+///
+/// The trace calls this as `(r, r, i) -> r`:
+/// `declared_result_type_for_target` projects a callee's `Result<T, PyError>`
+/// through the transparent `Ok` unwrap and the error travels out of band, the
+/// same shape `runtime_ops::call_callable_with_args` publishes. An operand
+/// outside the enum's discriminants cannot come from a correct lowering; it
+/// takes the same route `call_jit.rs` takes for an unknown compare tag — a
+/// published `TypeError` and the null sentinel, so a `GUARD_NO_EXCEPTION`
+/// fires instead of a silently wrong comparison.
+pub extern "C" fn compare_slot_jit_abi(a: i64, b: i64, op: i64) -> i64 {
+    let Some(op) = compare_op_from_discriminant(op) else {
+        return crate::runtime_ops::jit_publish_residual_error(PyError::type_error(format!(
+            "unknown compare op discriminant {op}"
+        )));
+    };
+    match compare_slot(a as PyObjectRef, b as PyObjectRef, op) {
+        Ok(result) => result as i64,
+        Err(error) => crate::runtime_ops::jit_publish_residual_error(error),
+    }
+}
+
 /// Comparison operator enum (mirrors RustPython's ComparisonOperator).
 #[derive(Debug, Clone, Copy)]
 pub enum CompareOp {
@@ -5691,6 +5735,20 @@ pub enum CompareOp {
 }
 
 impl CompareOp {
+    /// Every variant, in declaration order.
+    ///
+    /// `compare_op_from_discriminant` searches this rather than indexing it,
+    /// so the array is a set of variants to consider and not a position table:
+    /// reordering it cannot change which integer decodes to which operator.
+    pub const ALL: [CompareOp; 6] = [
+        CompareOp::Lt,
+        CompareOp::Le,
+        CompareOp::Gt,
+        CompareOp::Ge,
+        CompareOp::Eq,
+        CompareOp::Ne,
+    ];
+
     /// The Python operator symbol (`<`, `<=`, `>`, `>=`, `==`, `!=`) used in
     /// the "not supported between instances of" TypeError message.
     pub fn symbol(self) -> &'static str {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3036,12 +3036,75 @@ unsafe fn dunder_overridden(obj: PyObjectRef, dunder: &str, tp: PyObjectRef) -> 
     }
 }
 
+/// Special-method pair passed to the residual override gates below.  A
+/// residual call gives every argument one machine word, so a `&str` — a fat
+/// pointer — cannot be published through `jit_fnaddr`, and a traced caller
+/// is left holding an unbound symbolic residual where a bound call belongs.
+/// A fieldless enum is one word, so the gate stays bindable; the names are
+/// recovered inside the residual, where the lookups they feed already live.
+#[derive(Clone, Copy)]
+pub(crate) enum BinopDunder {
+    Add,
+    Sub,
+    Mul,
+    FloorDiv,
+    Mod,
+    TrueDiv,
+    Pow,
+    DivMod,
+    LShift,
+    RShift,
+    And,
+    Or,
+    Xor,
+}
+
+impl BinopDunder {
+    /// The forward name and its reflected counterpart, in that order.
+    fn names(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Add => ("__add__", "__radd__"),
+            Self::Sub => ("__sub__", "__rsub__"),
+            Self::Mul => ("__mul__", "__rmul__"),
+            Self::FloorDiv => ("__floordiv__", "__rfloordiv__"),
+            Self::Mod => ("__mod__", "__rmod__"),
+            Self::TrueDiv => ("__truediv__", "__rtruediv__"),
+            Self::Pow => ("__pow__", "__rpow__"),
+            Self::DivMod => ("__divmod__", "__rdivmod__"),
+            Self::LShift => ("__lshift__", "__rlshift__"),
+            Self::RShift => ("__rshift__", "__rrshift__"),
+            Self::And => ("__and__", "__rand__"),
+            Self::Or => ("__or__", "__ror__"),
+            Self::Xor => ("__xor__", "__rxor__"),
+        }
+    }
+}
+
+/// Unary special-method name, carried as a word for the same reason as
+/// [`BinopDunder`].
+#[derive(Clone, Copy)]
+pub(crate) enum UnaryDunder {
+    Pos,
+    Neg,
+    Invert,
+}
+
+impl UnaryDunder {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Pos => "__pos__",
+            Self::Neg => "__neg__",
+            Self::Invert => "__invert__",
+        }
+    }
+}
+
 /// Builtin sequence base selected by [`needs_seq_binop_dispatch`].  The
 /// caller passes this discriminant instead of a `&STR_TYPE`/… static so
 /// the type-static load stays inside the residual helper, off the traced
 /// `add` graph.
 #[derive(Clone, Copy)]
-enum SeqBase {
+pub(crate) enum SeqBase {
     Str,
     List,
     Tuple,
@@ -3059,13 +3122,13 @@ enum SeqBase {
 /// traced caller emits a residual call instead of carrying an
 /// unresolvable `LoadStatic` into its JitCode.
 #[majit_macros::dont_look_inside]
-unsafe fn needs_seq_binop_dispatch(
+pub(crate) unsafe fn needs_seq_binop_dispatch(
     a: PyObjectRef,
     b: PyObjectRef,
     base: SeqBase,
-    fwd: &str,
-    rev: &str,
+    op: BinopDunder,
 ) -> bool {
+    let (fwd, rev) = op.names();
     let tp: *const pyre_object::PyType = match base {
         SeqBase::Str => &pyre_object::STR_TYPE,
         SeqBase::List => &pyre_object::LIST_TYPE,
@@ -3087,7 +3150,12 @@ unsafe fn needs_seq_binop_dispatch(
 /// keeps the base type-static loads in the residual call, off the traced
 /// `add` graph.
 #[majit_macros::dont_look_inside]
-unsafe fn needs_bytes_binop_dispatch(a: PyObjectRef, b: PyObjectRef, fwd: &str, rev: &str) -> bool {
+pub(crate) unsafe fn needs_bytes_binop_dispatch(
+    a: PyObjectRef,
+    b: PyObjectRef,
+    op: BinopDunder,
+) -> bool {
+    let (fwd, rev) = op.names();
     bytes_operand_overrides(a, fwd, rev) || bytes_operand_overrides(b, fwd, rev)
 }
 
@@ -3267,12 +3335,12 @@ unsafe fn numeric_operand_overrides(obj: PyObjectRef, dunder: &str, rdunder: &st
 /// this residual helper, off the traced numeric graph; the hot int path is
 /// specialized separately via `guard_class` in the JIT.
 #[majit_macros::dont_look_inside]
-unsafe fn needs_numeric_binop_dispatch(
+pub(crate) unsafe fn needs_numeric_binop_dispatch(
     a: PyObjectRef,
     b: PyObjectRef,
-    fwd: &str,
-    rev: &str,
+    op: BinopDunder,
 ) -> bool {
+    let (fwd, rev) = op.names();
     numeric_operand_overrides(a, fwd, rev) || numeric_operand_overrides(b, fwd, rev)
 }
 
@@ -3285,7 +3353,7 @@ unsafe fn needs_numeric_binop_dispatch(
 /// `FROZENSET_TYPE` statics here, so keep that load in this residual helper
 /// off the traced graph — mirrors `needs_seq`/`needs_bytes`/`needs_numeric`.
 #[majit_macros::dont_look_inside]
-unsafe fn needs_set_binop_dispatch(a: PyObjectRef, b: PyObjectRef) -> bool {
+pub(crate) unsafe fn needs_set_binop_dispatch(a: PyObjectRef, b: PyObjectRef) -> bool {
     let is_exact_setlike = |obj| {
         pyre_object::is_exact_type(obj, &pyre_object::setobject::SET_TYPE)
             || pyre_object::is_exact_type(obj, &pyre_object::setobject::FROZENSET_TYPE)
@@ -3295,29 +3363,29 @@ unsafe fn needs_set_binop_dispatch(a: PyObjectRef, b: PyObjectRef) -> bool {
 }
 
 /// Unary analog: true when numeric operand `a` overrides the unary
-/// special `dunder` relative to its builtin base.
+/// special named by `op` relative to its builtin base.
 #[majit_macros::dont_look_inside]
-unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
+pub(crate) unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, op: UnaryDunder) -> bool {
     let Some(t) = numeric_base_type_of_overriding_subclass(a) else {
         return false;
     };
-    dunder_overridden(a, dunder, t.as_ptr())
+    dunder_overridden(a, op.name(), t.as_ptr())
 }
 
 /// Call the overriding unary special on a numeric subclass operand before
 /// the Rust fast path.  Returns `None` when `a` is an exact builtin
-/// numeric or does not override `dunder`, so the caller falls through.
+/// numeric or does not override `op`, so the caller falls through.
 unsafe fn try_numeric_unaryop_override(
     a: PyObjectRef,
-    dunder: &str,
+    op: UnaryDunder,
 ) -> Result<Option<PyObjectRef>, PyError> {
-    if !needs_numeric_unaryop_dispatch(a, dunder) {
+    if !needs_numeric_unaryop_dispatch(a, op) {
         return Ok(None);
     }
     let Some(t) = crate::typedef::r#type(a) else {
         return Ok(None);
     };
-    let Some(method) = lookup_in_type_where(t.as_ptr(), dunder) else {
+    let Some(method) = lookup_in_type_where(t.as_ptr(), op.name()) else {
         return Ok(None);
     };
     Ok(Some(crate::call::call_function_impl_result(method, &[a])?))
@@ -3397,7 +3465,7 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `+` and `+=` — one body, see [`binop_type_error`].
 pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__add__", "__radd__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::Add);
         // A sequence left operand has no `nb_add` to offer, so the numeric
         // override runs the right operand's alone; the concat branches below
         // are `PyNumber_Add`'s `sq_concat` fall-through and already reach
@@ -3427,7 +3495,7 @@ pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
             // descroperation.py:664 "unicode + string subclass" — a str
             // subclass overriding `__add__`/`__radd__` must reach the
             // reflected dispatch; otherwise concat directly.
-            if needs_seq_binop_dispatch(a, b, SeqBase::Str, "__add__", "__radd__")
+            if needs_seq_binop_dispatch(a, b, SeqBase::Str, BinopDunder::Add)
                 && let Some(result) =
                     try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
@@ -3451,7 +3519,7 @@ pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
             }
         }
         if is_list(a) && is_list(b) {
-            if needs_seq_binop_dispatch(a, b, SeqBase::List, "__add__", "__radd__")
+            if needs_seq_binop_dispatch(a, b, SeqBase::List, BinopDunder::Add)
                 && let Some(result) =
                     try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
@@ -3480,7 +3548,7 @@ pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
             }
         }
         if is_tuple(a) && is_tuple(b) {
-            if needs_seq_binop_dispatch(a, b, SeqBase::Tuple, "__add__", "__radd__")
+            if needs_seq_binop_dispatch(a, b, SeqBase::Tuple, BinopDunder::Add)
                 && let Some(result) =
                     try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
@@ -3508,7 +3576,7 @@ pub(crate) fn add_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
                 // Only a real bytes-like rhs can carry a subclass `__radd__`;
                 // a memoryview cannot, so dispatch only when both are bytes-like.
                 if pyre_object::bytesobject::is_bytes_like(b)
-                    && needs_bytes_binop_dispatch(a, b, "__add__", "__radd__")
+                    && needs_bytes_binop_dispatch(a, b, BinopDunder::Add)
                     && let Some(result) =
                         try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
                 {
@@ -3571,7 +3639,7 @@ pub(crate) fn sub_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         {
             return Ok(result);
         }
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__sub__", "__rsub__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::Sub);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
@@ -3618,7 +3686,7 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `*` and `*=` — one body, see [`binop_type_error`].
 pub(crate) fn mul_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__mul__", "__rmul__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::Mul);
         // As in [`binop_add_impl`]: a sequence operand carries no
         // `nb_multiply`, so only the other operand's runs here.
         if numeric_override
@@ -3755,7 +3823,7 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `//` and `//=` — one body, see [`binop_type_error`].
 pub(crate) fn floordiv_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__floordiv__", "__rfloordiv__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::FloorDiv);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__floordiv__", "__rfloordiv__")?
@@ -3811,7 +3879,7 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `%` and `%=` — one body, see [`binop_type_error`].
 pub(crate) fn mod_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__mod__", "__rmod__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::Mod);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
@@ -3893,7 +3961,7 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `/` and `/=` — one body, see [`binop_type_error`].
 pub(crate) fn truediv_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::TrueDiv);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
@@ -3951,7 +4019,7 @@ pub(crate) fn truediv_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str)
 /// fast paths nor `__pow__` / `__rpow__` produce a result.
 fn pow_binary(a: &mut PyObjectRef, b: &mut PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(*a, *b, "__pow__", "__rpow__");
+        let numeric_override = needs_numeric_binop_dispatch(*a, *b, BinopDunder::Pow);
         if numeric_override {
             if let Some(result) = try_dispatch_binary_special(a, b, "__pow__", "__rpow__")? {
                 return Ok(Some(result));
@@ -4722,7 +4790,7 @@ pub fn pow3(mut base: PyObjectRef, mut exp: PyObjectRef, mut modulus: PyObjectRe
 pub fn divmod(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     let numeric_override;
     unsafe {
-        numeric_override = needs_numeric_binop_dispatch(a, b, "__divmod__", "__rdivmod__");
+        numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::DivMod);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
@@ -4910,7 +4978,7 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `<<` and `<<=` — one body, see [`binop_type_error`].
 pub(crate) fn lshift_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__lshift__", "__rlshift__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::LShift);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
@@ -4944,7 +5012,7 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// `>>` and `>>=` — one body, see [`binop_type_error`].
 pub(crate) fn rshift_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> PyResult {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__rshift__", "__rrshift__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::RShift);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
@@ -4985,7 +5053,7 @@ pub(crate) fn and_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         {
             return Ok(result);
         }
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__and__", "__rand__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::And);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
@@ -5069,7 +5137,7 @@ pub(crate) fn or_impl(a: PyObjectRef, b: PyObjectRef, symbol: &str) -> PyResult 
     };
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
-        let numeric = needs_numeric_binop_dispatch(a, b, "__or__", "__ror__");
+        let numeric = needs_numeric_binop_dispatch(a, b, BinopDunder::Or);
         if set_override
             && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")?
         {
@@ -5163,7 +5231,7 @@ pub(crate) fn xor_impl(mut a: PyObjectRef, mut b: PyObjectRef, symbol: &str) -> 
         {
             return Ok(result);
         }
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__xor__", "__rxor__");
+        let numeric_override = needs_numeric_binop_dispatch(a, b, BinopDunder::Xor);
         if numeric_override
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
@@ -5767,7 +5835,7 @@ impl CompareOp {
 
 pub fn pos(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__pos__")? {
+        if let Some(result) = try_numeric_unaryop_override(a, UnaryDunder::Pos)? {
             return Ok(result);
         }
         pos_inner(a)
@@ -5858,7 +5926,7 @@ fn bad_operand_type(descr: &str, a: PyObjectRef) -> PyError {
 
 pub fn neg(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__neg__")? {
+        if let Some(result) = try_numeric_unaryop_override(a, UnaryDunder::Neg)? {
             return Ok(result);
         }
         neg_inner(a)
@@ -5938,7 +6006,7 @@ pub(crate) fn bool_invert_deprecation_text() -> PyObjectRef {
 
 pub fn invert(a: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_numeric_unaryop_override(a, "__invert__")? {
+        if let Some(result) = try_numeric_unaryop_override(a, UnaryDunder::Invert)? {
             return Ok(result);
         }
         if is_bool(a) {

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -42,7 +42,12 @@ fn inplace_dunder_name(op: BinaryOperator) -> Option<&'static str> {
 fn skips_inplace_special(a: PyObjectRef, b: PyObjectRef, op: BinaryOperator) -> bool {
     matches!(op, BinaryOperator::InplaceMultiply)
         && unsafe { crate::objspace::descroperation::is_repeat_sequence(a) }
-        && !unsafe { crate::objspace::descroperation::seq_repeat_override(a, &["__imul__"]) }
+        && !unsafe {
+            crate::objspace::descroperation::seq_repeat_override(
+                a,
+                crate::objspace::descroperation::RepeatDunder::IMul,
+            )
+        }
         && unsafe { crate::baseobjspace::lookup(b, "__index__").is_none() }
 }
 

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -54,7 +54,14 @@ pub fn binary_value(
     // descroperation.py `inplace_impl` — consult the in-place
     // special first; fall through to the binary op below when absent or
     // `NotImplemented`.
-    if let Some(idunder) = inplace_dunder_name(op).filter(|_| !skips_inplace_special(a, b, op)) {
+    // Written as a let-chain rather than `Option::filter`: the combinator's
+    // closure captures `a`, `b` and `op`, so it reaches the JIT as an
+    // aggregate plus a `call_once` whose path the host does not bind, and a
+    // walk of this handler stops at that residual.  The chain evaluates the
+    // guard only in the `Some` arm, exactly as `filter` did.
+    if let Some(idunder) = inplace_dunder_name(op)
+        && !skips_inplace_special(a, b, op)
+    {
         // `seq_bug_compat` applies only to `+=` / `*=`; pass the reflected
         // name so the builtin-sequence rhs-first branch can fire.
         let (rdunder, seq_bug_compat) = match op {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1918,6 +1918,13 @@ fn op_arg_as_usize(arg: OpArg) -> usize {
 /// body still emits a residual_call to the third-party helpers, but
 /// the OUTER call site is tagged elidable so the walker's
 /// `try_fold_pure_call_via_executor` fold path runs end-to-end.
+///
+/// Every handler that resolves an `Arg<VarNum>` to a localsplus index
+/// goes through here, not only the `LOAD_FAST` family it is named for:
+/// `STORE_FAST`, `DELETE_FAST`, `LOAD_FAST_AND_CLEAR`, `MAKE_CELL` and
+/// the `*_DEREF` handlers all carry the same field type, and each raw
+/// `var_num.get(op_arg).as_usize()` left in a handler body is one
+/// unbindable third-party residual on that opcode's walked path.
 #[inline]
 #[majit_macros::elidable_cannot_raise]
 pub fn load_fast_var_num_to_index(
@@ -2797,7 +2804,7 @@ where
     let Instruction::StoreFast { var_num } = instruction else {
         unreachable!()
     };
-    executor.store_fast(var_num.get(op_arg).as_usize())?;
+    executor.store_fast(load_fast_var_num_to_index(var_num, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -2809,7 +2816,7 @@ pub fn execute_delete_fast<E: OpcodeStepExecutor>(
     let Instruction::DeleteFast { var_num } = instruction else {
         unreachable!()
     };
-    executor.delete_fast(var_num.get(op_arg).as_usize())?;
+    executor.delete_fast(load_fast_var_num_to_index(var_num, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3213,7 +3220,7 @@ pub fn execute_make_cell<E: OpcodeStepExecutor>(
     let Instruction::MakeCell { i } = instruction else {
         unreachable!()
     };
-    executor.make_cell(i.get(op_arg).as_usize())?;
+    executor.make_cell(load_fast_var_num_to_index(i, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3237,7 +3244,7 @@ pub fn execute_load_deref<E: OpcodeStepExecutor>(
     let Instruction::LoadDeref { i } = instruction else {
         unreachable!()
     };
-    executor.load_deref(i.get(op_arg).as_usize())?;
+    executor.load_deref(load_fast_var_num_to_index(i, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3249,7 +3256,7 @@ pub fn execute_store_deref<E: OpcodeStepExecutor>(
     let Instruction::StoreDeref { i } = instruction else {
         unreachable!()
     };
-    executor.store_deref(i.get(op_arg).as_usize())?;
+    executor.store_deref(load_fast_var_num_to_index(i, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3261,7 +3268,7 @@ pub fn execute_delete_deref<E: OpcodeStepExecutor>(
     let Instruction::DeleteDeref { i } = instruction else {
         unreachable!()
     };
-    executor.delete_deref(i.get(op_arg).as_usize())?;
+    executor.delete_deref(load_fast_var_num_to_index(i, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3297,7 +3304,7 @@ pub fn execute_load_fast_and_clear<E: OpcodeStepExecutor>(
     let Instruction::LoadFastAndClear { var_num } = instruction else {
         unreachable!()
     };
-    executor.load_fast_and_clear(var_num.get(op_arg).as_usize())?;
+    executor.load_fast_and_clear(load_fast_var_num_to_index(var_num, op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3570,7 +3577,7 @@ pub fn execute_load_from_dict_or_deref<E: OpcodeStepExecutor>(
     let Instruction::LoadFromDictOrDeref { i } = instruction else {
         unreachable!()
     };
-    let idx = i.get(op_arg).as_usize();
+    let idx = load_fast_var_num_to_index(i, op_arg);
     // `idx` is a localsplus offset (cell / free var), not a `co_names` index.
     let name = crate::pyframe::deref_name_and_kind(code, idx).0;
     executor.load_from_dict_or_deref(idx, name)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1353,7 +1353,17 @@ impl Drop for InlineConcreteFrameGuard {
 /// guard's own index and was truncated away when the guard exited.
 struct ResidualFrameChainGuard {
     ec: *mut pyre_interpreter::PyExecutionContext,
-    frame: *mut pyre_interpreter::PyFrame,
+    /// A root, not a raw copy.  The callee frame an inline sub-walk executes
+    /// is a nursery allocation (`emit_new_pyframe_inline_with_params` ->
+    /// `NewWithVtable`), so a minor collection inside the residual relocates
+    /// it and `Drop`'s `f_backref` / `escaped()` reads would follow a stale
+    /// address.  The collector forwards `OWNER_ROOTS` in place
+    /// (`shadow_stack::walk_roots`), which is the same reason
+    /// [`current_inline_concrete_frame`] reads its frame back out of a root
+    /// rather than out of a copy.  Rooting is also why this can be an owner
+    /// root and not a shadow-stack slot: the shadow stack is LIFO and the
+    /// residual publishes across this scope.
+    frame_root: majit_gc::shadow_stack::OwnerRootGuard,
     previous_published: *mut pyre_interpreter::PyFrame,
     previous_shadow: Option<(*const super::CalleeLocalsShadow, u16)>,
     /// Whether this guard performed the chain write, so `Drop` restores only
@@ -1408,11 +1418,20 @@ impl ResidualFrameChainGuard {
         let previous_shadow = PUBLISHED_INLINE_SHADOW.with(|slot| slot.replace(shadow));
         Some(Self {
             ec,
-            frame,
+            frame_root: majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+                frame as usize,
+            )),
             previous_published,
             previous_shadow,
             entered,
         })
+    }
+
+    /// The frame as the collector last left it.  Every read below goes through
+    /// here rather than through a field, so a residual that collected cannot
+    /// hand `Drop` an address from before the move.
+    fn frame(&self) -> *mut pyre_interpreter::PyFrame {
+        self.frame_root.get().0 as *mut pyre_interpreter::PyFrame
     }
 }
 
@@ -1432,10 +1451,11 @@ impl Drop for ResidualFrameChainGuard {
                 // written to, so a collection during the residual forwarded it
                 // in place.  Only the `entered` path wrote `f_backref`, and
                 // only that path has anything to restore.
-                (*self.ec).topframeref = (*self.frame).f_backref;
+                (*self.ec).topframeref = (*self.frame()).f_backref;
             }
-            if (*self.frame).escaped() {
-                let f_back = (*self.frame).get_f_back();
+            let frame = self.frame();
+            if (*frame).escaped() {
+                let f_back = (*frame).get_f_back();
                 if !f_back.is_null() {
                     (*f_back).mark_as_escaped();
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1340,18 +1340,20 @@ impl Drop for InlineConcreteFrameGuard {
 /// would otherwise observe the caller as the running frame and resolve one
 /// level too shallow.  Scoped to the call itself so the walk's own frame
 /// bookkeeping outside it is untouched.
+///
+/// The displaced caller is parked in `frame.f_backref` and nowhere else:
+/// `executioncontext.py enter` writes it there and `leave` reads it back off
+/// the frame it is leaving, so the guard needs no saved copy of its own.  That
+/// is also what keeps the value rooted — `f_backref` is a traced `Type::Ref`
+/// field, so a minor collection inside the residual forwards a nursery
+/// `JitVirtualRef` in place, where a raw copy in this struct would go stale.
+/// Parking it on the shared shadow stack instead, which this guard used to do,
+/// made its restore a LIFO slot the residual could not publish across: the
+/// scope is one residual call, so anything the callee pushed sat above the
+/// guard's own index and was truncated away when the guard exited.
 struct ResidualFrameChainGuard {
     ec: *mut pyre_interpreter::PyExecutionContext,
     frame: *mut pyre_interpreter::PyFrame,
-    /// Shadow-stack index of the caller `topframeref` this guard displaced,
-    /// held there rather than in the struct because the residual runs
-    /// arbitrary user code.  Frames themselves never move — `FrameBox::new`
-    /// allocates old-gen — but once the tracer stores a `JitVirtualRef` in the
-    /// chain the displaced value is a nursery object, and a minor collection
-    /// inside the residual would leave `Drop` writing back a pre-move pointer.
-    /// Rooting lets the collector forward it in place, as `CurrentFrameGuard`
-    /// already does for the same field.
-    saved_root: usize,
     previous_published: *mut pyre_interpreter::PyFrame,
     previous_shadow: Option<(*const super::CalleeLocalsShadow, u16)>,
     /// Whether this guard performed the chain write, so `Drop` restores only
@@ -1398,7 +1400,6 @@ impl ResidualFrameChainGuard {
                 (*ec).topframeref = frame;
             }
         }
-        let saved_root = majit_gc::shadow_stack::push(majit_ir::GcRef(saved_topframeref as usize));
         // Published whether or not this guard wrote the chain: `frame` is the
         // one a force inside the residual must redirect its escape onto
         // (`flush_active_frame_escape`), and the chain already naming it makes
@@ -1408,7 +1409,6 @@ impl ResidualFrameChainGuard {
         Some(Self {
             ec,
             frame,
-            saved_root,
             previous_published,
             previous_shadow,
             entered,
@@ -1425,15 +1425,14 @@ impl Drop for ResidualFrameChainGuard {
             // reference to its caller, so the caller must stay materialised;
             // dropping that propagation would leave the escape recorded only on
             // a frame the walk owns privately.
-            // Read the root back before popping: a collection during the
-            // residual forwards it in place.
-            let saved_topframeref =
-                majit_gc::shadow_stack::get(self.saved_root).0 as *mut pyre_interpreter::PyFrame;
-            majit_gc::shadow_stack::pop_to(self.saved_root);
             PUBLISHED_INLINE_FRAME.with(|slot| slot.set(self.previous_published));
             PUBLISHED_INLINE_SHADOW.with(|slot| slot.set(self.previous_shadow));
             if self.entered {
-                (*self.ec).topframeref = saved_topframeref;
+                // The value `enter` displaced, read back off the frame it was
+                // written to, so a collection during the residual forwarded it
+                // in place.  Only the `entered` path wrote `f_backref`, and
+                // only that path has anything to restore.
+                (*self.ec).topframeref = (*self.frame).f_backref;
             }
             if (*self.frame).escaped() {
                 let f_back = (*self.frame).get_f_back();


### PR DESCRIPTION
Nineteen commits from the portal metatrace probe, in the order the walk hit them.

The last six answer a question the earlier thirteen kept re-asking: each fix moved the
walk's stop point, so each looked like the next wall. The measurement at the bottom shows
there is no wall left on this path — the walk now runs until its trace-length budget.

Each A/B pair below was measured at that commit's own base, not against a single
baseline build.

## The walk's residual bindings

- **`jit-trace: restore the residual frame chain from f_backref, not a shadow slot`** — `ResidualFrameChainGuard` brackets one residual call and parked the displaced `topframeref` on `majit_gc::shadow_stack`; `pop_to` truncates its own index and everything above it, so a slot the residual published was destroyed under the guard and a later bracket's checked read panicked. `executioncontext.py enter` already writes the displaced caller to `frame.f_backref`, which is also where it is rooted.
- **`interp: resolve every Arg<VarNum> through the bound index wrapper`** — eight handlers spelled `var_num.get(op_arg).as_usize()` inline; `oparg::VarNum::as_usize` is third-party, so each opened its jitcode with an unbindable symbolic residual. Routed through the same `#[elidable_cannot_raise]` wrapper the `LOAD_FAST` family already used.
- **`interp: bind eval_breaker_word::set_gc_interp`** — the first residual an `ENTRY=start` walk of `eval_loop_jit` meets.
- **`jit: publish compare_slot through the word ABI`**

## The vable identity

- Two probe commits (`MAJIT_VABLE_READ_PROBE`) print every exit of `vable_getarrayitem_ref_checked`, the vable OpRef, the standard box, the heapcache answer and the reading register.
- **`majit: stamp a residual call's result on the recorded box, not only the register`** — `execute_and_record_varargs` hands the executed value to `record_nospec`, so the recorded op carries it on its own frontend slot. Pyre's full-body walker did that; the jitcode-dispatch metainterpreter wrote the register and left the box unstamped, so `concrete_of_opref` answered `None`, `concrete_ptrs_eq` read that as "not equal", and `_nonstandard_virtualizable` marked the box nonstandard while the register and the traced heap pointer held the same address.
- **`interp: keep FrameAnchor::live out of inlining so its residual bridge is reached`** — `&self` on a one-word aggregate arrives as the word itself, so the inlined jitcode's `getfield_gc_i … offset 0` dereferenced the depth (`KERN_INVALID_ADDRESS` at `0x9`). Its whole body is a `dont_look_inside` call already.

## The scoped-call result type

`rewire_one_call_site` has three arms and each leaves the call's result meaning the payload, not the `Result` shell — but only the diamond said so on the op. `front::mir` types every aggregate `Ref`, so silence means "still a shell", and a callee that `int_return`s was invoked through `inline_call_*_r`.

- **`majit: retype a tail-forwarded scoped call to the callee's payload`** — a tail forward has no `__pos_0` read for `collapse_pos0_read` to narrow through. `is_true` shows both ends of the same defect: its two calls emit `inline_call_r_r` against callees that `int_return`, *and* its own returnblock inherits the `Ref` so `graph_result_kind` reports `r` to every `?`-site caller whose diamond did narrow. Sites whose suffix disagrees with the callee's `calldescr.result_type`: **182 → 89**; `is_true`'s calldescr `r->r` → `r->i`.
- **`majit: retype a rewrapped scoped call to the callee's payload`** — `catch_and_rewrap`'s normal arm builds a fresh `Ok` from the result, the same statement one block later. Sites whose suffix disagrees with the callee's return **terminator**: `emitted r, terminator i` **11 → 2**.

Two regression tests in `test_result_exc_lowering.rs`, each with a verified pre-fix control (`Ref(None)` → `Bool` / `Int`).

## The associated-type projection, and one residual it exposed

- **`majit: type a trait associated-type projection through the trait's unique impl`** — this is the `truth_value` item the previous revision listed as *not fixed*. The projection has two consumers: `charon_type_value_to_ast_string` (the rendered NAME) already resolved it through the trait's unique impl, while `tyref_to_value_type` (the register BANK) did not. A *required* trait method is lowered from the impl, where `Self` is concrete and `<PyFrame as TruthOpcodeHandler>::Truth` is already `bool`; a *provided* default body with no override is lowered from the trait's generic graph, where it stays `??TraitType` → `Ref`. Inside one caller the same value therefore reached a callee wanting `i` and one wanting `r`, and no kind for the caller's variable satisfies both. Extracting the shared half of the resolver and calling it from `tyref_to_value_type` is the whole fix.
  - `Clause::Bound` was never the obstacle the earlier note recorded: the walk reads the projection's own `trait_decl_ref`, which names `TruthOpcodeHandler`, and that trait has exactly one impl. The probe that reported `ToOwned` had printed the first `TraitType` it met, not this one.
  - Suffix vs callee **terminator** 37 → 35; `emitted r, terminator i` 3 → 1. Suffix vs callee **calldescr** 89 → 87. Walk: `Abort ops=958 depth=6 stop=opcode_pop_jump_if` → `Abort ops=1801 depth=7 stop=binary_value`.
  - Two production-LLBC regression tests in `test_trait_assoc_type_bank.rs`, one per lowering path (from the impl, and from a provided default body).
- **`interp: spell binary_value's in-place guard as a let-chain, not Option::filter`** — the residual the walk stopped on next. `Option::filter`'s closure captures `a`, `b` and `op`, so it reaches the JIT as an aggregate plus a `call_once` whose path the host binds no address for. The codebase already words this rule in `pyre-macros`. The chain evaluates the guard only in the `Some` arm, exactly as `filter` did. Walk: → `Abort ops=1824 depth=8 stop=add_impl`.

## The residual ABI: an argument is one machine word

`jit_fnaddr.rs` states the rule — one word per argument slot, classed `'i'`/`'r'`/`'f'` — and enforces it at the publication site, because its helpers take the function itself and `ResidualSlot` has no impl for a fat pointer. Four `dont_look_inside` override gates in `descroperation` carried their special-method names as `&str`, so none of them could be a row and every traced caller held an unbound symbolic residual.

- **`interp: pass the binop override gates a dunder discriminant, and publish their addresses`** — `needs_numeric_binop_dispatch`, `needs_seq_binop_dispatch`, `needs_bytes_binop_dispatch` and `needs_numeric_unaryop_dispatch` now take a fieldless `BinopDunder` / `UnaryDunder` and recover the names inside the residual, where the lookups they feed already live. A fieldless enum is a named integer to the front (`tyref_is_fieldless_enum_free`), so it fills exactly one slot. Five rows published (`needs_set_binop_dispatch` needed only the visibility widening).
- **`interp: pass the two sequence override gates a dunder discriminant, and publish their addresses`** — the same defect one layer down: `sequence_numeric_slot_is_null` took a `&str`, `seq_repeat_override` took a `&[&str]`. Both call sets are closed — `__add__`/`__mul__`, and `["__mul__","__rmul__"]`/`["__imul__"]` — so `BinopDunder` and a new `RepeatDunder` carry them.

Decoding `add_impl` out of the branch's own `jit_metadata.json` is what named the wall: its pos 9 is `residual_call_r_i sym=…needs_numeric_binop_dispatch`, and the reported `stop_cursor=19` is the op after it, because the metainterp bumps `pc` before running the handler.

!! Worth recording: the pre-fix `calldescr` for those gates reads `rrrr` — the front collapses `ValueType::Str` to `Type::Ref` and gives it **one** slot, so a `&str`'s length half is simply never passed and nothing on the front side objects. The `ResidualSlot` bound is the only thing that rejects it. `test_residual_dunder_arg_slots` therefore asserts on `ValueType::Str`, not on the argument count, and its header says why.

## Two defects the review surfaced

- **`jit-trace: root the residual frame chain guard's frame`** — `ResidualFrameChainGuard` held a raw `*mut PyFrame` across the residual it brackets. A compiled trace's inlined-callee frame is a nursery allocation (`emit_new_pyframe_inline_with_params` → `NewWithVtable`), so a minor collection inside the residual relocates it and `Drop`'s `f_backref` / `escaped()` reads follow a stale address. It is now an `OwnerRootGuard` read back through a `frame()` accessor; an owner root and not a shadow-stack slot for the guard's own stated reason — the shadow stack is LIFO and the residual publishes across this scope.
- **`majit: decline an assoc-type projection the four-hop walk left unresolved`** — `trait_assoc_projection_target` broke out of its four-hop loop but still returned the value it stopped on. If that value is itself a projection the caller resolves it by recursing into `tyref_to_value_type`, which re-enters the walk with a fresh budget, so an `A::X = B::Y`, `B::Y = A::X` binding recurses without bound. Declining when the stopped-on value is still a projection caps the whole resolution at four hops and is local; threading a depth through `tyref_to_value_type` would have charged every operand, field and parameter in the corpus for one arm.

## Housekeeping

- **`majit: cite the upstream call, bridge and frame sites by symbol`** — `scripts/check-new-line-citations.py --base origin/main` reported five `file:LINE` citations on this branch, not the one CodeRabbit surfaced. Each now names the symbol that decides (`CallControl.getcalldescr`, `UnrollOptimizer.optimize_bridge` ×2, `TraceIterator.__init__`, `MetaInterp.popframe`). The last had already rotted, which is the rule's own argument.

## Where the tip stands: the wall is gone, the budget is what stops the walk

| | before these six | tip |
|---|---|---|
| walk | `Abort recorded_ops=1824 depth=8 stop_jitcode=add_impl stop_cursor=19` | `Abort recorded_ops=6002 depth=7 stop_jitcode=pop_value stop_cursor=8` |
| `inline_call` sites | 10616 | 10617 |
| suffix vs callee **terminator** | 35 | 35 |
| suffix vs callee **calldescr** | 86 | 86 |
| callee `calldescr` vs its own terminator | 46 | 46 |
| production run and every `skip=1700` | correct | correct |

`recorded_ops` 1824 → 6002, and every census column is unmoved — the control that says these commits bound addresses rather than changing what the codewriter emits.

`pop_value` is not a new wall. `trace_limit` defaults to **6000** and the walk reported **6002**; `MAJIT_LOG=1` on the same binary prints `[jit] trace_jitcode aborting: trace too long at portal pc=18` immediately before the abort; and `PYRE_JIT="trace_limit=200000"` moves the stop to `recorded_ops=200001`, `stop_jitcode=getdebug_data`. The stop point follows the budget, not the code.

The last commit is what settled it. **`majit: name which cause made a vable descriptor lookup decline`** — `vable_field_descr` and `vable_array_descrs` collapsed two different causes into one `None`, and the abort is reported by jitcode and cursor alone, so from outside they are the same event. They are not the same defect: one is a trace started without `initialize_virtualizable`, the other a codewriter index that does not match the runtime declaration, and the fixes point in opposite directions. Both now report under the existing `MAJIT_VABLE_READ_PROBE` gate — and the line never printed, which is how the vable hypothesis died.

**Why the walk does not terminate on its own.** `MAJIT_PCSEQ=1` logs every merge-point re-entry: 943 visits, `seen_lh=-1` on all of them, and the walk stood on the traced header `pc=5` **40 times** without closing. Closing needs `seen_loop_header_for_jdindex >= 0`, stamped by the explicit `BC_LOOP_HEADER` that `can_enter_jit` emits or by the auto-stamp, which upstream gates on `has_compiled_targets(ptoken)`. `drive_portal_metatrace` seeds `frame.code_cursor = header_pc` and walks straight into `jit_merge_point`, never running a `loop_header`; on a first-ever trace there is no compiled target either. Every merge point is therefore the `< 0` no-op. That is a probe-harness gap, not a JIT defect, and it is why each binding so far only moved the stop point.

Header re-visits land at `num_ops` 0, 5110, 10200, 15290, 20380 — a flat **5090 recorded ops per iteration** of `while i < n: t += i; i += 1`. Raw recording, before any optimizer, but that is the figure to attack once the loop can close.

## Not fixed here

- 26 sites (`space_index_w` / `native_result`, `emitted i, terminator r`): a partial lowering the callee rule's `rewritten == 0 && tail_forwarded_returns == 0` gate does not catch, because it is an aggregate check.
- 8 sites (`call_intrinsic_1/2` → `typing_intrinsic_1/2`, `emitted v, terminator r`).
- 1 site (`prepare_file_argument` → `setdictvalue`, `emitted r, terminator i`).
- 46 jitcodes whose own `calldescr` disagrees with their own terminator (`widen_unit_return_to_void` did not fire). These agree at runtime — the callee `ref_return`s and the caller emits `_r` — so they are a descriptor defect, not a wrong answer.

## Verification

`cargo test -p majit-translate` 23 targets green, 0 failed, on a worktree with freshly re-extracted LLBC; `cargo test -p pyre-interpreter --no-default-features --features dynasm,cpyext` 484 passed, 0 failed; `cargo fmt --check` clean; `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=1 cargo check -p pyrex --bin pyre-dynasm --no-default-features --features dynasm,cpyext` rc=0; release build rc=0 with production output unaffected.

One probe-harness note, now with a cause. A `skip=0` probe run ends in a broken frame — `assertion failed: index < self.len` under `PyFrame::push_value` at the default limit, `TypeError: stack underflow during interpreter opcode` with the limit raised. The dispatch loop's own comment names the upstream remedy: a too-long trace is cancelled through `run_blackhole_interp_to_cancel_tracing` → `convert_and_run_from_pyjitpl`, which finishes the current jitcode frames in the blackhole so the half-executed opcode's remaining effects still run. `drive_portal_metatrace` returns `Abort` and runs no blackhole. Until it does, `skip=0` must be scored by its `walk action=` line and never by exit status; the production run and every `skip=1700` run print the correct result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs8Lh8cQrnq9tYS7i4nz6a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Result`-based call results so payload values retain the correct type during execution.
  * Improved JIT support for comparison operations, operator dispatch, fast local-variable access, and trait-associated types.
  * Improved frame restoration and garbage-collection safety during residual calls.

* **Diagnostics**
  * Added optional virtualizable-read and control-flow diagnostic output for troubleshooting.

* **Tests**
  * Added regression coverage for `Result` lowering, trait-associated type resolution, and residual operator-call compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

