### PR TITLE
object, macros, interp, jit, translate: populate the JIT's two link-time registries on wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
 name = "linkme"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1840,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2696,6 +2718,7 @@ version = "0.0.2"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
+ "ctor",
  "getrandom 0.4.3",
  "indexmap",
  "libc",
@@ -2840,6 +2863,7 @@ name = "pyre-object"
 version = "0.0.2"
 dependencies = [
  "bitflags 2.13.0",
+ "ctor",
  "indexmap",
  "linkme",
  "majit-gc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ smallvec = "1"
 # link-section distributed slice: `#[pyre_class]` appends each type's GC
 # descriptor to a whole-program slice the JIT driver checks for completeness.
 linkme = "0.3"
+ctor = "1"
 
 # cranelift backend
 cranelift-codegen = "0.134"

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -47,13 +47,6 @@ const CONST_PREFIX_HINTS: &[(&str, &[&str])] = &[
 /// the marker consts present in `llbcs`.
 pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> {
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
-    // The `type_object` residual resolves through `PYRE_TYPE_OBJECT_FNADDRS`, a
-    // native-only link-time slice (empty on wasm32, which linkme rejects).
-    // Residualizing there would emit a call to an unpublished address, so keep
-    // those accessors on the legacy walker when building for wasm.
-    let residualize_type_object = !std::env::var("TARGET")
-        .unwrap_or_default()
-        .starts_with("wasm32");
     for llbc in llbcs {
         let function_paths: HashSet<String> = llbc
             .iter_local_fns()
@@ -142,32 +135,25 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                 }
             }
         }
-        // Residualize the `#[pyre_methods]`-generated `type_object()`
-        // accessors.  The body is the `OnceLock<usize>` type-object cache
-        // (`make_builtin_type_with_layout` building the class namespace dict) —
-        // unliftable host plumbing whose lift fails at the `CELL` read and
-        // poisons every caller.  Stamping `dont_look_inside` prefills a
-        // signature-only stub and lets the codewriter emit a residual call to
-        // the accessor's registered C ABI address (published through the
-        // `PYRE_TYPE_OBJECT_FNADDRS` link-time slice into `jit_trace_fnaddrs`).
-        // Gated on the exact accessor signature — leaf `type_object`, no inputs,
-        // `*mut PyObject` return — never a stray same-named function.  Every
-        // `type_object` generator publishes a `PYRE_TYPE_OBJECT_FNADDRS` entry
-        // (`#[pyre_methods]`, `py_class!`, `py_class_typed!`, and the
-        // hand-written `_csv::dialect_class` accessor), so the stamped set
-        // equals the funcptr set and a stamped accessor always resolves to a
-        // real address.  Skipped entirely on wasm, which has no funcptr slice to
-        // resolve the residual against.
-        if residualize_type_object {
-            for fd in llbc.iter_local_fns() {
-                let path = strip_crate_prefix(&fd.item_meta.name_path());
-                let leaf = path.rsplit("::").next().unwrap_or(path.as_str());
-                if leaf == "type_object"
-                    && fd.signature.inputs.is_empty()
-                    && crate::front::mir::output_type_is_objectptr(&fd.signature.output, llbc)
-                {
-                    push_hint(&mut out, path, "dont_look_inside");
-                }
+        // Residualize the generated `type_object()` accessors.  The body is a
+        // `OnceLock<usize>` type-object cache — unliftable host plumbing whose
+        // lift fails at the `CELL` read and poisons every caller.  Stamping
+        // `dont_look_inside` prefills a signature-only stub and lets the
+        // codewriter emit a residual call to the accessor's registered C ABI
+        // address.  Gated on the exact accessor signature — leaf `type_object`,
+        // no inputs, `*mut PyObject` return — never a stray same-named
+        // function.  Every generator of such an accessor registers its address
+        // for the consumer's `fnaddr` table, on every target, so the stamped
+        // set equals the published set and a stamped accessor always resolves
+        // to a real address.
+        for fd in llbc.iter_local_fns() {
+            let path = strip_crate_prefix(&fd.item_meta.name_path());
+            let leaf = path.rsplit("::").next().unwrap_or(path.as_str());
+            if leaf == "type_object"
+                && fd.signature.inputs.is_empty()
+                && crate::front::mir::output_type_is_objectptr(&fd.signature.output, llbc)
+            {
+                push_hint(&mut out, path, "dont_look_inside");
             }
         }
     }

--- a/pyre/extra_tests/snippets/stdlib_codecs_escape.py
+++ b/pyre/extra_tests/snippets/stdlib_codecs_escape.py
@@ -1,3 +1,4 @@
+# pyre-check: gate=1
 """PyPy _codecs.escape_decode parity used by protocol-0 pickle."""
 
 import _codecs
@@ -23,7 +24,8 @@ for encoded, expected in cases.items():
 
 raw = b"a\n\\b\x00c\td\xe5"
 assert _codecs.escape_encode(raw) == (b"a\\n\\\\b\\x00c\\td\\xe5", len(raw))
-assert _codecs.escape_encode(b"'") == (b"'", 1)
+# A single quote is escaped, and the count reports the input length.
+assert _codecs.escape_encode(b"'") == (b"\\'", 1)
 
 assert codecs.escape_decode(b"a\\x00\\n") == (b"a\x00\n", 7)
 assert _codecs.escape_decode(b"[\\x]\\x", "ignore") == (b"[]", 6)

--- a/pyre/extra_tests/snippets/stdlib_posix.py
+++ b/pyre/extra_tests/snippets/stdlib_posix.py
@@ -1,3 +1,5 @@
+# pyre-check: gate=1
+# pyre-check: platforms=darwin,linux
 import gc
 import shutil
 import sys
@@ -79,6 +81,15 @@ class FsPathBytes:
 assert os.fspath(FsPathOk()) == "fspath-ok"
 assert os.fspath(FsPathProperty()) == "fspath-property"
 assert os.fspath(FsPathBytes()) == b"fspath-bytes"
+
+# Builtins taking a path resolve the descriptor the same way, so what the
+# property answers is what gets called and its result is the name opened.
+try:
+    open(FsPathProperty())
+except FileNotFoundError as exc:
+    assert "fspath-property" in str(exc), exc
+else:
+    raise AssertionError("open(FsPathProperty()) did not raise")
 
 try:
     os.fspath(FsPathInt())

--- a/pyre/extra_tests/snippets/stdlib_warnings.py
+++ b/pyre/extra_tests/snippets/stdlib_warnings.py
@@ -1,3 +1,4 @@
+# pyre-check: gate=1
 import _warnings
 import os
 import sys
@@ -112,6 +113,31 @@ class Loader:
         return "first line\nsecond line\n"
 
 
+class Spec:
+    def __init__(self, loader):
+        self.loader = loader
+
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    _warnings.warn_explicit(
+        "loader source",
+        UserWarning,
+        "loader.py",
+        2,
+        module_globals={
+            "__spec__": Spec(Loader()),
+            "__name__": "warnings_source_test",
+        },
+    )
+    assert len(caught) == 1
+    # A loader-provided source line feeds the direct stderr fallback only;
+    # WarningMessage.line remains None.
+    assert caught[0].line is None
+
+# module_globals is read through __spec__.loader; naming the loader only as
+# __loader__, or disagreeing with __spec__.loader, is deprecated and warns
+# before the source lookup runs.
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
     _warnings.warn_explicit(
@@ -121,10 +147,26 @@ with warnings.catch_warnings(record=True) as caught:
         2,
         module_globals={"__loader__": Loader(), "__name__": "warnings_source_test"},
     )
-    assert len(caught) == 1
-    # PyPy uses a loader-provided source line only for the direct stderr
-    # fallback; WarningMessage.line remains None.
-    assert caught[0].line is None
+    assert [entry.category for entry in caught] == [DeprecationWarning, UserWarning]
+    assert str(caught[0].message) == "Module globals is missing a __spec__.loader"
+    assert caught[-1].line is None
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    _warnings.warn_explicit(
+        "loader source",
+        UserWarning,
+        "loader.py",
+        2,
+        module_globals={
+            "__spec__": Spec(Loader()),
+            "__loader__": Loader(),
+            "__name__": "warnings_source_test",
+        },
+    )
+    assert [entry.category for entry in caught] == [DeprecationWarning, UserWarning]
+    assert str(caught[0].message) == "Module globals; __loader__ != __spec__.loader"
+    assert caught[-1].line is None
 
 
 class BadLoader:
@@ -143,7 +185,7 @@ with warnings.catch_warnings(record=True) as caught:
         UserWarning,
         "loader.py",
         1,
-        module_globals={"__loader__": BadLoader(), "__name__": "bad_source"},
+        module_globals={"__spec__": Spec(BadLoader()), "__name__": "bad_source"},
     )
     assert len(caught) == 1
 

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -142,3 +142,10 @@ cc = "1.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+# `type_object()` accessors publish their residual-call address through a
+# `linkme` link section off wasm32.  wasm32 rejects that section — a custom
+# `link_section` static there must be a plain byte list, and a descriptor
+# holds two pointers — so the accessors register from a constructor instead.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ctor = { workspace = true }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -20857,34 +20857,13 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             && !pyre_object::bytesobject::is_bytes(file_now)
             && !pyre_object::is_int(file_now)
     } {
-        let fspath_fn = crate::typedef::r#type(file_now).and_then(|pt| unsafe {
-            crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__")
-        });
-        // A `None` left on the type switches the protocol off the way
-        // `__hash__ = None` does, so the object is turned away as not
-        // path-like rather than reported as an uncallable `None`.
-        let Some(fspath_fn) = fspath_fn.filter(|&fn_obj| unsafe { !pyre_object::is_none(fn_obj) })
-        else {
-            return Err(crate::PyError::type_error(format!(
-                "expected str, bytes or os.PathLike object, not {}",
-                crate::gateway::short_type_name(file_now)
-            )));
-        };
-        let _ = pyre_object::gc_roots::pin_root(fspath_fn);
-        let fspath_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        let resolved = crate::call::call_function_impl_result(
-            pyre_object::gc_roots::shadow_stack_get(fspath_slot),
-            &[pyre_object::gc_roots::shadow_stack_get(file_slot)],
-        )?;
-        if unsafe {
-            !pyre_object::is_str(resolved) && !pyre_object::bytesobject::is_bytes(resolved)
-        } {
-            return Err(crate::PyError::type_error(format!(
-                "expected {}.__fspath__() to return str or bytes, not {}",
-                crate::gateway::short_type_name(pyre_object::gc_roots::shadow_stack_get(file_slot)),
-                crate::gateway::short_type_name(resolved)
-            )));
-        }
+        // The protocol itself is `fspath`'s: `__fspath__` is bound before it is
+        // called, so a descriptor on the type runs and what it answers is what
+        // gets called, and a `None` left there switches the protocol off rather
+        // than being called and reported as uncallable.  Both refusals name the
+        // object's own type, which is the wording this call site needs.
+        let resolved =
+            crate::module::posix::fspath(pyre_object::gc_roots::shadow_stack_get(file_slot))?;
         let _ = pyre_object::gc_roots::pin_root(resolved);
         file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -801,24 +801,25 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         push_abi_unsound_fnaddr(&mut entries, wrapper.path, wrapper.func as *const ());
     }
 
-    // `#[pyre_methods]` `type_object()` accessors are `dont_look_inside`
-    // (`majit-translate` `front::llbc_hints` stamps them: the JIT residualizes
-    // the `OnceLock` body rather than lifting its unliftable `CELL` read), so
-    // each residual call needs the accessor's runtime address.  The macro
-    // registers every `(path, fn)` into this link-time slice; iterate it
-    // instead of hand-listing ~46 module-qualified paths (which mis-resolve
-    // inline-mod spellings and miss per-module `cfg` gates).  Register the
-    // crate-stripped alias too, so either spelling of the residual
-    // `FunctionPath` resolves.  The descriptor carries the accessor as a
-    // `fn() -> PyObjectRef` rather than an address, so `p0` checks it the same
-    // way it checks a hand-written publication.
-    #[cfg(not(target_arch = "wasm32"))]
-    for desc in pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS {
-        p0(&mut entries, desc.path, desc.func);
-        if let Some((_crate_seg, rest)) = desc.path.split_once("::") {
-            p0(&mut entries, rest, desc.func);
+    // `type_object()` accessors are `dont_look_inside` (`majit-translate`
+    // `front::llbc_hints` stamps them: the JIT residualizes the `OnceLock` body
+    // rather than lifting its unliftable `CELL` read), so each residual call
+    // needs the accessor's runtime address.  Every accessor registers its
+    // `(path, fn)` through `register_type_object_fnaddr!`; iterate that
+    // registry instead of hand-listing ~46 module-qualified paths (which
+    // mis-resolve inline-mod spellings and miss per-module `cfg` gates).  The
+    // registry covers every target, because the stamp does: an accessor the
+    // front residualizes but this loop never publishes leaves the residual
+    // holding a symbolic fnaddr.  Register the crate-stripped alias too, so
+    // either spelling of the residual `FunctionPath` resolves.  The descriptor
+    // carries the accessor as a `fn() -> PyObjectRef` rather than an address,
+    // so `p0` checks it the same way it checks a hand-written publication.
+    pyre_object::lltype::for_each_type_object_fnaddr(|path, func| {
+        p0(&mut entries, path, func);
+        if let Some((_crate_seg, rest)) = path.split_once("::") {
+            p0(&mut entries, rest, func);
         }
-    }
+    });
 
     cpa2(
         &mut entries,
@@ -4355,26 +4356,17 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
 /// fully-qualified Rust path the flowgraph names the global read with
 /// (`PyreClassDescriptor::pytype_path`).
 ///
-/// Empty on `wasm32`, where the `PYRE_CLASS_DESCRIPTORS` registry does not
-/// exist (`linkme::distributed_slice` rejects the target).  That makes the
-/// binding set target-dependent, so `pyre-jit-trace`'s build script drops
-/// these rows when it is generating jitcodes *for* wasm: a name bound at
-/// build time but missing from the runtime pool keeps the build-process
-/// address baked in the constant pool, because
+/// Populated on every target.  The set has to be target-independent: a name
+/// bound at build time but missing from the runtime pool keeps the
+/// build-process address baked in the constant pool, because
 /// `runtime_fnaddr_patch::patch_static_addr_constants` only re-pairs names
 /// present in both.
 pub fn pyre_class_pytype_addrs() -> Vec<(&'static str, i64)> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        pyre_object::lltype::PYRE_CLASS_DESCRIPTORS
-            .iter()
-            .map(|d| (d.pytype_path, d.pytype_ptr as usize as i64))
-            .collect()
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        Vec::new()
-    }
+    let mut rows = Vec::new();
+    pyre_object::lltype::for_each_class_descriptor(|d| {
+        rows.push((d.pytype_path, d.pytype_ptr as usize as i64));
+    });
+    rows
 }
 
 /// Build-time addresses of the prebuilt dict-strategy singletons pyre
@@ -4854,12 +4846,10 @@ mod tests {
         assert_eq!(bindings["module::_random::Random::genrand32"], expected);
     }
 
-    /// `PYRE_TYPE_OBJECT_FNADDRS` is a native-only `distributed_slice`, so the
-    /// `#[pyre_methods]` `type_object()` residual addresses are published only
-    /// off wasm32.  Both the crate-qualified path (the residual `FunctionPath`)
+    /// Every `#[pyre_methods]` `type_object()` accessor publishes its residual
+    /// address.  Both the crate-qualified path (the residual `FunctionPath`)
     /// and the crate-stripped alias resolve to the accessor.
     #[test]
-    #[cfg(not(target_arch = "wasm32"))]
     fn jit_trace_fnaddrs_covers_deque_iter_type_object_residual() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
         let expected =
@@ -4882,7 +4872,6 @@ mod tests {
     /// a symbolic fnaddr and inline JIT descent aborts.  Guards the invariant
     /// that every `type_object` generator (macro or hand-written) registers.
     #[test]
-    #[cfg(not(target_arch = "wasm32"))]
     fn jit_trace_fnaddrs_covers_hand_written_csv_dialect_type_object() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
         assert!(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -4356,11 +4356,15 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
 /// fully-qualified Rust path the flowgraph names the global read with
 /// (`PyreClassDescriptor::pytype_path`).
 ///
-/// Populated on every target.  The set has to be target-independent: a name
-/// bound at build time but missing from the runtime pool keeps the
-/// build-process address baked in the constant pool, because
-/// `runtime_fnaddr_patch::patch_static_addr_constants` only re-pairs names
-/// present in both.
+/// Populated on every target.  Its membership still follows the module set,
+/// which a cross-target build cannot see: the list is read once in the build
+/// script, compiled for the host, and once at run time, compiled for the
+/// target, so a module declared behind `target_arch`, `unix` or `windows`
+/// appears in the first and not the second.  A name bound at build time and
+/// missing at run time keeps the build-process address baked in the constant
+/// pool, because `runtime_fnaddr_patch::patch_static_addr_constants` re-pairs
+/// only names present in both; `reject_unpaired_build_addrs` refuses the load
+/// once such an address actually reaches a constant pool.
 pub fn pyre_class_pytype_addrs() -> Vec<(&'static str, i64)> {
     let mut rows = Vec::new();
     pyre_object::lltype::for_each_class_descriptor(|d| {

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -542,16 +542,9 @@ macro_rules! py_class {
 
         // Publish this accessor's residual-call address so the JIT's
         // `dont_look_inside` residual for `type_object` resolves through
-        // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
-        // `#[pyre_methods]`-generated accessor.  Native only, matching the slice.
-        #[cfg(not(target_arch = "wasm32"))]
-        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
-        #[allow(non_upper_case_globals)]
-        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
-            ::pyre_object::lltype::TypeObjectFnDescriptor {
-                path: ::core::concat!(::core::module_path!(), "::type_object"),
-                func: type_object,
-            };
+        // `jit_trace_fnaddrs`, mirroring the `#[pyre_methods]`-generated
+        // accessor.
+        ::pyre_object::register_type_object_fnaddr!();
     };
 }
 
@@ -648,16 +641,9 @@ macro_rules! py_class_typed {
 
         // Publish this accessor's residual-call address so the JIT's
         // `dont_look_inside` residual for `type_object` resolves through
-        // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
-        // `#[pyre_methods]`-generated accessor.  Native only, matching the slice.
-        #[cfg(not(target_arch = "wasm32"))]
-        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
-        #[allow(non_upper_case_globals)]
-        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
-            ::pyre_object::lltype::TypeObjectFnDescriptor {
-                path: ::core::concat!(::core::module_path!(), "::type_object"),
-                func: type_object,
-            };
+        // `jit_trace_fnaddrs`, mirroring the `#[pyre_methods]`-generated
+        // accessor.
+        ::pyre_object::register_type_object_fnaddr!();
     };
 }
 

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -619,16 +619,9 @@ mod dialect_class {
 
     // Publish this accessor's residual-call address so the JIT's
     // `dont_look_inside` residual for `type_object` resolves through
-    // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
-    // `#[pyre_methods]`-generated accessors.  Native only, matching the slice.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
-    #[allow(non_upper_case_globals)]
-    static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
-        ::pyre_object::lltype::TypeObjectFnDescriptor {
-            path: ::core::concat!(::core::module_path!(), "::type_object"),
-            func: type_object,
-        };
+    // `jit_trace_fnaddrs`, mirroring the `#[pyre_methods]`-generated
+    // accessors.
+    ::pyre_object::register_type_object_fnaddr!();
 }
 
 // ── `_csv.reader` ──

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -1111,11 +1111,14 @@ fn real_main() {
     // call site.
     let static_pytype_addrs = pyre_interpreter::jit_static_pytype_addrs();
     // This script is compiled for the host even when the crate it feeds is
-    // built for wasm, so a name bound here is only useful if the runtime
-    // pool carries it too — `runtime_fnaddr_patch::patch_static_addr_constants`
-    // rewrites only names it finds in both, and an unmatched name keeps this
-    // process's address.  The `#[pyre_class]` registry populates on every
-    // target for that reason.
+    // built for another target, so a name bound here is only useful if the
+    // runtime pool carries it too — `runtime_fnaddr_patch::
+    // patch_static_addr_constants` rewrites only names it finds in both, and
+    // an unmatched name keeps this process's address.  The `#[pyre_class]`
+    // registry populates on every target for that reason; where the two pools
+    // can still disagree is the module set, which this process cannot read for
+    // another target, and `reject_unpaired_build_addrs` refuses the load if
+    // one of those names reaches a constant pool.
     let registry_rows = pyre_interpreter::pyre_class_pytype_addrs();
     let registry_keys: std::collections::HashSet<&str> =
         registry_rows.iter().map(|&(key, _)| key).collect();

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -1109,23 +1109,19 @@ fn real_main() {
     // build-script process the translator runs in, so the captured
     // addresses match a direct `&pyre_object::X` read at the codewriter
     // call site.
-    let mut static_pytype_addrs = pyre_interpreter::jit_static_pytype_addrs();
+    let static_pytype_addrs = pyre_interpreter::jit_static_pytype_addrs();
     // This script is compiled for the host even when the crate it feeds is
-    // built for wasm, so the `#[pyre_class]` registry is populated here and
-    // empty there.  Binding a name the wasm runtime cannot re-pair would
-    // leave this process's address baked in the constant pool
-    // (`runtime_fnaddr_patch::patch_static_addr_constants` rewrites only
-    // names it finds in both pools), so drop the registry-derived rows when
-    // the target is wasm and let those statics stay unbound instead.
+    // built for wasm, so a name bound here is only useful if the runtime
+    // pool carries it too — `runtime_fnaddr_patch::patch_static_addr_constants`
+    // rewrites only names it finds in both, and an unmatched name keeps this
+    // process's address.  The `#[pyre_class]` registry populates on every
+    // target for that reason.
     let registry_rows = pyre_interpreter::pyre_class_pytype_addrs();
     let registry_keys: std::collections::HashSet<&str> =
         registry_rows.iter().map(|&(key, _)| key).collect();
-    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
-        static_pytype_addrs.retain(|(key, _)| !registry_keys.contains(key));
-    }
     // Counts the rows that survived, not the registry's size: the table
     // drops every registry row whose static a hand-written row already
-    // names, and all of them when the target is wasm.
+    // names.
     let kept_from_registry = static_pytype_addrs
         .iter()
         .filter(|(key, _)| registry_keys.contains(key))

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -190,6 +190,7 @@ fn build_time_ref_bindings() -> Vec<(String, i64)> {
 /// call targets).
 pub fn patch_static_addr_constants(jitcodes: &mut [Arc<JitCode>]) {
     let correspondence = &*STATIC_ADDR_CORRESPONDENCE;
+    disarm_unpaired_build_addrs(jitcodes);
 
     if correspondence.is_empty() {
         return;
@@ -235,9 +236,108 @@ static STATIC_ADDR_CORRESPONDENCE: LazyLock<HashMap<i64, i64>> = LazyLock::new(|
     correspondence
 });
 
-/// Take both build -> runtime address snapshots now.
+/// Build addresses whose name the runtime pool cannot re-pair, keyed by the
+/// address, valued by the name it was bound under.
 ///
-/// Both maps are `LazyLock`, so without this they would be built at whatever
+/// Both correspondences above rewrite only names present in the build pool and
+/// the runtime one, so an unmatched name leaves the build process's address
+/// where the codewriter put it.  The two pools come from two compilations of
+/// the same list, and they answer a `cfg` differently whenever the build
+/// script's copy is configured differently from the crate it feeds: the script
+/// is built for the host, so a module behind `target_arch`, `unix` or
+/// `windows` registers its accessors and its `#[pyre_class]` statics there and
+/// not in a cross-target runtime, and it is a build-dependency with its own
+/// feature resolution, so a row behind a feature the binary turns off is
+/// bound here and absent there.
+///
+/// Binding such a name costs nothing while no jitcode carries its address, so
+/// the address in a constant pool is what this names, not the binding.
+///
+/// An address the correspondences do know is excluded: the build binary's
+/// identical-code folding can put a re-pairable name and an unmatched one on
+/// one address, and the constant then belongs to the name that re-pairs.
+static UNPAIRED_BUILD_ADDRS: LazyLock<HashMap<i64, String>> = LazyLock::new(|| {
+    let mut runtime_names: std::collections::HashSet<&'static str> =
+        pyre_interpreter::jit_trace_fnaddrs()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+    runtime_names.extend(
+        pyre_interpreter::jit_static_pytype_addrs()
+            .into_iter()
+            .map(|(name, _)| name),
+    );
+    runtime_names.extend(
+        pyre_interpreter::jit_static_ref_addrs()
+            .into_iter()
+            .map(|(name, _)| name),
+    );
+
+    let mut paired: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    let mut unpaired: HashMap<i64, String> = HashMap::new();
+    for (name, build_addr) in build_time_fnaddr_bindings()
+        .into_iter()
+        .chain(build_time_pytype_bindings())
+        .chain(build_time_ref_bindings())
+    {
+        if runtime_names.contains(name.as_str()) {
+            paired.insert(build_addr);
+        } else {
+            unpaired.insert(build_addr, name);
+        }
+    }
+    unpaired.retain(|addr, _| !paired.contains(addr));
+    unpaired
+});
+
+/// Take out the addresses no runtime name re-pairs, before anything reads them.
+///
+/// Such a value is a pointer into the build-script process, and every use the
+/// pools have for one is wrong with it: as a residual call target it enters
+/// whatever this process holds at that address, as a `PyType` operand it is
+/// dereferenced by a type test, and as a pointer-`eq` operand it answers "not
+/// this type" for every object.  Zero is the substitute because it is the one
+/// value none of those can mistake for a real target — a call through it faults
+/// on the first instruction, a dereference faults at the first field, and a
+/// comparison never matches.
+///
+/// All three pools are cleared, `constants_r` included: that pool already
+/// carries words that are not gcrefs — patched host statics and pre-patch
+/// string sentinels — and the collector's `drag_out_root` / `seed_major_root`
+/// gates reject a non-object word before any deref, so a zero there is read the
+/// same way the address it replaces was.
+fn disarm_unpaired_build_addrs(jitcodes: &mut [Arc<JitCode>]) {
+    let unpaired = &*UNPAIRED_BUILD_ADDRS;
+    if unpaired.is_empty() {
+        return;
+    }
+
+    for arc in jitcodes.iter_mut() {
+        let jc = Arc::get_mut(arc).expect(
+            "disarm_unpaired_build_addrs: Arc<JitCode> already shared before patch — \
+             every caller must run this before publishing the table to consumers",
+        );
+        if unpaired.contains_key(&jc.fnaddr) {
+            jc.fnaddr = 0;
+        }
+        if jc.try_body().is_some() {
+            let body = jc.body_mut();
+            for c in body
+                .constants_i
+                .iter_mut()
+                .chain(body.constants_r.iter_mut().map(|slot| slot.get_mut()))
+            {
+                if unpaired.contains_key(c) {
+                    *c = 0;
+                }
+            }
+        }
+    }
+}
+
+/// Take the build -> runtime address snapshots now.
+///
+/// Each map is a `LazyLock`, so without this it would be built at whatever
 /// moment the first jitcode happens to be decoded.  Once jitcode bodies decode
 /// lazily that moment is mid-trace, long after `init_typeobjects` has retagged
 /// the `PyType` singletons — and the map, frozen there, would then patch every
@@ -252,6 +352,10 @@ static STATIC_ADDR_CORRESPONDENCE: LazyLock<HashMap<i64, i64>> = LazyLock::new(|
 pub fn prime_address_correspondences() {
     LazyLock::force(&FNADDR_CORRESPONDENCE);
     LazyLock::force(&STATIC_ADDR_CORRESPONDENCE);
+    // Keyed by name rather than by address, so the instant it is taken does
+    // not change what it holds; forced here so no jitcode load pays to build
+    // it mid-trace.
+    LazyLock::force(&UNPAIRED_BUILD_ADDRS);
 }
 
 /// Resolve one build-process function address to this process's address.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4773,23 +4773,22 @@ fn build_gc() -> Box<MiniMarkGC> {
     deque_lock_descr.gc_type_id.set(deque_lock_tid);
 
     // ── GC-root registration completeness oracle ─────────────────────────
-    // Every `#[pyre_class]` type appends its descriptor to the whole-program
-    // `PYRE_CLASS_DESCRIPTORS` slice. A type with inline managed children must
+    // Every `#[pyre_class]` type registers its descriptor into the
+    // whole-program registry. A type with inline managed children must
     // be reachable by either its marker layout or the immortal-root offset
     // registry. Run the oracle only after the absolute-tail registrations so
     // hidden non-vtable GcStructs such as WeakrefLifeline are included too.
-    #[cfg(not(target_arch = "wasm32"))]
     {
         let mut unregistered: Vec<&'static str> = Vec::new();
-        for descr in pyre_object::lltype::PYRE_CLASS_DESCRIPTORS {
+        pyre_object::lltype::for_each_class_descriptor(|descr| {
             if descr.ptr_offsets.is_empty() {
-                continue;
+                return;
             }
             let in_offset_registry =
                 unsafe { pyre_object::gc_hook::offsets_for_pytype(descr.pytype_ptr) }
                     .is_some_and(|o| !o.is_empty());
             if in_offset_registry {
-                continue;
+                return;
             }
             let tid = descr.gc_type_id.get();
             let marker_traced = tid != pyre_object::lltype::TypeIdCell::UNASSIGNED
@@ -4805,7 +4804,7 @@ fn build_gc() -> Box<MiniMarkGC> {
             if !marker_traced {
                 unregistered.push(descr.pyname);
             }
-        }
+        });
         assert!(
             unregistered.is_empty(),
             "GC-root registration gap: #[pyre_class] type(s) with managed \

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1276,6 +1276,7 @@ fn expand_pyre_class(
     let ptr_offsets_const = format_ident!("W_{}_GC_PTR_OFFSETS", suffix);
     let descriptor_static = format_ident!("W_{}_PYRE_CLASS_DESCRIPTOR", suffix);
     let descriptor_slice_elem = format_ident!("W_{}_PYRE_CLASS_DESCRIPTOR_SLICE", suffix);
+    let descriptor_ctor_fn = format_ident!("__register_w_{}_pyre_class_descriptor", suffix);
 
     // When the user declared `type_id = N` we pre-initialize the cell
     // to `N` and additionally emit the legacy `pub const W_X_GC_TYPE_ID:
@@ -1399,15 +1400,21 @@ fn expand_pyre_class(
                 ),
             };
 
-        /// Link-time registration of this class's descriptor into the
-        /// whole-program `PYRE_CLASS_DESCRIPTORS` slice, so the JIT
-        /// driver's GC-root completeness oracle can see every
-        /// `#[pyre_class]` type without a hand-maintained list.  Native
-        /// only, matching the slice: `distributed_slice` rejects `wasm32`.
+        /// Registration of this class's descriptor into the whole-program
+        /// registry, so the JIT driver's GC-root completeness oracle and
+        /// the `PyType`-address binder see every `#[pyre_class]` type
+        /// without a hand-maintained list.  `distributed_slice` rejects
+        /// `wasm32`, which registers from a constructor instead.
         #[cfg(not(target_arch = "wasm32"))]
         #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_CLASS_DESCRIPTORS)]
         static #descriptor_slice_elem: &'static ::pyre_object::lltype::PyreClassDescriptor =
             &#descriptor_static;
+
+        #[cfg(target_arch = "wasm32")]
+        #[::ctor::ctor(unsafe)]
+        fn #descriptor_ctor_fn() {
+            ::pyre_object::lltype::register_class_descriptor(&#descriptor_static);
+        }
 
         impl ::pyre_object::lltype::PyreClassPyTypeOf for #st_name {
             const PYTYPE: *const ::pyre_object::PyType =
@@ -2543,16 +2550,8 @@ fn expand_pyre_methods(
         // Publish this accessor's residual-call address.  `type_object` is
         // `dont_look_inside` (the JIT never lifts the `OnceLock` body — its
         // `CELL` read is unliftable host plumbing), so the codewriter emits a
-        // residual call the runtime resolves through `jit_trace_fnaddrs`, which
-        // iterates this slice.  Native only, matching the slice.
-        #[cfg(not(target_arch = "wasm32"))]
-        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
-        #[allow(non_upper_case_globals)]
-        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
-            ::pyre_object::lltype::TypeObjectFnDescriptor {
-                path: ::core::concat!(::core::module_path!(), "::type_object"),
-                func: type_object,
-            };
+        // residual call the runtime resolves through `jit_trace_fnaddrs`.
+        ::pyre_object::register_type_object_fnaddr!();
     };
 
     Ok(quote! {

--- a/pyre/pyre-object/Cargo.toml
+++ b/pyre/pyre-object/Cargo.toml
@@ -18,3 +18,10 @@ indexmap = { workspace = true }
 rustpython-wtf8 = { workspace = true }
 linkme = { workspace = true }
 bitflags = { workspace = true }
+
+# `type_object()` accessors publish their residual-call address through a
+# `linkme` link section off wasm32.  wasm32 rejects that section — a custom
+# `link_section` static there must be a plain byte list, and a descriptor
+# holds two pointers — so the accessors register from a constructor instead.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ctor = { workspace = true }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -183,22 +183,65 @@ unsafe impl Sync for PyreClassDescriptor {}
 /// class descriptors — the Rust stand-in for RPython's translation-time
 /// walk over every `GcStruct` in the low-level type graph
 /// (`rpython/memory/gctransform/framework.py`), which pyre cannot do
-/// because Rust has no such pass.  Consumed only as a completeness
-/// *oracle*: the JIT driver's `build_gc` asserts, right before
-/// `freeze_types()`, that every descriptor with managed children was
-/// actually wired into the GC.  It is deliberately NOT used to *drive*
-/// registration — population is a link-section array whose completeness
-/// is not guaranteed on every backend (notably wasm), and an oracle
-/// degrades gracefully under under-population (it can only under-check,
-/// never false-alarm) whereas a driver could not.
+/// because Rust has no such pass.  Two consumers read it: the JIT
+/// driver's `build_gc` completeness *oracle*, which asserts right before
+/// `freeze_types()` that every descriptor with managed children was
+/// actually wired into the GC, and `pyre_class_pytype_addrs`, which binds
+/// each `PyType` static's address for the translation boundary.  The
+/// oracle degrades gracefully under under-population (it can only
+/// under-check, never false-alarm); the address binder does not, because
+/// a name bound at build time and missing at runtime keeps the
+/// build-process address.  Both populations below therefore have to hold
+/// the same set.
 ///
-/// Compiled native-only: `linkme::distributed_slice` rejects `wasm32`
-/// ("distributed_slice is not implemented for this platform"), and the
-/// sole consumer — `build_gc`'s oracle — is itself `wasm32`-gated, so the
-/// registry is dead weight there anyway.
+/// `distributed_slice` rejects `wasm32` ("distributed_slice is not
+/// implemented for this platform"), which carries the same set in
+/// [`WASM_CLASS_DESCRIPTORS`] instead; read both through
+/// [`for_each_class_descriptor`].
 #[cfg(not(target_arch = "wasm32"))]
 #[::linkme::distributed_slice]
 pub static PYRE_CLASS_DESCRIPTORS: [&'static PyreClassDescriptor] = [..];
+
+/// The same registry on wasm32, populated at constructor time.
+///
+/// `linkme` has no wasm32 arm, and the reason is the target rather than
+/// the crate: a static with a custom `link_section` must be a plain list
+/// of bytes there, with no relocation for a pointer field.  A constructor
+/// runs before any exported function of the module, so the set is
+/// complete by the time the JIT binds its address table, and it is
+/// emitted beside the type — so it inherits that module's `cfg` gates
+/// exactly as the link-section element does.
+#[cfg(target_arch = "wasm32")]
+pub static WASM_CLASS_DESCRIPTORS: std::sync::Mutex<Vec<&'static PyreClassDescriptor>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Append one type's descriptor to [`WASM_CLASS_DESCRIPTORS`].
+///
+/// Called only from the constructor `#[pyre_class]` emits.
+#[cfg(target_arch = "wasm32")]
+pub fn register_class_descriptor(descr: &'static PyreClassDescriptor) {
+    WASM_CLASS_DESCRIPTORS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(descr);
+}
+
+/// Visit every registered `#[pyre_class]` descriptor, whichever population
+/// the target carries.
+pub fn for_each_class_descriptor(mut visit: impl FnMut(&'static PyreClassDescriptor)) {
+    #[cfg(not(target_arch = "wasm32"))]
+    for descr in PYRE_CLASS_DESCRIPTORS {
+        visit(descr);
+    }
+    #[cfg(target_arch = "wasm32")]
+    for descr in WASM_CLASS_DESCRIPTORS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+    {
+        visit(descr);
+    }
+}
 
 /// Link-time descriptor for a `#[pyre_methods]`-generated `type_object()`
 /// accessor.  The accessor's body is the `OnceLock<usize>` type-object cache;
@@ -220,14 +263,96 @@ pub struct TypeObjectFnDescriptor {
 // process-global code; sharing across threads is sound.
 unsafe impl Sync for TypeObjectFnDescriptor {}
 
-/// Link-time registry of every `#[pyre_methods]` `type_object()` accessor,
-/// populated by the macro so `jit_trace_fnaddrs` publishes each residual-call
-/// address without a hand-maintained list (which would mis-resolve inline-mod
-/// paths and miss per-module `cfg` gates).  Native only, matching
-/// [`PYRE_CLASS_DESCRIPTORS`]: `distributed_slice` rejects `wasm32`.
+/// Link-time registry of every `type_object()` accessor, populated by
+/// [`register_type_object_fnaddr!`] so `jit_trace_fnaddrs` publishes each
+/// residual-call address without a hand-maintained list (which would
+/// mis-resolve inline-mod paths and miss per-module `cfg` gates).
+/// `distributed_slice` rejects `wasm32`, which carries the same set in
+/// [`WASM_TYPE_OBJECT_FNADDRS`] instead; read both through
+/// [`for_each_type_object_fnaddr`].
 #[cfg(not(target_arch = "wasm32"))]
 #[::linkme::distributed_slice]
 pub static PYRE_TYPE_OBJECT_FNADDRS: [TypeObjectFnDescriptor] = [..];
+
+/// The same registry on wasm32, populated at constructor time.
+///
+/// `linkme` has no wasm32 arm, and the reason is the target rather than the
+/// crate: a static with a custom `link_section` must be a plain list of bytes
+/// there, with no relocation for a pointer field, and a descriptor holds two.
+/// A constructor runs before any exported function of the module, so an entry
+/// is present by the time the JIT binds its address table, and it is emitted
+/// beside the accessor — so it inherits the module's `cfg` gates exactly as
+/// the link-section element does.
+#[cfg(target_arch = "wasm32")]
+pub static WASM_TYPE_OBJECT_FNADDRS: std::sync::Mutex<Vec<TypeObjectFnDescriptor>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Append one accessor to [`WASM_TYPE_OBJECT_FNADDRS`].
+///
+/// Called only from the constructor [`register_type_object_fnaddr!`] emits.
+/// An entry appended after `jit_trace_fnaddrs` has been read is not published,
+/// and the residual call keeps the address its build-time snapshot carried.
+#[cfg(target_arch = "wasm32")]
+pub fn register_type_object_fnaddr(path: &'static str, func: fn() -> crate::PyObjectRef) {
+    WASM_TYPE_OBJECT_FNADDRS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(TypeObjectFnDescriptor { path, func });
+}
+
+/// Visit every registered `type_object()` accessor, whichever population the
+/// target carries.
+///
+/// The JIT stamps the accessor `dont_look_inside` on every target, so a target
+/// that visited none would leave those residual calls bound to the addresses
+/// the build-script process recorded, which name nothing in the runtime one.
+pub fn for_each_type_object_fnaddr(
+    mut visit: impl FnMut(&'static str, fn() -> crate::PyObjectRef),
+) {
+    #[cfg(not(target_arch = "wasm32"))]
+    for desc in PYRE_TYPE_OBJECT_FNADDRS {
+        visit(desc.path, desc.func);
+    }
+    #[cfg(target_arch = "wasm32")]
+    for desc in WASM_TYPE_OBJECT_FNADDRS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+    {
+        visit(desc.path, desc.func);
+    }
+}
+
+/// Publish the enclosing module's `type_object()` accessor for the JIT's
+/// residual call.
+///
+/// Expanded beside every accessor — `#[pyre_methods]`, `py_class!`,
+/// `py_class_typed!`, and the hand-written `_csv::dialect_class` one — so each
+/// registration carries whatever `cfg` gates its module already carries.  A
+/// central list could not: the accessors sit behind nested gates, and one that
+/// fell behind would silently drop an address rather than fail to build.
+#[macro_export]
+macro_rules! register_type_object_fnaddr {
+    () => {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[::linkme::distributed_slice($crate::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
+        #[allow(non_upper_case_globals)]
+        static __PYRE_TYPE_OBJECT_FNADDR: $crate::lltype::TypeObjectFnDescriptor =
+            $crate::lltype::TypeObjectFnDescriptor {
+                path: ::core::concat!(::core::module_path!(), "::type_object"),
+                func: type_object,
+            };
+
+        #[cfg(target_arch = "wasm32")]
+        #[::ctor::ctor(unsafe)]
+        fn __pyre_register_type_object_fnaddr() {
+            $crate::lltype::register_type_object_fnaddr(
+                ::core::concat!(::core::module_path!(), "::type_object"),
+                type_object,
+            );
+        }
+    };
+}
 
 /// Compile-time bridge between a `#[pyre_class]` struct and its
 /// per-type static `PyType` / `PyreClassDescriptor`.  Implemented


### PR DESCRIPTION
`linkme::distributed_slice` rejects `wasm32` — a custom `link_section` static
there must be a plain list of bytes, with no relocation for a pointer field —
so `PYRE_TYPE_OBJECT_FNADDRS` and `PYRE_CLASS_DESCRIPTORS` were both empty in
the guest, and two consumers compensated by dropping work for that target:

- `front::llbc_hints` skipped the `dont_look_inside` stamp on every
  `type_object()` accessor when `TARGET` began with `wasm32`, so the
  codewriter emitted a walked accessor rather than a residual call.
- `pyre-jit-trace`'s prepass dropped every `#[pyre_class]`-derived static
  `PyType` address row for wasm, leaving those statics unbound.

Both registries now carry a wasm32 arm that registers from a `ctor`
constructor. The constructor is emitted beside the item, so it inherits that
module's `cfg` gates the way the link-section element does; a central list
could not, because the accessors sit behind nested gates and one that fell
behind would silently drop an address rather than fail to build.
`for_each_type_object_fnaddr` and `for_each_class_descriptor` read whichever
population the target holds, and the two compensating drops are removed.
`build_gc`'s GC-root completeness oracle, gated off wasm32 because the
registry did not exist there, runs on every target.

### Measured on `pyre/bench/fib_recursive.py`

| | wasm before | wasm after |
|---|---|---|
| generated jitcode census, `type_object` entries | 26 (walked) | **0** — the wasm and native censuses hold the same 3366 entries, none unique to either side |
| `[PREPASS statics] pytype rows` | 136 (0 of 136 registry rows kept) | **225 (89 of 136)** — the native reading |

### What this does not fix

Neither change moves the `fib_recursive` wasm trace-too-long abort:
`abort_diag too_long=1` and `guard_failures=1601` are unchanged. A cranelift
binary built with the wasm feature set (`--no-default-features --features
cranelift`) records the same over-limit trace and reports
`toolong_suppressed=1`, so that abort turns on the feature set rather than on
the target. `MAJIT_LOG=1` reads the two native builds directly: the full build
traces 3648 ops, the feature-matched one 6008 — eight over the 6000 limit.
Why dropping `host_env` lengthens that trace is open and not addressed here.

## Addressing the review

Codex found that binding every host registry row bakes host-process pointers
into a cross-target build. It does, and the hole is wider than the rows it
named: the build script is a build-*dependency* with its own feature
resolution, so a row behind a feature the binary turns off (`mmap_type`,
`_ctypes::cdata_bytes_object` under `--no-default-features --features
cranelift`) has been bound-but-unmatched on **native** builds since it landed.

`disarm_unpaired_build_addrs` closes both axes at the place that already owns
the build → runtime pairing: every build address no runtime name re-pairs is
set to zero in `JitCode.fnaddr`, `constants_i` and `constants_r` before the
table reaches a consumer. A call through zero faults on the first instruction,
a dereference faults at the first field, and a pointer comparison never
matches, so a path that reaches one says so instead of running against
build-process memory.

## The other commits

- `stdlib_warnings.py`'s `module_globals` blocks asserted a single recorded
  warning while naming the loader as `__loader__` alone. `warn_explicit` reads
  the loader through `__spec__.loader` and warns before the source lookup when
  the mapping carries no `__spec__`, so the assertion failed under CPython
  3.14.6 as well as under pyre.
- `_codecs.escape_encode(b"'")` answers `(b"\'", 1)` on CPython, pypy3 and
  pyre; the fixture asserted `(b"'", 1)`.
- `open()` re-spelled the PathLike protocol and called `__fspath__` unbound, so
  an object whose `__fspath__` is a property raised `TypeError: 'property'
  object is not callable`. It now goes through `posix::fspath`, as
  `pypy/module/_io/interp_io.py` `_open` does.

Those three snippets join the CI gate.

## Verification

- `pyre/check.py --backend dynasm,cranelift,wasm`: dynasm 533/533,
  cranelift 533/533, wasm 526/526, no jitstats baseline moved.
- `extra_tests/run.py --gated-only`: 174/174 on cpython, dynasm and cranelift.
- `extra_tests/parity_tests/run.py`: all pass.
- `cargo test --all` (207 test binaries, 0 failures), `cargo fmt --check`.

## The two red check.py legs

Both are the derived pypy floor: `synth/load_name_builtin_cell_fold` on macOS
cranelift (`0.4x < gate 0.416667x`, ceiling 2.5x) and
`synth/loop_callee_shared_mutation` on ubuntu dynasm (`0.8x < gate 1x`, ceiling
6.4x). The same fixture on the same backend reads **0.4x on macOS** and **1.7x
on ubuntu** in this very run, so the ceiling is calibrated for the host where
it reads 1.7x and lowering it to clear the macOS floor would fail that host
against the ceiling. main at this branch's merge base
([run 33565610870](https://github.com/youknowone/pyre/actions/runs/33565610870))
fails the same macOS job with three of the same class, and additionally fails
ubuntu dynasm on `test.test_threading: PASS -> TIMEOUT`, which this branch does
not reproduce (`CRASH 0, TIMEOUT 0`). Details in the PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wapwfqfqNe7kFcxQRx85P
