### PR TITLE
wasm, cranelift: three ops' own operand roles, a MemoryError the allocator never raised, a cond-call on the wrong arm, and seven declines

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -721,6 +721,22 @@ fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
         .unwrap_or_else(|| missing_layout_descr("array descr (item size/sign)", op))
 }
 
+/// `raw_load` / `raw_store` address `arg(0) + arg(1)` and nothing else: a raw
+/// buffer has no GC array header, so the descr's base size is not part of the
+/// address the way it is for the `GETARRAYITEM` family.
+fn emit_raw_addr(
+    sink: &mut PeepSink<'_, '_>,
+    constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &ValueLocals,
+    op: &Op,
+) {
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+    sink.i32_wrap_i64();
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
+    sink.i32_wrap_i64();
+    sink.i32_add();
+}
+
 fn array_item_is_float_from_descr(op: &Op) -> bool {
     op.with_array_descr(|ad| ad.item_type() == Type::Float)
         .unwrap_or_else(|| missing_layout_descr("array descr (item is_float)", op))
@@ -5228,6 +5244,40 @@ fn build_function(
                     s.i64_xor();
                 },
             ),
+            // resoperation.py `int_between(a, b, c)` is the three-operand
+            // range test `a <= b < c`, signed on all three. jtransform lowers
+            // the name directly (`jtransform_opname.rs`), and the bigint
+            // compare path mints it as `int_between(-1, i2 >> 48, 1)`, so a
+            // trace can carry it.
+            OpCode::IntBetween => {
+                let vi = op.pos.get().raw();
+                if !OpRef::raw_is_constant(vi) {
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
+                    sink.i64_le_s();
+                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
+                    sink.i64_lt_s();
+                    sink.i32_and();
+                    sink.i64_extend_i32_u();
+                    sink.local_set(value_types.local(vi));
+                }
+            }
+
+            // `float_mod` is C `fmod`: the interpreter evaluates it as Rust's
+            // `a % b`, which truncates toward zero. Wasm has no float
+            // remainder instruction, and `a - (a/b).floor() * b` answers
+            // Python's floored `%` instead — a different result for mixed
+            // signs, and inexact for a large quotient either way. Decline
+            // until there is a host helper to call.
+            OpCode::FloatMod => {
+                return Err(BackendError::Unsupported(
+                    "wasm backend: FloatMod is unsupported (fmod has no wasm \
+                     instruction); declining the trace"
+                        .to_string(),
+                ));
+            }
+
             // ── Extended integer ops ──
             OpCode::IntSignext => {
                 // int_signext(val, num_bytes): sign-extend from num_bytes width
@@ -5630,25 +5680,24 @@ fn build_function(
             }
 
             // ── Raw memory access ──
-            OpCode::RawLoadI => {
+            OpCode::RawLoadI | OpCode::RawLoadF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // ptr
-                    sink.i32_wrap_i64();
-                    emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref()); // offset
-                    sink.i32_wrap_i64();
-                    sink.i32_add();
-                    let (item_size, signed) = array_item_size_sign_from_descr(op);
-                    emit_sized_int_load(&mut sink, 0, item_size, signed);
+                    emit_raw_addr(&mut sink, constants, value_types, op);
+                    if op.opcode == OpCode::RawLoadF {
+                        sink.f64_load(mem64(0));
+                    } else {
+                        let (item_size, signed) = array_item_size_sign_from_descr(op);
+                        emit_sized_int_load(&mut sink, 0, item_size, signed);
+                    }
                     sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::RawStore => {
-                emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                sink.i32_wrap_i64();
-                emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
-                sink.i32_wrap_i64();
-                sink.i32_add();
+                emit_raw_addr(&mut sink, constants, value_types, op);
+                // `emit_resolve` hands back a Float operand as the `i64` its
+                // bits spell, so the width-sized integer store writes the same
+                // eight bytes an `f64.store` would.
                 emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
                 let (item_size, _signed) = array_item_size_sign_from_descr(op);
                 emit_sized_int_store(&mut sink, 0, item_size);
@@ -6137,7 +6186,9 @@ fn build_function(
             // — there is no `Newstr` / `Strsetitem` / `Copystrcontent`
             // producer outside majit's ported RPython infrastructure, so
             // string work stays in residual interpreter calls and none of
-            // these reach a wasm trace today.
+            // these reach a wasm trace today. The setitem pair is named here
+            // rather than left to the catch-all so the whole family declines
+            // from one place.
             //
             // They are declined rather than left as silent no-ops. The old
             // arms emitted nothing for the copies and, for the allocations, a
@@ -6150,7 +6201,9 @@ fn build_function(
             OpCode::Newstr
             | OpCode::Newunicode
             | OpCode::Copystrcontent
-            | OpCode::Copyunicodecontent => {
+            | OpCode::Copyunicodecontent
+            | OpCode::Strsetitem
+            | OpCode::Unicodesetitem => {
                 return Err(BackendError::Unsupported(format!(
                     "wasm backend: {:?} is unsupported (no rstr lowering); \
                      declining the trace",
@@ -7499,12 +7552,19 @@ fn build_function(
             | OpCode::Keepalive => {}
 
             _ => {
-                // An opcode with no codegen arm. If it produces a value (a
-                // result local that later ops read), silently skipping it
-                // leaves a stale slot and yields wrong results, so decline the
-                // whole trace and let the metainterp fall back to the
-                // interpreter (correct, unaccelerated). Side-effect-free
-                // metadata opcodes that produce no value are enumerated above.
+                // An opcode with no codegen arm declines the whole trace and
+                // lets the metainterp fall back to the interpreter (correct,
+                // unaccelerated). That covers a void opcode too: its `pos` is
+                // `OpRef::NONE`, whose raw is `u32::MAX`, and
+                // `raw_is_constant` rejects the sentinel range. So the only op
+                // that reaches here and emits nothing is one the optimizer
+                // folded into the constant namespace, which by then is pure and
+                // has no side effect left to drop.
+                //
+                // An opcode that must emit nothing belongs in one of the no-op
+                // arms above, where the reason it owes no code is written down;
+                // a side-effecting op put there is dropped in silence, which is
+                // what `CondCallN` was.
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     return Err(BackendError::Unsupported(format!(

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -7009,6 +7009,17 @@ fn build_function(
                     }
                 }
 
+                // The check `rewrite.py` `_gen_call_malloc_gc` puts after a
+                // collecting malloc: the vtable and class-word stores below
+                // address the result directly and must not run on a NULL.
+                emit_memory_error_check(
+                    &mut sink,
+                    value_types,
+                    vi,
+                    residual_type_base,
+                    ca.ca_reload_fn_ptr,
+                    ca.jf_top_addr,
+                );
                 if !OpRef::raw_is_constant(vi) {
                     // llmodel.py write_int_at_mem(res, vtable_offset,
                     // WORD, vtable). The `ob_type` field is pointer-width: 4
@@ -7443,6 +7454,18 @@ fn build_function(
                         sink.local_set(value_types.local(vi));
                     }
                 }
+                // The check `rewrite.py` `_gen_call_malloc_gc` puts after a
+                // collecting malloc. Here the helper writes the length field
+                // itself, so the NULL escapes into the following item stores
+                // rather than into a store this arm emits.
+                emit_memory_error_check(
+                    &mut sink,
+                    value_types,
+                    vi,
+                    residual_type_base,
+                    ca.ca_reload_fn_ptr,
+                    ca.jf_top_addr,
+                );
                 // `wasm_jit_alloc_array` collects; reload other live Refs. The
                 // inline-bump paths already emitted this inside their slow arms.
                 if residual_type_base.is_none()
@@ -8855,6 +8878,75 @@ fn exit_fail_args(op: &Op) -> Vec<OpRef> {
     op.getfailargs()
         .map(|fa| fa.iter().map(|a| a.to_opref()).collect())
         .unwrap_or_else(|| op.getarglist().iter().map(|a| a.to_opref()).collect())
+}
+
+/// x86/assembler.py `genop_discard_check_memory_error`: the NULL test
+/// `rewrite.py` `_gen_call_malloc_gc` attaches to every collecting malloc.
+/// wasm lowers `New` / `NewArray` itself in place of the GC rewrite, so it owes
+/// itself the same check — address 0 is ordinary linear memory here, so the
+/// vtable, class-word and item stores that follow an allocation would corrupt
+/// it silently rather than fault.
+///
+/// The failing arm is `_build_propagate_exception_path` in this backend's exit
+/// spelling. `_store_and_reset_exception` moves the `MemoryError` the
+/// allocation helper published (`lib.rs` `oom_signal_if_zero`) out of the
+/// shared cells and into the frame's first exit slot, `frame[0]` takes the
+/// reserved `exit_frame_with_exception_descr_ref` exit, and the function
+/// returns its frame pointer. It returns rather than branching to the hot-exit
+/// block because the epilogue there dispatches on a per-guard bridge cell, and
+/// this exit belongs to no guard and owns no cell.
+///
+/// A collecting helper can move the frame before it fails, so local 0 is
+/// reloaded on this arm; the reload reads the shadow-stack top, so a caller
+/// that already reloaded pays nothing for the second one.
+///
+/// Two configurations cannot deliver the exception and trap instead of
+/// reporting a wrong one: a cpu that was never handed
+/// `exit_frame_with_exception_descr_ref`, whose exit would resolve to a bare
+/// finish and hand the exception back as the loop's result (the same choice
+/// the cranelift sibling's `emit_memory_error_check` makes for an unattached
+/// `propagate_exception_descr`), and a `MemoryError` provider that was never
+/// registered, whose exit slot would carry a null reference into the
+/// frontend's re-raise.
+fn emit_memory_error_check(
+    sink: &mut PeepSink<'_, '_>,
+    value_types: &ValueLocals,
+    vi: u32,
+    residual_type_base: Option<u32>,
+    ca_reload_fn_ptr: i64,
+    jf_top_addr: Option<u32>,
+) {
+    if OpRef::raw_is_constant(vi) {
+        return;
+    }
+    sink.local_get(value_types.local(vi));
+    sink.i64_eqz();
+    sink.if_(BlockType::Empty);
+    if crate::failguard::exit_frame_with_exception_attached() {
+        emit_reload_frame_if_necessary(sink, residual_type_base, ca_reload_fn_ptr, jf_top_addr);
+        sink.local_get(0);
+        sink.i32_const(crate::jit_exc_value_addr() as i32);
+        sink.i64_load(mem64(0));
+        sink.i64_store(mem64(FRAME_SLOT_BASE));
+        sink.i32_const(crate::jit_exc_value_addr() as i32);
+        sink.i64_const(0);
+        sink.i64_store(mem64(0));
+        sink.i32_const(crate::jit_exc_type_addr() as i32);
+        sink.i64_const(0);
+        sink.i64_store(mem64(0));
+        sink.local_get(0);
+        sink.i64_load(mem64(FRAME_SLOT_BASE));
+        sink.i64_eqz();
+        sink.if_(BlockType::Empty);
+        sink.unreachable();
+        sink.end();
+        emit_guard_fail_index_store(sink, crate::failguard::FINISH_EXIT_INDEX_EXC);
+        sink.local_get(0);
+        sink.return_();
+    } else {
+        sink.unreachable();
+    }
+    sink.end();
 }
 
 fn emit_guard_fail_index_store(sink: &mut PeepSink<'_, '_>, guard_idx: u32) {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5222,11 +5222,9 @@ fn build_function(
                     OpCode::IntMulOvf => BinOp::I64Mul,
                     _ => unreachable!(),
                 };
-                let fused_guard = match binop {
-                    BinOp::I64Add | BinOp::I64Sub => next_ovf_guard(ops, op_idx),
-                    BinOp::I64Mul => None,
-                    _ => unreachable!(),
-                };
+                // Every overflow form leaves its predicate on the stack, so
+                // any of them can hand it straight to an adjacent guard.
+                let fused_guard = next_ovf_guard(ops, op_idx);
                 ovf_flag_live = match emit_ovf_binop(
                     &mut sink,
                     constants,
@@ -9249,7 +9247,10 @@ fn overflow_failure_cmp(cmp: CmpOp, fused_guard: OpCode) -> CmpOp {
         OpCode::GuardOverflow => match cmp {
             CmpOp::I64GtS => CmpOp::I64LeS,
             CmpOp::I64LtS => CmpOp::I64GeS,
-            _ => unreachable!("overflow comparison must be signed lt or gt"),
+            CmpOp::I64Ne => CmpOp::I64Eq,
+            _ => unreachable!(
+                "overflow comparison must be a constant bound or a sign-word inequality"
+            ),
         },
         _ => unreachable!("overflow fusion requires an overflow guard"),
     }
@@ -9273,19 +9274,8 @@ fn emit_ovf_binop(
     }
     let result_local = value_types.local(vi);
 
-    if matches!(binop, BinOp::I64Mul) {
-        debug_assert!(fused_guard.is_none());
-        // Keep both factors in the umulhi scratch bank. The hot signed-32
-        // overflow check below reuses them without resolving the SSA operands
-        // again; the slow 64-bit path is free to overwrite the same bank.
-        emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
-        sink.local_tee(value_local_count + 1);
-        emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
-        sink.local_tee(value_local_count + 2);
-    } else {
-        emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
-        emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
-    }
+    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
+    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     apply_binop(sink, binop);
     sink.local_set(result_local);
 
@@ -9346,18 +9336,27 @@ fn emit_ovf_binop(
             // every multiplication into a software 64x64->128 product. The
             // exact sign-extension checks preserve the full-width slow path
             // for every value outside that proven-safe domain.
-            sink.local_get(value_local_count + 1);
+            // Resolving an operand is the same single `local.get` that reading
+            // a scratch copy of it would be, so the check reads the operands
+            // and the umulhi bank stays the slow arm's alone.
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
             sink.i64_extend32_s();
-            sink.local_get(value_local_count + 1);
+            emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
             sink.i64_eq();
-            sink.local_get(value_local_count + 2);
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
             sink.i64_extend32_s();
-            sink.local_get(value_local_count + 2);
+            emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
             sink.i64_eq();
             sink.i32_and();
-            sink.if_(BlockType::Empty);
-            sink.i64_const(0);
-            sink.local_set(ovf_flag_local);
+            // Both arms answer the same one-bit predicate, so the block
+            // yields it rather than each arm storing it: an adjacent guard
+            // reads it off the stack the way the add and sub forms do, and
+            // only an unpaired op pays for the flag local. With no paired
+            // guard the predicate to yield is `GuardNoOverflow`'s -- "it
+            // overflowed" -- which is what that local is defined to hold.
+            let failure_of = fused_guard.unwrap_or(OpCode::GuardNoOverflow);
+            sink.if_(BlockType::Result(ValType::I32));
+            sink.i32_const(i32::from(matches!(failure_of, OpCode::GuardOverflow)));
             sink.else_();
 
             // Convert the unsigned high word to the signed high word:
@@ -9387,10 +9386,13 @@ fn emit_ovf_binop(
             sink.local_get(result_local);
             sink.i64_const(63);
             sink.i64_shr_s();
-            sink.i64_ne();
+            apply_cmp(sink, overflow_failure_cmp(CmpOp::I64Ne, failure_of));
+            sink.end();
+            if fused_guard.is_some() {
+                return OvfFlag::FusedCond;
+            }
             sink.i64_extend_i32_u();
             sink.local_set(ovf_flag_local);
-            sink.end();
             return OvfFlag::InLocal;
         }
         _ => unreachable!("overflow emitter requires add, sub, or mul"),

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -6253,8 +6253,10 @@ fn build_function(
                 }
             }
             // Emitted by `RawBufferPtrInfo::_force_elements` after a
-            // `RAW_MALLOC_VARSIZE_CHAR`, which pyre never produces, so this
-            // does not reach a wasm trace today. Declined rather than skipped:
+            // `RAW_MALLOC_VARSIZE_CHAR`. The sole carrier of that oopspec is
+            // `_cffi_backend::cdataobj::raw_malloc_varsize_char`, and
+            // `_cffi_backend` is not compiled for wasm32, so this does not
+            // reach a wasm trace. Declined rather than skipped:
             // the allocation helpers do return 0 on OOM (that is how
             // `alloc_with_type` drives this op on the native backends), and an
             // unchecked null is worse on wasm than on native — address 0 is

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -471,7 +471,12 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
     }
 
     fn i32_wrap_i64(&mut self) -> &mut Self {
-        if let Some(PendingInstruction::I64Const(value)) = self.pending.pop() {
+        // Inspect the tail before removing it, the way every other fold here
+        // does: `pending` is a lookbehind buffer, not an operand stack, so a
+        // tail this fold does not consume still owes its instruction to
+        // `flush`.
+        if let Some(PendingInstruction::I64Const(value)) = self.pending.last().copied() {
+            self.pending.pop();
             self.pending
                 .push(PendingInstruction::I32Const(value as u64 as u32 as i32));
         } else {
@@ -1988,15 +1993,6 @@ fn emit_reload_ca_input_refs_from_homes(
     }
 }
 
-/// llsupport/gc.py GcLLDescr_framework
-///   .get_typeid_from_classptr_if_gcremovetypeptr(classptr)
-/// Looks up the materialized table populated by the runner from the
-/// active gc_ll_descr. RPython resolves the same value via
-/// `cpu.gc_ll_descr.get_typeid_from_classptr_if_gcremovetypeptr`.
-fn lookup_typeid_from_classptr(table: &HashMap<i64, u32>, classptr: usize) -> Option<u32> {
-    table.get(&(classptr as i64)).copied()
-}
-
 /// Information about a guard exit collected during pre-scan.
 /// The live-position mask a guard's bridge inputargs were filtered by.
 ///
@@ -2048,6 +2044,34 @@ pub fn live_fail_arg_extent(meta_descr: Option<&majit_ir::DescrRef>, n: usize) -
         .iter()
         .rposition(|&live| live)
         .map_or(0, |i| i + 1)
+}
+
+/// Whether a guard's live fail-arg positions ARE the positional exit slots a
+/// frame bridge entry reads.
+///
+/// `emit_guard_fail_args_spill` writes fail argument `i` into slot `i`, holes
+/// included, because the deadframe readers index that same logical layout.
+/// `initialize_state_from_guard_failure` instead drops the holes, so bridge
+/// input `k` names the k-th LIVE position — the two orders coincide only while
+/// every hole trails the last live position. `rebuild_faillocs_from_descr` is
+/// where a location per live position is recovered; the frame entry in
+/// `build_function` has no such table and can only read slot `k`, so a caller
+/// that cannot honour this must decline the bridge.
+///
+/// A descr whose `rd_locs` was never sized to its fail-arg list declares every
+/// position live — the reading `live_fail_arg_mask` takes — and its positions
+/// are then the slots by construction.
+pub fn frame_entry_reads_live_positions(
+    fail_descr: &dyn majit_ir::FailDescr,
+    bridge_inputs: usize,
+) -> bool {
+    let n = fail_descr.fail_arg_types().len();
+    let locs = fail_descr.rd_locs();
+    if locs.len() != n {
+        return bridge_inputs == n;
+    }
+    let live = locs.iter().filter(|&&pos| pos != 0xFFFF).count();
+    bridge_inputs == live && locs[..live].iter().all(|&pos| pos != 0xFFFF)
 }
 
 pub struct GuardExit {
@@ -2291,6 +2315,15 @@ fn residual_call_typed_sig(
         // parameter puts it outside `residual_call_void_true_arity`'s uniform
         // word family.  `all_float` below is false for it, so it reaches the
         // allow-list check like every other mixed shape.
+        //
+        // Only a descr that records `()` names such a callee.  A void-recorded
+        // descr carrying `result_size == 8` (the `make_call_descr_void_word_abi`
+        // shape) names one that really returns a machine word, and an empty
+        // result list is a different type from the one the callee has.  The i64
+        // family `residual_call_void_word_arity` selects is where that ABI is
+        // spelled; where that family declines -- a float parameter it cannot
+        // carry -- the reflecting trampoline is the arm that stays correct.
+        Type::Void if cd.result_size() != 0 => return None,
         Type::Void => None,
     };
     let arg_types = cd.arg_types();
@@ -4935,39 +4968,44 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_ne();
                 } else {
-                    // gcremovetypeptr fallback (assembler.py:1893-1901):
-                    //   on x86_64 the typeid is a 32-bit value at offset 0.
-                    let class_arg = op.arg(1).to_opref();
-                    // history.py — inline-Const carries its class pointer directly.
-                    let classptr = class_arg.const_int_value().expect(
-                        "_cmp_guard_class: gcremovetypeptr requires \
-                             loc_classptr to be a ConstInt immediate \
-                             (aarch64/regalloc.py:829 op.getarg(1).getint())",
-                    );
-                    let expected_typeid =
-                        lookup_typeid_from_classptr(classptr_to_typeid, classptr as usize).expect(
-                            "GuardClass: vtable_offset is None but the wasm \
-                                 backend has no gc_ll_descr.\
-                                 get_typeid_from_classptr_if_gcremovetypeptr",
-                        );
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.i32_wrap_i64();
-                    sink.i32_load(MemArg {
-                        offset: 0,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i32_const(expected_typeid as i32);
-                    sink.i32_ne();
+                    // x86/assembler.py `_cmp_guard_class` hands the
+                    // gcremovetypeptr case to `_cmp_guard_gc_type`, whose
+                    // layout keeps the type id in the object's first word.
+                    // majit keeps it in the GC header word placed immediately
+                    // before the payload — the lower `TYPE_ID_BITS` of
+                    // `majit_gc::header::GcHeader`'s `tid_and_flags`, the
+                    // address the `GuardGcType`, `GuardIsObject` and
+                    // `GuardSubclass` arms read. Under that layout `obj[0]` is
+                    // a payload field, so comparing it against a type id
+                    // answers a different question.
+                    //
+                    // Reading the header instead is not enough on its own
+                    // here: this arm evaluates the class compare
+                    // unconditionally and ORs the null test in afterwards, so
+                    // for a NULL receiver `obj - GcHeader::SIZE` addresses
+                    // below linear memory and traps instead of failing the
+                    // guard — `genop_guard_guard_nonnull_class` avoids that
+                    // with a forward jump this arm does not have. Decline: a
+                    // frontend that emits GUARD_CLASS configures the vtable
+                    // offset (pyre passes `OB_TYPE_OFFSET`), so no trace pays
+                    // for the decline.
+                    return Err(BackendError::Unsupported(format!(
+                        "wasm backend: {:?} with cpu.vtable_offset = None \
+                         (gcremovetypeptr) is unsupported; the type id lives \
+                         in the GC header and this arm has no null-safe \
+                         header compare",
+                        op.opcode
+                    )));
                 }
                 if op.opcode == OpCode::GuardNonnullClass {
                     // x86/assembler.py genop_guard_guard_nonnull_class wraps
                     // `_cmp_guard_class` in `CMP(ptr, 1)` plus a forward `B`
                     // jump, so a NULL receiver reaches the guard already
                     // failing and never has its class read. Here the class
-                    // compare above has already run — harmlessly, since it
-                    // reads offset 0 or the vtable offset, both inside the
-                    // first page — so the guard's answer is the disjunction.
+                    // compare above has already run — harmlessly, since the
+                    // only shape this arm lowers reads the vtable offset, and
+                    // a NULL receiver puts that read inside the first page —
+                    // so the guard's answer is the disjunction.
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_eqz();
                     sink.i32_or();
@@ -5648,11 +5686,13 @@ fn build_function(
             }
 
             // ── GC memory ops ──
-            // The indexed forms are also wired as real frontend blackhole ops
-            // (blackhole.rs `gc_load_indexed_{i,f}` / `gc_store_indexed_{i,f}`),
-            // so an llop/buffer trace can carry them into the backend. This
-            // backend has no descr-driven lowering for them, so decline
-            // (interpreter fallback) rather than aborting the whole compile.
+            // The indexed forms have the same sole producer as the bare ones
+            // below — `GcRewriterImpl`, which this backend does not run — and
+            // no opimpl records them, so nothing carries them here. The
+            // blackhole wiring for `gc_load_indexed_{i,f}` /
+            // `gc_store_indexed_{i,f}` executes them, it does not trace them.
+            // Decline (interpreter fallback) rather than aborting the whole
+            // compile.
             OpCode::GcLoadIndexedI
             | OpCode::GcLoadIndexedR
             | OpCode::GcLoadIndexedF
@@ -6145,30 +6185,23 @@ fn build_function(
                 );
                 guard_idx += 1;
             }
+            // `reached_loop_header` mints this op only to donate its
+            // `rd_resume_position` to the guards `jump_to_existing_trace` and
+            // `inline_short_preamble` stamp; both `optimize_GUARD_FUTURE_CONDITION`
+            // arms then consume it into `patchguardop` and emit nothing, which is
+            // why nothing under `rpython/jit/backend` lowers it. Reaching a
+            // backend means the optimizer did not consume it, and there is
+            // nothing correct to lower it to: it is nullary, so there is no
+            // condition to test, and an exit publishing neither `frame[0]` nor
+            // the fail args leaves the resume reading whatever the frame last
+            // held.
             OpCode::GuardFutureCondition => {
-                // This arm writes neither the fail args nor `frame[0]`, so it
-                // keeps branching to the shared epilogue — giving it the
-                // ordinary guard spill would change what the exit reports, not
-                // just how it gets there. The epilogue takes a cell address
-                // when bridge dispatch is on; otherwise retain the unused index
-                // write unchanged.
-                if !guard_dispatch.param_type_indices.is_empty() {
-                    emit_guard_param_tail_call(
-                        &mut sink,
-                        constants,
-                        value_types,
-                        guard_idx,
-                        op,
-                        guard_dispatch,
-                    );
-                } else if guard_dispatch.enabled {
-                    emit_guard_bridge_dispatch(&mut sink, guard_idx, guard_dispatch);
-                } else {
-                    sink.i32_const(guard_idx as i32);
-                    sink.local_set(bridge_slot_local);
-                }
-                sink.br(block_exit_depth);
-                guard_idx += 1;
+                return Err(BackendError::Unsupported(
+                    "wasm backend: GuardFutureCondition is unsupported (the optimizer \
+                     consumes it into patchguardop and no backend lowers it); \
+                     declining the trace"
+                        .to_string(),
+                ));
             }
 
             // ── Quasi-immutable / record / assert ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5543,7 +5543,7 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     let base_size = emit_array_addr(&mut sink, constants, value_types, op);
-                    let (item_size, signed) = array_item_size_sign_from_descr(op);
+                    let (item_size, signed) = array_item_access_size_sign(op);
                     emit_sized_int_load(&mut sink, base_size, item_size, signed);
                     sink.local_set(value_types.local(vi));
                 }
@@ -5552,7 +5552,8 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     let base_size = emit_array_addr(&mut sink, constants, value_types, op);
-                    sink.i64_load32_u(memarg(base_size, 2));
+                    let (item_size, signed) = array_item_access_size_sign(op);
+                    emit_sized_int_load(&mut sink, base_size, item_size, signed);
                     sink.local_set(value_types.local(vi));
                 }
             }
@@ -5587,7 +5588,7 @@ fn build_function(
                     // A Ref item is pointer-width (4 bytes on wasm32). Storing a
                     // fixed 8 bytes would clobber the next item, or run past the
                     // array end on the last item and corrupt the heap.
-                    let (item_size, _signed) = array_item_size_sign_from_descr(op);
+                    let (item_size, _signed) = array_item_access_size_sign(op);
                     emit_sized_int_store(&mut sink, base_size, item_size);
                 }
             }
@@ -5618,14 +5619,11 @@ fn build_function(
                     // register class — it is what the value local was declared
                     // from — so it picks the load the same way the three
                     // `Getarrayitem` arms do.
-                    match op.opcode {
-                        OpCode::GetinteriorfieldGcF => {
-                            sink.f64_load(mem64(base));
-                        }
-                        OpCode::GetinteriorfieldGcR => {
-                            sink.i64_load32_u(memarg(base, 2));
-                        }
-                        _ => emit_sized_int_load(&mut sink, base, field.field_size, field.signed),
+                    if op.opcode == OpCode::GetinteriorfieldGcF {
+                        sink.f64_load(mem64(base));
+                    } else {
+                        let (size, signed) = field.access_size_sign();
+                        emit_sized_int_load(&mut sink, base, size, signed);
                     }
                     sink.local_set(value_types.local(vi));
                 }
@@ -5661,7 +5659,7 @@ fn build_function(
                     sink.f64_store(mem64(base));
                 } else {
                     emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
-                    emit_sized_int_store(&mut sink, base, field.access_size());
+                    emit_sized_int_store(&mut sink, base, field.access_size_sign().0);
                 }
             }
 
@@ -8278,10 +8276,32 @@ fn emit_array_addr(
     )
 }
 
-/// The width of a GC pointer in the wasm32 guest heap, which is what
-/// `GetarrayitemGcR` reads back. A descriptor's `field_size` reports the width
-/// on whichever target compiled it.
+/// The width of a GC pointer in the wasm32 guest heap.
+///
+/// A descriptor mints its width from the compiling target, so for a pyre descr
+/// this is already what `field_size` / `item_size` says. It stays as its own
+/// constant for the descr that does not: a pointer is four bytes here whatever
+/// the descr claims, and a reading arm and its writing arm must take the width
+/// from ONE place — the two spellings agreeing today is not the same as them
+/// being one rule.
 const GUEST_PTR_SIZE: usize = 4;
+
+/// The width an access to one array item moves, and how a read of it extends.
+/// The array twin of [`InteriorFieldLayout::access_size`]; every
+/// `GETARRAYITEM` / `SETARRAYITEM` arm reads it from here.
+///
+/// The address stride still comes from the descriptor's own `item_size`
+/// (`emit_array_addr`), which is what the allocation laid the array out with.
+fn array_item_access_size_sign(op: &Op) -> (usize, bool) {
+    op.with_array_descr(|ad| {
+        if ad.is_array_of_pointers() {
+            (GUEST_PTR_SIZE, false)
+        } else {
+            (ad.item_size(), ad.is_item_signed())
+        }
+    })
+    .unwrap_or_else(|| missing_layout_descr("array descr (item size/sign)", op))
+}
 
 /// `descr.py unpack_interiorfielddescr`: `ofs = basesize + field.offset`,
 /// plus the element stride and the field's own width / signedness / kind.
@@ -8298,14 +8318,15 @@ struct InteriorFieldLayout {
 }
 
 impl InteriorFieldLayout {
-    /// The width an access to this field moves. A pointer field is
-    /// guest-pointer-wide, the width `GetarrayitemGcR` reads back; the
-    /// descriptor's own `field_size` is the host's.
-    fn access_size(&self) -> usize {
+    /// The width an access to this field moves, and how a read of it extends.
+    /// A pointer is guest-pointer-wide and never extends as signed, whatever
+    /// the descriptor says; every reading and writing arm takes both from here
+    /// so the two cannot drift apart.
+    fn access_size_sign(&self) -> (usize, bool) {
         if self.is_ptr {
-            GUEST_PTR_SIZE
+            (GUEST_PTR_SIZE, false)
         } else {
-            self.field_size
+            (self.field_size, self.signed)
         }
     }
 }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4944,6 +4944,18 @@ fn build_function(
                     sink.i32_const(expected_typeid as i32);
                     sink.i32_ne();
                 }
+                if op.opcode == OpCode::GuardNonnullClass {
+                    // x86/assembler.py genop_guard_guard_nonnull_class wraps
+                    // `_cmp_guard_class` in `CMP(ptr, 1)` plus a forward `B`
+                    // jump, so a NULL receiver reaches the guard already
+                    // failing and never has its class read. Here the class
+                    // compare above has already run — harmlessly, since it
+                    // reads offset 0 or the vtable offset, both inside the
+                    // first page — so the guard's answer is the disjunction.
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    sink.i64_eqz();
+                    sink.i32_or();
+                }
                 emit_guard_if_exit(
                     &mut sink,
                     constants,
@@ -5750,6 +5762,82 @@ fn build_function(
                     );
                 }
             }
+            OpCode::CondCallValueI | OpCode::CondCallValueR => {
+                // x86/regalloc.py `consider_cond_call`, COND_CALL_VALUE arm:
+                // "Calls the function when args[0] is equal to 0 or NULL.
+                // Returns the result from the function call if done, or args[0]
+                // if it was not 0/NULL." Upstream forces the result into
+                // args[0]'s register and lets the call overwrite it; the result
+                // local plays that register's part here.
+                //
+                // The operand roles are COND_CALL's: predicate, callee, then the
+                // call's own arguments. Sharing the generic CALL arm read args[0]
+                // as the callee and args[1] as the first argument, and called
+                // unconditionally.
+                //
+                // `do_conditional_call` asserts the callee forces no virtual or
+                // virtualizable, so unlike the CALL arm this needs no force
+                // bracket.
+                let jit_call =
+                    jit_call_idx.expect("COND_CALL_VALUE op present but jit_call not imported");
+                let vi = op.pos.get().raw();
+                let has_result = !OpRef::raw_is_constant(vi);
+                let cond = op.arg(0).to_opref();
+                let func = op.arg(1).to_opref();
+                let call_args = &op.getarglist()[2..];
+
+                if has_result {
+                    emit_resolve(&mut sink, constants, value_types, cond);
+                    sink.local_set(value_types.local(vi));
+                }
+                // The predicate is a full word: `i32.wrap_i64` would read a
+                // value whose only set bits are above 32 as NULL and call on a
+                // live one, so the test has to be `i64.eqz`.
+                emit_resolve(&mut sink, constants, value_types, cond);
+                sink.i64_eqz();
+                sink.if_(BlockType::Empty);
+                emit_call_area_addr(&mut sink);
+                emit_resolve(&mut sink, constants, value_types, func);
+                sink.i64_store(mem64(STATIC_CALL_FUNC_OFS));
+                emit_call_area_addr(&mut sink);
+                sink.i64_const(call_args.len() as i64);
+                sink.i64_store(mem64(STATIC_CALL_NARGS_OFS));
+                for (i, arg) in call_args.iter().enumerate() {
+                    emit_call_area_addr(&mut sink);
+                    emit_resolve(&mut sink, constants, value_types, arg.to_opref());
+                    sink.i64_store(mem64(STATIC_CALL_ARGS_OFS + i as u64 * SLOT_SIZE));
+                }
+                emit_jit_call(&mut sink, jit_call);
+                if has_result {
+                    // Int and Ref are the only result types
+                    // `do_conditional_call` mints this opcode for, so the
+                    // trampoline's word needs no float reinterpretation.
+                    emit_call_area_addr(&mut sink);
+                    sink.i64_load(mem64(STATIC_CALL_RESULT_OFS));
+                    sink.local_set(value_types.local(vi));
+                }
+                sink.end();
+                // The call arm can collect, so reload after the `if`; on the
+                // arm that did not call, the slots the reload re-reads are the
+                // ones the stores kept current.
+                if call_can_collect(op) {
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        has_result.then_some(vi),
+                        frame,
+                    );
+                }
+            }
 
             // x86/assembler.py genop_guard_guard_gc_type:
             // GUARD_GC_TYPE: args[0] = object ref, args[1] = expected
@@ -6443,8 +6531,6 @@ fn build_function(
             | OpCode::CallAssemblerN
             | OpCode::CallReleaseGilI
             | OpCode::CallReleaseGilN
-            | OpCode::CondCallValueI
-            | OpCode::CondCallValueR
             | OpCode::CallLoopinvariantI
             | OpCode::CallLoopinvariantR
             | OpCode::CallLoopinvariantN
@@ -6466,6 +6552,16 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 let can_collect = call_can_collect(op);
 
+                // pyjitpl.py `direct_call_release_gil` records CALL_RELEASE_GIL_*
+                // as `[savebox, funcbox] + argboxes[1:]`, so its callee is arg 1
+                // and its own arguments start at 2. Every other CALL keeps the
+                // callee at arg 0.
+                let func_ofs = usize::from(matches!(
+                    op.opcode,
+                    OpCode::CallReleaseGilI | OpCode::CallReleaseGilF | OpCode::CallReleaseGilN
+                ));
+                let func_ptr_ref = op.arg(func_ofs).to_opref();
+
                 // Direct in-module residual call: skip the `jit_call` host hop and
                 // `call_indirect` the callee's table slot with a static
                 // `(i64×n)->i64` type. The residual ABI is uniformly i64 for
@@ -6476,12 +6572,12 @@ fn build_function(
                 if let (Some(base), Some(nargs)) =
                     (residual_type_base, residual_call_i64_arity(op, constants))
                 {
-                    let call_args = &op.getarglist()[1..];
+                    let call_args = &op.getarglist()[func_ofs + 1..];
                     for arg in call_args {
                         emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     }
                     // func_ptr (arg 0) is the table slot — wrap to i32 index.
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, func_ptr_ref);
                     sink.i32_wrap_i64();
                     // call_indirect(table_index, type_index): table 0, type for arity n.
                     sink.call_indirect(0, base + nargs as u32);
@@ -6516,11 +6612,11 @@ fn build_function(
                     // Direct in-module word-ABI void residual call: the callee
                     // really is `(i64×n)->i64` (descr result_size == 8), so use
                     // the i64 family and drop the dummy result.
-                    let call_args = &op.getarglist()[1..];
+                    let call_args = &op.getarglist()[func_ofs + 1..];
                     for arg in call_args {
                         emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     }
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, func_ptr_ref);
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, base + nargs as u32);
                     sink.drop();
@@ -6551,7 +6647,7 @@ fn build_function(
                     // Direct in-module typed residual call with the
                     // descr-derived mixed `(i64/f64...) -> i64/f64` signature.
                     let (params, _) = &sig;
-                    let call_args = &op.getarglist()[1..];
+                    let call_args = &op.getarglist()[func_ofs + 1..];
                     debug_assert_eq!(call_args.len(), params.len());
                     for (arg, ty) in call_args.iter().zip(params) {
                         if *ty == ValType::F64 {
@@ -6561,7 +6657,7 @@ fn build_function(
                         }
                     }
                     // func_ptr (arg 0) is the table slot — wrap to i32 index.
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, func_ptr_ref);
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, type_idx);
                     // A void callee leaves nothing on the stack, so there is
@@ -6599,11 +6695,11 @@ fn build_function(
                     // Direct in-module true-void residual call: the callee is
                     // `(i64×n)->()` (descr result_size == 0), so the call has no
                     // result to drop.
-                    let call_args = &op.getarglist()[1..];
+                    let call_args = &op.getarglist()[func_ofs + 1..];
                     for arg in call_args {
                         emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     }
-                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    emit_resolve(&mut sink, constants, value_types, func_ptr_ref);
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, base + nargs as u32);
                     if can_collect {
@@ -6626,9 +6722,7 @@ fn build_function(
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 
-                    // args[0] = func_ptr, args[1..] = call arguments
-                    let func_ptr_ref = op.arg(0).to_opref();
-                    let call_args = &op.getarglist()[1..];
+                    let call_args = &op.getarglist()[func_ofs + 1..];
 
                     // Store func_ptr to call area
                     emit_call_area_addr(&mut sink);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5825,12 +5825,12 @@ fn build_function(
                     sink.i64_store(mem64(STATIC_CALL_ARGS_OFS + i as u64 * SLOT_SIZE));
                 }
                 emit_jit_call(&mut sink, jit_call);
-                sink.end();
                 // COND_CALL sits inside the CALL opcode range, so a Ref living
-                // across it already owns a home; the collection that home
-                // exists for can happen on the taken arm. Reloading after the
-                // `if` covers both arms, and on the untaken one it re-reads
-                // slots the stores kept current.
+                // across it already owns a home. Only the arm that called can
+                // have collected, so the reload belongs on it: after the `if`
+                // it would run on the untaken arm too, re-reading slots that
+                // nothing moved, once per iteration of a loop whose whole
+                // reason for a COND_CALL is that the call is rare.
                 if call_can_collect(op) {
                     emit_reload_frame_if_necessary(
                         &mut sink,
@@ -5848,6 +5848,7 @@ fn build_function(
                         frame,
                     );
                 }
+                sink.end();
             }
             OpCode::CondCallValueI | OpCode::CondCallValueR => {
                 // x86/regalloc.py `consider_cond_call`, COND_CALL_VALUE arm:
@@ -5903,10 +5904,8 @@ fn build_function(
                     sink.i64_load(mem64(STATIC_CALL_RESULT_OFS));
                     sink.local_set(value_types.local(vi));
                 }
-                sink.end();
-                // The call arm can collect, so reload after the `if`; on the
-                // arm that did not call, the slots the reload re-reads are the
-                // ones the stores kept current.
+                // Only the arm that called can have collected, so the reload
+                // sits on it rather than after the `if`.
                 if call_can_collect(op) {
                     emit_reload_frame_if_necessary(
                         &mut sink,
@@ -5924,6 +5923,7 @@ fn build_function(
                         frame,
                     );
                 }
+                sink.end();
             }
 
             // x86/assembler.py genop_guard_guard_gc_type:

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -573,6 +573,23 @@ pub fn attach_finish_descr(exit_index: u32, descr: DescrRef) {
         FailDescrSlot::Registered(reserved_finish_descr(exit_index, Some(descr)));
 }
 
+/// Whether the cpu has been handed `exit_frame_with_exception_descr_ref`.
+///
+/// The memory-error check the allocation codegen emits leaves through
+/// [`FINISH_EXIT_INDEX_EXC`], and only the attached metainterp descr carries
+/// `is_exit_frame_with_exception`. The reserved entry on its own reads as a
+/// plain finish, which would hand the raised value back as the loop's result
+/// instead of raising it, so the emitter has to know which of the two it has.
+pub fn exit_frame_with_exception_attached() -> bool {
+    let mut reg = FAIL_DESCR_REGISTRY.lock();
+    let vec = reg.get_or_insert_with(Default::default);
+    reserve_finish_exit_block(vec);
+    matches!(
+        &vec[FINISH_EXIT_INDEX_EXC as usize],
+        FailDescrSlot::Registered(reserved) if reserved.meta_descr.is_some()
+    )
+}
+
 /// Stable, guest-memory dispatch entries, keyed by CALL_ASSEMBLER token.
 /// `Box` is intentional: an emitted module bakes the entry address.
 pub static WASM_CA_DISPATCH: parking_lot::Mutex<

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -87,8 +87,12 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
 /// edge. 40-43 split a rejected inline trial into value-layout,
 /// Ref-home-layout, missing-local-label, and other backend errors. 44 = a
 /// bridge compiled with a parameter entry; 45 = parameter entry declined
-/// because the source module has frame-only dispatch; 46 = parameter entry
-/// declined because the source guard and bridge input arities disagree; 47 =
+/// because the source module has frame-only dispatch; 46 = the bridge entry
+/// cannot name the source guard's fail arguments — a parameter entry whose
+/// arity disagrees with the guard's live count, or a frame entry whose
+/// positional slots are not where that guard spilled them (the two arms are
+/// mutually exclusive: `bridge_params_enabled` selects one for the whole
+/// process); 47 =
 /// LABEL publication suppressed because the bridge entry has nonzero parameters.
 /// 48 = an inline trial's LABEL-resume storage exceeds the frozen frame; 49 =
 /// the region carries a CALL_ASSEMBLER the owner build emits no arm for; 50 =
@@ -4212,6 +4216,24 @@ impl majit_backend::Backend for WasmBackend {
             }
             Some(inputargs.len())
         } else {
+            // A frame entry reads bridge input `k` out of the positional exit
+            // slot `k`, while `emit_guard_fail_args_spill` writes each fail
+            // argument into the slot named by its own resume position, holes
+            // included. `initialize_state_from_guard_failure` drops those
+            // holes, so input `k` is the k-th LIVE position and the two orders
+            // coincide only while every hole trails the last live one.
+            // `rebuild_faillocs_from_descr` is where a live position's own
+            // location is recovered instead; this entry has no table to do it
+            // with, so decline the shape rather than hand the bridge a
+            // neighbouring fail argument's slot.
+            if !codegen::frame_entry_reads_live_positions(fail_descr, inputargs.len()) {
+                diag_bump(46);
+                return Err(BackendError::Unsupported(
+                    "wasm backend: frame-entry bridge cannot address the source guard's \
+                     live fail-arg slots"
+                        .into(),
+                ));
+            }
             None
         };
         let allow_ca = ca_candidate;

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1590,6 +1590,24 @@ fn wasm_bh_alloc_struct(sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
     wasm_bh_alloc(sizedescr.resolve_gc_tid(), size)
 }
 
+/// `gc.py` malloc-helper OOM signalling, the twin of the dynasm runner's
+/// `oom_signal_if_zero`: translated `do_malloc_fixedsize_clear` raises
+/// `MemoryError`, which lowers to "store the singleton in `pos_exc_value`,
+/// return NULL". These trampolines return 0 directly, so the store belongs
+/// here — the emitted memory-error check (`codegen.rs`
+/// `emit_memory_error_check`) moves the value out of the cell and into the
+/// frame's exception exit slot.
+#[inline]
+fn oom_signal_if_zero(result: i64) -> i64 {
+    if result == 0 {
+        let value = majit_backend::memory_error_singleton_ref();
+        if value != 0 {
+            jit_exc_raise(value);
+        }
+    }
+    result
+}
+
 /// JIT-trace allocation trampoline target for `New` / `NewWithVtable`.
 ///
 /// A compiled trace cannot allocate directly (the GC lives behind the
@@ -1607,8 +1625,11 @@ fn wasm_bh_alloc_struct(sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
 /// allocation. So it uses the *collecting* `alloc_nursery_typed`, which
 /// triggers a minor collection on nursery-full instead of leaking to old-gen.
 pub extern "C" fn wasm_jit_alloc(type_id: i64, size: i64) -> i64 {
-    with_wasm_active_gc_mut(|gc| gc.alloc_nursery_typed(type_id as u32, size as usize).0 as i64)
-        .unwrap_or(0)
+    let obj = with_wasm_active_gc_mut(|gc| {
+        gc.alloc_nursery_typed(type_id as u32, size as usize).0 as i64
+    })
+    .unwrap_or(0);
+    oom_signal_if_zero(obj)
 }
 
 /// JIT-trace variable-size allocation trampoline target for `NewArray` /
@@ -1621,10 +1642,12 @@ pub extern "C" fn wasm_jit_alloc_array(
     length: i64,
     len_offset: i64,
 ) -> i64 {
+    // `incminimark.py external_malloc` refuses a negative length by raising
+    // `MemoryError`, so this edge signals like an exhausted heap.
     let Ok(length) = usize::try_from(length) else {
-        return 0;
+        return oom_signal_if_zero(0);
     };
-    with_wasm_active_gc_mut(|gc| {
+    let obj = with_wasm_active_gc_mut(|gc| {
         let obj = gc.alloc_varsize_typed(
             type_id as u32,
             base_size as usize,
@@ -1640,7 +1663,8 @@ pub extern "C" fn wasm_jit_alloc_array(
             obj.0 as i64
         }
     })
-    .unwrap_or(0)
+    .unwrap_or(0);
+    oom_signal_if_zero(obj)
 }
 
 /// Old-generation twin of [`wasm_jit_alloc`], selected by the `New` /
@@ -1655,8 +1679,10 @@ pub extern "C" fn wasm_jit_alloc_array(
 /// (`rewrite.rs` `handle_new`); wasm lowers `New` itself, so it must apply the
 /// same policy here.
 pub extern "C" fn wasm_jit_alloc_oldgen(type_id: i64, size: i64) -> i64 {
-    with_wasm_active_gc_mut(|gc| gc.alloc_oldgen_typed(type_id as u32, size as usize).0 as i64)
-        .unwrap_or(0)
+    let obj =
+        with_wasm_active_gc_mut(|gc| gc.alloc_oldgen_typed(type_id as u32, size as usize).0 as i64)
+            .unwrap_or(0);
+    oom_signal_if_zero(obj)
 }
 
 /// Old-generation twin of [`wasm_jit_alloc_array`], selected by the `NewArray` /
@@ -1671,10 +1697,10 @@ pub extern "C" fn wasm_jit_alloc_array_oldgen(
     len_offset: i64,
 ) -> i64 {
     let Ok(length) = usize::try_from(length) else {
-        return 0;
+        return oom_signal_if_zero(0);
     };
     let payload_size = base_size as usize + item_size as usize * length;
-    with_wasm_active_gc_mut(|gc| {
+    let obj = with_wasm_active_gc_mut(|gc| {
         let obj = gc.alloc_oldgen_typed(type_id as u32, payload_size);
         if obj.is_null() {
             0
@@ -1685,7 +1711,8 @@ pub extern "C" fn wasm_jit_alloc_array_oldgen(
             obj.0 as i64
         }
     })
-    .unwrap_or(0)
+    .unwrap_or(0);
+    oom_signal_if_zero(obj)
 }
 
 /// Table indices of the four allocation trampolines, for the `New*` /

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2321,6 +2321,55 @@ fn test_true_void_int_ref_call_uses_void_result_type_without_drop() {
 }
 
 #[test]
+fn a_pointer_array_item_is_read_and_written_at_the_same_width() {
+    use majit_ir::descr::SimpleArrayDescr;
+    use std::sync::Arc;
+
+    // A descriptor claiming the host's eight-byte pointer. The guest's is four,
+    // and whichever of the two the arms take, the read and the write have to
+    // take the same one: a four-byte read of an eight-byte write returns half a
+    // pointer, and an eight-byte write over four-byte items clobbers the next.
+    let descr: majit_ir::DescrRef = Arc::new(SimpleArrayDescr::new(0, 16, 8, 71, Type::Ref));
+    let inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Int, 1),
+        InputArg::from_type(Type::Ref, 2),
+    ];
+    let get = make_op(
+        OpCode::GetarrayitemGcR,
+        &[OpRef::input_arg_ref(0), OpRef::input_arg_int(1)],
+        OpRef::ref_op(3),
+    );
+    get.setdescr(Arc::clone(&descr));
+    let set = make_op(
+        OpCode::SetarrayitemGc,
+        &[
+            OpRef::input_arg_ref(0),
+            OpRef::input_arg_int(1),
+            OpRef::input_arg_ref(2),
+        ],
+        OpRef::NONE,
+    );
+    set.setdescr(descr);
+    let ops = vec![get, set, Op::new(OpCode::Finish, &[rb(OpRef::ref_op(3))])];
+    let (bytes, _guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+
+    let (mut narrow_loads, mut narrow_stores, mut wide_stores) = (0usize, 0usize, 0usize);
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I64Load32U { memarg } if memarg.offset == 16 => narrow_loads += 1,
+        wasmparser::Operator::I64Store32 { memarg } if memarg.offset == 16 => narrow_stores += 1,
+        wasmparser::Operator::I64Store { memarg } if memarg.offset == 16 => wide_stores += 1,
+        _ => {}
+    });
+    assert_eq!(
+        (narrow_loads, narrow_stores, wide_stores),
+        (1, 1, 0),
+        "the item read and the item write moved different widths"
+    );
+}
+
+#[test]
 fn an_allocation_is_followed_by_a_memory_error_check() {
     use majit_ir::descr::SimpleSizeDescr;
     use std::sync::Arc;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2321,6 +2321,38 @@ fn test_true_void_int_ref_call_uses_void_result_type_without_drop() {
 }
 
 #[test]
+fn an_allocation_is_followed_by_a_memory_error_check() {
+    use majit_ir::descr::SimpleSizeDescr;
+    use std::sync::Arc;
+
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let new_op = make_op(OpCode::New, &[], OpRef::ref_op(1));
+    new_op.setdescr(Arc::new(SimpleSizeDescr::new(0, 32, 53)));
+    let ops = vec![
+        new_op,
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let (bytes, _guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+
+    let mut seq: Vec<String> = Vec::new();
+    count_operators(&bytes, |op| seq.push(format!("{op:?}")));
+    // `rewrite.py` `_gen_call_malloc_gc` puts a NULL test after every
+    // collecting malloc, and the peephole pass fuses the arm's store-then-read
+    // of the result into a `local.tee`. Only the test itself is asserted: which
+    // of the two failing arms follows it turns on whether the cpu has been
+    // handed an `exit_frame_with_exception_descr_ref`, which a backend-only
+    // module build has not.
+    let checked = seq.windows(4).any(|w| {
+        w[0].starts_with("CallIndirect")
+            && w[1].starts_with("LocalTee")
+            && w[2] == "I64Eqz"
+            && w[3].starts_with("If")
+    });
+    assert!(checked, "the allocation emitted no NULL test: {seq:#?}");
+}
+
+#[test]
 fn test_true_void_family_does_not_shift_new_call_type() {
     use majit_ir::descr::SimpleSizeDescr;
     use std::sync::Arc;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -1085,6 +1085,67 @@ fn test_int_sub_ovf_guards_overflow() {
 }
 
 #[test]
+fn test_int_mul_ovf_fuses_its_adjacent_overflow_guard() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let guard = Op::new(OpCode::GuardNoOverflow, &[]);
+    guard.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+    let ops = vec![
+        make_op(
+            OpCode::IntMulOvf,
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            OpRef::int_op(2),
+        ),
+        guard,
+        Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]),
+    ];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+
+    let (mut widened, mut i32_result_blocks) = (0usize, 0usize);
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I64ExtendI32U => widened += 1,
+        wasmparser::Operator::If {
+            blockty: wasmparser::BlockType::Type(wasmparser::ValType::I32),
+        } => i32_result_blocks += 1,
+        _ => {}
+    });
+    // Both arms of the signed-32 split answer the same one-bit predicate, so
+    // the block yields it and the guard reads it off the stack -- the shape the
+    // add and sub forms already take, and the one every sibling backend takes
+    // by publishing a condition code instead of a stored flag.
+    assert_eq!(i32_result_blocks, 1, "the split yields the guard predicate");
+    assert_eq!(
+        widened, 0,
+        "a fused predicate never widens into a flag local"
+    );
+}
+
+#[test]
+fn test_int_mul_ovf_guard_overflow_inverts_on_both_split_arms() {
+    // `GuardOverflow` fails when the multiply did NOT overflow, so the fused
+    // predicate is the inverse of `GuardNoOverflow`'s on both arms of the
+    // signed-32 split: the constant the fast arm yields flips, and the
+    // full-width arm's sign-word comparison flips with it.
+    for (a, b) in [(6_i64, 7_i64), (i32::MAX as i64 + 1, 2)] {
+        assert_eq!(
+            execute_ovf_trace_with_guard(OpCode::IntMulOvf, OpCode::GuardOverflow, a, b).0,
+            0,
+            "{a} * {b} does not overflow, so GuardOverflow exits"
+        );
+    }
+    for (a, b) in [(i64::MIN, -1_i64), (1_i64 << 62, 3)] {
+        assert_eq!(
+            execute_ovf_trace_with_guard(OpCode::IntMulOvf, OpCode::GuardOverflow, a, b).0,
+            1,
+            "{a} * {b} overflows, so GuardOverflow passes"
+        );
+    }
+}
+
+#[test]
 fn test_int_mul_ovf_guards_overflow() {
     for (a, b, expected) in [
         (6, 7, 42),

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -6106,6 +6106,64 @@ fn int_between_is_two_signed_comparisons() {
 
 /// `genop_discard_cond_call`: CondCallN is a real conditional call, not a no-op.
 #[test]
+fn cond_call_reload_sits_on_the_arm_that_called() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Ref, 1),
+    ];
+    let ops = vec![
+        make_op(
+            OpCode::CondCallN,
+            &[
+                OpRef::input_arg_int(0),
+                OpRef::const_int(0x100),
+                OpRef::input_arg_ref(1),
+            ],
+            OpRef::NONE,
+        ),
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_ref(1))]),
+    ];
+    let frame = codegen::FrameGeometry::compact(
+        codegen::frame_value_slots(&inputargs, &ops),
+        codegen::count_ref_homes(&inputargs, &ops),
+        0,
+    );
+    let (bytes, _) = build_module_with_frame(
+        &inputargs,
+        &ops,
+        &indexmap::IndexMap::new(),
+        Some(0),
+        &codegen::GuardGcTypeInfo::default(),
+        frame,
+    );
+    validate_wasm(&bytes);
+    let mut seq: Vec<String> = Vec::new();
+    count_operators(&bytes, |op| seq.push(format!("{op:?}")));
+
+    // The reload exists because the callee may collect, so it belongs on the
+    // arm that called: between the `else` and the `end` that closes it, not
+    // after the join where the untaken arm would pay for it too.
+    let home = format!("offset: {},", frame.home_slot_base);
+    let else_at = seq
+        .iter()
+        .position(|o| o == "Else")
+        .expect("the cond call puts its trampoline in an else arm");
+    let end_at = else_at
+        + seq[else_at..]
+            .iter()
+            .position(|o| o == "End")
+            .expect("the else arm closes");
+    let reload_at = seq
+        .iter()
+        .position(|o| o.starts_with("I64Load ") && o.contains(&home))
+        .expect("the cond call reloads the live Ref from its home slot");
+    assert!(
+        else_at < reload_at && reload_at < end_at,
+        "the ref-home reload is outside the calling arm: {seq:#?}"
+    );
+}
+
+#[test]
 fn cond_call_n_emits_predicate_and_trampoline() {
     let inputargs = vec![
         InputArg::from_type(Type::Int, 0),

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -5961,6 +5961,68 @@ fn call_release_gil_takes_its_callee_from_arg_one() {
     );
 }
 
+/// `raw_load_f` is a translated operation (`insns.rs` BC_RAW_LOAD_F), and the
+/// int form was lowered while the float form declined the trace.
+#[test]
+fn raw_load_f_loads_a_double() {
+    use majit_ir::descr::SimpleArrayDescr;
+    use std::sync::Arc;
+
+    let descr = Arc::new(SimpleArrayDescr::new(1, 0, 8, 55, Type::Float));
+    let inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let load = make_op(
+        OpCode::RawLoadF,
+        &[OpRef::input_arg_ref(0), OpRef::input_arg_int(1)],
+        OpRef::float_op(2),
+    );
+    load.setdescr(descr);
+    let ops = vec![load, Op::new(OpCode::Finish, &[rb(OpRef::float_op(2))])];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    let mut f64_loads = 0;
+    count_operators(&bytes, |op| {
+        if matches!(op, wasmparser::Operator::F64Load { .. }) {
+            f64_loads += 1;
+        }
+    });
+    assert_eq!(f64_loads, 1, "the float raw load is an f64.load");
+}
+
+/// resoperation.py `int_between(a, b, c)` is `a <= b < c`, signed.
+#[test]
+fn int_between_is_two_signed_comparisons() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+        InputArg::from_type(Type::Int, 2),
+    ];
+    let ops = vec![
+        make_op(
+            OpCode::IntBetween,
+            &[
+                OpRef::input_arg_int(0),
+                OpRef::input_arg_int(1),
+                OpRef::input_arg_int(2),
+            ],
+            OpRef::int_op(3),
+        ),
+        Op::new(OpCode::Finish, &[rb(OpRef::int_op(3))]),
+    ];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    let (mut le_s, mut lt_s, mut ands) = (0, 0, 0);
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I64LeS => le_s += 1,
+        wasmparser::Operator::I64LtS => lt_s += 1,
+        wasmparser::Operator::I32And => ands += 1,
+        _ => {}
+    });
+    assert_eq!((le_s, lt_s, ands), (1, 1, 1), "a <= b, b < c, and");
+}
+
 /// `genop_discard_cond_call`: CondCallN is a real conditional call, not a no-op.
 #[test]
 fn cond_call_n_emits_predicate_and_trampoline() {

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -5828,6 +5828,139 @@ fn interior_field_ops_compile() {
     assert_eq!(shl, 1, "item_size 8 on the RAW store is get_scale 3");
 }
 
+/// Count the operators a test cares about in the one code section entry.
+fn count_operators(bytes: &[u8], mut f: impl FnMut(&wasmparser::Operator<'_>)) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            while !operators.eof() {
+                f(&operators.read().unwrap());
+            }
+        }
+    }
+}
+
+/// x86/regalloc.py `consider_cond_call`, COND_CALL_VALUE arm: the call happens
+/// when args[0] is 0/NULL, args[1] is the callee, and the result is args[0]
+/// otherwise. Sharing the generic CALL arm called unconditionally through
+/// args[0].
+#[test]
+fn cond_call_value_tests_its_value_and_calls_arg_one() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let ops = vec![
+        make_op(
+            OpCode::CondCallValueI,
+            &[
+                OpRef::input_arg_int(0),
+                OpRef::const_int(0x100),
+                OpRef::input_arg_int(1),
+            ],
+            OpRef::int_op(2),
+        ),
+        Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]),
+    ];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    let (mut eqz, mut ifs) = (0, 0);
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I64Eqz => eqz += 1,
+        wasmparser::Operator::If { .. } => ifs += 1,
+        _ => {}
+    });
+    assert!(eqz >= 1, "COND_CALL_VALUE tests its value with i64.eqz");
+    assert_eq!(ifs, 1, "the call sits under exactly one predicate");
+    assert!(
+        import_func_type(&bytes, "jit_call_compact").is_some(),
+        "COND_CALL_VALUE uses the residual trampoline"
+    );
+}
+
+/// x86/assembler.py `genop_guard_guard_nonnull_class` guards the class compare
+/// with `CMP(ptr, 1)`; sharing the GUARD_CLASS arm let a NULL receiver be
+/// decided by a read of linear-memory address 0, which on wasm does not trap.
+#[test]
+fn guard_nonnull_class_also_tests_for_null() {
+    let build = |opcode: OpCode| {
+        let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
+        let ops = vec![
+            make_guard(
+                opcode,
+                &[OpRef::input_arg_ref(0), OpRef::const_int(0x55)],
+                &[OpRef::input_arg_ref(0)],
+            ),
+            Op::new(OpCode::Finish, &[rb(OpRef::input_arg_ref(0))]),
+        ];
+        let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+        validate_wasm(&bytes);
+        let (mut eqz, mut ors) = (0, 0);
+        count_operators(&bytes, |op| match op {
+            wasmparser::Operator::I64Eqz => eqz += 1,
+            wasmparser::Operator::I32Or => ors += 1,
+            _ => {}
+        });
+        (eqz, ors)
+    };
+    assert_eq!(
+        build(OpCode::GuardClass),
+        (0, 0),
+        "GUARD_CLASS is the class compare alone"
+    );
+    assert_eq!(
+        build(OpCode::GuardNonnullClass),
+        (1, 1),
+        "GUARD_NONNULL_CLASS ors in a null test"
+    );
+}
+
+/// pyjitpl.py `direct_call_release_gil` records `[savebox, funcbox] + args`, so
+/// the callee is arg 1. The shared CALL arm read arg 0 — the `save_err`
+/// immediate — as the callee and passed the real function as the first
+/// argument.
+#[test]
+fn call_release_gil_takes_its_callee_from_arg_one() {
+    use majit_ir::descr::SimpleCallDescr;
+    use std::sync::Arc;
+
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let call = make_op(
+        OpCode::CallReleaseGilI,
+        &[
+            OpRef::const_int(0x11),  // save_err
+            OpRef::const_int(0x22),  // the real callee
+            OpRef::input_arg_int(0), // its one argument
+        ],
+        OpRef::int_op(1),
+    );
+    call.setdescr(Arc::new(SimpleCallDescr::new(
+        0x5100_0000,
+        vec![Type::Int],
+        Type::Int,
+        true,
+        8,
+        EffectInfo::default(),
+    )));
+    let ops = vec![call, Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))])];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    let mut nargs_consts = Vec::new();
+    count_operators(&bytes, |op| {
+        if let wasmparser::Operator::I64Const { value } = op {
+            nargs_consts.push(*value);
+        }
+    });
+    assert!(
+        nargs_consts.contains(&0x22),
+        "the callee stored to the call area is arg 1"
+    );
+    assert!(
+        nargs_consts.contains(&1),
+        "one call argument, not two: {nargs_consts:?}"
+    );
+}
+
 /// `genop_discard_cond_call`: CondCallN is a real conditional call, not a no-op.
 #[test]
 fn cond_call_n_emits_predicate_and_trampoline() {
@@ -5849,20 +5982,12 @@ fn cond_call_n_emits_predicate_and_trampoline() {
     ];
     let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
     validate_wasm(&bytes);
-    let mut eqz = 0;
-    let mut ifs = 0;
-    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
-        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
-            let mut operators = body.get_operators_reader().unwrap();
-            while !operators.eof() {
-                match operators.read().unwrap() {
-                    wasmparser::Operator::I64Eqz => eqz += 1,
-                    wasmparser::Operator::If { .. } => ifs += 1,
-                    _ => {}
-                }
-            }
-        }
-    }
+    let (mut eqz, mut ifs) = (0, 0);
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I64Eqz => eqz += 1,
+        wasmparser::Operator::If { .. } => ifs += 1,
+        _ => {}
+    });
     assert!(eqz >= 1, "CondCallN tests the predicate with i64.eqz");
     assert!(ifs >= 1, "CondCallN wraps the call in an if");
     assert!(

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3161,8 +3161,10 @@ impl OptHeap {
     /// thirteen `list.*` entries in `pyre-object/src/listobject.rs`, and the
     /// programmatic `mark_oopspec` table registers only the `jit.*` builtins and
     /// `newlist_clear` — so `_handle_stroruni_call` never fires and the
-    /// `opt_call_stroruni_*` handlers are unreachable.  And nothing ever assigns
-    /// `RawMallocVarsizeChar` to a call, so no virtual raw buffer is built.
+    /// `opt_call_stroruni_*` handlers are unreachable.  The raw-buffer half now
+    /// has one carrier, `_cffi_backend::cdataobj::raw_malloc_varsize_char`, so
+    /// a build that includes that module can reach the virtual raw buffer;
+    /// wasm32, which excludes it, cannot.
     ///
     /// Annotating a string helper with
     /// `#[majit_macros::oopspec("stroruni.concat")]` is what would make this


### PR DESCRIPTION
## Summary

Nine commits: eight against `majit-backend-wasm`, one against
`majit-backend-cranelift`.

The wasm backend's per-op `match` ends in a catch-all that **declines**
rather than skips — a void op's `pos` is `OpRef::None`, whose `raw()` is
`u32::MAX`, and `raw_is_constant` rejects the sentinel range, so the guard
holds. An opcode with no arm therefore aborts the trace; it is not silently
dropped. Every defect below is consequently in an arm that *was* reached and
did the wrong thing, or in an arm that should not have existed. The one place
a side-effecting op can be lost in silence is an explicit no-op arm, and the
catch-all's comment now says so.

### Reached and wrong

- **Three ops shared an arm with a sibling whose operand layout they do not
  have.** `COND_CALL_VALUE_I/R` sat in the generic `CALL` arm, so the emitted
  call went to an address taken from a data value and passed the real
  function as its first argument. `CALL_RELEASE_GIL_I/F/N` is recorded as
  `[savebox, funcbox] + argboxes[1:]`, so the same `arg(0) == callee` rule
  called its `save_err` immediate as an address. `GUARD_NONNULL_CLASS` was
  lowered byte-for-byte as `GUARD_CLASS`, so a NULL receiver was decided by a
  read at `0 + vtable_offset` — ordinary linear memory on wasm, not a fault.

- **A failed allocation returned 0 and the backend stored through it.** The
  four `wasm_jit_alloc*` trampolines end in `.unwrap_or(0)`, and the
  `New`/`NewWithVtable` and `NewArray`/`NewArrayClear` arms then wrote the
  vtable, class word and items into that result. On wasm address 0 is
  ordinary linear memory, so the stores landed. The trampolines now publish
  the `MemoryError` singleton through `jit_exc_raise` (the twin of the dynasm
  runner's `oom_signal_if_zero`), and `emit_memory_error_check` puts the NULL
  test after both allocation arms, moving the raised value into the frame's
  first exit slot and taking `FINISH_EXIT_INDEX_EXC`.

- **One field's width was spelled two ways.** An interior field was read at
  `field_size` and written at `access_size()`; an array item was read at a
  hardcoded four bytes and written at the descriptor's `item_size`. The two
  spellings agree only because every production descriptor derives its
  pointer width from the compiling target. Both pairs now read from
  `access_size_sign` / `array_item_access_size_sign`. Emitted bytes are
  unchanged.

- **`PeepSink::i32_wrap_i64`** read its lookbehind buffer with `pop()` rather
  than `last()`, so a tail it did not consume was dropped instead of flushed.

- **The conditional call's frame and Ref-home reload sat after the `end`**, so
  a trace ran both on every iteration whether or not the call happened. Only
  the calling arm can collect. Cranelift puts the same reload inside its
  `call_block`.

- **cranelift `COND_CALL_VALUE_I/R` called on the wrong arm.** It called when
  `args[0]` was non-zero; the op calls when `args[0]` *is* 0/NULL and
  otherwise returns `args[0]`. The arm was a copy of the plain `COND_CALL`
  above it, whose polarity is the opposite. `optimizeopt/rewrite.rs` folds
  `CondCallValueI(value=42, ..)` to `value` and `CondCallValueI(value=0, ..)`
  to `CallPureI`, which is the same rule. Two tests asserted the inverted
  answers; both now assert the folding rule's.

- **cranelift `FLOAT_MOD` was floored, not truncated.** It was lowered as
  `a - floor(a/b) * b`, while `eval_binop_f` executes the op as `a % b`, so
  `-7.0 % 3.0` was `2.0` in a compiled trace and `-1.0` in the blackhole it
  deopts into. The floored spelling also belongs to a layer above this op:
  `trace_helpers::concrete::float_mod` applies the sign correction and the
  signed zero on top of the truncated remainder. It now calls C `fmod`, the
  route `ll_math_fmod` takes; that call cannot collect, so it needs neither a
  gcmap nor a frame reload. The blackhole test covering negative operands
  only asserted `is_finite()`, which is why nothing caught this.

### Newly lowered

`RAW_LOAD_F` — `RAW_LOAD_I` and `RAW_STORE` were both already lowered, and
dynasm x86, aarch64 and cranelift all keep the pair on one arm. The shared
address moves into `emit_raw_addr`, which `RAW_STORE` now uses too.

`INT_BETWEEN` — jtransform lowers the name directly and the bigint compare
path mints `int_between(-1, i2 >> 48, 1)`, so a trace can carry it.

### Declined

Seven shapes with no correct lowering are now named declines rather than
catch-all declines carrying a message about a value-producing opcode — or, in
the first case, an incorrect emission:

- `GUARD_FUTURE_CONDITION` emitted an unconditional `br` to the shared
  epilogue, publishing neither `frame[0]` nor the fail args, so an exit
  through it left the resume reading whatever the frame last held. Both
  `optimize_GUARD_FUTURE_CONDITION` arms consume the op into `patchguardop`
  and nothing under `rpython/jit/backend` lowers it; it is also nullary, so
  there is no condition to test.
- The `GuardClass`/`GuardNonnullClass` arm for `cpu.vtable_offset = None`
  compared the object's first word against a type id, but majit keeps the
  type id in the GC header word *before* the payload, so `obj[0]` is a
  payload field there.
- A frame-entry bridge whose entry does not read live fail-arg positions: it
  reads input `k` out of exit slot `k`, while `emit_guard_fail_args_spill`
  writes each fail argument into the slot named by its own resume position,
  holes included. `frame_entry_reads_live_positions` decides that.
- A call descr recording a void result with `result_size == 8`, which
  `residual_call_typed_sig` accepted and gave an empty result list.
- `STRSETITEM` and `UNICODESETITEM` join the rstr block that already declines
  `NEWSTR` / `NEWUNICODE` / `COPYSTRCONTENT` / `COPYUNICODECONTENT`.
- `FLOAT_MOD` is C `fmod`; wasm has no float remainder instruction, and the
  floored spelling is a different result for mixed signs.

### Other

- `INT_MUL_OVF` was the one overflow form excluded from `OvfFlag::FusedCond`;
  both arms of the signed-32 split stored a flag that the paired guard then
  reloaded and compared. Upstream x86's `genop_int_mul_ovf` and aarch64's
  `emit_comp_op_int_mul_ovf` both leave the answer in the flags, and dynasm
  and cranelift both publish a condition. The `if` now yields the predicate
  and the guard reads it off the stack; `ovf_flag_local` is written only when
  there is no adjacent guard. The mul prologue's two dead scratch `local.tee`
  go with it.
- Two comments claiming nothing assigns the `raw_malloc_varsize_char` oopspec
  were stale — `_cffi_backend::cdataobj::raw_malloc_varsize_char` carries it
  and `_cffi_backend::ctypefunc` calls it. The wasm `CheckMemoryError`
  decline stands, but on the module's `#[cfg(not(target_arch = "wasm32"))]`
  rather than on the absence of a carrier.

### Verification

`pyre/check.py --backend wasm`: 524/524, no `.jitstats` movement.
`cargo test -p majit-backend-wasm`: 86 codegen tests, 6 new.
`cargo test -p majit-backend-cranelift`: 178 tests, 1 new.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly code generation for pointer-width accesses, raw loads and stores, conditional calls, overflow checks, and integer comparisons.
  * Added floating-point raw-load support.
  * Allocation failures now consistently raise a memory error instead of returning a null result silently.
  * Improved handling of exception exits and bridge frame-entry validation.
  * Unsupported trace conditions now decline safely rather than generating invalid code.

* **Tests**
  * Added regression coverage for allocation errors, pointer-array access, conditional calls, overflow handling, raw loads, and release-GIL calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->