### PR TITLE
metainterp, macros, ir: a preamble-less label its own jump specializes, an unresolved bridge close key, and a residual call's uncolored arguments

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -353,6 +353,13 @@ cover the condition they diagnose.
 - What it does: `MAJIT_NO_BRIDGE`: suppress bridge recording so every guard failure resumes through the blackhole.  Public because a frontend that owns its own guard-failure entry point has to honour it there too — gating only the jitdriver-internal paths leaves the variable set but inert, which reads as "bridges are off" while they keep recording.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
+### `MAJIT_NO_GUARD_RESUME_BRIDGE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `no_guard_resume_bridge_enabled()`
+- What it does: `MAJIT_NO_GUARD_RESUME_BRIDGE`: decline every bridge entry taken directly from a guard failure, so each one resumes through the blackhole and the bridge is grown from the next merge point instead.  Narrower than `MAJIT_NO_BRIDGE`, which suppresses bridge recording outright: this leaves the merge-point-grown bridges in place, so a wrong answer that survives `MAJIT_NO_BRIDGE` and disappears here is attributable to what the walk rebuilds from resume data rather than to bridges as such.  Costly — the blackhole arm reaches the merge point by interpreting — so it is a bisection tool, not a policy.  Off by default.
+- Retirement condition: Remove when a bridge entered from a guard failure records the same answer as the blackhole arm reaching the same merge point, so the two arms have nothing left to separate.
+
 ### `MAJIT_OPREF_VARIANT_AUDIT`
 
 - Read sites: 1 — `majit/majit-ir/src/opref_audit.rs`

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -255,6 +255,13 @@ cover the condition they diagnose.
 - What it does: **UNRECORDED** — no doc comment at the read site.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
+### `MAJIT_GUARD_RESUME_REFUSE_PENDING_FIELDS`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `guard_resume_refuse_pending_fields()`
+- What it does: Restores `guard_carries_pending_fields`, the refusal to build a guard-resume bridge for a guard whose deferred writes span more than one virtual. Off by default: upstream has no such refusal, and the double-application it once guarded against is answered by siting the decision ahead of `start_bridge_tracing` rather than by declining. Kept so the two answers stay comparable inside one binary, which a second build cannot do.
+- Retirement condition: Remove once no consumer needs the refusal restored to attribute a result.
+
 ### `MAJIT_HEAPDBG`
 
 - Read sites: 1 — `majit/majit-metainterp/src/lib.rs`

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -403,6 +403,13 @@ cover the condition they diagnose.
 - Default polarity: **OFF**; unset, empty, and `0` disable it.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
+### `MAJIT_SKIP_BRIDGES`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `bridge_fuel_skipped()`
+- What it does: `MAJIT_SKIP_BRIDGES=a,b,...`: decline exactly the listed `MAJIT_MAX_BRIDGES` sequence numbers and take every other one, so a bisect can ask whether one numbered bridge corrupts on its own or whether the corruption is cumulative. The fuel limit cannot answer that, because declining number N also declines everything after it.
+- Retirement condition: Remove with `MAJIT_MAX_BRIDGES`, once a compiled bridge cannot produce a value the same guard's blackhole resume would not.
+
 ### `MAJIT_SMALLIR`
 
 - Read sites: 1 — `majit/majit-metainterp/src/lib.rs`

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -13,6 +13,7 @@
 use crate::descr::DescrRef;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
 /// effectinfo.py `class UnsupportedFieldExc(Exception)`.
@@ -371,8 +372,14 @@ pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
         return Arc::new(EffectInfoCell::new(effect_info));
     }
 
-    static CACHE: LazyLock<Mutex<Vec<Arc<EffectInfoCell>>>> =
-        LazyLock::new(|| Mutex::new(Vec::new()));
+    // `effectinfo.py:14` spells the interner `_cache = {}` and `:147` probes
+    // it with `key in cls._cache`, so one lookup costs one hash of the key
+    // whatever the cache already holds. A sequence answered the same question
+    // by running `EffectInfo`'s `==` — which compares six descr sets
+    // element-wise — against every cell already interned, so the cost of
+    // interning the n-th distinct EffectInfo grew with n.
+    static CACHE: LazyLock<Mutex<HashMap<EffectInfo, Arc<EffectInfoCell>>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
     // `effectinfo.py:143-146` destructures `tgt_func, tgt_saveerr` but appends
     // the fresh-object breaker only `if tgt_func`, so `tgt_saveerr` never
     // enters the key, and upstream's only null-target value is
@@ -386,11 +393,15 @@ pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
     effect_info.call_release_gil_target = EffectInfo::_NO_CALL_RELEASE_GIL_TARGET;
 
     let mut cache = CACHE.lock();
-    if let Some(existing) = cache.iter().find(|existing| existing.get() == &effect_info) {
+    // The key is a copy rather than the cell's own EffectInfo because the cell
+    // is interior-mutable. Only `set_bitstrings` writes it, and the fields it
+    // writes are outside the `Eq`/`Hash` pair below, so the copy and the cell
+    // answer every probe identically.
+    if let Some(existing) = cache.get(&effect_info) {
         return existing.clone();
     }
-    let canonical = Arc::new(EffectInfoCell::new(effect_info));
-    cache.push(canonical.clone());
+    let canonical = Arc::new(EffectInfoCell::new(effect_info.clone()));
+    cache.insert(effect_info, canonical.clone());
     canonical
 }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1510,6 +1510,14 @@ impl<'c> Lowerer<'c> {
                         crate::jit_interp::CallPolicyKind::ResidualVoidCannotRaise,
                     );
                     let write_ei = self.residual_write_effect_info_tokens(func, !cannot_raise);
+                    // The register literals must be spelled inside the
+                    // `__builder` call itself: `regalloc`'s rewriter recolors
+                    // only the arguments of a non-aux builder method call, so
+                    // arguments bound to a local first would keep the register
+                    // numbers the lowerer handed out before coloring.
+                    let typed_args = typed_call_arg_tokens(&arg_bindings);
+                    let __arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
                     let call_stmt = if let Some(write_ei) = write_ei {
                         // Declared field mutator: residual with a write-set
                         // naming the mutated field so the optimizer invalidates
@@ -1518,7 +1526,7 @@ impl<'c> Lowerer<'c> {
                         quote! {
                             __builder.residual_call_void_canonical_via_target_with_effect_info(
                                 __fn_idx,
-                                __typed_args,
+                                #typed_args,
                                 #write_ei,
                             );
                         }
@@ -1526,40 +1534,22 @@ impl<'c> Lowerer<'c> {
                         quote! {
                             __builder.residual_call_void_canonical_via_target_with_effect_info(
                                 __fn_idx,
-                                __typed_args,
+                                #typed_args,
                                 majit_metainterp::cannot_raise_effect_info(),
                             );
                         }
                     } else {
                         quote! {
-                            __builder.residual_call_void_canonical_via_target(__fn_idx, __typed_args);
+                            __builder.residual_call_void_canonical_via_target(__fn_idx, #typed_args);
                         }
                     };
-                    if let Some(arg_regs) = int_arg_regs(&arg_bindings) {
-                        let typed_args = quote! {
-                            &[#(majit_metainterp::JitCallArg::int(#arg_regs)),*]
-                        };
-                        self.emit_op(
-                            OpMeta::linear(OpKind::Call, Register::ints(&arg_regs), vec![]),
-                            quote! {
-                                let __fn_idx = __builder.add_word_abi_fn_ptr_void(#word_void_addr);
-                                let __typed_args = #typed_args;
-                                #call_stmt
-                            },
-                        );
-                    } else {
-                        let typed_args = typed_call_arg_tokens(&arg_bindings);
-                        let __arg_regs: Vec<Register> =
-                            arg_bindings.iter().map(Register::from_binding).collect();
-                        self.emit_op(
-                            OpMeta::linear(OpKind::Call, __arg_regs, vec![]),
-                            quote! {
-                                let __fn_idx = __builder.add_word_abi_fn_ptr_void(#word_void_addr);
-                                let __typed_args = #typed_args;
-                                #call_stmt
-                            },
-                        );
-                    }
+                    self.emit_op(
+                        OpMeta::linear(OpKind::Call, __arg_regs, vec![]),
+                        quote! {
+                            let __fn_idx = __builder.add_word_abi_fn_ptr_void(#word_void_addr);
+                            #call_stmt
+                        },
+                    );
                 }
                 crate::jit_interp::CallPolicyKind::InlineVoid => {
                     let shared_path = inline_shared_path(&call.func)?;
@@ -2005,12 +1995,16 @@ impl<'c> Lowerer<'c> {
                     let throwaway_reg = self.alloc_reg();
                     let __arg_regs: Vec<Register> =
                         arg_bindings.iter().map(Register::from_binding).collect();
+                    // The register literals must be spelled inside the
+                    // `__builder` call itself: `regalloc`'s rewriter recolors
+                    // only the arguments of a non-aux builder method call, so
+                    // arguments bound to a local first would keep the register
+                    // numbers the lowerer handed out before coloring.
                     self.emit_op(
                         OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(throwaway_reg)]),
                         quote! {
                             let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                            let __typed_args = #typed_args;
-                            __builder.residual_call_ref_canonical_via_target(__fn_idx, __typed_args, #throwaway_reg);
+                            __builder.residual_call_ref_canonical_via_target(__fn_idx, #typed_args, #throwaway_reg);
                         },
                     );
                 }
@@ -2019,12 +2013,16 @@ impl<'c> Lowerer<'c> {
                     let throwaway_reg = self.alloc_reg();
                     let __arg_regs: Vec<Register> =
                         arg_bindings.iter().map(Register::from_binding).collect();
+                    // The register literals must be spelled inside the
+                    // `__builder` call itself: `regalloc`'s rewriter recolors
+                    // only the arguments of a non-aux builder method call, so
+                    // arguments bound to a local first would keep the register
+                    // numbers the lowerer handed out before coloring.
                     self.emit_op(
                         OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(throwaway_reg)]),
                         quote! {
                             let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                            let __typed_args = #typed_args;
-                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, __typed_args, #throwaway_reg, majit_metainterp::nursery_alloc_effect_info());
+                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, #typed_args, #throwaway_reg, majit_metainterp::nursery_alloc_effect_info());
                         },
                     );
                 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1234,12 +1234,16 @@ impl<'c> Lowerer<'c> {
                     let reg = self.alloc_reg();
                     let __arg_regs: Vec<Register> =
                         arg_bindings.iter().map(Register::from_binding).collect();
+                    // The register literals must be spelled inside the
+                    // `__builder` call itself: `regalloc`'s rewriter recolors
+                    // only the arguments of a non-aux builder method call, so
+                    // arguments bound to a local first would keep the register
+                    // numbers the lowerer handed out before coloring.
                     self.emit_op(
                         OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(reg)]),
                         quote! {
                             let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                            let __typed_args = #typed_args;
-                            __builder.residual_call_ref_canonical_via_target(__fn_idx, __typed_args, #reg);
+                            __builder.residual_call_ref_canonical_via_target(__fn_idx, #typed_args, #reg);
                         },
                     );
                     // jtransform.py:467-470 — a residual ref call can raise, so
@@ -1266,12 +1270,16 @@ impl<'c> Lowerer<'c> {
                     let reg = self.alloc_reg();
                     let __arg_regs: Vec<Register> =
                         arg_bindings.iter().map(Register::from_binding).collect();
+                    // The register literals must be spelled inside the
+                    // `__builder` call itself: `regalloc`'s rewriter recolors
+                    // only the arguments of a non-aux builder method call, so
+                    // arguments bound to a local first would keep the register
+                    // numbers the lowerer handed out before coloring.
                     self.emit_op(
                         OpMeta::linear(OpKind::Call, __arg_regs, vec![Register::ref_(reg)]),
                         quote! {
                             let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                            let __typed_args = #typed_args;
-                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, __typed_args, #reg, majit_metainterp::nursery_alloc_effect_info());
+                            __builder.residual_call_ref_canonical_via_target_with_effect_info(__fn_idx, #typed_args, #reg, majit_metainterp::nursery_alloc_effect_info());
                         },
                     );
                     // jtransform.py:467-470 — a residual ref call can raise, so

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
@@ -235,6 +235,10 @@ fn is_aux_builder_method(name: &str) -> bool {
 struct LiteralRegisterRewriter<'a> {
     mapping: &'a HashMap<Register, Register>,
     remaining: HashMap<Register, usize>,
+    /// Every register this rewriter recolored, accumulated across all the
+    /// builder calls in one statement so [`rewrite_statement`] can check that
+    /// the statement spelled each register the [`OpMeta`] declares.
+    recolored: &'a mut BTreeSet<Register>,
 }
 
 impl VisitMut for LiteralRegisterRewriter<'_> {
@@ -262,6 +266,7 @@ impl VisitMut for LiteralRegisterRewriter<'_> {
             "ambiguous cross-bank register literal {index} in one builder call"
         );
         *self.remaining.get_mut(&candidates[0]).unwrap() -= 1;
+        self.recolored.insert(candidates[0]);
         expr.lit = syn::Lit::Int(syn::LitInt::new(
             &format!("{}u16", replacement.index),
             lit.span(),
@@ -272,6 +277,7 @@ impl VisitMut for LiteralRegisterRewriter<'_> {
 struct BuilderStatementRewriter<'a> {
     mapping: &'a HashMap<Register, Register>,
     expected: HashMap<Register, usize>,
+    recolored: BTreeSet<Register>,
 }
 
 impl VisitMut for BuilderStatementRewriter<'_> {
@@ -280,6 +286,7 @@ impl VisitMut for BuilderStatementRewriter<'_> {
             let mut rewrite = LiteralRegisterRewriter {
                 mapping: self.mapping,
                 remaining: self.expected.clone(),
+                recolored: &mut self.recolored,
             };
             for arg in &mut call.args {
                 rewrite.visit_expr_mut(arg);
@@ -304,7 +311,25 @@ fn rewrite_statement(
     }
     let mut block: syn::Block = syn::parse2(quote!({ #statement }))
         .expect("macro-generated JitCode statement must parse as a Rust block");
-    BuilderStatementRewriter { mapping, expected }.visit_block_mut(&mut block);
+    let mut rewriter = BuilderStatementRewriter {
+        mapping,
+        expected: expected.clone(),
+        recolored: BTreeSet::new(),
+    };
+    rewriter.visit_block_mut(&mut block);
+    // Only the arguments of a non-aux `__builder` method call are recolored, so
+    // a register an operation declares but spells anywhere else — bound to a
+    // local first, say — would silently keep the number the lowerer handed out
+    // before coloring, and the emitted call would then read a register nothing
+    // ever writes. Every declared register must therefore appear as a literal
+    // the rewriter reached.
+    for reg in expected.keys() {
+        assert!(
+            rewriter.recolored.contains(reg),
+            "JitCode statement declares {reg:?} but never spells it inside a \
+             `__builder` call, so coloring cannot reach it: {statement}"
+        );
+    }
     block
         .stmts
         .into_iter()
@@ -383,5 +408,42 @@ mod tests {
             .map(ToString::to_string)
             .collect::<String>();
         assert!(!emitted.contains("3u16"));
+    }
+
+    /// The rewriter reaches only the arguments of a `__builder` call, so an
+    /// operation that binds its arguments to a local first would keep its
+    /// pre-coloring register numbers and call a register nothing writes.
+    #[test]
+    #[should_panic(expected = "never spells it inside a")]
+    fn a_declared_register_spelled_outside_the_builder_call_is_rejected() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.emit_op(
+            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(1)]),
+            quote! { __builder.load_const_i_value(1u16, 41i64); },
+        );
+        lowerer.emit_op(
+            OpMeta::linear(
+                OpKind::Call,
+                vec![Register::int(1)],
+                vec![Register::int(2)],
+            ),
+            quote! {
+                let __typed_args = &[majit_metainterp::JitCallArg::int(1u16)];
+                __builder.residual_call_int_canonical_via_target(__fn_idx, __typed_args, 2u16);
+            },
+        );
+        lowerer.emit_op(
+            OpMeta::terminal(vec![Register::int(2)]),
+            quote! { __builder.int_return(2u16); },
+        );
+
+        compact_registers(
+            &mut lowerer,
+            RegisterCounts {
+                ints: 1,
+                ..RegisterCounts::default()
+            },
+            Some(Register::int(2)),
+        );
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
@@ -422,11 +422,7 @@ mod tests {
             quote! { __builder.load_const_i_value(1u16, 41i64); },
         );
         lowerer.emit_op(
-            OpMeta::linear(
-                OpKind::Call,
-                vec![Register::int(1)],
-                vec![Register::int(2)],
-            ),
+            OpMeta::linear(OpKind::Call, vec![Register::int(1)], vec![Register::int(2)]),
             quote! {
                 let __typed_args = &[majit_metainterp::JitCallArg::int(1u16)];
                 __builder.residual_call_int_canonical_via_target(__fn_idx, __typed_args, 2u16);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5388,34 +5388,18 @@ impl<S: JitState> JitDriver<S> {
         // position to re-enter at; every other JitState resumes through its
         // own frontend.
         let dispatch = self.dispatch_jitcode().cloned()?;
-        // The cut below is a MASK, not a boundary. It refuses a guard whose
-        // deferred writes span more than one virtual, and the wrong answers
-        // that motivated it are not this entry's to begin with: they are made
-        // at the CLOSE, by the shape of the loop the bridge closes onto.
+        // The cut below is a MASK, not a boundary: it refuses a guard whose
+        // deferred writes span more than one virtual. The wrong answers that
+        // motivated it were never this entry's to begin with — they are made
+        // at the CLOSE, by a loop whose single LABEL its own closing JUMP
+        // specialized, and `compile_loop` now declines to compile that shape
+        // rather than publishing a label nothing can enter soundly (see
+        // `MetaInterp::closing_jump_fixes_label_slots`).
         //
-        // A jitdriver that drops `unroll` from its pass list compiles every
-        // loop through the simple-loop path, and that path mints ONE target
-        // token — nothing in front of it, and no virtual state on it. The
-        // loop's own closing JUMP still carries the traced iteration's
-        // constants: `remove_consts_and_duplicates` records a `SAME_AS` for
-        // each one, and the rewrite pass folds it straight back. Some of those
-        // slots are ones the body never reads, so the label is specialized to
-        // their constants while declaring plain boxes, and an entry supplying
-        // a different value in one of them keeps it for a single iteration and
-        // loses it to the back edge. Upstream never has that shape to enter:
-        // `compile_loop` peels, keeps the unspecialized preamble as
-        // `target_tokens[0]`, and gives the peeled label a virtual state, so
-        // `unroll.py jump_to_existing_trace` either matches that state or
-        // falls back to the preamble. Without the peel there is no preamble to
-        // fall back to and no state to match.
-        //
-        // Guard-resume entries are implicated only because they are the
-        // bridges that close onto such a loop; rebuilding from resume data is
-        // not itself what corrupts, which is why declining every one of them
-        // removes the wrong answer at a cost no policy would pay.
-        //
-        // The cut stays because it halves this frontend's guard failures. It
-        // is NOT a soundness argument, and it is not what makes an entry safe.
+        // What is left here is policy. Rebuilding a bridge entry from resume
+        // data is sound on its own; this only narrows which guards are given
+        // one. Nothing below depends on the cut for correctness, and removing
+        // it cannot reintroduce the close-side defect.
         //
         // Sited here rather than in the ladder below because
         // `compile.py ResumeGuardDescr.handle_fail` runs ONE of resume.py's

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -570,6 +570,19 @@ pub fn bridge_fuel_take() -> bool {
     }
     true
 }
+/// `MAJIT_NO_GUARD_RESUME_BRIDGE`: decline every bridge entry taken directly
+/// from a guard failure, so each one resumes through the blackhole and the
+/// bridge is grown from the next merge point instead.  Narrower than
+/// `MAJIT_NO_BRIDGE`, which suppresses bridge recording outright: this leaves
+/// the merge-point-grown bridges in place, so a wrong answer that survives
+/// `MAJIT_NO_BRIDGE` and disappears here is attributable to what the walk
+/// rebuilds from resume data rather than to bridges as such.  Costly — the
+/// blackhole arm reaches the merge point by interpreting — so it is a bisection
+/// tool, not a policy.  Off by default.
+fn no_guard_resume_bridge_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_NO_GUARD_RESUME_BRIDGE").is_some())
+}
 fn guardlog_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_GUARDLOG").is_some())
@@ -5417,6 +5430,9 @@ impl<S: JitState> JitDriver<S> {
         // for the applying one, which stores the deferred writes on its way
         // in, and the blackhole arm this decline hands the guard to then
         // stores them a second time.
+        if no_guard_resume_bridge_enabled() {
+            return None;
+        }
         if self.guard_carries_pending_fields(descr_arc) {
             let why = GuardResumeDecline::ReplayIncomplete;
             crate::mc_diag_bump(why.diag_slot());

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -539,6 +539,22 @@ pub fn no_bridge_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_NO_BRIDGE").is_some())
 }
+/// `MAJIT_SKIP_BRIDGES=a,b,...` (diagnostic): decline exactly the listed
+/// `MAJIT_MAX_BRIDGES` sequence numbers and take every other one.  Where the
+/// fuel limit answers "the first N are sound", this answers "is number N the
+/// one that corrupts, or is the corruption cumulative" — a distinction the
+/// limit cannot draw, because declining N also declines everything after it.
+/// Off by default; an unparsable entry is ignored rather than reported, since
+/// the variable exists only for a bisect the operator is reading anyway.
+fn bridge_fuel_skipped(n: u64) -> bool {
+    static SET: std::sync::OnceLock<Vec<u64>> = std::sync::OnceLock::new();
+    SET.get_or_init(|| {
+        std::env::var("MAJIT_SKIP_BRIDGES")
+            .map(|v| v.split(',').filter_map(|p| p.trim().parse().ok()).collect())
+            .unwrap_or_default()
+    })
+    .contains(&n)
+}
 /// `MAJIT_MAX_BRIDGES=N` (diagnostic): allow the first N bridge compilations
 /// and behave as `MAJIT_NO_BRIDGE` from then on.  Bisecting N names the bridge
 /// whose compilation first produces a wrong value, at seconds per run rather
@@ -563,6 +579,12 @@ pub fn bridge_fuel_take() -> bool {
     static USED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let n = USED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     if n >= limit {
+        return false;
+    }
+    if bridge_fuel_skipped(n) {
+        if std::env::var_os("MAJIT_BRIDGE_FUEL_LOG").is_some() {
+            eprintln!("@@@FUEL bridge #{n} SKIPPED");
+        }
         return false;
     }
     if std::env::var_os("MAJIT_BRIDGE_FUEL_LOG").is_some() {
@@ -5366,63 +5388,34 @@ impl<S: JitState> JitDriver<S> {
         // position to re-enter at; every other JitState resumes through its
         // own frontend.
         let dispatch = self.dispatch_jitcode().cloned()?;
-        // OPEN, and the cut below is a MASK rather than the boundary. It
-        // refuses a guard whose deferred writes span more than one virtual,
-        // and at the parameter table's `trace_eagerness` a self-interpreting
-        // workload is byte-exact with it in place. Lowering that parameter —
-        // nothing else — reproduces the same class of wrong answer WITH the
-        // cut in place, deterministically, from one setting downwards.
+        // The cut below is a MASK, not a boundary. It refuses a guard whose
+        // deferred writes span more than one virtual, and the wrong answers
+        // that motivated it are not this entry's to begin with: they are made
+        // at the CLOSE, by the shape of the loop the bridge closes onto.
         //
-        // What that reproduction settles, and what it overturns:
+        // A jitdriver that drops `unroll` from its pass list compiles every
+        // loop through the simple-loop path, and that path mints ONE target
+        // token — nothing in front of it, and no virtual state on it. The
+        // loop's own closing JUMP still carries the traced iteration's
+        // constants: `remove_consts_and_duplicates` records a `SAME_AS` for
+        // each one, and the rewrite pass folds it straight back. Some of those
+        // slots are ones the body never reads, so the label is specialized to
+        // their constants while declaring plain boxes, and an entry supplying
+        // a different value in one of them keeps it for a single iteration and
+        // loses it to the back edge. Upstream never has that shape to enter:
+        // `compile_loop` peels, keeps the unspecialized preamble as
+        // `target_tokens[0]`, and gives the peeled label a virtual state, so
+        // `unroll.py jump_to_existing_trace` either matches that state or
+        // falls back to the preamble. Without the peel there is no preamble to
+        // fall back to and no state to match.
         //
-        //   * declining EVERY guard-resume entry restores the correct output
-        //     at every `trace_eagerness` tried, and also with the cut widened
-        //     to serve every deferred-write guard. This entry is the necessary
-        //     component; the virtual count is not.
-        //   * `MAJIT_MAX_BRIDGES` bisects the reproduction to one entry, and
-        //     that entry carries NO deferred writes and NO virtuals at all.
-        //     Seventy-one guard-resume entries precede it and are sound. The
-        //     shape this comment used to blame — a two-node push chain whose
-        //     outer virtual names the inner and whose one deferred write is
-        //     the list head — is what the cut refuses, not what corrupts.
+        // Guard-resume entries are implicated only because they are the
+        // bridges that close onto such a loop; rebuilding from resume data is
+        // not itself what corrupts, which is why declining every one of them
+        // removes the wrong answer at a cost no policy would pay.
         //
-        // What the corrupting entry records is a bridge that closes with a
-        // JUMP into an already-compiled loop, and it passes a VARIABLE in the
-        // argument position that every other close in the same run fills with
-        // a literal — one of a handful of literals, each the value the loop
-        // behind that target token was specialized on. The bridge's own
-        // guards prove only that the variable is not one OTHER literal.
-        //
-        // Nothing in this frontend's close path proves the incoming state
-        // satisfies the target label: `unroll.py jump_to_existing_trace` is
-        // where upstream generates the guards that make a specialized label
-        // safe to enter, and its per-target-token log is EMPTY for this
-        // workload — with the unroll pass enabled as well as without it.
-        // Enabling that pass changes which bytes come out wrong and not that
-        // they are wrong, so the missing pass is not by itself the account.
-        //
-        // Also measured out, in the same reproduction:
-        //
-        //   * a `GuardRequirement` whose box is not reachable from the jump
-        //     arguments emits nothing and is skipped rather than declined —
-        //     a real hole, but declining on it fires on no target token here
-        //     and leaves every wrong byte unchanged,
-        //   * `rd_locs.len()` equals `num_failargs` on every guard in the
-        //     refused census, so no failarg resolves through the deadframe's
-        //     out-of-range identity-slot fallback,
-        //   * the bridge's inputargs are contiguous and cover every failarg,
-        //   * the rewrite lowers a resumed `New` to the headerless nursery
-        //     opcode, so materialized objects come from the frontend's own
-        //     pool at the offsets their descrs carry, and
-        //   * the collector is not involved: the wrong bytes are identical
-        //     with collection disabled, the run performs none, and the
-        //     frontend's own structural invariant stays silent. What the
-        //     served entry produces is a wrong VALUE on an intact structure.
-        //
-        // The cut stays because it is measured to halve this frontend's
-        // guard failures and because widening it is measured to produce a
-        // wrong answer at the shipped parameter; it is NOT a soundness
-        // argument, and the entry above it is where the account is still owed.
+        // The cut stays because it halves this frontend's guard failures. It
+        // is NOT a soundness argument, and it is not what makes an entry safe.
         //
         // Sited here rather than in the ladder below because
         // `compile.py ResumeGuardDescr.handle_fail` runs ONE of resume.py's

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4012,11 +4012,33 @@ impl<S: JitState> JitDriver<S> {
                             .meta
                             .trace_ctx()
                             .and_then(|ctx| ctx.close_greens.clone());
-                        let resolved_key = self
-                            .meta
-                            .trace_ctx()
-                            .and_then(|ctx| ctx.close_green_key_hash())
-                            .or_else(|| self.current_trace_green_key());
+                        // `get_procedure_token(greenboxes)` (pyjitpl.py) walks
+                        // the cell chain and settles a chained bucket on the
+                        // greens themselves; a bare bucket hash cannot, because a
+                        // bucket whose occupant was filed under a minted cell key
+                        // holds no cell AT the hash. `compile_loop` files and
+                        // looks its loop up under the resolved key
+                        // (`WarmEnterState::resolve_cell_key`), so a door reading
+                        // the unresolved hash and a `compile_loop` reading the
+                        // resolved one answer differently about one close: the
+                        // door reports no target and falls through to a
+                        // `compile_loop` that refuses the same key for already
+                        // having a loop, giving the trace up as ABORT_BAD_LOOP.
+                        // The guard is left as it was, so every later failure
+                        // retraces it to the same answer and no bridge is ever
+                        // built. Resolve here so both doors read one cell.
+                        let close_key = self.meta.trace_ctx().and_then(|ctx| ctx.close_green_key());
+                        let resolved_key = match &close_key {
+                            Some(key) => {
+                                let make_key = || key.clone();
+                                Some(self.meta.resolve_cell_key(
+                                    key.get_uhash(),
+                                    Some(&make_key as &dyn Fn() -> majit_ir::GreenKey),
+                                ))
+                            }
+                            // `ctx.green_key` is resolved at trace start.
+                            None => self.current_trace_green_key(),
+                        };
                         // The cell token a close resolves is `jump_op.getdescr()`
                         // upstream (unroll.py:196 `cell_token =
                         // jump_op.getdescr()`, :321-322 `jitcelltoken =
@@ -4032,7 +4054,11 @@ impl<S: JitState> JitDriver<S> {
                         );
                         if crate::closedbg_enabled() {
                             eprintln!(
-                                "@@@CLOSE BRIDGE-TARGET close_greens={close_greens:?} resolved_key={} origin_key={}",
+                                "@@@CLOSE BRIDGE-TARGET close_greens={close_greens:?} close_hash={} resolved_key={} origin_key={}",
+                                close_key
+                                    .as_ref()
+                                    .map(|k| k.get_uhash() as i64)
+                                    .unwrap_or(-1),
                                 resolved_key.map(|k| k as i64).unwrap_or(-1),
                                 self.current_trace_green_key()
                                     .map(|k| k as i64)

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -605,6 +605,18 @@ fn no_guard_resume_bridge_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_NO_GUARD_RESUME_BRIDGE").is_some())
 }
+/// Restores the refusal of a guard-resume bridge for a guard whose deferred
+/// writes span more than one virtual.
+///
+/// Off by default, because upstream has no such refusal —
+/// `compile.py ResumeGuardDescr.handle_fail` bridges whenever `must_compile`
+/// fires. The cut decides a large share of every bridge opportunity, so the
+/// two answers have to stay comparable inside ONE binary; a second build is
+/// not a control for that question.
+fn guard_resume_refuse_pending_fields() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_GUARD_RESUME_REFUSE_PENDING_FIELDS").is_some())
+}
 fn guardlog_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_GUARDLOG").is_some())
@@ -5388,18 +5400,22 @@ impl<S: JitState> JitDriver<S> {
         // position to re-enter at; every other JitState resumes through its
         // own frontend.
         let dispatch = self.dispatch_jitcode().cloned()?;
-        // The cut below is a MASK, not a boundary: it refuses a guard whose
-        // deferred writes span more than one virtual. The wrong answers that
-        // motivated it were never this entry's to begin with — they are made
-        // at the CLOSE, by a loop whose single LABEL its own closing JUMP
-        // specialized, and `compile_loop` now declines to compile that shape
-        // rather than publishing a label nothing can enter soundly (see
-        // `MetaInterp::closing_jump_fixes_label_slots`).
+        // The cut below is OFF by default and upstream has no equivalent:
+        // `compile.py ResumeGuardDescr.handle_fail` bridges whenever
+        // `must_compile` fires, whatever the guard's deferred writes look
+        // like. What the guard's pendingfields once threatened was a double
+        // application — the entry's applying reader storing them on its way
+        // in and the blackhole arm this decline hands the guard to storing
+        // them again — and that is answered by SITING the decision ahead of
+        // `start_bridge_tracing`, which is where it now is, not by refusing.
+        // A guard admitted here reaches exactly one of the two readers.
         //
-        // What is left here is policy. Rebuilding a bridge entry from resume
-        // data is sound on its own; this only narrows which guards are given
-        // one. Nothing below depends on the cut for correctness, and removing
-        // it cannot reintroduce the close-side defect.
+        // The wrong answers that later narrowed the cut to `nv > 1` were
+        // never this entry's either: they are made at the CLOSE, by a loop
+        // whose single LABEL its own closing JUMP specialized, and
+        // `compile_loop` now declines to compile that shape rather than
+        // publishing a label nothing can enter soundly (see
+        // `MetaInterp::closing_jump_fixes_label_slots`).
         //
         // Sited here rather than in the ladder below because
         // `compile.py ResumeGuardDescr.handle_fail` runs ONE of resume.py's
@@ -5410,7 +5426,7 @@ impl<S: JitState> JitDriver<S> {
         if no_guard_resume_bridge_enabled() {
             return None;
         }
-        if self.guard_carries_pending_fields(descr_arc) {
+        if guard_resume_refuse_pending_fields() && self.guard_carries_pending_fields(descr_arc) {
             let why = GuardResumeDecline::ReplayIncomplete;
             crate::mc_diag_bump(why.diag_slot());
             if crate::majit_log_enabled() {
@@ -6665,9 +6681,19 @@ impl<S: JitState> JitDriver<S> {
                         bh_sf.float_scalar_base,
                         bh_sf.num_float_scalars,
                     );
-                    let sf_before_i = bh.registers_i[sf_i.clone()].to_vec();
-                    let sf_before_r = bh.registers_r[sf_r.clone()].to_vec();
-                    let sf_before_f = bh.registers_f[sf_f.clone()].to_vec();
+                    // Three register-bank copies, and their only purpose is
+                    // `guard_may_bridge` below, whose only reader takes them
+                    // under `should_bridge`. A guard the counter has not
+                    // fired for pays them on every failure and asks nothing
+                    // of them, and that is the common case by orders of
+                    // magnitude.
+                    let sf_before = should_bridge.then(|| {
+                        (
+                            bh.registers_i[sf_i.clone()].to_vec(),
+                            bh.registers_r[sf_r.clone()].to_vec(),
+                            bh.registers_f[sf_f.clone()].to_vec(),
+                        )
+                    });
                     let outcome = loop {
                         match bh.resume_mainloop(cur_exc) {
                             Ok(next_exc) => match bh.nextblackholeinterp.take() {
@@ -6724,11 +6750,17 @@ impl<S: JitState> JitDriver<S> {
                     //
                     // A walk that crossed a frame boundary is not judged by one
                     // frame's registers, so it does not qualify.
-                    let tail_wrote_state = bh.registers_i[sf_i] != sf_before_i[..]
-                        || bh.registers_r[sf_r] != sf_before_r[..]
-                        || bh.registers_f[sf_f] != sf_before_f[..];
-                    let guard_may_bridge =
-                        bh_frames_popped == 0 && !bh.called_residual.get() && !tail_wrote_state;
+                    let guard_may_bridge = match &sf_before {
+                        Some((before_i, before_r, before_f)) => {
+                            let tail_wrote_state = bh.registers_i[sf_i] != before_i[..]
+                                || bh.registers_r[sf_r] != before_r[..]
+                                || bh.registers_f[sf_f] != before_f[..];
+                            bh_frames_popped == 0 && !bh.called_residual.get() && !tail_wrote_state
+                        }
+                        // Only reachable with `should_bridge` false, where the
+                        // reader below short-circuits before asking.
+                        None => false,
+                    };
                     let mut portal_crn_handled = false;
                     let resume_pc = match outcome {
                         // Next merge point reached (loop back-edge): flush the

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1899,6 +1899,14 @@ pub const MC_DIAG_LABELS: &[&str] = &[
     // value identifies compatibility callers that still need typed-key
     // threading.
     "confirm_enter_jit_missing_key",
+    // A bridge close resolved a head target token that carries a virtual
+    // state. `unroll.py jump_to_preamble` asserts the head has none before
+    // pointing the JUMP at it, because entering a specialized label needs the
+    // guards `_jump_to_existing_trace` generates from that state, and the
+    // unconditional take has no way to produce them. The close declines
+    // instead, so a nonzero value names the traces that lost a bridge to an
+    // invariant upstream states as unreachable.
+    "bridge_close_head_target_has_virtual_state",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1907,6 +1907,19 @@ pub const MC_DIAG_LABELS: &[&str] = &[
     // instead, so a nonzero value names the traces that lost a bridge to an
     // invariant upstream states as unreachable.
     "bridge_close_head_target_has_virtual_state",
+    // A loop the unroll-free retry path compiled would have had its single
+    // LABEL specialized by its own closing JUMP: the JUMP fills a slot the
+    // LABEL declares as a box with a constant, and with no peel there is
+    // neither an unspecialized preamble to enter through nor a virtual state
+    // to match. The compile is aborted rather than published. A nonzero value
+    // names the loops a jitdriver that disables `unroll` does not get.
+    "peel_less_loop_label_is_const_specialized",
+    // The same shape reached through `compile_simple_loop`, whose single
+    // LABEL is the only entry the key gets. Upstream's segmented compile
+    // cannot produce it — it records an unreachable FINISH and asks for no
+    // back edge — so a nonzero value names traces that arrived here carrying
+    // one, and were refused rather than published.
+    "segmented_loop_label_is_const_specialized",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -444,6 +444,17 @@ pub struct Optimizer {
     /// is NON-fatal (exported_loop_state = None) instead of escaping as an
     /// InvalidLoop that discards the bridge (the pi guard-9 infinite-deopt hang).
     building_bridge: bool,
+    /// Whether this call is the one `compile.py`'s `SimpleCompileData.optimize`
+    /// makes. That one runs `Optimizer.optimize_loop`, whose result is a
+    /// `BasicLoopInfo` and the operations; the short-preamble export and the
+    /// `ExportedState` it produces belong to `UnrollOptimizer.optimize_preamble`
+    /// alone, and `unroll.py:454-457`'s force-then-flush-then-virtual-state runs
+    /// only there. pyre folds that preview into the shared
+    /// `optimize_with_constants_and_inputs_at`, so a simple compile needs this
+    /// flag to reach the same shape: no forcing of the closing JUMP's arguments
+    /// for a preamble that is not being built, and no exported state, which no
+    /// reader of a simple loop's result consults.
+    pub simple_compile: bool,
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
     /// Taken from MIStaticData at optimizer construction, returned after.
     /// descr.py:25-47: descriptors get descr_index assigned inline during
@@ -1520,6 +1531,7 @@ impl Optimizer {
             final_ctx: None,
             pending_bridge_rd: None,
             building_bridge: false,
+            simple_compile: false,
             all_descrs: Arc::new(Vec::new()),
             constant_fold_alloc: None,
             string_length_resolver: None,
@@ -3141,7 +3153,10 @@ impl Optimizer {
         // for the preview virtual-state mismatch below propagates out of
         // `optimize_with_constants_and_inputs_at`, not just the closure.
         let building_bridge = self.building_bridge;
-        self.exported_loop_state = match jump {
+        // `Optimizer.optimize_loop` (optimizer.py) is the whole of
+        // `SimpleCompileData.optimize`; there is no `optimize_preamble` behind
+        // it to export for. See [`Self::simple_compile`].
+        self.exported_loop_state = match jump.filter(|_| !self.simple_compile) {
             Some(jump) => 'export: {
                 // RPython unroll.py:454-457 order:
                 //   end_args = [force_box_for_end_of_preamble(a) for a ...]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9796,6 +9796,11 @@ impl<M: Clone> MetaInterp<M> {
         self.clear_retrace_state();
         if let Some(ctx) = self.tracing.take() {
             let green_key = ctx.green_key;
+            // A recorder panic settles the question the `MAX_TRACE_ABORT_COUNT`
+            // ceiling would otherwise take that many attempts to reach: the walk
+            // stopped on something about the jitcode it was reading, so every
+            // later attempt at this key reads it again. Ban the key here.
+            let permanent = permanent || ctx.recorder_panicked;
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] abort trace at key={} (permanent={})",

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7092,10 +7092,15 @@ impl<M: Clone> MetaInterp<M> {
         // namespace, so no seed can resolve cut-op lookups anyway; an explicit
         // empty seed states that (producer lookup runs off new_operations /
         // phase1_emit_ops / resop_refs).
-        unroll_opt.phase2_input_ops_seed = Some(if cross_loop_cut.is_none() {
-            preamble_data.base.operations().to_vec()
-        } else {
+        // Only the peeling arm below reads this seed. When the jitdriver's
+        // `enable_opts` omits `unroll`, the optimize call is `InvalidLoop`
+        // before it looks at any of `unroll_opt`, and the retry builds its own
+        // `explicit_input_ops_seed` from the same operations — so populating it
+        // here would copy the whole recorded trace to be dropped.
+        unroll_opt.phase2_input_ops_seed = Some(if no_unroll || cross_loop_cut.is_some() {
             Vec::new()
+        } else {
+            preamble_data.base.operations().to_vec()
         });
         unroll_opt.call_pure_results = preamble_data.call_pure_results.clone();
         // RPython Box type parity: each InputArg carries its type from
@@ -7122,11 +7127,19 @@ impl<M: Clone> MetaInterp<M> {
         // intrinsic attribute on the Box itself, so no raw-u32 type
         // side-table propagation is needed; callers recover the type
         // through `OpRef::ty()` / `Const::get_type()`.
-        unroll_opt.snapshot_boxes = snapshot_map.clone();
-        unroll_opt.snapshot_frame_sizes = snapshot_frame_size_map.clone();
-        unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
-        unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
-        unroll_opt.snapshot_frame_pcs = snapshot_frame_pcs.clone();
+        // Phase 1's copy of the snapshot banks. The originals stay owned here
+        // because the `InvalidLoop` arm below moves them into the unroll-free
+        // optimizer, so this is a second set, one `Vec<SnapshotBox>` per
+        // recorded guard. A trace that records guards in the thousands makes
+        // that the largest single allocation of the compile, and the arm that
+        // never peels never reads it.
+        if !no_unroll {
+            unroll_opt.snapshot_boxes = snapshot_map.clone();
+            unroll_opt.snapshot_frame_sizes = snapshot_frame_size_map.clone();
+            unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
+            unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
+            unroll_opt.snapshot_frame_pcs = snapshot_frame_pcs.clone();
+        }
         // The original snapshot maps are re-cloned into `simple_opt` on the
         // InvalidLoop retry below, so they must stay rooted across the WHOLE
         // unroll. Each phase's `replace_compile_snapshot_roots` overwrites the
@@ -7140,15 +7153,26 @@ impl<M: Clone> MetaInterp<M> {
             &mut snapshot_vref_map,
         ]);
         // Until the first phase replace, also root unroll_opt's own clones (the
-        // phase-1 source) alongside the persistent originals.
-        self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
-            &mut unroll_opt.snapshot_boxes,
-            &mut unroll_opt.snapshot_vable_boxes,
-            &mut unroll_opt.snapshot_vref_boxes,
-            &mut snapshot_map,
-            &mut snapshot_vable_map,
-            &mut snapshot_vref_map,
-        ]);
+        // phase-1 source) alongside the persistent originals. Where there is no
+        // phase 1 those clones were never taken, and naming empty banks here
+        // would root nothing; the originals still are, which is what the arm
+        // that moves them into the unroll-free optimizer needs.
+        self.compile_snapshot_refs = if no_unroll {
+            collect_snapshot_const_ptr_slots(&mut [
+                &mut snapshot_map,
+                &mut snapshot_vable_map,
+                &mut snapshot_vref_map,
+            ])
+        } else {
+            collect_snapshot_const_ptr_slots(&mut [
+                &mut unroll_opt.snapshot_boxes,
+                &mut unroll_opt.snapshot_vable_boxes,
+                &mut unroll_opt.snapshot_vref_boxes,
+                &mut snapshot_map,
+                &mut snapshot_vable_map,
+                &mut snapshot_vref_map,
+            ])
+        };
 
         // RPython compile.py:278-294 parity: Phase 1 results must survive
         // Phase 2 InvalidLoop. Phase 1 writes to phase1_out on the caller's

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6987,7 +6987,7 @@ impl<M: Clone> MetaInterp<M> {
         // optimizer's `&[Op]` surface gets owned data. The deep-clone
         // mirrors PyPy's `cls()` fresh ResOperation per iteration —
         // optimizer mutations don't leak into TreeLoop.ops identity.
-        let trace_ops: Vec<Op> = preamble_data
+        let mut trace_ops: Vec<Op> = preamble_data
             .base
             .operations()
             .iter()
@@ -7037,11 +7037,6 @@ impl<M: Clone> MetaInterp<M> {
             }
         }
 
-        // Save trace_ops + constants snapshot for potential unroll-free retry
-        // (pyjitpl.py:3016-3021).
-        let trace_ops_snapshot = trace_ops.clone();
-        let constants_snapshot = constants.clone();
-
         // PyPy: pyjitpl.py:3016-3017 gates unrolling on `unroll` in
         // warmstate.enable_opts. MAJIT_NO_UNROLL remains a diagnostic override.
         let no_unroll_reason = crate::unroll_skip_reason(
@@ -7049,6 +7044,19 @@ impl<M: Clone> MetaInterp<M> {
             self.warm_state.get_enable_opts(),
         );
         let no_unroll = no_unroll_reason.is_some();
+
+        // Save trace_ops + constants snapshot for potential unroll-free retry
+        // (pyjitpl.py:3016-3021).
+        //
+        // `compile.py:271-273` reaches `compile_simple_loop` by branching before
+        // `PreambleCompileData` exists, and hands it the same trace object. Pyre
+        // reaches that compile through the retry below instead, so the copy is
+        // what stands in for the branch: it exists because a peeling attempt
+        // that ran first may have left the recorded operations forwarded. When
+        // the attempt is skipped they are still as the recorder left them, and
+        // the retry takes them rather than a copy.
+        let trace_ops_snapshot: Option<Vec<Op>> = (!no_unroll).then(|| trace_ops.clone());
+        let constants_snapshot = constants.clone();
 
         // Use UnrollOptimizer for preamble peeling when available.
         // compile.py: compile_loop → PreambleCompileData + LoopCompileData.
@@ -7285,6 +7293,9 @@ impl<M: Clone> MetaInterp<M> {
                         // read-only after `setup_descrs`; `bridgeopt.py:155`
                         // indexes it blind.
                         simple_opt.all_descrs = unroll_opt.all_descrs.clone();
+                        // compile.py:272 `compile_simple_loop` — this retry is
+                        // that call, so it optimizes as `SimpleCompileData` does.
+                        simple_opt.simple_compile = true;
                         // history.py/261/307: `Const.type` /
                         // `InputArg.type` are intrinsic on the box;
                         // no raw-u32 type side-table propagation is
@@ -7310,9 +7321,12 @@ impl<M: Clone> MetaInterp<M> {
                         // `Rc<Op>`), so producer lookup resolves identity.
                         simple_opt.explicit_input_ops_seed =
                             Some(preamble_data.base.operations().to_vec());
+                        // Consumed here and nowhere else, so the operations move
+                        // into their `Rc`s instead of being copied into them.
                         let trace_ops_snapshot_rc: Vec<majit_ir::OpRc> = trace_ops_snapshot
-                            .iter()
-                            .map(|op| std::rc::Rc::new(op.clone()))
+                            .unwrap_or_else(|| std::mem::take(&mut trace_ops))
+                            .into_iter()
+                            .map(std::rc::Rc::new)
                             .collect();
                         let retry_result =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7677,9 +7677,23 @@ impl<M: Clone> MetaInterp<M> {
         // fall back to and no state to match, so declining the loop is the
         // only answer left that is not the wrong one.
         //
+        // Only for a jitdriver whose `enable_opts` has no `unroll` at all.
+        // `retried_without_unroll` is also set by the other route into this
+        // retry — the `InvalidLoop` the peeling attempt itself raised, which
+        // `compile.py` answers by trying one last time without unrolling. That
+        // retry is a rescue: the key does peel, this trace's peeled form was
+        // rejected, and what the retry publishes is the only compile the trace
+        // will get. Declining it costs the loop and the rescue both, and
+        // nothing upstream declines it. Where the driver has no peel the shape
+        // is not one trace's bad luck but every loop the key will ever hold, so
+        // there refusing is the whole of the answer.
+        //
         // The abort ceiling turns a key that keeps producing this shape into a
         // `JC_DONT_TRACE_HERE`, so the frontend converges on interpreting it.
-        if retried_without_unroll && Self::closing_jump_fixes_label_slots(&compiled_ops) {
+        if no_unroll
+            && retried_without_unroll
+            && Self::closing_jump_fixes_label_slots(&compiled_ops)
+        {
             crate::mc_diag_bump(crate::mc_diag_slot(
                 "peel_less_loop_label_is_const_specialized",
             ));

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7654,6 +7654,46 @@ impl<M: Clone> MetaInterp<M> {
         // resume.py parity: rd_numb is now produced inline during optimization
         // (ctx.emit → store_final_boxes_in_guard) rather than post-assembly.
 
+        // A loop compiled without the peel has ONE label and no virtual
+        // state, so nothing distinguishes a general entry from a specialized
+        // one — and the loop's own closing JUMP specializes it wherever it
+        // fills a slot the LABEL declares as a box with a constant. The body
+        // may never read that slot, so a value any entry supplies survives one
+        // iteration and the back edge writes the constant over it. The peel is
+        // what keeps that from mattering: it leaves the unspecialized preamble
+        // at `target_tokens[0]` and puts the loop's invariants in the peeled
+        // label's virtual state, which `unroll.py jump_to_existing_trace` must
+        // match or fall back to the preamble for.
+        //
+        // Refusing the compile is a DEVIATION. `pyjitpl.py` computes
+        // `can_use_unroll = cpu.supports_guard_gc_type and 'unroll' in
+        // enable_opts` and forwards a false value through `compile_loop` to
+        // `compile_simple_loop`, which publishes exactly this shape with
+        // `patch_jumpop_at_end=True`; `optimize_bridge` then takes
+        // `target_tokens[0]` through `jump_to_preamble`, whose only assertion
+        // is that the head carries no virtual state. Nothing on that route
+        // examines the closing JUMP, so the specialized label is entered with
+        // no guard proving the constant. With no peel there is no preamble to
+        // fall back to and no state to match, so declining the loop is the
+        // only answer left that is not the wrong one.
+        //
+        // The abort ceiling turns a key that keeps producing this shape into a
+        // `JC_DONT_TRACE_HERE`, so the frontend converges on interpreting it.
+        if retried_without_unroll && Self::closing_jump_fixes_label_slots(&compiled_ops) {
+            crate::mc_diag_bump(crate::mc_diag_slot(
+                "peel_less_loop_label_is_const_specialized",
+            ));
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[jit] unroll-free loop label is specialized by its own \
+                     closing jump at key={green_key}"
+                );
+            }
+            self.warm_state.abort_tracing(green_key, false);
+            self.exported_state = None;
+            return CompileOutcome::Aborted;
+        }
+
         // Use the pre-allocated token object if available (for self-recursion
         // support), otherwise allocate a fresh one.
         let mut token = if let Some((pk, token)) = self.pending_token.take() {
@@ -10592,6 +10632,35 @@ impl<M: Clone> MetaInterp<M> {
 
         let optimized_ops = compile::strip_stray_overflow_guards(optimized_ops);
 
+        // This path mints one TargetToken with no virtual state and no
+        // preamble in front of it, so its LABEL is the only entry the key
+        // has — and the trace's own closing JUMP specializes that LABEL
+        // wherever it fills a slot the LABEL declares as a box with a
+        // constant. See `closing_jump_fixes_label_slots` for why that is a
+        // wrong answer rather than a lost optimization, and `compile_loop`'s
+        // sibling refusal for the same shape reached the other way.
+        //
+        // The segmented caller is upstream's `patch_jumpop_at_end=False`
+        // case: `pyjitpl.py _create_segmented_trace_and_blackhole` records an
+        // unreachable FINISH and asks for no back edge, so the LABEL it
+        // publishes exists only for a later segment to close onto. A trace
+        // that arrives here carrying a back edge is outside that contract,
+        // and the closing JUMP below would descr it onto this very token.
+        if Self::closing_jump_fixes_label_slots(&optimized_ops) {
+            crate::mc_diag_bump(crate::mc_diag_slot(
+                "segmented_loop_label_is_const_specialized",
+            ));
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[jit] compile_simple_loop: label is specialized by its own \
+                     closing jump at key={green_key}"
+                );
+            }
+            self.warm_state.abort_tracing(green_key, false);
+            self.compile_snapshot_refs.clear();
+            return None;
+        }
+
         // Allocate token and compile.
         let token_num = self.warm_state.alloc_token_number();
         // `compile.py jitcell_token = make_jitcell_token(jitdriver_sd)`.
@@ -11100,6 +11169,40 @@ impl<M: Clone> MetaInterp<M> {
             packed.push(value);
         }
         Some(packed)
+    }
+
+    /// Whether the loop's own closing JUMP fills a slot the LABEL declares as
+    /// a box with a constant, which makes the LABEL a specialized entry.
+    ///
+    /// `remove_consts_and_duplicates` (pyjitpl.py) records a `SAME_AS` for
+    /// every constant it meets in the merge point's live boxes, and the
+    /// rewrite pass folds that straight back, so a slot whose value the
+    /// metainterp knows as a constant reaches the optimized JUMP as one.
+    /// Against a LABEL that declares a box there, the pair says "any value may
+    /// enter, and this constant is what leaves" — sound for the trace that
+    /// recorded it, and an overwrite for anything else that enters.
+    ///
+    /// An op list whose LABEL has not been synthesized yet answers from the
+    /// JUMP alone: that LABEL will declare the trace's inputargs, which are
+    /// boxes without exception, so every constant in the JUMP lands on one.
+    ///
+    /// Conservative on purpose: a constant an operation in the loop genuinely
+    /// derives is refused too. Both compiles that consult this publish a
+    /// single label with no preamble behind it, and there refusing the compile
+    /// costs a loop where admitting it costs the answer.
+    fn closing_jump_fixes_label_slots(ops: &[majit_ir::OpRc]) -> bool {
+        let Some(jump) = ops.last().filter(|op| op.opcode == OpCode::Jump) else {
+            return false;
+        };
+        let jump_args = jump.getarglist();
+        let Some(label) = ops.iter().find(|op| op.opcode == OpCode::Label) else {
+            return jump_args.iter().any(|arg| arg.is_constant());
+        };
+        let label_args = label.getarglist();
+        jump_args
+            .iter()
+            .zip(label_args.iter())
+            .any(|(jump_arg, label_arg)| jump_arg.is_constant() && !label_arg.is_constant())
     }
 
     fn front_entry_index_for(tokens: &[crate::history::TargetToken]) -> Option<usize> {
@@ -27380,5 +27483,95 @@ mod loop_side_table_tests {
             Some(7),
             "copying old_entry.loop_header_pc across keeps the close target"
         );
+    }
+}
+
+/// The predicate that tells a specialized label from a general one on a loop
+/// compiled without the peel.
+///
+/// `compile_simple_loop` mints one TargetToken and gives it no
+/// `virtual_state`, so the only evidence a close has that the label is
+/// specialized is the loop's own closing JUMP: a constant there against a box
+/// in the LABEL says "any value may enter, and this constant is what leaves".
+/// The body may never read that slot, so a value the close supplies survives
+/// exactly one iteration and the back edge writes the constant over it.
+#[cfg(test)]
+mod closing_jump_fixes_label_slots_tests {
+    use super::*;
+    use majit_ir::operand::Operand;
+    use majit_ir::{Op, OpRef, Type};
+
+    fn op(opcode: OpCode, args: &[OpRef]) -> majit_ir::OpRc {
+        let args: Vec<Operand> = args.iter().map(|a| Operand::bound_from_opref(*a)).collect();
+        std::rc::Rc::new(Op::new(opcode, &args))
+    }
+
+    /// An `OpRef` naming a producer, i.e. what a LABEL declares each of its
+    /// slots as.
+    fn boxed(pos: u32) -> OpRef {
+        OpRef::op_typed(pos, Type::Int)
+    }
+
+    #[test]
+    fn a_constant_against_a_declared_box_is_the_specializing_shape() {
+        let ops = vec![
+            op(OpCode::Label, &[boxed(1), boxed(2)]),
+            op(OpCode::Jump, &[boxed(1), OpRef::ConstInt(605)]),
+        ];
+        assert!(
+            MetaInterp::<()>::closing_jump_fixes_label_slots(&ops),
+            "slot 1 enters as a box and leaves as 605, so anything that enters \
+             carrying another value loses it on the back edge",
+        );
+    }
+
+    /// The control: a loop whose closing JUMP hands every slot back as the box
+    /// it was declared as is a general entry, and refusing closes onto it
+    /// would cost bridges for nothing.
+    #[test]
+    fn a_jump_that_returns_every_slot_unchanged_is_a_general_entry() {
+        let ops = vec![
+            op(OpCode::Label, &[boxed(1), boxed(2)]),
+            op(OpCode::Jump, &[boxed(1), boxed(2)]),
+        ];
+        assert!(!MetaInterp::<()>::closing_jump_fixes_label_slots(&ops));
+    }
+
+    /// A slot the LABEL itself declares as a constant is already specialized
+    /// in a way every entry has to match, and the JUMP handing the same
+    /// constant back adds nothing.
+    #[test]
+    fn a_constant_the_label_itself_declares_is_not_this_defect() {
+        let ops = vec![
+            op(OpCode::Label, &[boxed(1), OpRef::ConstInt(605)]),
+            op(OpCode::Jump, &[boxed(1), OpRef::ConstInt(605)]),
+        ];
+        assert!(!MetaInterp::<()>::closing_jump_fixes_label_slots(&ops));
+    }
+
+    /// Without a back edge there is no loop to speak about.
+    #[test]
+    fn an_op_list_without_a_closing_jump_answers_no() {
+        assert!(!MetaInterp::<()>::closing_jump_fixes_label_slots(&[]));
+        assert!(!MetaInterp::<()>::closing_jump_fixes_label_slots(&[op(
+            OpCode::Label,
+            &[boxed(1)]
+        )]));
+    }
+
+    /// The compile-time site runs before the LABEL is synthesized, and that
+    /// LABEL will declare the trace's inputargs — boxes without exception. A
+    /// constant in the JUMP therefore lands on one, and answering from the
+    /// JUMP alone is what lets the check sit ahead of the token.
+    #[test]
+    fn a_jump_with_no_label_yet_answers_from_the_jump_alone() {
+        assert!(MetaInterp::<()>::closing_jump_fixes_label_slots(&[op(
+            OpCode::Jump,
+            &[boxed(1), OpRef::ConstInt(605)]
+        )]));
+        assert!(!MetaInterp::<()>::closing_jump_fixes_label_slots(&[op(
+            OpCode::Jump,
+            &[boxed(1), boxed(2)]
+        )]));
     }
 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -13250,15 +13250,30 @@ impl<M: Clone> MetaInterp<M> {
     /// every guard has recovery_layout with header_pc on all frames.
     /// Returns None only if the (green_key, trace_id, fail_index) lookup
     /// itself fails — a metadata consistency error, not a missing field.
+    ///
+    /// Resolved here rather than through `get_compiled_exit_layout_in_trace`,
+    /// which answers the same two lookups by building a whole
+    /// `CompiledExitLayout` around them: `StoredExitLayout::public` copies the
+    /// exit types and clones three `Arc`s, and the backend arm reassembles a
+    /// `ResumeStorage` out of clones of the fail descriptor's whole `rd_*`
+    /// pool. A caller after one `u64` drops every one of them again, and this
+    /// one runs on each reported guard failure. The resolution order is the
+    /// same — the trace's own entry first, the backend's only when the trace
+    /// holds none — so the two agree on which layout answers.
     pub fn get_merge_point_pc(
         &self,
         green_key: u64,
         trace_id: u64,
         fail_index: u32,
     ) -> Option<u64> {
-        let exit_layout =
-            self.get_compiled_exit_layout_in_trace(green_key, trace_id, fail_index)?;
-        let recovery = exit_layout.recovery_layout.as_ref()?;
+        let compiled = self.compiled_loops.get(&green_key)?;
+        if let Some((_, trace)) = Self::trace_for_exit(compiled, trace_id)
+            && let Some(layout) = trace.exit_layouts.get(&fail_index)
+        {
+            return layout.recovery_layout.as_ref()?.frames.first()?.header_pc;
+        }
+        let backend = self.backend_fail_descr_layout(compiled, trace_id, fail_index)?;
+        let recovery = backend.recovery_layout.as_ref()?;
         recovery.frames.first()?.header_pc
     }
 
@@ -24795,6 +24810,78 @@ mod tests {
             .get_rd_pendingfields(green_key, trace_id, fail_index)
             .expect("stored exit layout should expose rd_pendingfields");
         assert!(pendingfields.is_empty());
+    }
+
+    /// The trace's own entry is the whole answer once it exists: a guard the
+    /// trace holds with no recovery layout resolves to no merge point rather
+    /// than to whatever the backend would say about the same fail index.
+    /// `get_compiled_exit_layout_in_trace` picks the layout the same way, and
+    /// reads `recovery_layout` off it afterwards.
+    #[test]
+    fn a_trace_entry_without_a_recovery_layout_answers_no_merge_point() {
+        let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let green_key = 61;
+        let trace_id = 67;
+        let fail_index = 2;
+
+        let mut exit_layouts: indexmap::IndexMap<u32, StoredExitLayout> = indexmap::IndexMap::new();
+        exit_layouts.insert(
+            fail_index,
+            StoredExitLayout {
+                source_op_index: Some(0),
+                recovery_layout: None,
+                resume_layout: None,
+                storage: None,
+                descr: Some(crate::compile::make_fail_descr_typed(vec![Type::Int])),
+                op_arg_types_for_jump: None,
+            },
+        );
+
+        let mut traces = indexmap::IndexMap::new();
+        traces.insert(
+            trace_id,
+            CompiledTrace {
+                inputargs: vec![],
+                ops: vec![],
+                constants: majit_ir::ConstMap::new(),
+                exit_layouts,
+                terminal_exit_layouts: indexmap::IndexMap::new(),
+            },
+        );
+
+        let token = std::sync::Arc::new(JitCellToken::new(3));
+        meta.warm_state_mut().memory_manager.keep_loop_alive(&token);
+        meta.warm_state_mut()
+            .attach_procedure_to_interp(green_key, std::sync::Arc::clone(&token));
+        meta.compiled_loops.insert(
+            green_key,
+            CompiledEntry {
+                token: std::sync::Arc::downgrade(&token),
+                meta: std::sync::Arc::new(()),
+                front_target_tokens: Vec::new(),
+                front_entry_index: None,
+                front_target_source_positions: None,
+                root_trace_id: trace_id,
+                traces,
+                previous_tokens: Vec::new(),
+                loop_header_pc: None,
+                next_global_opref: 0,
+            },
+        );
+
+        assert_eq!(
+            meta.get_merge_point_pc(green_key, trace_id, fail_index),
+            None
+        );
+        // A fail index the trace does not hold falls through to the backend,
+        // which holds nothing for this fixture either.
+        assert_eq!(meta.get_merge_point_pc(green_key, trace_id, 99), None);
+        // An unknown green key resolves no compiled entry at all.
+        assert_eq!(
+            meta.get_merge_point_pc(green_key + 1, trace_id, fail_index),
+            None
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8392,6 +8392,31 @@ impl<M: Clone> MetaInterp<M> {
                 crate::mc_diag_bump(29); // compile_trace: no front target token
                 return CompileOutcome::Cancelled;
             };
+            // `unroll.py jump_to_preamble` reaches this same unconditional
+            // take of the head, and it opens with
+            // `assert cell_token.target_tokens[0].virtual_state is None`.
+            // That assertion is what makes the take sound: a head carrying a
+            // virtual state is a specialized label, and entering one needs the
+            // guards `_jump_to_existing_trace` derives from that state — which
+            // the take, by construction, does not emit. The crate layering
+            // keeps `virtual_state` off the backend's descr list (see the note
+            // below), so read it from the `compiled_loops` projection the head
+            // is mirrored into. Upstream states this as unreachable; declining
+            // costs a bridge where crashing would cost the process.
+            if self
+                .compiled_loops
+                .get(&green_key)
+                .and_then(|compiled| compiled.front_target_tokens.first())
+                .is_some_and(|front| front.virtual_state.is_some())
+            {
+                if crate::closedbg_enabled() {
+                    eprintln!("@@@CANCEL-SITE line={}", line!());
+                }
+                crate::mc_diag_bump(crate::mc_diag_slot(
+                    "bridge_close_head_target_has_virtual_state",
+                ));
+                return CompileOutcome::Cancelled;
+            }
             // The descr list on the token and the value list in
             // `compiled_loops` are two projections of one thing, written by
             // separate statements, and nothing else checks that they agree.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3093,6 +3093,7 @@ where
                     // The unwind left `code_cursor` inside the panicking
                     // instruction, so the frames name no resumable position.
                     ctx.abort_after_panic = true;
+                    ctx.recorder_panicked = true;
                     sym.abort_portal_op();
                     return TraceAction::Abort;
                 }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -556,6 +556,14 @@ pub struct TraceCtx {
     /// instruction boundary).  RPython has no counterpart: it has no panic arm
     /// here.
     pub abort_after_panic: bool,
+    /// Set alongside [`Self::abort_after_panic`], and never consumed before the
+    /// abort reaches the warm-state cell, so `abort_trace_live` can ban the
+    /// green key on the first panic instead of retrying it.  What the recorder
+    /// panicked on is a property of the jitcode it is walking, not of the values
+    /// this attempt happened to see, so every later attempt at the same key
+    /// reads the same thing and panics again.  RPython has no counterpart: it
+    /// has no panic arm here.
+    pub recorder_panicked: bool,
     /// Set when the walk refused a residual call whose target was still a
     /// symbolic path hash.  A dispatch-arm sub-JitCode may contain an earlier
     /// residual call that already executed concretely, so neither replaying
@@ -1776,6 +1784,7 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
+            recorder_panicked: false,
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
@@ -1875,6 +1884,7 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
+            recorder_panicked: false,
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1122,6 +1122,8 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "inline_frame_trim_blanked_live_int",
                 "confirm_enter_jit_missing_key",
                 "bridge_close_head_target_has_virtual_state",
+                "peel_less_loop_label_is_const_specialized",
+                "segmented_loop_label_is_const_specialized",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1121,6 +1121,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "guard_resume_decline_reserved_identity",
                 "inline_frame_trim_blanked_live_int",
                 "confirm_enter_jit_missing_key",
+                "bridge_close_head_target_has_virtual_state",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Fourteen commits on the JIT metainterpreter, its macro lowerer and the IR, all produced by running aheui's self-interpreter (`aheui.aheui`) under `--jit`. Four of them are why that workload did not terminate; the rest is policy, compile time and per-guard-failure cost found on the way there. Every leg below is byte-identity checked against `--no-jit`, and nothing here changes the aheui corpus output.

The first CI run on this branch was red, in one cause, on all four `pyre/check.py` jobs. It is diagnosed and fixed here; see **What the first CI run caught** below before reading the rest.

### Non-termination and wrong answers

**`macros`: a residual call's argument registers were spelled outside the `__builder` call** — 7d41bb3

`regalloc::BuilderStatementRewriter` recolors integer literals only inside the arguments of a non-aux `__builder` method call. Four ref-returning and two void residual arms bound their `JitCallArg` list to a local first, so those argument registers kept the numbers the lowerer handed out before coloring, while the destination register — spelled inside the call — was recolored. aheui's `queue_push` emitted `residual_call_ir_r alloc_node_jit(i2, i3)` for values held in i1 and i2; i3 is never written, so every trace attempt panicked in `read_canonical_call_args`. `--jit aheui.aheui < quine.aheui` then compiled nothing and did not terminate, and `pi.jinseo.aheui` printed a different digit sequence from the fifth decimal. Corpus divergence against `--no-jit` goes 2 → 1; `pi.jinseo.aheui` 139.8 ms → 29.8 ms. `rewrite_statement` now asserts every register an operation declares was reached by the rewriter, so a statement that spells one elsewhere fails at macro expansion.

**`metainterp`: the bridge close read a raw bucket hash where `compile_loop` reads a resolved cell key** — c6a0ce1

The door read `close_green_key_hash()` and passed it to `has_compiled_targets`, while `compile_loop` puts the same key through `WarmEnterState::resolve_cell_key` first. When a bucket's occupant is filed under a minted cell key the two disagree, so the door reported no target and fell through to a `compile_loop` that refused the resolved key for already having a loop. The guard was left unchanged, so every later failure retraced to the same answer. On `logo.aheui` at `MAJIT_TRACE_LIMIT=12000`: 1024 bridge attempts, `bridges_compiled=0`, 495060 guard failures and no finish within 60 s, against 0.17 s after.

**`metainterp`: a preamble-less loop whose own closing JUMP specializes its single LABEL is refused before its `JitCellToken` exists** — 7532c20

Two paths mint one `TargetToken` with no `virtual_state` and nothing in front of it, so its LABEL is the only entry the key gets: `compile_loop`'s retry for a jitdriver whose `enable_opts` omits `unroll`, mirroring `compile.py compile_simple_loop`, and `compile_simple_loop` itself. `remove_consts_and_duplicates` records a `SAME_AS` for each constant in the merge point's live boxes and the rewrite pass folds it back, so a slot the body never reads leaves as that constant while the LABEL declares a plain box — anything entering with a different value keeps it for one iteration and loses it on the first back edge. The peel is what prevents this, and with `unroll` off there is neither a preamble to fall back to nor a state to match, so the compile is abandoned and `MAX_TRACE_ABORT_COUNT` latches `JC_DONT_TRACE_HERE`.

Measured on the self-interpreted 40col quine with a peel-less `enable_opts` list: before, `MAJIT_MAX_BRIDGES=2000` produced 3743 bytes instead of 4810 and production defaults did not terminate within 90 s; after, both produce 4810, with 351 compiles refused and 16 loops and 8 bridges still compiled. Both new `mc_diag` counters read 0 at production defaults, where `loops_compiled`/`bridges_compiled` are unchanged.

**`metainterp`: ban the green key on the first recorder panic** — 6096770

`abort_trace_live` took `permanent` from its caller alone, so an abort raised by the `catch_unwind` around `run_one_step` was retried until the abort ceiling banned the cell. What the recorder panicked on is a property of the jitcode it walks, not of the values one attempt saw.

**`metainterp`: carry `unroll.py jump_to_preamble`'s assertion into the bridge close** — e9eca31

`compile_trace` points a closing bridge JUMP at `token.target_tokens[0]` unconditionally, which is the take `jump_to_preamble` makes — and that function opens by asserting the head carries no virtual state, because the guards that make a specialized label safe come from `_jump_to_existing_trace`, which this take does not run. All 71 bridge closes on the 40col quine resolve a head with no virtual state, so the new arm is not taken there.

### Policy

**`metainterp`: stop refusing a guard-resume bridge for a guard whose deferred writes span more than one virtual** — badb72b

Upstream has no such refusal: `compile.py ResumeGuardDescr.handle_fail` bridges whenever `must_compile` fires. The refusal was introduced against a double application of the guard's pendingfields, and `d2f627aa218` answered that by moving the decision ahead of `start_bridge_tracing`, where it still sits — a guard admitted there reaches exactly one of `resume.py`'s two readers. The later narrowing to `rd_virtuals.len() > 1` was aimed at wrong answers made at the close, by the loop shape `compile_loop` now declines to compile at all. Default off, with `MAJIT_GUARD_RESUME_REFUSE_PENDING_FIELDS` restoring the refusal in the same binary; setting it reproduces the old counters exactly.

| production defaults, one binary, env-switched | guard failures | bridges |
| --- | --- | --- |
| `aheui.aheui < quine.puzzlet` | 24083 → 15516 (−36%) | 47 → 57 |
| `aheui.aheui < quine.puzzlet.40col` | 72193 → 26420 (−63%) | 89 → 120 |
| `logo.aheui` | 201, unchanged | 1, unchanged |

Same commit: the register-bank snapshot taken before the blackhole resume feeds `guard_may_bridge`, whose only reader takes it under `should_bridge`. Every guard failure the counter had not fired for paid three `to_vec()` copies for a question nobody asks; they are now taken only when `should_bridge` is set.

### Compile time and memory

- **`metainterp`: leave the short-preamble export unbuilt on a simple compile, and hand it the recorded operations** — 0ecd278. `compile.py:271-273` branches to `compile_simple_loop` before `PreambleCompileData` exists, and the short-preamble export and its `ExportedState` belong to `UnrollOptimizer.optimize_preamble`; pyre folded that preview into the shared optimize call, so it ran for a simple compile too and the state was dropped — both readers of `exported_loop_state` are on the retrace path. logo's reported optimization time 33.1 ms → 30.1 ms (min of 9).
- **`metainterp`: skip the unroll input set when the jitdriver disables peeling** — 633acc4. On a 24652-op single-trace compile, peak RSS 128.5 MB → 112.2 MB; a workload whose traces are small shows no change.
- **`metainterp`: read a guard's merge point pc without building the exit layout around it** — 47ca7ca. `get_merge_point_pc` resolved through `get_compiled_exit_layout_in_trace`, which does the same two lookups and then builds a `CompiledExitLayout` out of them — a copy of the exit types, three `Arc` clones, and on the backend arm a `ResumeStorage` reassembled from clones of the fail descriptor's whole `rd_*` pool — all dropped again by a caller after one `u64`. `handle_fail` asks on every reported guard failure.
- **`ir`: probe the `EffectInfo` interner by hash instead of scanning it** — 10ae7bb. The `Vec` answered a probe with six element-wise descr-set comparisons against every cell already interned; `effectinfo.py:14` spells the same interner `_cache = {}` and `:147` probes it with `key in cls._cache`.

### Diagnostics

- `MAJIT_NO_GUARD_RESUME_BRIDGE` — 73cd897. Declines only a bridge entered directly at a guard failure; `MAJIT_NO_BRIDGE` suppresses bridge recording outright and so cannot separate that from a bridge grown from a merge point.
- `MAJIT_SKIP_BRIDGES=a,b,…` — dad2f36. Declines exactly the listed `MAJIT_MAX_BRIDGES` sequence numbers and takes every other one, which is what separates "entry N is what corrupts" from "the corruption is cumulative" — the fuel limit alone cannot, because declining N declines everything after it. The same commit drops a refuted account from `bridge_from_guard_resume_position`'s comment: it blamed the guard-resume entry and named `unroll.py generate_guards` as the repair owed, and `generate_guards` runs only for a target token that has a virtual state.

Both have `majit/gate-triage.md` entries.

### What the first CI run caught

`7532c20` gated its refusal on `retried_without_unroll`, while the comment beside it described the case as "a jitdriver whose `enable_opts` omits `unroll`". The flag is broader: it is also set by the other route into the same retry — the `InvalidLoop` the peeling attempt itself raised, which `compile.py` answers by trying one last time without unrolling. With `max_unroll_loops` at its default 0 (`rlib/jit.py:598`), `cancelled_too_many_times()` is already true on the first cancel, so a frontend that peels reaches the unroll-free compile *only* that way and immediately.

Refusing it left every rescued key aborting to `MAX_TRACE_ABORT_COUNT` and banned. All four `pyre/check.py` jobs failed — 44 dynasm, 45 wasm, 45 cranelift — and the failures classify into one cause:

| count | failure | attribution |
| --- | --- | --- |
| 71 | `jit-stats change — loops_aborted 0 -> ` a multiple of 5 | this branch |
| 8 | exec ratio gate | consequence of the loops lost above |
| 5 | timeout | consequence |
| 4 | `nothing compiled for loop:…` | consequence |
| 1 | `range_step_one_shapes` has no `.wasm.jitstats` / `.cranelift.jitstats` | **not this branch** |

`fannkuch` reached `loops_aborted 0 -> 469, guard_failures 5450 -> 98778`, which is the CodSpeed 3.4 s → 9 s. The mc_diag lines from those runs read `peel_less_loop_label_is_const_specialized=5` beside `unroll_free_retry_rescued=5` and `unroll_cancelled_invalid_loop=0` — that route and no other.

`e699b515` gates on the reason instead: `no_unroll && retried_without_unroll`. Where `enable_opts` carries no `unroll` the shape is every loop the key will ever hold and there is no peeled alternative to fall back to, which is the case the refusal was reasoned about; a rescue after a peel the optimizer rejected is the compile that trace will otherwise not get, and nothing upstream declines it. With `unroll` removed from aheui's `enable_opts` the refusal still fires — `logo.aheui` 5 refusals with `loops_compiled=0`, the self-interpreted 40col quine 452 with `loops_compiled=16`, still printing its 4810 bytes — and at the production default both report 0.

The rerun after `e699b515` confirms it: `pyre/check.py --backend cranelift` went from **45 failed / 490 passed** to **1 failed / 535 passed**, with **zero** reported jit-stats changes and `peel_less_loop_label_is_const_specialized=0`. The one remaining failure is the missing-baseline row.

The last row is a gap on `main`: `0fdcf4a` (#1645) shipped `range_step_one_shapes.dynasm.jitstats` and no wasm or cranelift baseline, and it landed after `main`'s last completed CI run, so this branch is the first to reach it. It is not touched here.

### What this PR does not carry

- **No wall-clock A/B of its own.** The aheui numbers above are counters, byte identity, reported optimization time and peak RSS; the machine was loaded throughout, and a timing run under load grades the load. CodSpeed is the wall-clock instrument that did run.

<sub>— *PR description written by Claude*</sub>

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.
