### PR TITLE
mmap's stale pointer and borrowed pattern after `__index__`, a cloned class namespace, ten getset deleters, and three POSIX-only modules off Windows

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6399,17 +6399,30 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
 }
 
 /// `type_new_set_classcell` / `type_new_set_classdictcell` refuse a namespace
-/// entry that is not a cell.  The offending type is spelled with `%.200R`,
-/// i.e. the repr of the type object rather than its bare name.
+/// entry that is not a cell.  The offending type is spelled with `%.200R`, so
+/// a metaclass `__repr__` renders it — and when that repr raises,
+/// `_PyErr_FormatV` returns without setting the `TypeError`, leaving the
+/// repr's own exception in its place.
 pub(crate) fn cell_slot_type_error(key: &str, value: PyObjectRef) -> crate::PyError {
-    let name = match crate::typedef::r#type(value) {
-        Some(w_valtype) => unsafe {
-            crate::baseobjspace::type_repr_qualified_name(w_valtype.as_ptr())
+    // `%.200R` clips the rendering at 200 code points.
+    const MAX_REPR_CODE_POINTS: usize = 200;
+    let rendered = match crate::typedef::r#type(value) {
+        Some(w_valtype) => match unsafe { crate::display::py_repr_wtf8(w_valtype.as_ptr()) } {
+            Ok(rendered) => rendered,
+            Err(error) => return error,
         },
-        None => crate::error::type_name_of(value),
+        None => rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "<class '{}'>",
+            crate::error::type_name_of(value)
+        )),
     };
-    crate::PyError::type_error(format!(
-        "{key} must be a nonlocal cell, not <class '{name}'>"
+    let mut clipped = rustpython_wtf8::Wtf8Buf::new();
+    for point in rendered.code_points().take(MAX_REPR_CODE_POINTS) {
+        clipped.push(point);
+    }
+    crate::PyError::type_error(crate::display::wtf8_format!(
+        format!("{key} must be a nonlocal cell, not "),
+        clipped
     ))
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6540,7 +6540,27 @@ fn type_descr_new_with_metaclass(
         let _class_ns_root = pyre_object::gc_roots::push_roots();
         let namespace_root = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(w_namespace_dict);
-        let class_ns = pyre_object::w_dict_new();
+        // `type.__new__` accepts any `dict` subclass as the namespace
+        // (the check is `PyDict_Check`, not `PyDict_CheckExact`); resolve
+        // the dict backing so e.g. an `enum._EnumDict` class body is
+        // walked instead of dropped.
+        //
+        // `type_new_init` opens with `PyDict_Copy(ctx->orig_dict)` and then
+        // mutates that one dict, so the scratch namespace is a clone rather
+        // than a per-key refill.  The clone carries each key's cached hash,
+        // where a re-store would call `__hash__` again — running a
+        // side-effecting one an extra time, and dropping the entry outright
+        // once that `__hash__` starts raising, since the store surface cannot
+        // report an error.
+        let backing_root = pyre_object::gc_roots::shadow_stack_len();
+        let w_ns_backing = pyre_object::gc_roots::pin_root(w_ns_backing);
+        let class_ns = if w_ns_backing.is_null() {
+            pyre_object::w_dict_new()
+        } else {
+            unsafe {
+                pyre_object::w_dict_copy(pyre_object::gc_roots::shadow_stack_get(backing_root))
+            }
+        };
         let class_ns_root = pyre_object::gc_roots::shadow_stack_len();
         let class_ns = pyre_object::gc_roots::pin_root(class_ns);
         // type_new_classcell — capture the `__classcell__` cell and keep
@@ -6553,15 +6573,10 @@ fn type_descr_new_with_metaclass(
         // can introduce such a key; every later pass installs descriptors
         // under interned names.
         let mut has_non_string_key = false;
-        // `type.__new__` accepts any `dict` subclass as the namespace
-        // (the check is `PyDict_Check`, not `PyDict_CheckExact`); resolve
-        // the dict backing so e.g. an `enum._EnumDict` class body is
-        // walked instead of dropped.
         let w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(namespace_root);
-        if !w_ns_backing.is_null() {
-            let backing_root = pyre_object::gc_roots::shadow_stack_len();
-            let w_ns_backing = pyre_object::gc_roots::pin_root(w_ns_backing);
-            let items = unsafe { pyre_object::w_dict_items(w_ns_backing) };
+        {
+            let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+            let items = unsafe { pyre_object::w_dict_items(class_ns) };
             let item_root = pyre_object::gc_roots::shadow_stack_len();
             for &(key, value) in &items {
                 let _ = pyre_object::gc_roots::pin_root(key);
@@ -6570,38 +6585,27 @@ fn type_descr_new_with_metaclass(
             for index in 0..items.len() {
                 let key = pyre_object::gc_roots::shadow_stack_get(item_root + index * 2);
                 let value = pyre_object::gc_roots::shadow_stack_get(item_root + index * 2 + 1);
-                let key_text = if unsafe { pyre_object::is_str(key) } {
-                    Some(unsafe { pyre_object::w_str_get_wtf8(key) })
-                } else {
+                if !unsafe { pyre_object::is_str(key) } {
                     has_non_string_key = true;
-                    None
-                };
-                if key_text
-                    .as_ref()
-                    .is_some_and(|key| key.as_str() == Ok("__classcell__"))
-                {
-                    if !unsafe { pyre_object::is_cell(value) } {
-                        return Err(cell_slot_type_error("__classcell__", value));
-                    }
-                    let root = pyre_object::gc_roots::shadow_stack_len();
-                    let _ = pyre_object::gc_roots::pin_root(value);
-                    classcell_root = Some(root);
                     continue;
                 }
-                if key_text
-                    .as_ref()
-                    .is_some_and(|key| key.as_str() == Ok("__classdictcell__"))
-                {
-                    if !unsafe { pyre_object::is_cell(value) } {
-                        return Err(cell_slot_type_error("__classdictcell__", value));
-                    }
-                    let root = pyre_object::gc_roots::shadow_stack_len();
-                    let _ = pyre_object::gc_roots::pin_root(value);
+                let key_text = unsafe { pyre_object::w_str_get_wtf8(key) };
+                let name = match key_text.as_str() {
+                    Ok(name @ ("__classcell__" | "__classdictcell__")) => name,
+                    _ => continue,
+                };
+                if !unsafe { pyre_object::is_cell(value) } {
+                    return Err(cell_slot_type_error(name, value));
+                }
+                let root = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(value);
+                if name == "__classcell__" {
+                    classcell_root = Some(root);
+                } else {
                     classdictcell_root = Some(root);
-                    continue;
                 }
                 let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-                unsafe { pyre_object::w_dict_store(class_ns, key, value) };
+                unsafe { pyre_object::w_dict_delitem_str_no_proxy(class_ns, name) };
             }
         }
         // typeobject.py:ensure_common_attributes / ensure_module_attr.  Direct

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -20016,7 +20016,7 @@ fn eintr_retry(e: std::io::Error) -> Result<(), crate::PyError> {
     eintr_retry_with(e, fd_io_err)
 }
 
-/// PyPy `W_FileIO.direct_read`: perform one raw read of at most `n` bytes.
+/// PyPy `W_FileIO.read_w`: perform one raw read of at most `n` bytes.
 ///
 /// This must not fill the requested size.  A pipe may have one complete line
 /// available while its writer remains open; waiting for the rest of the
@@ -20028,8 +20028,7 @@ fn fd_read(fd: i32, n: usize) -> Result<Option<Vec<u8>>, crate::PyError> {
     // reaches here as a request the allocator cannot meet.  `os.read` sizes
     // its buffer through `rffi.scoped_alloc_buffer`, which raises
     // `MemoryError`; an infallible `vec![0; n]` would abort the process.
-    let mut out = try_vec_with_capacity::<u8>(n)?;
-    out.resize(n, 0);
+    let mut out = try_vec_zeroed(n)?;
     loop {
         let got = match fd_read_into(fd, &mut out) {
             Ok(got) => got,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -5556,37 +5556,23 @@ fn build_class_inner(
         crate::builtins::type_new_set_hash_if_eq(class_ns);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         crate::builtins::type_new_wrap_special_methods(class_ns);
-        let dict_root = pyre_object::gc_roots::shadow_stack_len();
-        let dict_obj = pyre_object::w_dict_new();
-        let dict_obj = pyre_object::gc_roots::pin_root(dict_obj);
         // `PyDict_Copy(ctx->orig_dict)` — the class dict is the namespace as
-        // the body left it, keys of every type included.  The pairs sit in a
-        // native Vec the collector does not walk while each store hashes its
-        // own key and may grow the destination, so they are rooted and read
-        // back one at a time.
+        // the body left it, keys of every type included.  The clone carries
+        // each key's cached hash across, where a per-key re-store would call
+        // `__hash__` again — running a side-effecting one an extra time, and
+        // dropping the entry outright once that `__hash__` starts raising,
+        // because the store surface cannot report an error.
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
-        let entries = unsafe { pyre_object::w_dict_items(class_ns) };
-        let mut has_non_string_key = false;
-        {
-            let _entry_roots = pyre_object::gc_roots::push_roots();
-            let entry_root = pyre_object::gc_roots::shadow_stack_len();
-            for &(key, value) in &entries {
-                let _ = pyre_object::gc_roots::pin_root(key);
-                let _ = pyre_object::gc_roots::pin_root(value);
-            }
-            for index in 0..entries.len() {
-                let key = pyre_object::gc_roots::shadow_stack_get(entry_root + index * 2);
-                let value = pyre_object::gc_roots::shadow_stack_get(entry_root + index * 2 + 1);
-                if value.is_null() {
-                    continue;
-                }
-                if !unsafe { pyre_object::is_str(key) } {
-                    has_non_string_key = true;
-                }
-                let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
-                unsafe { pyre_object::w_dict_store(dict_obj, key, value) };
-            }
-        }
+        let dict_root = pyre_object::gc_roots::shadow_stack_len();
+        let dict_obj = unsafe { pyre_object::w_dict_copy(class_ns) };
+        let dict_obj = pyre_object::gc_roots::pin_root(dict_obj);
+        // `_PyDict_HasOnlyStringKeys(type->tp_dict)` decides the
+        // `RuntimeWarning` reported below; reading the keys answers it
+        // without hashing any of them.
+        let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
+        let has_non_string_key = unsafe { pyre_object::w_dict_items(class_ns) }
+            .iter()
+            .any(|&(key, _)| !unsafe { pyre_object::is_str(key) });
         let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
         // Slot creation, C3 validation and `__set_name__` below all allocate
         // and can execute Python; the nascent type has no other referrer

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -614,7 +614,7 @@ fn finish_init(
     // before the uninitialized-object one, so a module that both left an
     // exception set and came back untyped is reported as the raise.
     if let Some(pending) = pyerrors::take_pending_error() {
-        return Err(system_error_from_cause(
+        return Err(crate::error::system_error_from_cause(
             format!("initialization of {name} raised unreported exception"),
             pending,
         ));
@@ -870,33 +870,6 @@ pub(super) fn from_c_result(result: *mut CPyObject) -> Result<PyObjectRef, crate
     let value = unsafe { pyobject::from_ref(result) };
     unsafe { pyobject::decref(result) };
     Ok(value)
-}
-
-/// `_PyErr_FormatFromCause`: a `SystemError` carrying `cause` as both its
-/// `__context__` and its `__cause__`.
-///
-/// An extension that reported success while leaving an exception set has
-/// already lost the raise site, so the exception it left behind is the only
-/// description of what went wrong and is chained onto the report rather than
-/// discarded.
-pub(super) fn system_error_from_cause(
-    message: String,
-    mut cause: crate::PyError,
-) -> crate::PyError {
-    let roots = pyre_object::gc_roots::push_roots();
-    let cause_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(cause.to_exc_object());
-    let mut error = crate::PyError::new(crate::PyErrorKind::SystemError, message);
-    let error_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(error.to_exc_object());
-    let w_cause = pyre_object::gc_roots::shadow_stack_get(cause_slot);
-    let w_error = pyre_object::gc_roots::shadow_stack_get(error_slot);
-    unsafe {
-        pyre_object::interp_exceptions::w_exception_set_context(w_error, w_cause);
-        pyre_object::interp_exceptions::w_exception_set_cause(w_error, w_cause);
-        pyre_object::interp_exceptions::w_exception_set_suppress_context(w_error, true);
-    }
-    unsafe { crate::PyError::from_exc_object(w_error) }
 }
 
 /// `_imp.exec_dynamic` — PyPy `cpyext/api.py:exec_extension_module`.

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -735,7 +735,7 @@ pub(super) fn create_module_from_def_and_spec(
             && let Some(pending) = pyerrors::take_pending_error()
         {
             unsafe { pyobject::decref(result) };
-            return Err(super::system_error_from_cause(
+            return Err(crate::error::system_error_from_cause(
                 format!("creation of module {name} raised unreported exception"),
                 pending,
             ));
@@ -834,7 +834,7 @@ fn exec_def_of(module: PyObjectRef, def: *mut CPyModuleDef) -> Result<(), crate:
                 }));
             }
             if let Some(pending) = pyerrors::take_pending_error() {
-                return Err(super::system_error_from_cause(
+                return Err(crate::error::system_error_from_cause(
                     format!(
                         "execution of module {} raised unreported exception",
                         text_or_empty(unsafe { (*def).m_name })

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -338,6 +338,31 @@ fn _break_context_cycle(w_value: PyObjectRef, w_context: PyObjectRef) -> Result<
     Ok(())
 }
 
+/// `_PyErr_FormatFromCause`: a `SystemError` carrying `cause` as both its
+/// `__context__` and its `__cause__`.
+///
+/// A callee that reported success while leaving an exception set has already
+/// lost the raise site, so the exception it left behind is the only
+/// description of what went wrong and is chained onto the report rather than
+/// discarded.  `_Py_CheckFunctionResult` raises through here, and so does the
+/// C-API shim's own success-with-exception check.
+pub(crate) fn system_error_from_cause(message: String, mut cause: PyError) -> PyError {
+    let roots = pyre_object::gc_roots::push_roots();
+    let cause_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(cause.to_exc_object());
+    let mut error = PyError::new(PyErrorKind::SystemError, message);
+    let error_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(error.to_exc_object());
+    let w_cause = pyre_object::gc_roots::shadow_stack_get(cause_slot);
+    let w_error = pyre_object::gc_roots::shadow_stack_get(error_slot);
+    unsafe {
+        pyre_object::interp_exceptions::w_exception_set_context(w_error, w_cause);
+        pyre_object::interp_exceptions::w_exception_set_cause(w_error, w_cause);
+        pyre_object::interp_exceptions::w_exception_set_suppress_context(w_error, true);
+    }
+    unsafe { PyError::from_exc_object(w_error) }
+}
+
 /// Record `active` as `exc.__context__` when `exc` is raised while `active`
 /// is the exception currently being handled — the shared primitive for both
 /// explicit (`raise`) and implicit (builtin/operator) raises.  Only writes

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -818,8 +818,18 @@ pub fn install_builtin_modules() {
             not(target_arch = "wasm32")
         ))]
         pyre_install_module!(_cffi_backend);
-        #[cfg(not(target_arch = "wasm32"))]
+        // Both are POSIX-only upstream, and their callers know it:
+        // `shared_memory.py` and `resource_tracker.py` import `_posixshmem`
+        // only in their `os.name != 'nt'` arm, and `subprocess.py` imports
+        // `_posixsubprocess` only in the `else` of `if _mswindows`.  PyPy's
+        // pypyoption drops `_posixsubprocess` from `working_modules` on
+        // win32 and builds `_posixshmem` as a cffi shim that Windows never
+        // gets.  Registering an empty module here instead flips availability
+        // probes such as `test_audit`'s `import_module("_posixsubprocess")`
+        // from skip to run.
+        #[cfg(unix)]
         pyre_install_module!(_posixshmem);
+        #[cfg(unix)]
         pyre_install_module!(_posixsubprocess);
         pyre_install_module!(_multiprocessing);
     }
@@ -868,6 +878,10 @@ pub fn install_builtin_modules() {
     register_builtin_module("_string", init_string_module);
     register_builtin_module("_tracemalloc", init_tracemalloc);
     register_builtin_module("_sysconfig", init_sysconfig_stub);
+    // `_get_sysconfigdata` is reached only from `_init_posix`, which
+    // `sysconfig` runs when `os.name == 'posix'`; a Windows run takes
+    // `_init_non_posix` and never names this module.
+    #[cfg(not(windows))]
     register_builtin_module("_sysconfigdata", init_sysconfigdata);
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -98,7 +98,7 @@ fn init_cfuncptr_type(ns: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("restype", restype_getter, 2),
             crate::make_builtin_function_with_arity("restype", restype_setter, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity("restype", restype_deleter, 2),
             "restype",
         ),
     );
@@ -108,7 +108,7 @@ fn init_cfuncptr_type(ns: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("argtypes", argtypes_getter, 2),
             crate::make_builtin_function_with_arity("argtypes", argtypes_setter, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity("argtypes", argtypes_deleter, 2),
             "argtypes",
         ),
     );
@@ -669,6 +669,14 @@ fn restype_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(pyre_object::w_none())
 }
 
+/// `_ctypes_CFuncPtr_restype_set_impl`'s `value == NULL` branch clears both
+/// `restype` and the `_check_retval_` checker it was derived from, leaving the
+/// getter to answer from the class again.
+fn restype_deleter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    instance_del(args[1], RESTYPE_KEY);
+    Ok(pyre_object::w_none())
+}
+
 fn argtypes_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let obj = args[1];
     if let Some(v) = instance_get(obj, ARGTYPES_KEY) {
@@ -699,6 +707,13 @@ fn argtypes_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     Ok(pyre_object::w_none())
 }
 
+/// `_ctypes_CFuncPtr_argtypes_set_impl` treats a NULL operand exactly as it
+/// treats `None`: the argtypes and their converters are cleared.
+fn argtypes_deleter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    instance_del(args[1], ARGTYPES_KEY);
+    Ok(pyre_object::w_none())
+}
+
 fn errcheck_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(instance_get(args[1], ERRCHECK_KEY).unwrap_or_else(pyre_object::w_none))
 }
@@ -718,15 +733,22 @@ fn errcheck_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 }
 
 fn errcheck_deleter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let d = crate::baseobjspace::getdict_native(args[1]);
-    if !d.is_null() {
-        // Deleting one that was never set is not an error.
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_delitem_str(d, ERRCHECK_KEY);
-            drop_settled(d);
-        }
-    }
+    instance_del(args[1], ERRCHECK_KEY);
     Ok(pyre_object::w_none())
+}
+
+/// Drop one of the per-instance slots a [`CallPlan`] is settled from.  Every
+/// key here reaches the plan, so the delete drops it the way [`instance_set`]
+/// does; deleting one that was never set is not an error.
+fn instance_del(obj: PyObjectRef, key: &str) {
+    let d = crate::baseobjspace::getdict_native(obj);
+    if d.is_null() {
+        return;
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_delitem_str(d, key);
+        drop_settled(d);
+    }
 }
 
 /// Reject keyword arguments: ctypes foreign calls and `_CFuncPtr(...)` take

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -248,7 +248,7 @@ fn install_shared_meta(ns: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("__pointer_type__", pointer_type_get, 2),
             crate::make_builtin_function_with_arity("__pointer_type__", pointer_type_set, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity("__pointer_type__", pointer_type_del, 2),
             "__pointer_type__",
         ),
     );
@@ -259,6 +259,11 @@ fn install_shared_meta(ns: PyObjectRef) {
     );
 }
 
+/// No `fdel`: upstream `_fields_` is an ordinary class attribute that
+/// `_structunion_setattro` intercepts on the way through `tp_setattro`, so a
+/// delete there re-runs `PyCStructUnionType_update_stginfo` and then removes
+/// the class-dict entry.  Reproducing that needs the setattro hook this getset
+/// stands in for, not a deleter.
 fn install_fields_getset(ns: PyObjectRef) {
     type_ns_store(
         ns,
@@ -400,7 +405,15 @@ fn init_pointer_base(ns: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("contents", contents_get, 2),
             crate::make_builtin_function_with_arity("contents", contents_set, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity(
+                "contents",
+                |_args| {
+                    Err(crate::PyError::type_error(
+                        "Pointer does not support item deletion",
+                    ))
+                },
+                2,
+            ),
             "contents",
         ),
     );
@@ -1121,16 +1134,51 @@ fn meta_from_param(args: &[PyObjectRef]) -> PyResult {
     Ok(args.get(1).copied().unwrap_or_else(pyre_object::w_none))
 }
 
+/// `%R must have storage info`: `ctype_get_pointer_type` and
+/// `ctype_set_pointer_type` open with this refusal, and the setter is what
+/// serves a delete.
+fn no_storage_info(cls: PyObjectRef) -> crate::PyError {
+    let rendered = match unsafe { crate::display::py_repr_wtf8(cls) } {
+        Ok(rendered) => rendered,
+        Err(error) => return error,
+    };
+    crate::PyError::type_error(crate::display::wtf8_format!(
+        rendered,
+        " must have storage info"
+    ))
+}
+
 fn pointer_type_get(args: &[PyObjectRef]) -> PyResult {
     let cls = args[1];
-    if let Some(info) = stginfo::stginfo_of(cls)
-        && let Some(pt) = stginfo::stginfo_pointer_type(info)
-    {
+    // `ctype_get_pointer_type` splits the two absences: a class with no
+    // storage info at all is the `TypeError` above, and one whose
+    // `pointer_type` is unset names itself with `%R`.
+    let Some(info) = stginfo::stginfo_of(cls) else {
+        return Err(no_storage_info(cls));
+    };
+    if let Some(pt) = stginfo::stginfo_pointer_type(info) {
         return Ok(pt);
     }
+    let rendered = unsafe { crate::display::py_repr_wtf8(cls) }?;
     Err(crate::PyError::attribute_error(
-        "type has no attribute '__pointer_type__'",
+        crate::display::wtf8_format!(rendered, " has no attribute '__pointer_type__'"),
     ))
+}
+
+/// The setter's operand reaches `Py_XSETREF` unchecked, so deleting clears
+/// the cached pointer type and the next read reports it absent again.
+/// `stginfo_pointer_type` spells absence as `None`, which is what the clear
+/// stores; a raw null would instead read back as a getter that answered
+/// nothing, and the attribute machinery would fall through to the descriptor.
+fn pointer_type_del(args: &[PyObjectRef]) -> PyResult {
+    let cls = args[1];
+    match stginfo::stginfo_of(cls) {
+        Some(info) => {
+            stginfo::stginfo_set_pointer_type(info, pyre_object::w_none());
+            Ok(pyre_object::w_none())
+        }
+        None => Err(no_storage_info(cls)),
+    }
 }
 
 fn pointer_type_set(args: &[PyObjectRef]) -> PyResult {
@@ -1141,9 +1189,7 @@ fn pointer_type_set(args: &[PyObjectRef]) -> PyResult {
             stginfo::stginfo_set_pointer_type(info, value);
             Ok(pyre_object::w_none())
         }
-        None => Err(crate::PyError::attribute_error(
-            "cannot set '__pointer_type__'",
-        )),
+        None => Err(no_storage_info(cls)),
     }
 }
 
@@ -2192,7 +2238,11 @@ fn install_char_array_getsets(cls: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("raw", char_array_get_raw, 2),
             crate::make_builtin_function_with_arity("raw", char_array_set_raw, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity(
+                "raw",
+                |_args| Err(crate::PyError::attribute_error("cannot delete attribute")),
+                2,
+            ),
             "raw",
         ),
     );
@@ -2253,7 +2303,11 @@ fn install_wchar_array_getsets(cls: PyObjectRef) {
         crate::typedef::make_getset_property_named(
             crate::make_builtin_function_with_arity("value", wchar_array_get_value, 2),
             crate::make_builtin_function_with_arity("value", wchar_array_set_value, 3),
-            pyre_object::PY_NULL,
+            crate::make_builtin_function_with_arity(
+                "value",
+                |_args| Err(crate::PyError::type_error("can't delete attribute")),
+                2,
+            ),
             "value",
         ),
     );

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -214,10 +214,20 @@ impl W_BufferedReader {
     /// in a memoryview, and `_raw_read` wraps a `SubBuffer` of the destination
     /// in a `SimpleView`; either way the read lands where the caller wants it
     /// and no second buffer is allocated or copied through.
-    fn raw_read(&mut self, dest: *mut u8, length: usize) -> Result<usize, crate::PyError> {
+    fn raw_read(
+        &mut self,
+        w_owner: PyObjectRef,
+        dest: *mut u8,
+        length: usize,
+    ) -> Result<usize, crate::PyError> {
         let _roots = pyre_object::gc_roots::push_roots();
         let _ = pyre_object::gc_roots::pin_root(self.self_obj());
-        let sp = pyre_object::gc_roots::shadow_stack_len() - 1;
+        // `SubBuffer(buffer, start, length)` holds the destination buffer
+        // itself, so the storage `dest` names outlives the `readinto` even
+        // when the call reassigns the field it was read from.  `dest` is a
+        // bare address, so the owner is rooted here instead.
+        let _ = pyre_object::gc_roots::pin_root(w_owner);
+        let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let _ = pyre_object::gc_roots::pin_root(crate::builtins::w_memoryview_new_raw_window(
             dest as usize,
             length,
@@ -225,12 +235,12 @@ impl W_BufferedReader {
         let outcome = super::call_method_result(
             self.w_raw,
             "readinto",
-            &[pyre_object::gc_roots::shadow_stack_get(sp + 1)],
+            &[pyre_object::gc_roots::shadow_stack_get(sp + 2)],
         );
         // The window names memory this call borrowed, so it is closed whatever
         // the outcome rather than left writable to a raw stream that kept it.
         let _ =
-            crate::builtins::memoryview_release(&[pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
+            crate::builtins::memoryview_release(&[pyre_object::gc_roots::shadow_stack_get(sp + 2)]);
         let result = outcome?;
         if unsafe { pyre_object::is_none(result) } {
             return Err(make_blocking_error());
@@ -254,7 +264,7 @@ impl W_BufferedReader {
         let dest = unsafe {
             pyre_object::bytearrayobject::w_bytearray_data_mut(self.buffer)[start..].as_mut_ptr()
         };
-        let size = self.raw_read(dest, length)?;
+        let size = self.raw_read(self.buffer, dest, length)?;
         if size > 0 {
             self.read_end = (start + size) as i64;
             self.raw_pos = self.read_end;
@@ -364,10 +374,11 @@ impl W_BufferedReader {
             // `out + written`: the whole reservation above is the destination,
             // so the block lands in it with nothing copied afterwards.  The
             // reservation is exact and never exceeded, so the pointer stays
-            // valid for every pass.
+            // valid for every pass, and no Python object names it for the
+            // raw stream to drop.
             let written = output.len();
             let dest = unsafe { output.as_mut_ptr().add(written) };
-            let size = match self.raw_read(dest, block) {
+            let size = match self.raw_read(pyre_object::w_none(), dest, block) {
                 Ok(size) => size,
                 Err(error) if is_blocking_error(&error) => {
                     return if output.is_empty() {
@@ -458,15 +469,17 @@ impl W_BufferedReader {
                     let requested = size as usize;
                     // `_io__Buffered_read1_impl` allocates the whole request
                     // with `PyBytes_FromStringAndSize(NULL, n)` and fills it
-                    // from a single raw read.
+                    // from a single raw read.  The reservation is local, so
+                    // there is no owner for the raw stream to drop.
                     let mut out = crate::builtins::try_vec_with_capacity::<u8>(requested)?;
-                    let read = match this.raw_read(out.as_mut_ptr(), requested) {
-                        Ok(read) => read,
-                        // `r == -2` there -- the raw stream would have blocked
-                        // -- is read as zero bytes, not as an error.
-                        Err(error) if is_blocking_error(&error) => 0,
-                        Err(error) => return Err(error),
-                    };
+                    let read =
+                        match this.raw_read(pyre_object::w_none(), out.as_mut_ptr(), requested) {
+                            Ok(read) => read,
+                            // `r == -2` there -- the raw stream would have blocked
+                            // -- is read as zero bytes, not as an error.
+                            Err(error) if is_blocking_error(&error) => 0,
+                            Err(error) => return Err(error),
+                        };
                     unsafe { out.set_len(read) };
                     return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&out));
                 }
@@ -523,9 +536,10 @@ impl W_BufferedReader {
                 if remaining > this.buffer_size as usize {
                     // `_buffered_readinto_generic` reads into
                     // `buf.buf + written`, so the raw stream fills the caller's
-                    // own buffer and nothing is copied afterwards.
+                    // own buffer and nothing is copied afterwards.  `target`
+                    // roots that buffer's owner for its whole lease.
                     let dest = (unsafe { target.as_mut_slice() })[written..].as_mut_ptr();
-                    let size = match this.raw_read(dest, remaining) {
+                    let size = match this.raw_read(pyre_object::w_none(), dest, remaining) {
                         Ok(size) => size,
                         Err(error) if is_blocking_error(&error) => break,
                         Err(error) => return Err(error),

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -158,10 +158,20 @@ impl W_BufferedRandom {
         Ok(pos)
     }
 
-    fn raw_read(&mut self, dest: *mut u8, length: usize) -> Result<usize, crate::PyError> {
+    fn raw_read(
+        &mut self,
+        w_owner: PyObjectRef,
+        dest: *mut u8,
+        length: usize,
+    ) -> Result<usize, crate::PyError> {
         let _roots = pyre_object::gc_roots::push_roots();
         let _ = pyre_object::gc_roots::pin_root(self.self_obj());
-        let sp = pyre_object::gc_roots::shadow_stack_len() - 1;
+        // `SubBuffer(buffer, start, length)` holds the destination buffer
+        // itself, so the storage `dest` names outlives the `readinto` even
+        // when the call reassigns the field it was read from.  `dest` is a
+        // bare address, so the owner is rooted here instead.
+        let _ = pyre_object::gc_roots::pin_root(w_owner);
+        let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let _ = pyre_object::gc_roots::pin_root(crate::builtins::w_memoryview_new_raw_window(
             dest as usize,
             length,
@@ -169,12 +179,12 @@ impl W_BufferedRandom {
         let outcome = super::call_method_result(
             self.w_raw,
             "readinto",
-            &[pyre_object::gc_roots::shadow_stack_get(sp + 1)],
+            &[pyre_object::gc_roots::shadow_stack_get(sp + 2)],
         );
         // The window names memory this call borrowed, so it is closed whatever
         // the outcome rather than left writable to a raw stream that kept it.
         let _ =
-            crate::builtins::memoryview_release(&[pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
+            crate::builtins::memoryview_release(&[pyre_object::gc_roots::shadow_stack_get(sp + 2)]);
         let result = outcome?;
         if unsafe { pyre_object::is_none(result) } {
             return Err(super::buffered::make_blocking_error());
@@ -198,7 +208,7 @@ impl W_BufferedRandom {
         let dest = unsafe {
             pyre_object::bytearrayobject::w_bytearray_data_mut(self.buffer)[start..].as_mut_ptr()
         };
-        let size = self.raw_read(dest, length)?;
+        let size = self.raw_read(self.buffer, dest, length)?;
         if size > 0 {
             self.read_end = (start + size) as i64;
             self.raw_pos = self.read_end;
@@ -457,10 +467,11 @@ impl W_BufferedRandom {
             // `out + written`: the whole reservation above is the destination,
             // so the block lands in it with nothing copied afterwards.  The
             // reservation is exact and never exceeded, so the pointer stays
-            // valid for every pass.
+            // valid for every pass, and no Python object names it for the
+            // raw stream to drop.
             let written = output.len();
             let dest = unsafe { output.as_mut_ptr().add(written) };
-            let size = match self.raw_read(dest, block) {
+            let size = match self.raw_read(pyre_object::w_none(), dest, block) {
                 Ok(size) => size,
                 Err(error) if super::buffered::is_blocking_error(&error) => {
                     return if output.is_empty() {
@@ -549,15 +560,17 @@ impl W_BufferedRandom {
                     let requested = size as usize;
                     // `_io__Buffered_read1_impl` allocates the whole request
                     // with `PyBytes_FromStringAndSize(NULL, n)` and fills it
-                    // from a single raw read.
+                    // from a single raw read.  The reservation is local, so
+                    // there is no owner for the raw stream to drop.
                     let mut out = crate::builtins::try_vec_with_capacity::<u8>(requested)?;
-                    let read = match this.raw_read(out.as_mut_ptr(), requested) {
-                        Ok(read) => read,
-                        // `r == -2` there -- the raw stream would have blocked
-                        // -- is read as zero bytes, not as an error.
-                        Err(error) if super::buffered::is_blocking_error(&error) => 0,
-                        Err(error) => return Err(error),
-                    };
+                    let read =
+                        match this.raw_read(pyre_object::w_none(), out.as_mut_ptr(), requested) {
+                            Ok(read) => read,
+                            // `r == -2` there -- the raw stream would have blocked
+                            // -- is read as zero bytes, not as an error.
+                            Err(error) if super::buffered::is_blocking_error(&error) => 0,
+                            Err(error) => return Err(error),
+                        };
                     unsafe { out.set_len(read) };
                     return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&out));
                 }
@@ -612,9 +625,10 @@ impl W_BufferedRandom {
                 if remaining > this.buffer_size as usize {
                     // `_buffered_readinto_generic` reads into
                     // `buf.buf + written`, so the raw stream fills the caller's
-                    // own buffer and nothing is copied afterwards.
+                    // own buffer and nothing is copied afterwards.  `target`
+                    // roots that buffer's owner for its whole lease.
                     let dest = (unsafe { target.as_mut_slice() })[written..].as_mut_ptr();
-                    let size = match this.raw_read(dest, remaining) {
+                    let size = match this.raw_read(pyre_object::w_none(), dest, remaining) {
                         Ok(size) => size,
                         Err(error) if super::buffered::is_blocking_error(&error) => break,
                         Err(error) => return Err(error),

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -1621,13 +1621,17 @@ proxy_binary!(proxy_floordiv, crate::baseobjspace::floordiv);
 proxy_binary_reflected!(proxy_rfloordiv, crate::baseobjspace::floordiv);
 proxy_binary!(proxy_mod, crate::baseobjspace::mod_);
 proxy_binary_reflected!(proxy_rmod, crate::baseobjspace::mod_);
-// pow / rpow — interp__weakref.py:363 generates a 3-arg wrapper because
-// `('pow', '**', 3, ['__pow__', '__rpow__'])` has arity=3 but
-// `forcing_count = len(special_methods) = 2`, so the optional modulo
-// operand passes through unforced. The two-arg form hands off to
-// `space.pow`, whose forward/reverse dance lets `__rpow__` answer; the
-// three-arg form hands off to `space.pow3`, which consults only the
-// forward `__pow__` (descroperation.py:450) and never the reflected slot.
+// pow / rpow — the `ObjSpace.MethodTable` loop in interp__weakref.py
+// generates a 3-arg wrapper from
+// `('pow', '**', 3, ['__pow__', '__rpow__'])`, whose
+// `forcing_count = len(special_methods) = 2` leaves the optional modulo
+// operand unforced. `WRAP_TERNARY` dereferences it whenever it is present,
+// so a proxy modulus reaches the slot as its referent and a dead one raises
+// `ReferenceError`; that is what `proxy_pow_modulus` below restores. The
+// two-arg form hands off to `space.pow`, whose forward/reverse dance lets
+// `__rpow__` answer; the three-arg form hands off to `space.pow3`, which
+// consults only the forward `__pow__` (`DescrOperation.pow`) and never the
+// reflected slot.
 /// `wrap_ternaryfunc`'s count check, written here rather than declared at the
 /// registration: the modulo operand is optional, so the slice is two or three
 /// long and there is no single arity for the gateway to enforce.  Without it
@@ -1642,14 +1646,24 @@ fn proxy_pow_arity(args: &[PyObjectRef]) -> Result<(), PyError> {
     Ok(())
 }
 
+/// `WRAP_TERNARY`'s `if (w != NULL) { UNWRAP(w); }`.  The dereference comes
+/// before the `None` test, so a dead proxy modulus raises `ReferenceError`
+/// rather than being read as "no modulus".
+fn proxy_pow_modulus(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
+    if args.len() < 3 || args[2].is_null() {
+        return Ok(PY_NULL);
+    }
+    force(args[2])
+}
+
 pub fn proxy_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     proxy_pow_arity(args)?;
     let w_obj0 = force(args[0])?;
     let w_obj1 = force(args[1])?;
-    let has_modulo =
-        args.len() >= 3 && !args[2].is_null() && !unsafe { pyre_object::is_none(args[2]) };
+    let w_obj2 = proxy_pow_modulus(args)?;
+    let has_modulo = !w_obj2.is_null() && !unsafe { pyre_object::is_none(w_obj2) };
     if has_modulo {
-        crate::baseobjspace::pow3(w_obj0, w_obj1, args[2])
+        crate::baseobjspace::pow3(w_obj0, w_obj1, w_obj2)
     } else {
         crate::baseobjspace::pow(w_obj0, w_obj1)
     }
@@ -1661,10 +1675,10 @@ pub fn proxy_rpow(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     // two operands; the modulo argument keeps its slot.
     let w_obj0 = force(args[0])?;
     let w_obj1 = force(args[1])?;
-    let has_modulo =
-        args.len() >= 3 && !args[2].is_null() && !unsafe { pyre_object::is_none(args[2]) };
+    let w_obj2 = proxy_pow_modulus(args)?;
+    let has_modulo = !w_obj2.is_null() && !unsafe { pyre_object::is_none(w_obj2) };
     if has_modulo {
-        crate::baseobjspace::pow3(w_obj1, w_obj0, args[2])
+        crate::baseobjspace::pow3(w_obj1, w_obj0, w_obj2)
     } else {
         crate::baseobjspace::pow(w_obj1, w_obj0)
     }
@@ -2639,9 +2653,8 @@ mod tests {
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 20);
     }
 
-    /// `__pow__` is a 3-arg row in MethodTable. The wrapper must force
-    /// the first two operands and pass the optional modulo through
-    /// unchanged — PyPy's `forcing_count = len(special_methods) = 2`.
+    /// `__pow__` is a 3-arg row in MethodTable, but the slice reaching the
+    /// wrapper is two long when no modulus is given.
     #[test]
     fn test_proxy_pow_two_arg_form() {
         let _g = super::lock_proxy_tests();
@@ -2651,6 +2664,45 @@ mod tests {
         // 2-arg form: 2 ** 8 == 256
         let result = proxy_pow(&[proxy, pyre_object::w_int_new(8)]).unwrap();
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 256);
+    }
+
+    /// `WRAP_TERNARY` dereferences the modulo operand, so `pow` sees the
+    /// referent and not the proxy: `pow(2, 8, proxy_to_100) == 56`.
+    #[test]
+    fn test_proxy_pow_forces_modulus() {
+        let _g = super::lock_proxy_tests();
+        crate::typedef::init_typeobjects();
+        let modulus = W_Proxy_new(pyre_object::w_int_new(100), PY_NULL);
+        let proxy = W_Proxy_new(pyre_object::w_int_new(2), PY_NULL);
+        let result = proxy_pow(&[proxy, pyre_object::w_int_new(8), modulus]).unwrap();
+        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 56);
+        // Reflected wrapper swaps only the first two operands.
+        let modulus = W_Proxy_new(pyre_object::w_int_new(100), PY_NULL);
+        let proxy = W_Proxy_new(pyre_object::w_int_new(8), PY_NULL);
+        let result = proxy_rpow(&[proxy, pyre_object::w_int_new(2), modulus]).unwrap();
+        assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 56);
+    }
+
+    /// A dead modulo proxy is dereferenced before the `None` test, so it
+    /// raises `ReferenceError` instead of reading as "no modulus".
+    #[test]
+    fn test_proxy_pow_dead_modulus_raises_reference_error() {
+        let _g = super::lock_proxy_tests();
+        crate::typedef::init_typeobjects();
+        let dead = W_Proxy_new(pyre_object::w_none(), PY_NULL);
+        write_attr(dead, ATTR_W_OBJ_WEAK, pyre_object::w_none());
+        for wrapper in [
+            proxy_pow as fn(&[PyObjectRef]) -> Result<PyObjectRef, PyError>,
+            proxy_rpow,
+        ] {
+            let proxy = W_Proxy_new(pyre_object::w_int_new(2), PY_NULL);
+            let err = wrapper(&[proxy, pyre_object::w_int_new(8), dead]).unwrap_err();
+            assert_eq!(err.kind, crate::PyErrorKind::ReferenceError);
+            assert_eq!(
+                err.message_text(),
+                "weakly-referenced object no longer exists"
+            );
+        }
     }
 
     /// pypy/interpreter/baseobjspace.py — `__instancecheck__`

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -900,40 +900,53 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 return Err(crate::PyError::type_error("find() missing pattern"));
             }
             let obj = args[0];
-            let (p, len) = mmap_ptr(obj)?;
+            let (_, len_at_entry) = mmap_ptr(obj)?;
+            // `interp_mmap.py find` is handed `space.bufferstr_w(w_tofind)`, a
+            // copy.  The pattern's own storage is not held across the
+            // `getindex_w` calls below: a `bytearray` pattern reallocated by
+            // one of their `__index__` hooks would leave a borrowed slice
+            // naming freed memory.
             let needle = unsafe {
                 if !pyre_object::bytesobject::is_bytes_like(args[1]) {
                     return Err(crate::PyError::type_error(
                         "find: pattern must be bytes-like",
                     ));
                 }
-                pyre_object::bytesobject::bytes_like_data(args[1])
+                pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
             };
             // `interp_mmap.py find(w_tofind, w_start=None,
             // w_end=None)` defaults w_start to `self.mmap.pos` then
             // routes through rmmap.find which handles negative start /
             // end by adding `size` and clamping to 0.
             let cur = mmap_get_attr_i64(obj, "_pos") as usize;
-            let start = if args.len() >= 3 {
-                let s = mmap_index_w(obj, args[2])?;
-                if s < 0 {
-                    ((s + len as i64).max(0)) as usize
-                } else {
-                    (s as usize).min(len)
-                }
-            } else {
-                cur
+            let start_raw = match args.get(2) {
+                Some(&value) => Some(mmap_index_w(obj, value)?),
+                None => None,
             };
-            let end = if args.len() >= 4 {
-                let e = mmap_index_w(obj, args[3])?;
-                if e < 0 {
-                    ((e + len as i64).max(0)) as usize
-                } else {
-                    (e as usize).min(len)
-                }
-            } else {
-                len
+            let end_raw = match args.get(3) {
+                Some(&value) => Some(mmap_index_w(obj, value)?),
+                None => None,
             };
+            // `rmmap.find` reads `self.data` and `self.size` at this point,
+            // after the `check_valid()` that follows `getindex_w`: an
+            // `__index__` above is free to `resize()` the mapping, which
+            // installs a new view at a new address.  Both the pointer and
+            // every bound are therefore taken from the mapping as it is now.
+            let (p, len) = mmap_ptr(obj)?;
+            let clamp = |v: i64| {
+                if v < 0 {
+                    ((v + len as i64).max(0)) as usize
+                } else {
+                    (v as usize).min(len)
+                }
+            };
+            let start = start_raw.map_or_else(|| cur.min(len), clamp);
+            // [3.14-spec] `mmap_gfind_lock_held` evaluates `end = self->size`
+            // at entry and the clamp below it only ever lowers the value, so a
+            // mapping grown by one of the conversions above keeps the size it
+            // had on the way in.  `interp_mmap.py find` reads `self.mmap.size`
+            // after the start conversion instead, which reports the new one.
+            let end = end_raw.map_or_else(|| len_at_entry.min(len), clamp);
             if start > end {
                 return Ok(pyre_object::w_int_new(-1));
             }
@@ -945,7 +958,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 return Ok(pyre_object::w_int_new(-1));
             }
             let pos = (0..=hay.len().saturating_sub(needle.len()))
-                .find(|&i| &hay[i..i + needle.len()] == needle)
+                .find(|&i| &hay[i..i + needle.len()] == needle.as_slice())
                 .map(|i| (start + i) as i64)
                 .unwrap_or(-1);
             Ok(pyre_object::w_int_new(pos))
@@ -960,40 +973,46 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 return Err(crate::PyError::type_error("rfind() missing pattern"));
             }
             let obj = args[0];
-            let (p, len) = mmap_ptr(obj)?;
+            let (_, len_at_entry) = mmap_ptr(obj)?;
+            // `interp_mmap.py rfind` is handed `space.bufferstr_w(w_tofind)`, a
+            // copy.  The pattern's own storage is not held across the
+            // `getindex_w` calls below: a `bytearray` pattern reallocated by
+            // one of their `__index__` hooks would leave a borrowed slice
+            // naming freed memory.
             let needle = unsafe {
                 if !pyre_object::bytesobject::is_bytes_like(args[1]) {
                     return Err(crate::PyError::type_error(
                         "rfind: pattern must be bytes-like",
                     ));
                 }
-                pyre_object::bytesobject::bytes_like_data(args[1])
+                pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
             };
             // `interp_mmap.py rfind(w_tofind, w_start=None,
             // w_end=None)` defaults w_start to `self.mmap.pos`, not 0.
             // Negative args run through rmmap.find which adds `size`
             // and clamps to 0.
             let cur = mmap_get_attr_i64(obj, "_pos") as usize;
-            let start = if args.len() >= 3 {
-                let s = mmap_index_w(obj, args[2])?;
-                if s < 0 {
-                    ((s + len as i64).max(0)) as usize
-                } else {
-                    (s as usize).min(len)
-                }
-            } else {
-                cur
+            let start_raw = match args.get(2) {
+                Some(&value) => Some(mmap_index_w(obj, value)?),
+                None => None,
             };
-            let end = if args.len() >= 4 {
-                let e = mmap_index_w(obj, args[3])?;
-                if e < 0 {
-                    ((e + len as i64).max(0)) as usize
-                } else {
-                    (e as usize).min(len)
-                }
-            } else {
-                len
+            let end_raw = match args.get(3) {
+                Some(&value) => Some(mmap_index_w(obj, value)?),
+                None => None,
             };
+            // As in `find`: the mapping `getindex_w` left behind is the one
+            // this reads, so the address and every bound come from it.
+            let (p, len) = mmap_ptr(obj)?;
+            let clamp = |v: i64| {
+                if v < 0 {
+                    ((v + len as i64).max(0)) as usize
+                } else {
+                    (v as usize).min(len)
+                }
+            };
+            let start = start_raw.map_or_else(|| cur.min(len), clamp);
+            // As in `find`: the entry size bounds the default end.
+            let end = end_raw.map_or_else(|| len_at_entry.min(len), clamp);
             if start > end {
                 return Ok(pyre_object::w_int_new(-1));
             }
@@ -1006,7 +1025,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             }
             let pos = (0..=hay.len().saturating_sub(needle.len()))
                 .rev()
-                .find(|&i| &hay[i..i + needle.len()] == needle)
+                .find(|&i| &hay[i..i + needle.len()] == needle.as_slice())
                 .map(|i| (start + i) as i64)
                 .unwrap_or(-1);
             Ok(pyre_object::w_int_new(pos))
@@ -1064,12 +1083,27 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 }
                 let obj = args[0];
                 let index = args[1];
-                let (_, len) = mmap_ptr(obj)?;
-                let len_i64 = len as i64;
+                let _ = mmap_ptr(obj)?;
                 if unsafe { pyre_object::is_slice(index) } {
-                    let (start, stop, step) =
-                        unsafe { crate::baseobjspace::normalize_slice(index, len_i64)? };
-                    let (p, _) = mmap_ptr(obj)?;
+                    // `mmap_subscript` runs `PySlice_Unpack` (which may call
+                    // `__index__`), then `CHECK_VALID`, and only then
+                    // `PySlice_AdjustIndices(self->size, ...)` — so the size
+                    // the bounds are clamped against is the one the mapping
+                    // has after that call, not before it.
+                    let (start_raw, stop_raw, step) = unsafe {
+                        crate::sliceobject::slice_unpack(
+                            pyre_object::sliceobject::w_slice_get_start(index),
+                            pyre_object::sliceobject::w_slice_get_stop(index),
+                            pyre_object::sliceobject::w_slice_get_step(index),
+                        )?
+                    };
+                    let (p, len) = mmap_ptr(obj)?;
+                    let (start, stop, step, _) = crate::sliceobject::slice_adjust_indices(
+                        start_raw,
+                        stop_raw,
+                        step,
+                        len as i64,
+                    );
                     if step == 1 {
                         if stop <= start {
                             return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&[]));
@@ -1090,7 +1124,11 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                     return Ok(pyre_object::bytesobject::w_bytes_from_bytes(&out));
                 }
                 let mut idx = mmap_index_w(obj, index)?;
-                let (p, _) = mmap_ptr(obj)?;
+                // `mmap_subscript`'s integer arm re-checks validity after
+                // `PyNumber_AsSsize_t` and then reads `self->size`, so a
+                // `resize()` from that `__index__` moves the bound too.
+                let (p, len) = mmap_ptr(obj)?;
+                let len_i64 = len as i64;
                 if idx < 0 {
                     idx += len_i64;
                 }
@@ -1125,12 +1163,25 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 if access == MMAP_ACCESS_READ {
                     return Err(crate::PyError::type_error("mmap is read-only"));
                 }
-                let (_, len) = mmap_ptr(obj)?;
-                let len_i64 = len as i64;
+                let _ = mmap_ptr(obj)?;
                 if unsafe { pyre_object::is_slice(index) } {
-                    let (start, stop, step) =
-                        unsafe { crate::baseobjspace::normalize_slice(index, len_i64)? };
-                    let (p, _) = mmap_ptr(obj)?;
+                    // `mmap_ass_subscript` splits the same way `mmap_subscript`
+                    // does: unpack, re-check, then adjust against the size the
+                    // mapping has now.
+                    let (start_raw, stop_raw, step) = unsafe {
+                        crate::sliceobject::slice_unpack(
+                            pyre_object::sliceobject::w_slice_get_start(index),
+                            pyre_object::sliceobject::w_slice_get_stop(index),
+                            pyre_object::sliceobject::w_slice_get_step(index),
+                        )?
+                    };
+                    let (p, len) = mmap_ptr(obj)?;
+                    let (start, stop, step, _) = crate::sliceobject::slice_adjust_indices(
+                        start_raw,
+                        stop_raw,
+                        step,
+                        len as i64,
+                    );
                     let length = if step > 0 && stop > start {
                         (1 + (i128::from(stop) - i128::from(start) - 1) / i128::from(step)) as i64
                     } else if step < 0 && start > stop {
@@ -1174,7 +1225,8 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                     return Ok(pyre_object::w_none());
                 }
                 let mut idx = mmap_index_w(obj, index)?;
-                let (p, _) = mmap_ptr(obj)?;
+                let (p, len) = mmap_ptr(obj)?;
+                let len_i64 = len as i64;
                 if idx < 0 {
                     idx += len_i64;
                 }
@@ -1242,7 +1294,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
         "madvise",
         crate::make_builtin_function("madvise", |args| {
             let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            let (_, total) = mmap_ptr(obj)?;
+            let _ = mmap_ptr(obj)?;
             if args.len() < 2 {
                 return Err(crate::PyError::type_error("madvise() requires option"));
             }
@@ -1251,14 +1303,18 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 Some(&value) => mmap_index_w(obj, value)?,
                 None => 0,
             };
+            let length_arg = match args.get(3) {
+                Some(&value) => Some(mmap_index_w(obj, value)?),
+                None => None,
+            };
+            // Every `__index__` above could have resized the mapping, so the
+            // extent the advice is applied to is read once they are all done.
+            let (_, total) = mmap_ptr(obj)?;
             if start_raw < 0 || usize::try_from(start_raw).map_or(true, |start| start >= total) {
                 return Err(crate::PyError::value_error("madvise start out of bounds"));
             }
             let start = start_raw as usize;
-            let length_raw = match args.get(3) {
-                Some(&value) => mmap_index_w(obj, value)?,
-                None => (total - start) as i64,
-            };
+            let length_raw = length_arg.unwrap_or((total - start) as i64);
             if length_raw < 0 {
                 return Err(crate::PyError::value_error("madvise length invalid"));
             }

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -76,10 +76,10 @@ pub mod _overlapped;
 #[allow(non_snake_case)]
 pub mod _pickle;
 #[allow(non_snake_case)]
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
+#[cfg(all(unix, not(feature = "sandbox")))]
 pub mod _posixshmem;
 #[allow(non_snake_case)]
-#[cfg(not(feature = "sandbox"))]
+#[cfg(all(unix, not(feature = "sandbox")))]
 pub mod _posixsubprocess;
 #[allow(non_snake_case)]
 pub mod _pypy_generic_alias;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -949,19 +949,25 @@ pub mod frame_locals_proxy {
             // Routing it into `update` instead iterated the operand: a list of
             // pairs was accepted and a `str` reported a `dict.update` error.
             //
-            // A merge that fails AFTER that type check propagates its real
-            // exception here.  `framelocalsproxy_inplace_or` instead returns
-            // `NotImplemented` with the exception still set, and the binary-op
-            // machinery reports that as `SystemError: <slot wrapper
-            // '__ior__' of 'FrameLocalsProxy' objects> returned a result with
-            // an exception set` — measured with a `dict` subclass whose
-            // `keys()` raises.
-            // Reporting the operand's own error is deliberate; do not
-            // "restore" the SystemError.
-            if !self.merge(other)? {
-                return Ok(pyre_object::w_not_implemented());
+            // A merge that fails AFTER that type check does not surface its own
+            // exception: `framelocalsproxy_inplace_or` returns `NotImplemented`
+            // with the exception still set, `binary_iop1` discards that and
+            // falls through to `framelocalsproxy_or`, and the `PyDict_Update`
+            // there calls the proxy's `keys` — whose `_Py_CheckFunctionResult`
+            // sees the pending exception and raises the chained `SystemError`.
+            //
+            // pyre cannot tell an explicit `p.__ior__(d)` from `|=`, so the
+            // message names `keys` in both, where the explicit call names the
+            // `__ior__` slot wrapper instead.
+            match self.merge(other) {
+                Ok(true) => Ok(self as *mut FrameLocalsProxy as PyObjectRef),
+                Ok(false) => Ok(pyre_object::w_not_implemented()),
+                Err(error) => Err(crate::error::system_error_from_cause(
+                    "<method 'keys' of 'FrameLocalsProxy' objects> returned a result with an exception set"
+                        .to_string(),
+                    error,
+                )),
             }
-            Ok(self as *mut FrameLocalsProxy as PyObjectRef)
         }
 
         fn __eq__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1931,7 +1931,15 @@ fn patch_object_class_descriptor() {
         make_getset_property_full(
             class_getter,
             class_setter,
-            pyre_object::PY_NULL,
+            make_builtin_function_with_arity(
+                "__class__",
+                |_args| {
+                    Err(crate::PyError::type_error(
+                        "can't delete __class__ attribute",
+                    ))
+                },
+                2,
+            ),
             pyre_object::PY_NULL,
             object_type,
             Some("__class__"),
@@ -8853,7 +8861,11 @@ fn init_frame_type(ns: PyObjectRef) {
             make_getset_property_named(
                 lineno_getter,
                 lineno_setter,
-                pyre_object::PY_NULL,
+                make_builtin_function_with_arity(
+                    "f_lineno",
+                    |_args| Err(crate::PyError::attribute_error("cannot delete attribute")),
+                    2,
+                ),
                 "f_lineno",
             ),
         )
@@ -8901,13 +8913,30 @@ fn init_frame_type(ns: PyObjectRef) {
             make_getset_property_named(
                 trace_lines_getter,
                 trace_lines_setter,
-                pyre_object::PY_NULL,
+                make_builtin_function_with_arity(
+                    "f_trace_lines",
+                    |_args| {
+                        Err(crate::PyError::type_error(
+                            "can't delete numeric/char attribute",
+                        ))
+                    },
+                    2,
+                ),
                 "f_trace_lines",
             ),
         )
     };
 
-    // f_trace_opcodes — read/write bool (pyframe.py:793-797).
+    // f_trace_opcodes — read/write bool (pyframe.py fget_f_trace_opcodes /
+    // fset_f_trace_opcodes).
+    //
+    // `frame_trace_opcodes_set_impl` opens with `PyBool_Check(value)` and has
+    // no null branch, so a delete faults there rather than answering.  The
+    // message below is `frame_lineno_set_impl`'s own null branch, the
+    // frame-attribute spelling of a refused delete.  An explicit `fdel` is
+    // installed only to override what stands in for it: with none,
+    // `descr_property_del` answers its own
+    // `cannot delete '%s' attribute of immutable type '%N'`.
     let trace_opcodes_getter = make_builtin_function_with_arity(
         "f_trace_opcodes",
         crate::pyframe::descr_typecheck_fget_f_trace_opcodes,
@@ -8925,7 +8954,11 @@ fn init_frame_type(ns: PyObjectRef) {
             make_getset_property_named(
                 trace_opcodes_getter,
                 trace_opcodes_setter,
-                pyre_object::PY_NULL,
+                make_builtin_function_with_arity(
+                    "f_trace_opcodes",
+                    |_args| Err(crate::PyError::attribute_error("cannot delete attribute")),
+                    2,
+                ),
                 "f_trace_opcodes",
             ),
         )
@@ -11650,8 +11683,11 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                         if fset.is_null() || unsafe { pyre_object::is_none(fset) } {
                             return Err(getset_no_accessor(w_self, "writable"));
                         }
-                        // ...or runs the setter, whose own refusal for a null
-                        // value is the setter's to word.
+                        // ...or reports the refusal below.  A setter with a
+                        // NULL-value branch of its own words that branch
+                        // through an `fdel` at its registration, because a
+                        // pyre setter is a builtin called with a real
+                        // argument slice and has no null operand to receive.
                         // typedef.py:404-405:
                         //   raise oefmt(space.w_AttributeError,
                         //       "cannot delete '%s' attribute of immutable type '%N'",

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -3636,17 +3636,19 @@ pub unsafe fn connection_read_plain(
 ) -> TlsResult<Vec<u8>> {
     use std::io::Read;
     let connection = unsafe { &mut *connection };
-    connection.process_received_tls()?;
     // `_ssl__SSLSocket_read_impl` allocates the destination with
     // `PyBytes_FromStringAndSize(NULL, len)` before it reaches `SSL_read`, so
     // a length no allocator can satisfy raises rather than aborting.  The
     // `resize` below cannot grow past what this reserved, so it cannot abort
-    // either.
+    // either.  It also comes before the queued records are fed in: those
+    // advance the read cursor and latch the peer's close/alert state, and a
+    // refused reservation must not consume them.
     let mut output: Vec<u8> = Vec::new();
     if output.try_reserve_exact(size).is_err() {
         return Err((TLS_ERROR_NO_MEMORY, String::new()));
     }
     output.resize(size, 0);
+    connection.process_received_tls()?;
     match connection.active_mut()?.reader().read(&mut output) {
         // A clean close_notify is EOF at the Python stream layer. CPython's
         // SSL_read wrapper returns b"" here; SSLZeroReturnError is reserved

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1371,19 +1371,36 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
     /// `fromcache(UnicodeDictStrategy)` / `get_empty_storage()` pair rather
     /// than starting the copy on the object strategy.  Every key below is a
     /// str, so the fill stays on the strategy it was born with.
+    ///
+    /// A dict that has already promoted to object storage takes the
+    /// `AbstractTypedStrategy.copy` route instead — upstream leaves
+    /// `ModuleDictStrategy` when it switches, so that is the `copy` it
+    /// reaches.  Cloning the backing keeps each key's cached hash, where a
+    /// re-store would call `__hash__` again and drop the entry (silently,
+    /// this being an infallible surface) once the key's hash started raising.
     unsafe fn copy(&self, w_dict: PyObjectRef) -> PyObjectRef {
+        if let Some(entries) = crate::dictmultiobject::w_module_dict_object_storage(w_dict) {
+            let new_storage = crate::gc_storage::gc_alloc_storage_box(
+                entries.clone(),
+                crate::dictmultiobject::object_dict_storage_gc_type_id(),
+            );
+            return crate::dictmultiobject::w_dict_new_with(
+                &crate::dictmultiobject::OBJECT_DICT_STRATEGY_REF,
+                new_storage as *mut u8,
+            );
+        }
         let strategy = &crate::dictmultiobject::UNICODE_DICT_STRATEGY_REF;
         let new_dict =
             crate::dictmultiobject::w_dict_new_with(strategy, strategy.get_empty_storage());
-        if let Some(entries) = crate::dictmultiobject::w_module_dict_object_storage(w_dict) {
-            for (k, &v) in entries.iter() {
-                crate::dictmultiobject::w_dict_store(new_dict, k.obj, v);
-            }
-            return new_dict;
-        }
         let storage = crate::dictmultiobject::w_module_dict_module_storage(w_dict);
         for (key, &cell) in storage.entries.iter() {
             let unwrapped = unwrap_cell(cell);
+            // An empty cell names nothing — `getitem_str` reads a null unwrap
+            // as absence — so it does not become a null-valued entry of the
+            // ordinary dict this hands back.
+            if unwrapped.is_null() {
+                continue;
+            }
             let key_obj = _wrapkey(key);
             crate::dictmultiobject::w_dict_store(new_dict, key_obj, unwrapped);
         }


### PR DESCRIPTION
Ten commits from a review round on #1634 plus the Windows survey's remaining
gaps. Every answer below was measured against `python3.14` (3.14.2) on the
same host rather than read off; the probe scripts are recorded per commit.

### `mmap` dereferenced a pointer its own argument conversion had invalidated

`find`, `rfind`, `__getitem__`, `__setitem__` and `madvise` read the mapping's
address and size **before** running `__index__` on their arguments. An
`__index__` that calls `resize()` installs a new view at a new address and one
that calls `close()` unmaps it, so the pointer the method then dereferenced was
stale — a use-after-free reachable from pure Python.

`mmap_gfind_lock_held` re-checks validity after `getindex_w` and clamps against
`self->size` there; `mmap_subscript` and `mmap_ass_subscript` run
`PySlice_Unpack`, then `CHECK_VALID`, then `PySlice_AdjustIndices(self->size,
...)`; `mmap_mmap_madvise_impl` converts every argument before the bounds check.
All five now collect the raw conversions first and take the address and every
bound from the mapping as it stands afterwards. The slice paths use
`slice_unpack` + `slice_adjust_indices` for that split rather than
`normalize_slice`, which does both halves at once.

`find` and `rfind` also borrowed the search pattern's bytes across the same
window: `bytes_like_data` hands back a slice into the object's live storage, so
a `bytearray` pattern reallocated by one of those `__index__` hooks left it
naming freed memory. `interp_mmap.py find` is handed
`space.bufferstr_w(w_tofind)`, a copy; both take one now. (3.14 converts the
pattern with `y*` and so raises `BufferError` from the mutation instead — a
read export on an arbitrary bytes-like is its own change.)

One `[3.14-spec]` item came out of the same reading. `mmap_gfind_lock_held`
evaluates the default `end` as `self->size` **at entry** and its clamp only
ever lowers that, so a mapping grown by one of the conversions keeps the size
it had on the way in; `interp_mmap.py` reads `self.mmap.size` after the start
conversion and reports the new one. The entry size is carried for that default.

Ten-case probe driving a resizing and a closing `__index__` through each method:
pyre matches 3.14 on all ten. A `bytearray` pattern cleared and regrown under
`find`/`rfind` answers `0` / `4092` — the copied pattern's real matches — where
before the fix the comparison read freed heap.

### The class namespace is cloned, not refilled

`type_new_init` opens with `PyDict_Copy(ctx->orig_dict)` and mutates the copy.
`type_descr_new_with_metaclass` and `build_class_inner` built an empty dict and
re-stored every item into it, which re-runs each key's `__hash__` rather than
carrying the cached hash across — and **drops the entry outright** once that
`__hash__` starts raising, because the store surface cannot report an error.
Both now `w_dict_copy` the namespace's dict backing and delete
`__classcell__` / `__classdictcell__` from the copy.

`ModuleDictStrategy::copy`'s promoted branch reached `w_dict_store` for the same
reason and now clones the `ObjectDictStorage` directly; its cell branch skips
entries whose cell holds no value, which `w_dict_store` would have stored as a
null.

### Eight getsets owed a deleter

A getset installed with a setter and a null deleter reported the generic
`cannot delete attribute` — or, on an immutable type such as `frame`, the
type-level `cannot delete 'X' attribute of immutable type 'frame'` — instead of
each setter's own `value == NULL` message. A census of the 13 sites with a real
setter measured each against 3.14 in an isolated subprocess; ten now carry the
deleter their upstream setter's `value == NULL` branch spells:
`object.__class__`, `frame.f_lineno`, `frame.f_trace_lines`,
`frame.f_trace_opcodes`, `_Pointer`'s `contents` and `__pointer_type__`, a
`c_char` array's `raw`, a `c_wchar` array's `value`, and `CFuncPtr`'s `restype`
and `argtypes`. Twelve of the thirteen now answer exactly what 3.14.2 answers.

`__pointer_type__`'s deleter stores `None`, which `stginfo_pointer_type` already
reads as absence; a stored null was read back as "the getter answered nothing"
and let `type.__getattribute__` fall through to the descriptor, so
`c_int.__pointer_type__` answered `<attribute '__pointer_type__' of
'CType_Type' objects>` after a delete. Reaching that state also showed its three
accessors merging the two absences `ctype_get_pointer_type` and
`ctype_set_pointer_type` keep apart: no storage info at all is
`%R must have storage info`, a `TypeError`, and an unset `pointer_type` is
`%R has no attribute '__pointer_type__'`, which names the class rather than the
word "type".

`frame_trace_opcodes_set_impl` has no null branch at all, so
`del f.f_trace_opcodes` **faults** in 3.14.2 and still faults at `v3.15.0rc2`;
it answers `frame_lineno_set_impl`'s `cannot delete attribute` here, the
frame-attribute spelling of a refused delete from the same file.

The thirteenth, `Structure._fields_`, keeps no deleter. Measured, 3.14 lets the
delete through — `_fields_` is an ordinary type-dict entry there that
`tp_setattro` only intercepts on assignment, so `del S._fields_` removes it and
the next read is the plain `type object 'S' has no attribute '_fields_'`. pyre
models it as a getset, which shadows the dict entry and refuses. Matching the
observable by hand-writing the getter and deleter messages would paper over the
structural difference; moving `_fields_` behind a `tp_setattro` interception is
its own change. The reason is at the site.

### Windows loses three POSIX-only builtin modules

`_posixshmem`, `_posixsubprocess` and `_sysconfigdata` were registered on every
platform, so Windows had them in `sys.builtin_module_names` and importable.
Their stdlib callers reach them only from a POSIX branch — `shared_memory` and
`resource_tracker` guard on `os.name != 'nt'`, `subprocess` on the `else` of
`if _mswindows`, and `sysconfig` runs `_init_posix` only when
`os.name == 'posix'` — and registering them anyway flips availability probes
such as `test_audit`'s `import_module("_posixsubprocess")` from skip to run.
All three are `#[cfg]`-gated off Windows now; the three-way surface
(`builtin_module_names` / `stdlib_module_names` / import) matches 3.14.2 exactly.

Gating the registration leaves `init_sysconfigdata` and the five helpers only
it reaches (`soabi_tag`, `extension_loader_present`, `on_path`,
`quote_for_cflags`, `sysconfigdata_base_prefix`) dead on Windows, so that build
warns for them. They stay ungated: the file already carries some twenty
Windows-dead functions for the same reason, and the alternative is cfg churn
across six more definitions this host cannot compile for the platforms where
they are live.

### The rest, each measured

- **`_io`**: `raw_read` took a bare `*mut u8` into storage owned by a Python
  object. `fill_buffer` passes a pointer derived from `self.buffer`, and the raw
  stream's `readinto` can run Python that reassigns that field, so the storage
  was reachable only through a field the call is free to overwrite. Both
  `raw_read`s now take the owner and pin it for the call's duration.
- **`_weakref`**: `WRAP_TERNARY` runs `UNWRAP(w)` on `__pow__`'s modulus
  whenever the slot is non-NULL, so a dead proxy there raises `ReferenceError`.
  `proxy_pow`/`proxy_rpow` tested for `None` first and read a dead proxy as
  "no modulus".
- **`type`**: a non-cell `__classcell__` is spelled `%.200R`, so a metaclass
  `__repr__` renders it and the text clips at 200. `cell_slot_type_error` built
  `<class '...'>` from the bare qualified name, ignoring the `__repr__` and
  never clipping; a raising `__repr__` now replaces the `TypeError` the way
  `_PyErr_FormatV` leaves it.
- **`FrameLocalsProxy`**: `framelocalsproxy_or` calls `PyDict_Update`, whose
  failure reaches `binary_iop1` as a slot that both returned a result and left
  an exception set, and `_Py_CheckFunctionResult` turns that into a
  `SystemError` chaining the original. `__ior__` returned the error unchanged.
  `system_error_from_cause` moves from `cpyext` (macOS/Linux only) to `error.rs`.
- **`os.read`** reserved with `try_vec_with_capacity` and then `resize`d, and the
  `resize` grows infallibly; one `try_vec_zeroed` does both fallibly.
- **`_ssl`**: `connection_read_plain` drained rustls before growing its
  destination, so a failed reservation left the decrypted records consumed with
  nowhere to report them.

### Found, measured, not fixed here

`mmap` raises its read-only `TypeError` **before** the validity check in
`write`, `write_byte`, `move`, `resize` and `__setitem__`, so a closed
`ACCESS_READ` mapping reports read-only rather than closed;
`mmap_ass_subscript_lock_held` does `CHECK_VALID` then `is_writable`, and
`descr_setitem` does `check_valid()` then `check_writeable()`. The ordering is
unchanged by this PR and fixing it properly is a wider round: pyre's refusal is
`mmap is read-only` where `is_writable` says
`mmap can't modify a readonly memory map.`, and `is_resizeable` tests the export
count **before** the access mode where pyre tests it after.

### Not in this PR

`_ssl` hands the interpreter a **Win32** code where an `errno` is expected:
`io_error` is `error.raw_os_error()`, which on Windows is the Win32 code, and
`native_result` feeds it to `os_error_with_errno`. `ctx.keylog_filename = <a
directory>` answers `OSError [Errno 5] Input/output error` where 3.14 answers
`PermissionError [Errno 13]`, and a missing directory answers
`ProcessLookupError [Errno 3]` for `FileNotFoundError [Errno 2]`. It is
pre-existing on `main` and it is what `test_ssl::test_keylog_defaults` is red on
here.

The fix is not local: `NativeResult`'s `i32` carries three things — `0`
("make an `SSLError`"), a `TLS_ERROR_*` constant, and a raw OS code — so
translating at either end either catches the constants or needs the errmap in
the wrong crate. Widening that channel is its own round.

### Gate

On this Windows host at the head:

| item | result |
|---|---|
| `cargo check -p pyre-interpreter --features dynasm,host_env` | pass |
| wasm32 `cargo check -p pyre-wasm --features web` | pass |
| `extract-llbc.py majit-rlib pyre-object pyre-interpreter pyre-jit` | pass |
| `cargo build --release --features dynasm,cpyext --bin pyre-dynasm` | pass |
| `cargo build --release --features cranelift,cpyext --bin pyre-cranelift` | pass |
| `scripts/check-new-line-citations.py --base origin/main` | pass |

`cpython_tests`, against the built `pyre-dynasm`, all **no regressions**:
`test_ctypes`, `test_code`, `test_descr`, `test_weakref` PASS; `test_frame`
improves `SKIP -> PASS`. `test_mmap` (FAIL, 40 errors), `test_sys_settrace`
(CRASH) and `test_io` (TIMEOUT) are unchanged from their recorded status —
`test_mmap`'s errors are the pre-existing `allocate_stable` old-generation file
locks, and no test in the stdlib deletes `f_trace_opcodes`, so the settrace
crash cannot involve this branch.

The ten commits were adversarially reviewed before this PR was opened. That
review is what found the `find`/`rfind` pattern borrow, the entry-size `end`,
the `__pointer_type__` accessors and the `mmap` check ordering above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ctypes` property deletion behavior and error messages.
  * Fixed weak-reference proxies used as the modulus in `pow()`, including correct errors for expired proxies.
  * Improved `mmap` operations when mappings change size during argument conversion.
  * Prevented incorrect reads and state changes during buffered I/O and TLS memory-allocation failures.
  * Improved type and system error reporting, including clearer chained exceptions.
  * Corrected class and module namespace copying to preserve entries reliably.
  * Limited certain POSIX-specific built-in modules to Unix platforms.
  * Made deletion of protected frame and class properties report appropriate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->