### PR TITLE
jit: charge the recursion counter for activations the trace mints

### DIFF
--- a/pyre/extra_tests/parity_tests/warm_recursion_honours_the_recursion_limit.py
+++ b/pyre/extra_tests/parity_tests/warm_recursion_honours_the_recursion_limit.py
@@ -1,0 +1,75 @@
+# pyre-check: pypy-diverges: pins 3.14's hard cutoff at the limit; pypy3's is
+# approximate, so it answers rec(1000) under a limit of 500 and raises only
+# once the native stack budget runs out. Its jitcodes are built before
+# `insert_ll_stackcheck` runs -- `driver.py`'s `pyjitpl_lltype` task depends on
+# `rtype` alone while `stackcheckinsertion_lltype` follows `backendopt` -- so
+# compiled code there answers to the backend's native stack probe and to
+# nothing else.
+# CPython-suite gap: test_sys exercises `sys.setrecursionlimit` on cold frames
+# only, so nothing there grades a recursion whose levels all run as compiled
+# code.
+# parity-tests reason: a self-recursive function warmed past the function-entry
+# threshold runs its recursion through the trace's own `CALL_ASSEMBLER`. Every
+# level below the first is an activation the trace mints, so it reaches no
+# interpreter door, and the logical half of the recursion check has no other
+# place to run.
+# `recursion_limit_survives_jit_warmup.py` sits next to this one and does not
+# cover it: it asks that the depth reached stay at or under the limit, which is
+# satisfied whenever the native byte budget cuts in first -- the very case its
+# own docstring records. A limit the compiled path ignores entirely still
+# passes there, so the cutoff has to be graded against a depth the budget
+# cannot reach.
+
+"""A warm recursive function still answers to `sys.setrecursionlimit`.
+
+`rec` is entered thousands of times before the limit is lowered, so the JIT
+owns it by the time the deep call arrives. The limit has to bound that call
+the same way it bounds `cold_rec`, which is the same function text run once.
+
+The module body deliberately keeps the deep call in a helper of its own and
+does not wrap it in a `try`/`finally`: both change which of the module frame's
+statements run compiled, and the recursion has to start from compiled code for
+this to grade anything.
+"""
+
+import sys
+
+
+def rec(n):
+    return 0 if n <= 0 else rec(n - 1) + 1
+
+
+def cold_rec(n):
+    return 0 if n <= 0 else cold_rec(n - 1) + 1
+
+
+def warm_overflows(depth):
+    try:
+        rec(depth)
+    except RecursionError:
+        return True
+    return False
+
+
+def cold_overflows(depth):
+    try:
+        cold_rec(depth)
+    except RecursionError:
+        return True
+    return False
+
+
+# Warm past the function-entry threshold, so `rec` is entered as compiled code
+# rather than through the interpreter's own activation door.
+for _ in range(3000):
+    rec(20)
+
+sys.setrecursionlimit(500)
+assert rec(100) == 100
+assert warm_overflows(1000), "a warm recursion outran a limit of 500"
+assert cold_overflows(1000)
+# The budget the raise consumed is given back, so the next call answers.
+assert rec(100) == 100
+sys.setrecursionlimit(1000)
+
+print("OK")

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -327,16 +327,19 @@ pub fn bump_frame_entry_count() {
 #[inline]
 pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
     let key = frame as usize;
+    let saved_depth = PY_RECURSION_DEPTH.with(|d| d.get());
     if ACCOUNTED_ACTIVATION.with(|c| c.get()) == key {
         return RecursionDepthGuard {
             prev: key,
             spent: false,
+            saved_depth,
         };
     }
-    PY_RECURSION_DEPTH.with(|d| d.set(d.get() + 1));
+    PY_RECURSION_DEPTH.with(|d| d.set(saved_depth + 1));
     RecursionDepthGuard {
         prev: ACCOUNTED_ACTIVATION.with(|c| c.replace(key)),
         spent: true,
+        saved_depth,
     }
 }
 
@@ -350,27 +353,78 @@ pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
 /// activation to account for itself.
 #[inline]
 pub fn enter_native_dispatch() -> RecursionDepthGuard {
-    PY_RECURSION_DEPTH.with(|d| d.set(d.get() + 1));
+    let saved_depth = PY_RECURSION_DEPTH.with(|d| d.get());
+    PY_RECURSION_DEPTH.with(|d| d.set(saved_depth + 1));
     RecursionDepthGuard {
         prev: ACCOUNTED_ACTIVATION.with(|c| c.get()),
         spent: true,
+        saved_depth,
     }
 }
 
 /// RAII guard that releases the [`PY_RECURSION_DEPTH`] unit on drop.
+///
+/// It restores the depth this activation was entered with rather than
+/// subtracting its own unit.  Compiled code charges and releases the units of
+/// the activations it mints itself ([`jit_charge_recursion_unit`]), and an exit
+/// that leaves compiled code between one of those pairs — a guard failure, a
+/// raise — skips the release the same way it skips the `ec.topframeref`
+/// restore.  Restoring the entry value closes both halves at the activation
+/// boundary, which is where `pyre-jit`'s `TopFrameRefGuard` already balances
+/// the frame chain for the same exits.
 pub struct RecursionDepthGuard {
     prev: usize,
     spent: bool,
+    saved_depth: u32,
 }
 
 impl Drop for RecursionDepthGuard {
     #[inline]
     fn drop(&mut self) {
+        PY_RECURSION_DEPTH.with(|d| d.set(self.saved_depth));
         if self.spent {
-            PY_RECURSION_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
             ACCOUNTED_ACTIVATION.with(|c| c.set(self.prev));
         }
     }
+}
+
+/// Spend one recursion unit on the activation `frame` names, without a guard
+/// to give it back.
+///
+/// This is [`enter_recursive_frame`]'s body for a caller that cannot hold an
+/// RAII value: a compiled trace, which records the charge as an operation and
+/// records the matching [`jit_release_recursion_unit`] where it records
+/// `executioncontext.leave`.  Claiming `ACCOUNTED_ACTIVATION` here is what
+/// keeps a frame that later reaches a portal door — a guard failure resuming
+/// this same activation — from paying a second time.
+///
+/// `units` is more than one where the trace mints more than one activation
+/// before it reaches this call: a fragment inlines a run of callee levels and
+/// only then hands the rest to `CALL_ASSEMBLER`, so the seam that survives to
+/// run time pays for the whole run at once.  Charging per inlined level
+/// instead would be exact at the moment of the call and wrong afterwards —
+/// a guard leaving the callee skips the recorded release the same way it skips
+/// the `ec.topframeref` restore, and unlike that slot the depth is read by
+/// every call, so the drift is a spurious `RecursionError` rather than a stale
+/// frame link.
+///
+/// Returns the claim it displaced, which is the value its release takes back.
+/// The trace threads that word from the one to the other, so the pair is held
+/// together by a dataflow edge rather than by two separate spellings of the
+/// caller, and no reader has to recover a frame from `f_backref`, which holds
+/// the caller's *vref* and not the caller.
+#[majit_macros::dont_look_inside]
+pub fn jit_charge_recursion_unit(frame: *const PyFrame, units: u32) -> usize {
+    PY_RECURSION_DEPTH.with(|d| d.set(d.get() + units));
+    ACCOUNTED_ACTIVATION.with(|c| c.replace(frame as usize))
+}
+
+/// Give back the units [`jit_charge_recursion_unit`] spent, restoring the claim
+/// it returned.
+#[majit_macros::dont_look_inside]
+pub fn jit_release_recursion_unit(displaced_activation: usize, units: u32) {
+    PY_RECURSION_DEPTH.with(|d| d.set(d.get().saturating_sub(units)));
+    ACCOUNTED_ACTIVATION.with(|c| c.set(displaced_activation));
 }
 
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3562,6 +3562,21 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         "pyre_interpreter::stack_check::drain_jit_pending_exception",
         crate::stack_check::drain_jit_pending_exception_jit_abi,
     );
+    // The two halves of `execute_frame`'s activation seam, for the fold that
+    // mints a callee activation inside compiled code and records
+    // `executioncontext.enter` / `leave` for it.  Both touch the recursion
+    // counter thread-local, so they are residual Calls like the rest of this
+    // block rather than anything the optimizer may fold.
+    cp2(
+        &mut entries,
+        "pyre_interpreter::stack_check::jit_activation_enter",
+        crate::stack_check::jit_activation_enter_abi,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::stack_check::jit_activation_leave",
+        crate::stack_check::jit_activation_leave_abi,
+    );
 
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -763,9 +763,7 @@ pub fn stack_check() -> Result<(), PyError> {
     // CPython 3.14 checks `py_recursion_remaining`, i.e. Python interpreter
     // depth, independently of native stack protection.  pyre's matching
     // counter is bumped around every user-function call.
-    if crate::call::py_recursion_depth() >= get_recursion_limit() as u32 {
-        return Err(PyError::recursion_error("maximum recursion depth exceeded"));
-    }
+    recursion_depth_check()?;
     let current = current_sp();
     let end = PYRE_STACKTOOBIG.stack_end.load(Ordering::Relaxed);
     let length = PYRE_STACKTOOBIG.stack_length.load(Ordering::Relaxed);
@@ -787,6 +785,74 @@ pub extern "C" fn stack_check_jit_abi() -> i64 {
         Ok(()) => 0,
         Err(error) => crate::runtime_ops::jit_publish_residual_error(error),
     }
+}
+
+/// The logical half of [`stack_check`]: `execute_frame`'s entry test against
+/// `sys.getrecursionlimit()`.
+///
+/// Split out because the two halves have different homes once the code is
+/// compiled.  The native half is what the backend emits at every fragment
+/// entry (`_call_header_with_stack_check`), which is where upstream puts the
+/// whole of `rstack.stack_check`; repeating it in a residual call at the same
+/// boundary would only pay for it twice.  The logical half has no such home,
+/// so it is the half a synthesized activation has to carry.
+#[inline]
+fn recursion_depth_check() -> Result<(), PyError> {
+    if crate::call::py_recursion_depth() >= get_recursion_limit() as u32 {
+        return Err(PyError::recursion_error("maximum recursion depth exceeded"));
+    }
+    Ok(())
+}
+
+/// `pyframe.py execute_frame`'s activation entry, in the form a trace can
+/// record.
+///
+/// `insert_ll_stackcheck` (`rpython/translator/transform.py`) puts
+/// `stack_check()` at operation 0 of the start block of every graph carrying
+/// `insert_stack_check_here`, and `pyframe.py` puts that marker on
+/// `execute_frame` — so the check runs ahead of that function's own
+/// `executioncontext.enter(self)`.
+///
+/// Traces upstream never carry it: `driver.py`'s `pyjitpl_lltype` task depends
+/// on `rtype` alone while `stackcheckinsertion_lltype` runs after
+/// `backendopt`, so the jitcodes are built before the operation exists.  What
+/// covers compiled code there is the native SP probe the backend emits once
+/// per fragment entry (`_call_header_with_stack_check`), and that is the whole
+/// of `rstack.stack_check`, which tests nothing but the stack.
+///
+/// [`stack_check`] here tests logical depth against `sys.getrecursionlimit()`
+/// as well, and `execute_frame`'s entry is that half's only home.  A fold that
+/// mints a callee activation inside compiled code has to run it there or the
+/// limit binds nothing for as long as the recursion stays compiled — the
+/// shape `insert_ll_stackcheck` names when it sets `inhibit_tail_call`, a
+/// recursion that consumes no stack and so answers no stack probe.
+///
+/// `units` counts the activations the fragment reaching this call has minted,
+/// so the check runs against the depth they all add up to rather than against
+/// the one this call names.  The charge goes first for that reason, and is
+/// given back when the check refuses: an activation that never begins owes no
+/// unit.
+///
+/// Returns the word [`jit_activation_leave_abi`] takes back, which the trace
+/// threads from the one call to the other.  The error travels on the published
+/// -exception channel the following guard reads, not in this result, so the
+/// result is free to carry the pairing.
+pub extern "C" fn jit_activation_enter_abi(callee_frame: i64, units: i64) -> i64 {
+    let units = units as u32;
+    let displaced =
+        crate::call::jit_charge_recursion_unit(callee_frame as *const crate::PyFrame, units);
+    if let Err(error) = recursion_depth_check() {
+        crate::call::jit_release_recursion_unit(displaced, units);
+        return crate::runtime_ops::jit_publish_residual_error(error);
+    }
+    displaced as i64
+}
+
+/// The `finally` half of the same seam — `executioncontext.leave`'s position
+/// in `execute_frame` — giving back what [`jit_activation_enter_abi`] spent.
+pub extern "C" fn jit_activation_leave_abi(displaced_activation: i64, units: i64) -> i64 {
+    crate::call::jit_release_recursion_unit(displaced_activation as usize, units as u32);
+    0
 }
 
 /// rpython/rlib/rstack.py `stack_almost_full` parity.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1976,6 +1976,30 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // over: without it the activation the CALL_ASSEMBLER runs never reaches
     // `topframeref`, so `sys._getframe().f_back` walks straight from the
     // callee's callee to this caller and every level in between is missing.
+    // Ahead of it stands `execute_frame`'s operation 0, which
+    // `insert_ll_stackcheck` (`rpython/translator/transform.py`) puts in front
+    // of the `enter` the next line records.  Upstream keeps it out of jitcodes
+    // and lets the backend's per-fragment SP probe stand for it; that probe
+    // answers the native half only, and `jit_activation_enter_abi` documents
+    // why the logical half has to be recorded here instead.
+    //
+    // It pays for the inlined levels above it as well.  This fold re-enters
+    // the fragment that inlined them, so charging one unit here would count
+    // one activation per fragment and divide the recursion's depth by the
+    // inline width; `open_inline_activations` is that width, and it is
+    // charged here because this is the seam a guard cannot leave unbalanced.
+    let units = ctx
+        .trace_ctx
+        .const_int(i64::from(open_inline_activations() + 1));
+    let displaced_activation = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallI,
+        pyre_interpreter::stack_check::jit_activation_enter_abi as *const (),
+        &[callee_frame, units],
+        &[Type::Ref, Type::Int],
+        Type::Int,
+        majit_metainterp::can_raise_effect_info(),
+    );
+    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
     record_ec_enter_frame_chain(ctx.trace_ctx, callee_frame, ec);
 
     // do_residual_call step 1 (`pyjitpl.py`): FORCE_TOKEN +
@@ -2162,6 +2186,17 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // calls).  The residual exposure — a failing GUARD_NOT_FORCED — is the one
     // `TopFrameRefGuard` (`pyre-jit/src/eval.rs`) already covers.
     record_ec_leave_frame_chain(ctx.trace_ctx, callee_frame, ec);
+    // `execute_frame`'s `finally` half of the same seam: the unit the enter
+    // spent, given back where the frame chain is given back.  It takes the
+    // enter's own result, so the two are one dataflow edge apart.
+    ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallI,
+        pyre_interpreter::stack_check::jit_activation_leave_abi as *const (),
+        &[displaced_activation, units],
+        &[Type::Int, Type::Int],
+        Type::Int,
+        majit_metainterp::cannot_raise_effect_info(),
+    );
     // pyjitpl.py `handle_possible_exception`.
     if exec_raised {
         // Raising branch (pyjitpl.py): `GUARD_EXCEPTION` with
@@ -3172,6 +3207,42 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         false,
         None,
     )
+}
+
+/// How many activations the fragment being recorded has minted by inlining a
+/// callee body, at the point the walk has reached.
+///
+/// Record-time only: it costs the compiled code nothing and exists so the one
+/// seam that does survive to run time can name the width it stands for.  The
+/// walk is single-threaded and this counts its own nesting, so a thread-local
+/// is the whole of the state.
+fn open_inline_activations() -> u32 {
+    OPEN_INLINE_ACTIVATIONS.with(|c| c.get())
+}
+
+thread_local! {
+    static OPEN_INLINE_ACTIVATIONS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Holds one inlined level open for as long as the walk is inside its body.
+///
+/// A guard rather than a pair of calls because the region between
+/// [`walker_ec_enter`] and [`walker_ec_leave`] has many ways out — a declined
+/// sub-walk, a poisoned pc, a rewind — and a width that leaks would price
+/// every later `CALL_ASSEMBLER` in the same trace too high.
+struct OpenInlineActivation;
+
+impl OpenInlineActivation {
+    fn open() -> Self {
+        OPEN_INLINE_ACTIVATIONS.with(|c| c.set(c.get() + 1));
+        Self
+    }
+}
+
+impl Drop for OpenInlineActivation {
+    fn drop(&mut self) {
+        OPEN_INLINE_ACTIVATIONS.with(|c| c.set(c.get().saturating_sub(1)));
+    }
 }
 
 /// `executioncontext.py ExecutionContext.enter`, at an inlined call.
@@ -6522,11 +6593,11 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // so `enter` runs on a real frame object.  The frame `perform_call` →
     // `newframe` pushes (`pyjitpl.py, 1862-1874`) is the tracer's
     // `MIFrame` instead, and is not what `enter` takes its vref of.
-    let entered_ec = callee_frame_seeded && !ca_concrete_frame.is_null() && {
+    let entered_ec = if callee_frame_seeded && !ca_concrete_frame.is_null() {
         let concrete_ec = pyre_interpreter::call::getexecutioncontext()
             as *mut pyre_interpreter::PyExecutionContext;
         if concrete_ec.is_null() {
-            false
+            None
         } else {
             walker_ec_enter(
                 ctx.trace_ctx,
@@ -6535,8 +6606,24 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 ca_concrete_frame,
                 concrete_ec,
             );
-            true
+            // This inlined level is an activation `execute_frame` would have
+            // charged the recursion counter for.  Counting it at RUN time is
+            // what a recorded call would do, and that is exactly wrong here: a
+            // guard leaving this callee skips the recorded release the same
+            // way it skips the `ec.topframeref` restore below, and a loop that
+            // keeps running inside one portal activation never reaches the
+            // boundary that repairs it — the depth then climbs until an
+            // unrelated call raises `RecursionError`.
+            //
+            // So the level is counted at RECORD time instead, as a width the
+            // seam that does survive to run time — the `CALL_ASSEMBLER` fold,
+            // which runs once per fragment entry — charges in one go.  The
+            // guard makes the width balanced across every early return between
+            // here and the `leave`.
+            Some(OpenInlineActivation::open())
         }
+    } else {
+        None
     };
     let (callee_outcome, callee_class_of_last_exc_is_const) = {
         let mut sub_wc = WalkContext {
@@ -7040,7 +7127,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // Converging needs the `leave` reachable from those guard exits — a
     // resume-side leave, or the exception path recording its own — not a
     // reorder.
-    if entered_ec {
+    if let Some(open_activation) = entered_ec {
         let concrete_ec = pyre_interpreter::call::getexecutioncontext()
             as *mut pyre_interpreter::PyExecutionContext;
         // `leave(frame, w_exitvalue, got_exception)` — the caller passes true
@@ -7058,6 +7145,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             concrete_ec,
             got_exception,
         );
+        drop(open_activation);
     }
     // RPython has one MetaInterp shared by every MIFrame.  The sub-walk uses
     // a copied FbwWalkMode only to satisfy Rust's nested borrow, so write the


### PR DESCRIPTION
`sys.setrecursionlimit` did not bound a recursion once the JIT owned it. Under a limit of 500, a warm self-recursive function answered **1,000,000 levels**; it now raises at 503 (cold raises at 497, CPython 3.14 at 499).

## Why

pyre's `stack_check()` carries a logical depth test against `sys.getrecursionlimit()` in addition to PyPy's native stack probe — a deliberate choice this tree records in `set_recursion_limit` ("Logical depth below is what enforces the newly lowered Python limit"). That logical half's only home is `execute_frame`'s entry, where `insert_ll_stackcheck` puts `stack_check()` at operation 0.

The JIT synthesizes that entry in two places — the inlined-callee fold and the `CALL_ASSEMBLER` fold — and both jumped over the operation in front of it. Nothing on the compiled path consulted the limit.

Upstream has no equivalent hole: its jitcodes are built before the check exists (`driver.py`'s `pyjitpl_lltype` depends on `rtype` alone, while `stackcheckinsertion_lltype` follows `backendopt`), and the backend's per-fragment SP probe covers the whole of `rstack.stack_check`, which is native-only.

## Shape

One runtime call pair per fragment, at the `CALL_ASSEMBLER` seam — the only seam a guard cannot leave unbalanced. The inlined levels above it are counted at **record time** by an `OpenInlineActivation` RAII guard and charged by that seam in one go, so the accumulated count is exact while the check granularity is the inline width.

Counting inlined levels with recorded ops instead was measured and rejected: a guard leaving an inlined callee skips the recorded release the same way it skips the `ec.topframeref` restore, and a loop running inside one portal activation never reaches the boundary that repairs it. That drifted into a spurious `RecursionError` at 3 frames deep and 47 red benchmarks.

Two smaller fixes ride along:

- `recursion_depth_check()` is split out of `stack_check()`. The seam calls only the logical half, since the backend already emits the native probe at every fragment entry — worth 12% on `fib_recursive`/cranelift.
- `jit_release_recursion_unit` took `PyFrame.f_backref` as "the caller frame". That field holds the caller's *vref*, not the caller. The enter now returns the claim it displaces and the leave takes it back, pairing the two by a dataflow edge.

## Verification

| gate | result |
|---|---|
| `check.py` dynasm | 535 passed, 0 failed |
| `check.py` cranelift | 534 passed, 1 failed — pre-existing, see below |
| `parity_tests/run.py` | all pass (115 scripts) |
| `cpython_tests/run.py --backend dynasm` | pass |
| `cargo test --all` | pass |
| `cargo fmt --check`, new-line-citations | pass |

The one cranelift failure is `synth/range_step_one_shapes`: `range_step_one_shapes.cranelift.jitstats` does not exist in the tree (only the dynasm baseline was recorded). `main` fails the same row on the same platform, so it is untouched here.

`fib_recursive`/cranelift did regress and was brought back under its gate (2.7x → 2.3x, gate 2.5x) by the logical-only split. No jitstats baseline needed re-recording.

**Scope note:** the gate results above were produced on the pre-rebase tree. This branch was then rebased onto #1625 and #1648; the rebased tree type-checks and passes fmt/citations, but the benchmark and test gates have not been re-run on the new base. CI is the authority there.

The new parity fixture is `pypy-diverges`: pypy3's limit is approximate for the reason above, so it answers `rec(1000)` under a limit of 500. It also documents why its sibling `recursion_limit_survives_jit_warmup.py` did not catch this — that one asserts the depth reached stays *at or under* the limit, which is satisfied whenever the native byte budget cuts in first, exactly the case its own docstring records.

— *commented by Claude*