### PR TITLE
rtyper: a Void operand's Constant, the char-to-string add rule on both sides, a family-keyed IndirectCall's pre-rtyper shape, and the annotator error carried as an object (#346)

### DIFF
--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -274,11 +274,17 @@ census. In particular `int_pow`, `pow` and `opcode_get_iter` (Slice A's
 deferral note) name no record now; re-derive a population from a fresh census
 before working any item list in this document.
 
-**Provenance.** Branch `rtyper2` at `3d7db8a9053`, probes at `9bfbafe3f80`,
-release profile, default features, `build/llbc` re-extracted for `majit-rlib
+**Provenance.** Branch `rtyper2` with the batch below applied: release
+profile, default features, `build/llbc` re-extracted for `majit-rlib
 pyre-object pyre-interpreter pyre-jit` at each tree, `PYRE_RTYPER_VERBOSE=1
 cargo build --release -p pyre-jit-trace`, graded by the build's own exit status
 and by the stderr file's mtime against the build start, never by `ls -t` alone.
+
+The baseline and the probe of each pair below were taken on one tree, and the
+branch has been rebased past that tree since, so those commits are no longer
+reachable by hash. What survives a rebase is the pair — a movement measured
+against its own baseline — not the absolute, which the section after next
+re-measures on a later base and finds different.
 
 A census is comparable only to another census taken on the same tree with the
 same artefacts. Both halves matter: a rebase that touches any of the four
@@ -375,3 +381,51 @@ Either add `Box` to the interned placeholder set (it is likewise one universal
 tag with no enum ambiguity, so the stated justification for the other three
 covers it) or give the ctor an owner path. Both change the existing
 `ShallowInitBox` lowering, so neither ships without its own census.
+
+### What a base move does to these numbers
+
+Re-taken with the same batch applied on a base 238 files further on, and
+`build/llbc` re-extracted for all four crates, phase A reads 1889 and phase B
+reads 5. Neither is comparable to the 1848 and 25 above — that is the rule at
+the top of this section, applied to itself. What carries over is the
+composition.
+
+Phase B's two shapes at that base:
+
+- `pyre_object::interp_exceptions::is_exception` — `don't know how to convert
+  from <InstanceRepr Ptr GcStruct pyobject::PyType> to <RootClassRepr Ptr
+  Struct object_vtable>`. There is no such conversion upstream to port:
+  `convert_from_to` between instance reprs is `pairtype(InstanceRepr,
+  InstanceRepr)`, the only pairtype naming a class repr is
+  `pairtype(ClassesPBCRepr, ClassRepr)`, and an instance's vtable is reached
+  by an *operation* — `InstanceRepr.rtype_type`, which reads the `typeptr`
+  field or calls `ll_inst_type`. So the site to change is the one asking the
+  rtyper to convert, not the pairtype table.
+- Four graphs — `topframe_for_locals` and three
+  `__majit_wrap_descr_typecheck_*` getters — all failing on the same op,
+  `simple_call(jit_force_virtualizable, frame)`, whose result variable carries
+  `SomeNone` and no concretetype, which is what the rtyper's `the annotator
+  doesn't agree that 'simple_call' has no return value` reports. The same
+  graphs were `MAJIT_RTYPER skip` rows on the earlier base; the base moved the
+  force gateways, and the graphs now reach phase B to fail there.
+
+### The one slice the census names: a dead vtable read
+
+Every `Blocked block` record is a `getattr` (189 of them at that base), and 68
+name a vtable slot on a receiver whose `SomeInstance` classdef is the empty
+`{vtable}` class: `__cast_instance_intrinsic(recv, "{vtable}")`, then
+`getattr(.., "method_strategy_kind")`. 58 of the 68 were `IndirectCall`
+records before that wall was closed, so this is where most of that wall's
+relocated victims went — the victim map the grading rule above asks for, one
+slice later.
+
+The cause is on the `OpKind::IndirectCall` arm. It drops the `funcptr`
+*operand*, because the `getattr` re-derives it from the receiver — but the ops
+that *defined* that operand, the vtable cast and the slot read, are already in
+the graph, and the annotator still annotates them, against a class with no
+fields. The front end cannot simply stop emitting them: the residual path
+still calls through that pointer for real (`codewriter/call.rs`'s
+`IndirectCall { graphs: None, funcptr, .. }`, and its `inline.rs` and
+`result_exc.rs` peers). So the repair is a dead-op sweep over the flowspace
+graph in the prepass, which is a design rather than a registration, and it
+needs its own census.

--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -264,3 +264,114 @@ opname lives in `insns.bin` (build OUT_DIR `target/debug/build/pyre-jit-trace-<h
 `strings insns.bin | rg newlist`), not stderr. The cluster's hot graphs (`setitem_list`,
 `getitem_list`, `w_list_setitem`, `setitem_bytearray`) only lift once ALL their stacked walls close —
 expect most of the census movement on the LAST slice.
+
+## Superseding census — 2026-09-02
+
+The Slice A/B/C item lists above are historical. They were derived from a
+268/276-record census, and the two-phase prepass has since grown its subject
+set by an order of magnitude, so their named subjects no longer exist in the
+census. In particular `int_pow`, `pow` and `opcode_get_iter` (Slice A's
+deferral note) name no record now; re-derive a population from a fresh census
+before working any item list in this document.
+
+**Provenance.** Branch `rtyper2` at `3d7db8a9053`, probes at `9bfbafe3f80`,
+release profile, default features, `build/llbc` re-extracted for `majit-rlib
+pyre-object pyre-interpreter pyre-jit` at each tree, `PYRE_RTYPER_VERBOSE=1
+cargo build --release -p pyre-jit-trace`, graded by the build's own exit status
+and by the stderr file's mtime against the build start, never by `ls -t` alone.
+
+A census is comparable only to another census taken on the same tree with the
+same artefacts. Both halves matter: a rebase that touches any of the four
+extracted crates restales `build/llbc`, and the chain order is therefore
+extract → test → census, never test → census on artefacts from an older tree.
+
+**Phase A = 1883 records, one record per subject.** Reading a record: split on
+`(?=\[PREPASS )`; a trailing `thread '<unnamed>' … panicked` block belongs to
+the NEXT record; the subject is the record head, and the nested chain inside
+one record is a free victim map. The text is JSON-escaped and quotes
+identifiers in backticks, so a needle must be copied out of the file, never
+retyped.
+
+| family | records | share |
+|---|---|---|
+| unregistered CallRegistry path | 1203 | 63.9% |
+| Blocked block | 202 | 10.7% |
+| classdef-less `getattr` | 171 | 9.1% |
+| UnionError | 147 | 7.8% |
+| no analyser registered | 44 | 2.3% |
+| undefined operand | 27 | 1.4% |
+| other | 89 | 4.7% |
+
+### The frontier is flat, and the census total is not the metric
+
+`MAJIT_RTYPER_FRONTIER=1` resumes past every unresolvable call instead of
+stopping at the first, so each subject reports its whole call-wall set rather
+than the wall it happened to reach first. On this tree 629 subjects carry wall
+rows; 397 of them have a single distinct wall, and **the largest single wall
+serves 25 subjects** (`undefined operand`), the next 8, then 7, 7, 6, 6. No
+registry closure on this frontier buys more than ~1.3% of phase A.
+
+That flatness is why a wall's record count going to zero says nothing on its
+own. The `IndirectCall` wall (253 records, then the single largest leaf) was
+closed at `9bfbafe3f80`: the wall went 253 → 0 and **not one graph lifted** —
+all 253 subjects relocated, to Blocked block (60), `iter::sources::once::once`
+(52), `Chain::next` (22), UnionError (15) and eleven smaller heads. Grade a
+wall by the per-subject victim map — for each subject that named X in the
+baseline, what is its head cause in the probe — not by the total.
+
+Two co-blocking stacks are already measured and should be assumed, not
+rediscovered:
+
+- `getattr_str_impl` (baseobjspace.rs:5791) holds `w_method_new` at :5928 and,
+  through `object_getattr_miss` at :6345 → `getdictvalue` → `has_mapdict_layout`,
+  `W_INT_USER_GC_TYPE_ID` at mapdict.rs:644. Source order decides which is
+  reported. The signature is visible in the census as a near-even split inside
+  one class family (`_io::buffered_random` 9/9, `_io::buffered` 8/9,
+  `_io::textio` 13/7).
+- Foreign `core::iter` adapters chain among themselves: registering
+  `iter::sources::once::once` moves its victims to `Chain::chain`, then to
+  `Chain::next`, which is an adapter state machine with no RPython counterpart.
+  The cure for that family is source-side (do not write the adapter chain), not
+  a registry row.
+
+### What the first graded batch moved, and where the frontier went
+
+Three changes measured together against the 1883-record baseline:
+`Constant(None, Void)` for a Void operand, the `SomeChar`/`SomeString` MRO
+edge, and dropping the `chain(once(..))` adapter out of `w_method_new`.
+Phase A 1883 → 1848; 48 subjects left the fail list, 13 entered it, no graph
+that previously cleared phase A stopped clearing it.
+
+The 13 entrants are not regressions. Each appears nowhere in the baseline
+census — not as a failure and not as a skip — because its caller blocked
+before it could be reached. They fail at a merge (`Method ∪ W_FloatObject` and
+kin), which is the wall behind `w_method_new`, one level deeper than the wall
+that was closed.
+
+The frontier also moved from phase A to phase B for the first time on this
+family. Phase B had **zero** failures in the baseline; it now has 25, and all
+25 carry one message: `pair(rtype_add) not implemented for (StringRepr,
+CharRepr)`. That is the rtyper-side twin of the annotator MRO edge, closed in
+the same commit; it is recorded here because the shape recurs. A rule ported
+at the annotator alone will surface its rtyper half as a phase-B wall, and
+phase-B counts are not in the phase-A histogram — read both.
+
+### Refuted: lowering `Box::new_uninit` to a zero-arg synthetic ctor
+
+A no-arg `boxed::Box::new_uninit()` (32 records / 14 graphs) looks like it
+should lower to `CallTarget::synthetic_transparent_ctor("Box")` with no args,
+the spelling `Rvalue::ShallowInitBox` already uses. It should not, as written:
+
+- A zero-arg `SyntheticTransparentCtor` is first read as a unit-variant
+  singleton (`flowspace_adapter.rs`, the `args.is_empty()` arm). `"Box"` is not
+  on `is_synthetic_unit_variant_path`, so it falls through.
+- The general arm then interns by qualname only for the fixed placeholder tags
+  `Tuple | Array | Closure`. `synthetic_transparent_ctor` leaves `owner_path`
+  empty, so `"Box"` takes the `HostObject::new_class` branch and mints a fresh
+  `ClassDesc` **per site** — the exact split the same arm's comment warns about,
+  whose symptom is a UnionError at a join with no common base.
+
+Either add `Box` to the interned placeholder set (it is likewise one universal
+tag with no enum ambiguity, so the stated justification for the other three
+covers it) or give the ctor an owner path. Both change the existing
+`ShallowInitBox` lowering, so neither ships without its own census.

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -1239,11 +1239,13 @@ impl RPythonAnnotator {
         // upstream "the annotator stops" semantics.
         self.bookkeeper
             .compute_at_fixpoint()
-            .unwrap_or_else(|err| panic!("compute_at_fixpoint failed: {err}"));
+            .unwrap_or_else(|err| std::panic::panic_any(err.in_stage("compute_at_fixpoint")));
         // upstream: `if block_subset is None: perform_normalizations(self)`
         if block_subset.is_none() {
             super::super::translator::rtyper::normalizecalls::perform_normalizations(self)
-                .unwrap_or_else(|err| panic!("perform_normalizations failed: {err}"));
+                .unwrap_or_else(|err| {
+                    std::panic::panic_any(err.in_stage("perform_normalizations"))
+                });
         }
     }
 

--- a/majit/majit-translate/src/annotator/binaryop.rs
+++ b/majit/majit-translate/src/annotator/binaryop.rs
@@ -1396,8 +1396,8 @@ fn init_string_pairtype(
 }
 
 fn string_string_add(ann: &RPythonAnnotator, hl: &HLOperation) -> SomeValue {
-    // `SomeChar` is a `SomeString` subclass (model.py:309), and
-    // `pairtype(SomeChar, SomeChar)` (binaryop.py:374) registers only
+    // `SomeChar` is a `SomeString` subclass (model.py), and
+    // `pairtype(SomeChar, SomeChar)` (binaryop.py) registers only
     // `union`, so a char operand on either side resolves to this arm
     // through the MRO and the result is a `SomeString` either way.
     fn extract(sv: &SomeValue, side: &str) -> (bool, Option<Vec<u8>>) {

--- a/majit/majit-translate/src/annotator/binaryop.rs
+++ b/majit/majit-translate/src/annotator/binaryop.rs
@@ -1396,24 +1396,40 @@ fn init_string_pairtype(
 }
 
 fn string_string_add(ann: &RPythonAnnotator, hl: &HLOperation) -> SomeValue {
-    let s1 = match ann.annotation(&hl.args[0]) {
-        Some(SomeValue::String(s)) => s,
-        _ => panic!("string_string_add: arg 0 is not SomeString"),
-    };
-    let s2 = match ann.annotation(&hl.args[1]) {
-        Some(SomeValue::String(s)) => s,
-        _ => panic!("string_string_add: arg 1 is not SomeString"),
-    };
-    let mut result = SomeString::new(false, s1.inner.no_nul && s2.inner.no_nul);
+    // `SomeChar` is a `SomeString` subclass (model.py:309), and
+    // `pairtype(SomeChar, SomeChar)` (binaryop.py:374) registers only
+    // `union`, so a char operand on either side resolves to this arm
+    // through the MRO and the result is a `SomeString` either way.
+    fn extract(sv: &SomeValue, side: &str) -> (bool, Option<Vec<u8>>) {
+        let (inner, is_immutable_constant) = match sv {
+            SomeValue::String(s) => (&s.inner, s.is_immutable_constant()),
+            SomeValue::Char(c) => (&c.inner, c.is_immutable_constant()),
+            other => panic!("string_string_add: {side} is not SomeString/SomeChar: {other:?}"),
+        };
+        // upstream reads `str.const` only under `is_immutable_constant()`,
+        // so a non-constant operand contributes no const half.
+        let bytes = is_immutable_constant
+            .then(|| match inner.base.const_box.as_ref().map(|c| &c.value) {
+                Some(ConstValue::ByteStr(b)) => Some(b.clone()),
+                _ => None,
+            })
+            .flatten();
+        (inner.no_nul, bytes)
+    }
+    let a = ann
+        .annotation(&hl.args[0])
+        .expect("string_string_add: lhs unbound");
+    let b = ann
+        .annotation(&hl.args[1])
+        .expect("string_string_add: rhs unbound");
+    let (no_nul1, c1) = extract(&a, "arg 0");
+    let (no_nul2, c2) = extract(&b, "arg 1");
+    let mut result = SomeString::new(false, no_nul1 && no_nul2);
     // upstream: `if str1.is_immutable_constant() and str2.is_immutable_constant():
     //              result.const = str1.const + str2.const`
-    if s1.is_immutable_constant()
-        && s2.is_immutable_constant()
-        && let (Some(c1), Some(c2)) = (&s1.inner.base.const_box, &s2.inner.base.const_box)
-        && let (ConstValue::ByteStr(a), ConstValue::ByteStr(b)) = (&c1.value, &c2.value)
-    {
-        let mut combined = a.clone();
-        combined.extend_from_slice(b);
+    if let (Some(a), Some(b)) = (c1, c2) {
+        let mut combined = a;
+        combined.extend_from_slice(&b);
         result.inner.base.const_box = Some(Constant::new(ConstValue::ByteStr(combined)));
     }
     SomeValue::String(result)

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -3024,6 +3024,57 @@ impl fmt::Display for AnnotatorError {
 
 impl std::error::Error for AnnotatorError {}
 
+/// Read a caught panic payload as text.
+///
+/// Upstream's handlers catch a typed exception and read its fields —
+/// `annrpython.py:530` catches `AnnotatorError` to attach `source`,
+/// `rtyper.py:493` catches `TyperError` to attach `where` — and the message
+/// text is produced once, at the terminal report (`annrpython.py:244`,
+/// `'\n-----'.join(str(e) for e in self.errors)`). A pyre unwind carries
+/// either the error object or an already-formatted string, so the object is
+/// read first and the string is the fallback.
+///
+/// Every consumer of an annotator unwind must go through this one reader.
+/// A site that hand-rolls `downcast_ref::<String>` reads an object payload
+/// as "unrecognised", and the dual gate then treats a routine unported
+/// subject as a real bug because [`crate::translator::rtyper::cutover::is_known_unported`]
+/// never sees the message.
+///
+/// `None` is reserved for a payload that is neither — each caller keeps its
+/// own wording for that case.
+pub fn panic_payload_text(payload: &(dyn std::any::Any + Send)) -> Option<String> {
+    if let Some(err) = payload.downcast_ref::<AnnotatorError>() {
+        return Some(err.to_string());
+    }
+    if let Some(text) = payload.downcast_ref::<String>() {
+        return Some(text.clone());
+    }
+    if let Some(text) = payload.downcast_ref::<&'static str>() {
+        return Some((*text).to_string());
+    }
+    None
+}
+
+impl AnnotatorError {
+    /// Name the annotator entry point that was driving when this error
+    /// surfaced, without changing the error's class.
+    ///
+    /// Upstream raises `AnnotatorError` from inside `compute_at_fixpoint`
+    /// and `complete_pending_blocks` and lets it propagate as itself; the
+    /// class is what tells a handler which half of the translator failed,
+    /// and `rtyper.py:493` keeps `TyperError` separate for the other half.
+    /// A caller that reformats one into the other erases that distinction,
+    /// after which the stage is recoverable only by matching substrings of
+    /// the rendered text.
+    pub fn in_stage(mut self, stage: &str) -> Self {
+        self.msg = Some(match self.msg.take() {
+            Some(msg) => format!("{stage} failed: {msg}"),
+            None => format!("{stage} failed"),
+        });
+        self
+    }
+}
+
 // ---------------------------------------------------------------------------
 // union() dispatch (A4.6) — model.py + binaryop.py pair().union().
 // ---------------------------------------------------------------------------

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2269,14 +2269,14 @@ impl SomeValueTag {
             T::Type => &[T::Type, T::Object],
             // String family: `SomeString`, `SomeUnicodeString` and
             // `SomeByteArray` share a `SomeStringOrUnicode` base
-            // (model.py:288, 296, 304) that carries no pairtype
+            // (model.py) that carries no pairtype
             // registration, so naming it here would resolve nothing — those
             // three resolve to themselves then Object. The two element tags
             // do inherit from a registered class: `SomeChar(SomeString)`
-            // (model.py:309) and `SomeUnicodeCodePoint(SomeUnicodeString)`
-            // (model.py:318). That edge is load-bearing — `pairtype(SomeChar,
-            // SomeChar)` (binaryop.py:374) defines only `union`, so `chr + chr`
-            // reaches `pairtype(SomeString, SomeString).add` (binaryop.py:338)
+            // and `SomeUnicodeCodePoint(SomeUnicodeString)` (model.py). That
+            // edge is load-bearing — `pairtype(SomeChar, SomeChar)`
+            // (binaryop.py) defines only `union`, so `chr + chr` reaches
+            // `pairtype(SomeString, SomeString).add` (binaryop.py)
             // through it, and a char operand serves every other `SomeString`
             // pair the same way.
             T::String => &[T::String, T::Object],
@@ -3037,9 +3037,9 @@ impl std::error::Error for AnnotatorError {}
 /// Read a caught panic payload as text.
 ///
 /// Upstream's handlers catch a typed exception and read its fields —
-/// `annrpython.py:530` catches `AnnotatorError` to attach `source`,
-/// `rtyper.py:493` catches `TyperError` to attach `where` — and the message
-/// text is produced once, at the terminal report (`annrpython.py:244`,
+/// `flowin` (annrpython.py) catches `AnnotatorError` to attach `source`,
+/// `gottypererror` (rtyper.py) catches `TyperError` to attach `where` — and
+/// the message text is produced once, at the terminal report (`complete`,
 /// `'\n-----'.join(str(e) for e in self.errors)`). A pyre unwind carries
 /// either the error object or an already-formatted string, so the object is
 /// read first and the string is the fallback.
@@ -3072,7 +3072,8 @@ impl AnnotatorError {
     /// Upstream raises `AnnotatorError` from inside `compute_at_fixpoint`
     /// and `complete_pending_blocks` and lets it propagate as itself; the
     /// class is what tells a handler which half of the translator failed,
-    /// and `rtyper.py:493` keeps `TyperError` separate for the other half.
+    /// and `gottypererror` (rtyper.py) keeps `TyperError` separate for the
+    /// other half.
     /// A caller that reformats one into the other erases that distinction,
     /// after which the stage is recoverable only by matching substrings of
     /// the rendered text.

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2267,13 +2267,23 @@ impl SomeValueTag {
             // Type chain: SomeTypeOf < SomeType < SomeObject (model.py).
             T::TypeOf => &[T::TypeOf, T::Type, T::Object],
             T::Type => &[T::Type, T::Object],
-            // String family shares a SomeStringOrUnicode base upstream; dispatch
-            // is flat — each tag resolves to itself then Object.
+            // String family: `SomeString`, `SomeUnicodeString` and
+            // `SomeByteArray` share a `SomeStringOrUnicode` base
+            // (model.py:288, 296, 304) that carries no pairtype
+            // registration, so naming it here would resolve nothing — those
+            // three resolve to themselves then Object. The two element tags
+            // do inherit from a registered class: `SomeChar(SomeString)`
+            // (model.py:309) and `SomeUnicodeCodePoint(SomeUnicodeString)`
+            // (model.py:318). That edge is load-bearing — `pairtype(SomeChar,
+            // SomeChar)` (binaryop.py:374) defines only `union`, so `chr + chr`
+            // reaches `pairtype(SomeString, SomeString).add` (binaryop.py:338)
+            // through it, and a char operand serves every other `SomeString`
+            // pair the same way.
             T::String => &[T::String, T::Object],
             T::UnicodeString => &[T::UnicodeString, T::Object],
             T::ByteArray => &[T::ByteArray, T::Object],
-            T::Char => &[T::Char, T::Object],
-            T::UnicodeCodePoint => &[T::UnicodeCodePoint, T::Object],
+            T::Char => &[T::Char, T::String, T::Object],
+            T::UnicodeCodePoint => &[T::UnicodeCodePoint, T::UnicodeString, T::Object],
             T::List => &[T::List, T::Object],
             T::Tuple => &[T::Tuple, T::Object],
             T::Dict => &[T::Dict, T::Object],

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -594,10 +594,14 @@ pub fn simple_call_SomeObject(ann: &RPythonAnnotator, hl: &HLOperation) -> Optio
     // through to `consider_op`, which binds Impossible without blocking.
     match s_func.call(&argspec) {
         Ok(cell) => cell,
-        // Match upstream's substring so the dual-gate `is_known_unported`
-        // Skip classification matches RPython's `compute_at_fixpoint`
-        // failures (`bookkeeper.py:108-118` propagates uncaught).
-        Err(e) => panic!("compute_at_fixpoint failed: {e}"),
+        // `bookkeeper.py:108-118` propagates uncaught, so the error leaves
+        // the annotator as itself. Carrying the `AnnotatorError` rather
+        // than a rendering of it keeps the failing stage in the payload's
+        // type, which is how `annrpython.py:530` knows to attach `source`
+        // and how `rtyper.py:493` stays a separate handler; `in_stage`
+        // names the entry point inside the message the way upstream
+        // composes it at the raise site.
+        Err(e) => std::panic::panic_any(e.in_stage("compute_at_fixpoint")),
     }
 }
 
@@ -615,7 +619,7 @@ pub fn call_args(ann: &RPythonAnnotator, hl: &HLOperation) -> Option<SomeValue> 
     let callspec = super::argument::complex_args(&shape, args_s);
     match s_func.call(&callspec) {
         Ok(cell) => cell,
-        Err(e) => panic!("compute_at_fixpoint failed: {e}"),
+        Err(e) => std::panic::panic_any(e.in_stage("compute_at_fixpoint")),
     }
 }
 

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -594,11 +594,12 @@ pub fn simple_call_SomeObject(ann: &RPythonAnnotator, hl: &HLOperation) -> Optio
     // through to `consider_op`, which binds Impossible without blocking.
     match s_func.call(&argspec) {
         Ok(cell) => cell,
-        // `bookkeeper.py:108-118` propagates uncaught, so the error leaves
-        // the annotator as itself. Carrying the `AnnotatorError` rather
-        // than a rendering of it keeps the failing stage in the payload's
-        // type, which is how `annrpython.py:530` knows to attach `source`
-        // and how `rtyper.py:493` stays a separate handler; `in_stage`
+        // `compute_at_fixpoint` (bookkeeper.py) propagates uncaught, so the
+        // error leaves the annotator as itself. Carrying the
+        // `AnnotatorError` rather than a rendering of it keeps the failing
+        // stage in the payload's type, which is how `flowin`
+        // (annrpython.py) knows to attach `source` and how `gottypererror`
+        // (rtyper.py) stays a separate handler; `in_stage`
         // names the entry point inside the message the way upstream
         // composes it at the raise site.
         Err(e) => std::panic::panic_any(e.in_stage("compute_at_fixpoint")),

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3883,7 +3883,16 @@ impl CallControl {
                 else {
                     continue;
                 };
-                let Some((trait_root, method_name)) = family_key.take() else {
+                // Read the key without clearing it. The two-phase prepass runs
+                // after this fill on the same shared store, and its flowspace
+                // adapter needs the same `(trait_root, method_name)` to emit
+                // the pre-rtyper `getattr` + `simple_call` shape — an
+                // `indirect_call` op does not exist before rtyping. The later
+                // `rpbc::lower_indirect_calls` re-enters its own `take()` arm
+                // and recomputes `graphs` through `all_impls_for_indirect`,
+                // which is this same lookup over the same map, so the value it
+                // writes is unchanged.
+                let Some((trait_root, method_name)) = family_key.clone() else {
                     continue;
                 };
                 let family = trait_method_impls
@@ -11809,6 +11818,11 @@ mod tests {
     /// `CallControl.find_all_graphs`.  A MIR vtable call starts with the same
     /// identity in `family_key`; graph discovery must materialise it on the
     /// registered graph, not wait for the later jitcode clone.
+    ///
+    /// The key survives that materialisation: the flowspace adapter reads the
+    /// same `(trait_root, method_name)` later, off this same shared store, to
+    /// emit the pre-rtyper `getattr` + `simple_call` shape.  It is consumed
+    /// where it is spent, in `rpbc::lower_indirect_calls`, on the graph clone.
     #[test]
     fn graph_discovery_materializes_deferred_vtable_family() {
         let mut cc = CallControl::new();
@@ -11851,7 +11865,11 @@ mod tests {
         else {
             panic!("caller operation must remain an indirect call");
         };
-        assert!(family_key.is_none(), "the rtyping key must be consumed");
+        assert_eq!(
+            family_key.as_ref().map(|(t, m)| (t.as_str(), m.as_str())),
+            Some(("Handler", "run")),
+            "the vtable-slot identity must outlive graph discovery"
+        );
         assert_eq!(
             graphs.as_ref().map(Vec::len),
             Some(2),

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -321,13 +321,8 @@ impl CodeWriter {
         let outcome = match dual_gate_outcome {
             Ok(result) => result,
             Err(payload) => {
-                let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
-                    (*s).to_string()
-                } else if let Some(s) = payload.downcast_ref::<String>() {
-                    s.clone()
-                } else {
-                    "<unrecognised panic payload>".to_string()
-                };
+                let msg = crate::annotator::model::panic_payload_text(&*payload)
+                    .unwrap_or_else(|| "<unrecognised panic payload>".to_string());
                 if crate::translator::rtyper::cutover::is_known_unported(&msg) {
                     Ok(crate::translator::rtyper::cutover::DualGateOutcome::Skip(
                         format!("registry build panicked: {msg}"),

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -700,7 +700,6 @@ mod tests {
         }
     }
 
-    #[test]
     /// The rewrite emits a machine-word `*_ovf`, so only the atoms whose
     /// overflow bound IS that word may reach it.
     #[test]
@@ -713,6 +712,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn rewrite_lifts_checked_add_to_add_ovf_with_overflow_edge() {
         let mut g = FunctionGraph::new("test_checked_add");
         let a = g.startblock;

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -336,13 +336,8 @@ pub(crate) fn dual_gate_check_with_registry(
         }
         Err(payload) => {
             unpoison_failed_subject_callees(call_registry, &session_at_entry, lift_sources);
-            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
-                (*s).to_string()
-            } else if let Some(s) = payload.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "<unrecognised panic payload>".to_string()
-            };
+            let msg = crate::annotator::model::panic_payload_text(&*payload)
+                .unwrap_or_else(|| "<unrecognised panic payload>".to_string());
             if is_known_unported(&msg) {
                 return Ok(DualGateOutcome::Skip(msg));
             }
@@ -355,13 +350,8 @@ pub(crate) fn dual_gate_check_with_registry(
         super::legacy_resolve::resolve_types(legacy_graph);
     }));
     if let Err(payload) = baseline {
-        let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
-            (*s).to_string()
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "<unrecognised panic payload>".to_string()
-        };
+        let msg = crate::annotator::model::panic_payload_text(&*payload)
+            .unwrap_or_else(|| "<unrecognised panic payload>".to_string());
         return Err(format!(
             "dual-gate baseline panicked (legacy walker crashed before \
              comparison could run — comparison cannot validate the real \
@@ -3871,10 +3861,7 @@ fn run_phase_b_rtype_isolated(
             if let Err(payload) = result {
                 cutoff_panics += 1;
                 if let Some(trace) = trace {
-                    let payload = payload
-                        .downcast_ref::<&str>()
-                        .map(|message| (*message).to_string())
-                        .or_else(|| payload.downcast_ref::<String>().cloned())
+                    let payload = crate::annotator::model::panic_payload_text(&*payload)
                         .unwrap_or_else(|| "<non-string panic payload>".to_string());
                     eprintln!("[DTRACE-CUTPANIC] {trace} payload={payload:?}");
                 }
@@ -4371,13 +4358,8 @@ pub(crate) fn dual_gate_outcome_from_cache(
         super::legacy_resolve::resolve_types(legacy);
     }));
     if let Err(payload) = baseline {
-        let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
-            (*s).to_string()
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "<unrecognised panic payload>".to_string()
-        };
+        let msg = crate::annotator::model::panic_payload_text(&*payload)
+            .unwrap_or_else(|| "<unrecognised panic payload>".to_string());
         return Err(format!(
             "two-phase baseline panicked (legacy walker crashed before comparison): {msg}"
         ));
@@ -4678,6 +4660,43 @@ mod tests {
         let msg = "unexpected rtyper invariant failure";
         assert_eq!(unported_category(msg), None);
         assert!(!is_known_unported(msg));
+    }
+
+    /// An annotator half that fails leaves the unwind carrying its
+    /// `AnnotatorError`, not a rendering of it — the payload's type is what
+    /// names the failing stage, the way the exception class does upstream.
+    /// Every consumer therefore has to read it through
+    /// `panic_payload_text`; a site that still hand-rolls
+    /// `downcast_ref::<String>` sees "unrecognised" and turns a routine
+    /// unported subject into a hard dual-gate failure.
+    #[test]
+    fn annotator_error_payload_routes_through_the_shared_reader() {
+        use crate::annotator::model::{AnnotatorError, panic_payload_text};
+
+        let payload = std::panic::catch_unwind(|| {
+            std::panic::panic_any(
+                AnnotatorError::new("calltable row not found in CallFamily for simple_call")
+                    .in_stage("compute_at_fixpoint"),
+            )
+        })
+        .expect_err("panic_any always unwinds");
+
+        assert!(
+            payload.downcast_ref::<String>().is_none(),
+            "the payload is the error object, so the string downcast must miss"
+        );
+
+        let text = panic_payload_text(&*payload).expect("the object arm reads it");
+        assert!(
+            text.contains("compute_at_fixpoint failed"),
+            "the entry point stays in the message: {text:?}"
+        );
+        assert_eq!(
+            unported_category(&text),
+            Some("annotator-fixpoint-failed"),
+            "an annotator-stage failure keeps its Skip route: {text:?}"
+        );
+        assert!(is_known_unported(&text));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1268,6 +1268,75 @@ fn translate_op_or_frontier(
     }
 }
 
+/// Lower a `dyn Trait` virtual call to the pre-rtyper shape:
+/// `getattr(receiver, method_name)` then `simple_call(bound_method, args[1..])`,
+/// with the receiver narrowed to the trait family's base `ClassDef` first when
+/// the trait is a registered dispatch family.
+///
+/// `args[0]` is the receiver; the rationale for this shape is on the
+/// `CallTarget::Indirect` arm of [`translate_op`], which is one of the two
+/// callers. The other is that arm's pyre-internal twin, `OpKind::IndirectCall`
+/// carrying a `family_key`: an `indirect_call` op has no pre-rtyper spelling
+/// upstream — `rpbc.py:193-194` mints it inside `rtype_simple_call`, so
+/// everything the annotator sees is still a `simple_call` — and the adapter is
+/// the entry into annotation, so both spellings must arrive here as one.
+fn dyn_trait_dispatch_ops(
+    arg_hls: Vec<Hlvalue>,
+    trait_root: &str,
+    method_name: &str,
+    result: Hlvalue,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
+) -> Result<Vec<FlowspaceOp>, TyperError> {
+    let mut iter = arg_hls.into_iter();
+    let receiver = iter.next().ok_or_else(|| {
+        TyperError::message(
+            "Call::Indirect has empty args: dyn-Trait receiver must be args[0]".to_string(),
+        )
+    })?;
+    let base_root = call_registry
+        .bookkeeper()
+        .registered_trait_family_base_root(trait_root);
+    let mut ops = Vec::with_capacity(3);
+    // Narrow the receiver to the family base classdef when the
+    // trait is a registered dispatch family.
+    let getattr_receiver = if let Some(base_root) = base_root {
+        let callable_host = HOST_ENV
+            .lookup_builtin(crate::runtime_names::shims::CAST_INSTANCE)
+            .ok_or_else(|| {
+                TyperError::message(
+                    "__cast_instance_intrinsic missing from HOST_ENV bootstrap".to_string(),
+                )
+            })?;
+        let narrowed = Hlvalue::Variable(Variable::new());
+        ops.push(FlowspaceOp::new(
+            "simple_call",
+            vec![
+                Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host))),
+                receiver,
+                Hlvalue::Constant(Constant::new(ConstValue::byte_str(&base_root))),
+            ],
+            narrowed.clone(),
+        ));
+        narrowed
+    } else {
+        receiver
+    };
+    let bound_method = Hlvalue::Variable(Variable::new());
+    let mut call_args = Vec::with_capacity(iter.size_hint().0 + 1);
+    call_args.push(bound_method.clone());
+    call_args.extend(iter);
+    ops.push(FlowspaceOp::new(
+        "getattr",
+        vec![
+            getattr_receiver,
+            Hlvalue::Constant(Constant::new(ConstValue::byte_str(method_name))),
+        ],
+        bound_method,
+    ));
+    ops.push(FlowspaceOp::new("simple_call", call_args, result));
+    Ok(ops)
+}
+
 pub fn translate_op(
     op: &SpaceOperation,
     value_map: &HashMap<Variable, Hlvalue>,
@@ -3016,60 +3085,13 @@ pub fn translate_op(
                 CallTarget::Indirect {
                     method_name,
                     trait_root,
-                } => {
-                    let mut iter = arg_hls.into_iter();
-                    let receiver = iter.next().ok_or_else(|| {
-                        TyperError::message(
-                            "Call::Indirect has empty args: dyn-Trait receiver must be args[0]"
-                                .to_string(),
-                        )
-                    })?;
-                    let base_root = call_registry
-                        .bookkeeper()
-                        .registered_trait_family_base_root(trait_root);
-                    let mut ops = Vec::with_capacity(3);
-                    // Narrow the receiver to the family base classdef when the
-                    // trait is a registered dispatch family.
-                    let getattr_receiver = if let Some(base_root) = base_root {
-                        let callable_host = HOST_ENV
-                            .lookup_builtin(crate::runtime_names::shims::CAST_INSTANCE)
-                            .ok_or_else(|| {
-                                TyperError::message(
-                                    "__cast_instance_intrinsic missing from HOST_ENV bootstrap"
-                                        .to_string(),
-                                )
-                            })?;
-                        let narrowed = Hlvalue::Variable(Variable::new());
-                        ops.push(FlowspaceOp::new(
-                            "simple_call",
-                            vec![
-                                Hlvalue::Constant(Constant::new(ConstValue::HostObject(
-                                    callable_host,
-                                ))),
-                                receiver,
-                                Hlvalue::Constant(Constant::new(ConstValue::byte_str(&base_root))),
-                            ],
-                            narrowed.clone(),
-                        ));
-                        narrowed
-                    } else {
-                        receiver
-                    };
-                    let bound_method = Hlvalue::Variable(Variable::new());
-                    let mut call_args = Vec::with_capacity(iter.size_hint().0 + 1);
-                    call_args.push(bound_method.clone());
-                    call_args.extend(iter);
-                    ops.push(FlowspaceOp::new(
-                        "getattr",
-                        vec![
-                            getattr_receiver,
-                            Hlvalue::Constant(Constant::new(ConstValue::byte_str(method_name))),
-                        ],
-                        bound_method,
-                    ));
-                    ops.push(FlowspaceOp::new("simple_call", call_args, result));
-                    Ok(ops)
-                }
+                } => dyn_trait_dispatch_ops(
+                    arg_hls,
+                    trait_root,
+                    method_name,
+                    result,
+                    call_registry,
+                ),
                 CallTarget::UnsupportedExpr => Err(TyperError::message(format!(
                     "translate_op: Call with CallTarget::UnsupportedExpr at \
                      result={} — frontend coverage gap; the `front::mir` \
@@ -3081,30 +3103,45 @@ pub fn translate_op(
         }
 
         // ─── Pyre-internal: IndirectCall ───
-        // RPython `rpython/rtyper/rpbc.py:216-217`:
+        // An `indirect_call` op has no pre-rtyper spelling. Upstream mints it
+        // inside the rtyper — `rpbc.py:193-194` `rtype_simple_call(self, hop):
+        // return self.call(hop)`, which reaches the emit at `rpbc.py:215-217`:
         // ```python
         // vlist.append(hop.inputconst(Void, row_of_graphs.values()))
         // v = hop.genop('indirect_call', vlist, resulttype=rresult)
         // ```
-        // The trailing `c_graphs` Constant must carry actual graph
-        // identities — pyre's parity emits `ConstValue::Graphs(Vec<usize>)`
-        // via `GraphKey::of(&g.graph).as_usize()` (see
-        // `translator/rtyper/rpbc.rs`). The flowspace adapter
-        // doesn't have access to the graph registry that resolves
-        // `CallPath` segments to `Rc<RefCell<FunctionGraph>>` references,
-        // so it cannot construct a faithful `ConstValue::Graphs`. A
-        // synthetic `ConstValue::List(byte_str(qualname))` would silently
-        // drop indirect-call analysis (`graphanalyze.rs` falls back
-        // to `top_result()` for any non-Graphs ConstValue), so fail-loud
-        // is the parity-correct behaviour: `IndirectCall` must be lowered
-        // by `rpbc.rs` (the rtyper-equivalent layer that owns the graph
-        // registry) before reaching the flowspace adapter.
+        // Everything the annotator sees is still a `simple_call`
+        // (`flowspace/operation.py:663-664`, `annotator/unaryop.py:114-118`),
+        // and this adapter is the entry into annotation. So the op cannot be
+        // lowered to a flowspace `indirect_call` before arriving here: the
+        // trailing `c_graphs` Constant that `graphanalyze.py:117-119` reads out
+        // of `op.args[-1]` is a product of rtyping, which has not run yet.
+        //
+        // `family_key` carries the pre-rtyper identity of the vtable slot, so a
+        // dyn-trait dispatch lowers to the same `getattr` + `simple_call` shape
+        // as its `CallTarget::Indirect` twin. `funcptr` is dropped: it is the
+        // `Field[Adt(vtable), slot]` projection, which the `getattr` re-derives
+        // from the receiver at the level the annotator works in.
+        OpKind::IndirectCall {
+            args,
+            family_key: Some((trait_root, method_name)),
+            ..
+        } => {
+            let arg_hls = args
+                .iter()
+                .enumerate()
+                .map(|(i, v)| lookup_operand(value_map, v, op, &format!("args[{i}]")))
+                .collect::<Result<Vec<_>, _>>()?;
+            let result = resolve_result_hlvalue(op, value_map)?;
+            dyn_trait_dispatch_ops(arg_hls, trait_root, method_name, result, call_registry)
+        }
+        // A stored function pointer — no trait receiver and no method name, so
+        // there is nothing for a `getattr` to name. It keeps failing loud.
         OpKind::IndirectCall { .. } => Err(TyperError::message(format!(
-            "translate_op: IndirectCall at result={} must be lowered to \
-             a flowspace `indirect_call` op with `ConstValue::Graphs(Vec<\
-             usize>)` candidate-graph keys by `rpbc.rs:1481-1490` before \
-             reaching the adapter; synthesising a `ConstValue::List` here \
-             would break `graphanalyze.rs:333` indirect-call analysis",
+            "translate_op: IndirectCall at result={} carries no `family_key`, \
+             so it names no dyn-trait vtable slot the adapter can lower to the \
+             pre-rtyper `getattr` + `simple_call` shape; a raw function-pointer \
+             callee has no such shape before rtyping",
             fmt_op_result(op),
         ))),
 
@@ -6433,15 +6470,13 @@ mod tests {
     }
 
     #[test]
-    fn translate_op_indirect_call_surfaces_rpbc_invariant() {
-        // OpKind::IndirectCall must be lowered by `rpbc.rs`
-        // (the rtyper-equivalent layer that owns the graph registry
-        // and can resolve CallPath → ConstValue::Graphs(Vec<usize>))
-        // before reaching the flowspace adapter. Synthesising
-        // `ConstValue::List(byte_str)` here would break
-        // `graphanalyze.rs` indirect-call analysis (any non-Graphs
-        // ConstValue falls back to `top_result()`); fail-loud is the
-        // parity-correct behaviour.
+    fn translate_op_indirect_call_without_family_key_fails_loud() {
+        // An IndirectCall carrying no `family_key` is a stored function
+        // pointer: it names no trait receiver and no method, so there is
+        // nothing for a `getattr` to spell, and a function pointer has no
+        // pre-rtyper shape at all — upstream only ever mints `indirect_call`
+        // inside `rpbc.py:193-217`, after rtyping. Fail-loud is the
+        // parity-correct behaviour for that arm.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
@@ -6459,12 +6494,58 @@ mod tests {
             },
         };
         let err = translate_op(&op, &value_map, &empty_call_registry())
-            .expect_err("IndirectCall must surface rpbc.rs invariant break");
+            .expect_err("a family-key-less IndirectCall must fail loud");
         let msg = format!("{err}");
         assert!(
-            msg.contains("IndirectCall") && msg.contains("rpbc.rs"),
-            "fail-loud must cite IndirectCall + rpbc.rs:1481, got: {msg}"
+            msg.contains("IndirectCall") && msg.contains("family_key"),
+            "fail-loud must name IndirectCall and the missing family_key, got: {msg}"
         );
+    }
+
+    /// An IndirectCall that does carry a `family_key` names a dyn-trait vtable
+    /// slot, and lowers to the same pre-rtyper shape as its `CallTarget::
+    /// Indirect` twin: `getattr(receiver, method)` then `simple_call`. The
+    /// annotator never sees an `indirect_call` — `rpbc.py:193-194` mints that
+    /// inside `rtype_simple_call`, downstream of here.
+    #[test]
+    fn translate_op_indirect_call_with_family_key_lowers_to_getattr_simple_call() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_fixture");
+        let vars = mint_vars(&mut graph, 11);
+        for v in &vars[1..4] {
+            value_map.insert(v.clone(), Hlvalue::Variable(Variable::new()));
+        }
+        let op = SpaceOperation {
+            result: Some(vars[3].clone()),
+            kind: OpKind::IndirectCall {
+                funcptr: vars[1].clone(),
+                args: vec![vars[2].clone()],
+                graphs: None,
+                family_key: Some(("Handler".to_string(), "run".to_string())),
+                result_ty: ValueType::Int,
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("a family-keyed IndirectCall lowers to the dyn-dispatch shape");
+        let names: Vec<&str> = translated.iter().map(|o| o.opname.as_str()).collect();
+        assert_eq!(names, vec!["getattr", "simple_call"]);
+        let Hlvalue::Constant(ref name_const) = translated[0].args[1] else {
+            panic!("getattr's second arg must be the method-name Constant");
+        };
+        assert!(matches!(
+            name_const.value,
+            ConstValue::ByteStr(ref bytes) if bytes == b"run"
+        ));
+        // The bound method threads from getattr.result into simple_call.args[0],
+        // and args[0] of the op — the receiver — is consumed by the getattr.
+        let Hlvalue::Variable(ref m1) = translated[0].result else {
+            panic!("getattr result must be Variable");
+        };
+        let Hlvalue::Variable(ref m2) = translated[1].args[0] else {
+            panic!("simple_call's first arg must be the bound method Variable");
+        };
+        assert_eq!(m1.id(), m2.id());
+        assert_eq!(translated[1].args.len(), 1, "the receiver is not re-passed");
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -400,6 +400,34 @@ fn const_ref_gcref_constant(addr: Option<i64>) -> Constant {
     Constant::with_concretetype(ConstValue::LLPtr(Box::new(p)), GCREF.clone())
 }
 
+/// A Void-typed operand is spelled as a Void `Constant`, never as a
+/// `Variable`: `jtransform.py:83-85` renames every Void var to
+/// `Constant(None, lltype.Void)` before it can be read, and
+/// `rmodel.py:361-363` `pairtype(Repr, VoidRepr).convert_from_to`
+/// converts into Void as `inputconst(lltype.Void, None)`.
+///
+/// The front end relies on that: `front::mir` mints a Void operand with
+/// no defining operation when a field read lands on a fieldless enum,
+/// and says so — "No defining operation, matching the bare
+/// `Constant(None, lltype.Void)` the argument lists skip". Materialising
+/// that constant here is the other half of the same decision, so a Void
+/// operand resolves instead of tripping the undefined-operand invariant.
+///
+/// Only Void is treated this way. A missing operand of any other kind
+/// still fails loud: it names a value some op was supposed to define.
+fn void_constant_for(v: &Variable) -> Option<Hlvalue> {
+    matches!(
+        v.concretetype.borrow().as_ref(),
+        Some(crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Void)
+    )
+    .then(|| {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::None,
+            crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Void,
+        ))
+    })
+}
+
 /// Look up the `Hlvalue` for an operand `Variable`. Surfaces a
 /// fail-loud `TyperError` when the operand is undefined (every
 /// referenced operand `Variable` must have been seeded by
@@ -424,7 +452,11 @@ fn lookup_operand(
     op: &SpaceOperation,
     arg_role: &str,
 ) -> Result<Hlvalue, TyperError> {
-    value_map.get(operand).cloned().ok_or_else(|| {
+    value_map
+        .get(operand)
+        .cloned()
+        .or_else(|| void_constant_for(operand))
+        .ok_or_else(|| {
         let result_label = match op.result.as_ref() {
             Some(var) => format!("Some({var:?})"),
             None => "None".to_string(),
@@ -3669,7 +3701,11 @@ fn link_arg_to_hlvalue(
         // to round-trip through `constant_from_constvalue` and
         // mint a fresh id.
         LinkArg::Const(cv) => Ok(Hlvalue::Constant(cv.clone())),
-        LinkArg::Value(var) => value_map.get(var).cloned().ok_or_else(|| {
+        LinkArg::Value(var) => value_map
+            .get(var)
+            .cloned()
+            .or_else(|| void_constant_for(var))
+            .ok_or_else(|| {
             TyperError::message(format!(
                 "translate_op: undefined operand {var:?} as Link.args[{arg_index}] entry \
                  (source block {source_block_id:?} -> target block {target_block_id:?}) — \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -401,9 +401,10 @@ fn const_ref_gcref_constant(addr: Option<i64>) -> Constant {
 }
 
 /// A Void-typed operand is spelled as a Void `Constant`, never as a
-/// `Variable`: `jtransform.py:83-85` renames every Void var to
+/// `Variable`: `do_rename` inside `Transformer.optimize_block`
+/// (jtransform.py) renames every Void var to
 /// `Constant(None, lltype.Void)` before it can be read, and
-/// `rmodel.py:361-363` `pairtype(Repr, VoidRepr).convert_from_to`
+/// `pairtype(Repr, VoidRepr).convert_from_to` (rmodel.py)
 /// converts into Void as `inputconst(lltype.Void, None)`.
 ///
 /// The front end relies on that: `front::mir` mints a Void operand with
@@ -1309,7 +1310,7 @@ fn translate_op_or_frontier(
 /// `CallTarget::Indirect` arm of [`translate_op`], which is one of the two
 /// callers. The other is that arm's pyre-internal twin, `OpKind::IndirectCall`
 /// carrying a `family_key`: an `indirect_call` op has no pre-rtyper spelling
-/// upstream — `rpbc.py:193-194` mints it inside `rtype_simple_call`, so
+/// upstream — `rpbc.py` mints it inside `rtype_simple_call`, so
 /// everything the annotator sees is still a `simple_call` — and the adapter is
 /// the entry into annotation, so both spellings must arrive here as one.
 fn dyn_trait_dispatch_ops(
@@ -3132,17 +3133,20 @@ pub fn translate_op(
 
         // ─── Pyre-internal: IndirectCall ───
         // An `indirect_call` op has no pre-rtyper spelling. Upstream mints it
-        // inside the rtyper — `rpbc.py:193-194` `rtype_simple_call(self, hop):
-        // return self.call(hop)`, which reaches the emit at `rpbc.py:215-217`:
+        // inside the rtyper — `rpbc.py` `rtype_simple_call(self, hop):
+        // return self.call(hop)`, which reaches the emit in
+        // `FunctionReprBase.call`:
         // ```python
         // vlist.append(hop.inputconst(Void, row_of_graphs.values()))
         // v = hop.genop('indirect_call', vlist, resulttype=rresult)
         // ```
         // Everything the annotator sees is still a `simple_call`
-        // (`flowspace/operation.py:663-664`, `annotator/unaryop.py:114-118`),
+        // (`SimpleCall` in `flowspace/operation.py`,
+        // `simple_call_SomeObject` in `annotator/unaryop.py`),
         // and this adapter is the entry into annotation. So the op cannot be
         // lowered to a flowspace `indirect_call` before arriving here: the
-        // trailing `c_graphs` Constant that `graphanalyze.py:117-119` reads out
+        // trailing `c_graphs` Constant that `GraphAnalyzer.analyze`
+        // (graphanalyze.py) reads out
         // of `op.args[-1]` is a product of rtyping, which has not run yet.
         //
         // `family_key` carries the pre-rtyper identity of the vtable slot, so a
@@ -6507,7 +6511,8 @@ mod tests {
         // pointer: it names no trait receiver and no method, so there is
         // nothing for a `getattr` to spell, and a function pointer has no
         // pre-rtyper shape at all — upstream only ever mints `indirect_call`
-        // inside `rpbc.py:193-217`, after rtyping. Fail-loud is the
+        // inside `rtype_simple_call` and `FunctionReprBase.call` (rpbc.py),
+        // after rtyping. Fail-loud is the
         // parity-correct behaviour for that arm.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
@@ -6537,7 +6542,7 @@ mod tests {
     /// An IndirectCall that does carry a `family_key` names a dyn-trait vtable
     /// slot, and lowers to the same pre-rtyper shape as its `CallTarget::
     /// Indirect` twin: `getattr(receiver, method)` then `simple_call`. The
-    /// annotator never sees an `indirect_call` — `rpbc.py:193-194` mints that
+    /// annotator never sees an `indirect_call` — `rpbc.py` mints that
     /// inside `rtype_simple_call`, downstream of here.
     #[test]
     fn translate_op_indirect_call_with_family_key_lowers_to_getattr_simple_call() {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -457,17 +457,17 @@ fn lookup_operand(
         .cloned()
         .or_else(|| void_constant_for(operand))
         .ok_or_else(|| {
-        let result_label = match op.result.as_ref() {
-            Some(var) => format!("Some({var:?})"),
-            None => "None".to_string(),
-        };
-        TyperError::message(format!(
-            "translate_op: undefined operand {operand:?} as {arg_role} of {opkind} \
+            let result_label = match op.result.as_ref() {
+                Some(var) => format!("Some({var:?})"),
+                None => "None".to_string(),
+            };
+            TyperError::message(format!(
+                "translate_op: undefined operand {operand:?} as {arg_role} of {opkind} \
              (result {result_label}) — adapter invariant broken (every referenced \
              operand must be defined as a block inputarg or op result)",
-            opkind = opkind_variant_name(&op.kind),
-        ))
-    })
+                opkind = opkind_variant_name(&op.kind),
+            ))
+        })
 }
 
 /// Resolve the `Hlvalue` result slot for a legacy op. When the op has
@@ -3117,13 +3117,9 @@ pub fn translate_op(
                 CallTarget::Indirect {
                     method_name,
                     trait_root,
-                } => dyn_trait_dispatch_ops(
-                    arg_hls,
-                    trait_root,
-                    method_name,
-                    result,
-                    call_registry,
-                ),
+                } => {
+                    dyn_trait_dispatch_ops(arg_hls, trait_root, method_name, result, call_registry)
+                }
                 CallTarget::UnsupportedExpr => Err(TyperError::message(format!(
                     "translate_op: Call with CallTarget::UnsupportedExpr at \
                      result={} — frontend coverage gap; the `front::mir` \
@@ -3706,13 +3702,13 @@ fn link_arg_to_hlvalue(
             .cloned()
             .or_else(|| void_constant_for(var))
             .ok_or_else(|| {
-            TyperError::message(format!(
-                "translate_op: undefined operand {var:?} as Link.args[{arg_index}] entry \
+                TyperError::message(format!(
+                    "translate_op: undefined operand {var:?} as Link.args[{arg_index}] entry \
                  (source block {source_block_id:?} -> target block {target_block_id:?}) — \
                  adapter invariant broken (every referenced operand must be \
                  defined as a block inputarg or op result)",
-            ))
-        }),
+                ))
+            }),
     }
 }
 

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -655,6 +655,33 @@ fn dispatch_rtype_op(
         | (AbstractStringRepr, AbstractStringRepr, "inplace_add") => {
             committed(super::rstr::pair_abstract_string_rtype_add(r1, r2, hop))
         }
+        // `rtype_add` is defined at exactly one place, `pairtype(
+        // AbstractStringRepr, AbstractStringRepr)` (rstr.py:651-659); no
+        // char pairtype defines one. A char operand reaches that body
+        // through `CharRepr(AbstractCharRepr, StringRepr)` and
+        // `UniCharRepr(AbstractUniCharRepr, UnicodeRepr)`
+        // (lltypesystem/rstr.py:291, 294), which is also where
+        // `char_repr.repr` comes from: `StringRepr.repr = string_repr`
+        // and `UniCharRepr.repr = unicode_repr` (lltypesystem/rstr.py:
+        // 1262-1264), so `rtype_add` coerces both operands to the
+        // string surface and calls the same `ll_strconcat`. The two
+        // functions below already coerce that way, and
+        // `pair_convert_from_to` already carries the Char→Str /
+        // UniChar→Unicode `ll_chr2str` edge, so the mixed and char-only
+        // pairs need dispatch entries and no lowering of their own.
+        // Pyre's CharRepr pair_mro is [CharRepr, Repr] (explicit-arm
+        // design, as for the comparisons below), so they are spelled
+        // out rather than inherited.
+        (StringRepr, CharRepr, "add" | "inplace_add")
+        | (CharRepr, StringRepr, "add" | "inplace_add")
+        | (CharRepr, CharRepr, "add" | "inplace_add") => {
+            committed(super::rstr::pair_string_string_rtype_add(hop))
+        }
+        (UnicodeRepr, UniCharRepr, "add" | "inplace_add")
+        | (UniCharRepr, UnicodeRepr, "add" | "inplace_add")
+        | (UniCharRepr, UniCharRepr, "add" | "inplace_add") => {
+            committed(super::rstr::pair_unicode_unicode_rtype_add(hop))
+        }
         // rtuple.py — `pairtype(TupleRepr, TupleRepr).rtype_add`
         // (and its `rtype_inplace_add` alias) concatenates two tuples
         // by per-position getfield + newtuple_cached.

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -656,14 +656,14 @@ fn dispatch_rtype_op(
             committed(super::rstr::pair_abstract_string_rtype_add(r1, r2, hop))
         }
         // `rtype_add` is defined at exactly one place, `pairtype(
-        // AbstractStringRepr, AbstractStringRepr)` (rstr.py:651-659); no
+        // AbstractStringRepr, AbstractStringRepr)` (rstr.py); no
         // char pairtype defines one. A char operand reaches that body
         // through `CharRepr(AbstractCharRepr, StringRepr)` and
         // `UniCharRepr(AbstractUniCharRepr, UnicodeRepr)`
-        // (lltypesystem/rstr.py:291, 294), which is also where
-        // `char_repr.repr` comes from: `StringRepr.repr = string_repr`
-        // and `UniCharRepr.repr = unicode_repr` (lltypesystem/rstr.py:
-        // 1262-1264), so `rtype_add` coerces both operands to the
+        // (lltypesystem/rstr.py), which is also where `char_repr.repr`
+        // comes from: `StringRepr.repr = string_repr` and
+        // `UniCharRepr.repr = unicode_repr` (lltypesystem/rstr.py), so
+        // `rtype_add` coerces both operands to the
         // string surface and calls the same `ll_strconcat`. The two
         // functions below already coerce that way, and
         // `pair_convert_from_to` already carries the Char→Str /

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -384,6 +384,23 @@ fn dispatch_convert_from_to(
         (FunctionRepr, FunctionsPBCRepr) => {
             super::rpbc::pair_function_repr_functions_pbc_convert_from_to(r_from, r_to, v, llops)
         }
+        // rpbc.py — pairtype(MultipleFrozenPBCRepr,
+        // FunctionRepr).convert_from_to: a frozen-PBC pointer feeding a
+        // constant-function repr drops its runtime value and materialises
+        // the target's own `s_pbc.const` at Void.
+        //
+        // The other five frozen-PBC pairs upstream registers
+        // (`MultipleFrozenPBCRepr` × `MultipleUnrelatedFrozenPBCRepr` /
+        // `MultipleFrozenPBCRepr`, `SingleFrozenPBCRepr` ×
+        // `MultipleFrozenPBCRepr`, `MultipleFrozenPBCReprBase` ×
+        // `SingleFrozenPBCRepr`, `FunctionRepr` ×
+        // `MultipleFrozenPBCRepr`) are still unported. The
+        // `MultipleFrozenPBCReprBase` one additionally needs that base in
+        // `pair_mro`, which currently sends both `Multiple*` reprs
+        // straight to `Repr`.
+        (MultipleFrozenPBCRepr, FunctionRepr) => {
+            super::rpbc::pair_multiple_frozen_pbc_function_repr_convert_from_to(r_to)
+        }
         // rpbc.py — pairtype(FunctionsPBCRepr,
         // FunctionsPBCRepr).convert_from_to: upstream identity if
         // `r_fpbc1.lowleveltype == r_fpbc2.lowleveltype`, else

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -3948,7 +3948,7 @@ pub(super) fn pair_function_repr_functions_pbc_convert_from_to(
 
 /// RPython `pairtype(MultipleFrozenPBCRepr, FunctionRepr)
 ///                  .convert_from_to((r_frozen1, r_fn2), v, llops)`
-/// (rpbc.py:836-840):
+/// (rpbc.py):
 ///
 /// ```python
 /// def convert_from_to((r_frozen1, r_fn2), v, llops):
@@ -3978,7 +3978,7 @@ pub(super) fn pair_multiple_frozen_pbc_function_repr_convert_from_to(
         })?;
     // upstream: `if r_fn2.lowleveltype is Void:` … `return NotImplemented`.
     // `FunctionRepr.lowleveltype` is the class attribute `Void`
-    // (rpbc.py:318), so the guard normally holds; a repr that answers
+    // (rpbc.py), so the guard normally holds; a repr that answers
     // otherwise falls through to the next pair_mro entry.
     if !matches!(r_fn2.lowleveltype(), LowLevelType::Void) {
         return Ok(None);

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -3946,6 +3946,63 @@ pub(super) fn pair_function_repr_functions_pbc_convert_from_to(
     Ok(Some(Hlvalue::Constant(result)))
 }
 
+/// RPython `pairtype(MultipleFrozenPBCRepr, FunctionRepr)
+///                  .convert_from_to((r_frozen1, r_fn2), v, llops)`
+/// (rpbc.py:836-840):
+///
+/// ```python
+/// def convert_from_to((r_frozen1, r_fn2), v, llops):
+///     if r_fn2.lowleveltype is Void:
+///         value = r_fn2.s_pbc.const
+///         return Constant(value, Void)
+///     return NotImplemented
+/// ```
+///
+/// The target is a constant function, so its repr carries no runtime
+/// value and the source pointer is dropped: the conversion materialises
+/// the target's own constant at `Void`. Unlike the
+/// `pairtype(FunctionsPBCRepr, FunctionRepr)` sibling — which yields
+/// `inputconst(Void, None)` — upstream puts `s_pbc.const` in the
+/// `Constant` here, and builds it directly rather than through
+/// `FunctionRepr.convert_const`, whose answer is always `None`.
+pub(super) fn pair_multiple_frozen_pbc_function_repr_convert_from_to(
+    r_to: &dyn Repr,
+) -> Result<Option<Hlvalue>, TyperError> {
+    let r_fn2 = (r_to as &dyn std::any::Any)
+        .downcast_ref::<FunctionRepr>()
+        .ok_or_else(|| {
+            TyperError::message(
+                "pair_multiple_frozen_pbc_function_repr_convert_from_to: r_to is not \
+                 FunctionRepr",
+            )
+        })?;
+    // upstream: `if r_fn2.lowleveltype is Void:` … `return NotImplemented`.
+    // `FunctionRepr.lowleveltype` is the class attribute `Void`
+    // (rpbc.py:318), so the guard normally holds; a repr that answers
+    // otherwise falls through to the next pair_mro entry.
+    if !matches!(r_fn2.lowleveltype(), LowLevelType::Void) {
+        return Ok(None);
+    }
+    // upstream: `value = r_fn2.s_pbc.const`. FunctionRepr is the repr for
+    // a constant function, so the SomePBC carries a const_box.
+    let value = r_fn2
+        .base
+        .s_pbc
+        .base
+        .const_box
+        .as_ref()
+        .map(|c| c.value.clone())
+        .ok_or_else(|| {
+            TyperError::message(
+                "pair_multiple_frozen_pbc_function_repr_convert_from_to: FunctionRepr \
+                 s_pbc has no const — the constant-function invariant is violated",
+            )
+        })?;
+    // upstream: `return Constant(value, Void)`.
+    let c = crate::translator::rtyper::rmodel::inputconst_from_lltype(&LowLevelType::Void, &value)?;
+    Ok(Some(Hlvalue::Constant(c)))
+}
+
 pub(super) fn pair_small_function_set_functions_pbc_convert_from_to(
     r_from: &dyn Repr,
     r_to: &dyn Repr,

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -4956,9 +4956,9 @@ mod tests {
 
     /// A Char operand concatenated with a String reaches the same
     /// `pair(AbstractStringRepr, AbstractStringRepr).rtype_add` body
-    /// (rstr.py:651-659), because `CharRepr(AbstractCharRepr,
-    /// StringRepr)` (lltypesystem/rstr.py:291) inherits
-    /// `StringRepr.repr = string_repr` (:1262) — so `str1_repr` is the
+    /// (rstr.py), because `CharRepr(AbstractCharRepr,
+    /// StringRepr)` (lltypesystem/rstr.py) inherits
+    /// `StringRepr.repr = string_repr` — so `str1_repr` is the
     /// string surface on both sides and the char coerces through
     /// `ll_chr2str` before the one `ll_strconcat`. No char pairtype
     /// defines an `rtype_add` of its own.

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -4993,9 +4993,9 @@ mod tests {
         );
         hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
         hop.args_s.borrow_mut().extend([
-            crate::annotator::model::SomeValue::String(
-                crate::annotator::model::SomeString::new(false, false),
-            ),
+            crate::annotator::model::SomeValue::String(crate::annotator::model::SomeString::new(
+                false, false,
+            )),
             crate::annotator::model::SomeValue::Char(crate::annotator::model::SomeChar::new(false)),
         ]);
         hop.args_r.borrow_mut().extend([
@@ -5017,7 +5017,11 @@ mod tests {
             .filter(|op| op.opname == "direct_call")
             .map(|op| format!("{:?}", op.args[0]))
             .collect();
-        assert_eq!(called.len(), 2, "one chr2str coercion, one concat: {called:?}");
+        assert_eq!(
+            called.len(),
+            2,
+            "one chr2str coercion, one concat: {called:?}"
+        );
         assert!(
             called[0].contains("ll_chr2str"),
             "the char operand coerces first: {called:?}"

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -4954,6 +4954,80 @@ mod tests {
         );
     }
 
+    /// A Char operand concatenated with a String reaches the same
+    /// `pair(AbstractStringRepr, AbstractStringRepr).rtype_add` body
+    /// (rstr.py:651-659), because `CharRepr(AbstractCharRepr,
+    /// StringRepr)` (lltypesystem/rstr.py:291) inherits
+    /// `StringRepr.repr = string_repr` (:1262) — so `str1_repr` is the
+    /// string surface on both sides and the char coerces through
+    /// `ll_chr2str` before the one `ll_strconcat`. No char pairtype
+    /// defines an `rtype_add` of its own.
+    #[test]
+    fn pair_rtype_add_string_char_coerces_through_ll_chr2str_then_ll_strconcat() {
+        use crate::flowspace::model::Variable;
+        use crate::translator::rtyper::rtyper::LowLevelOpList;
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_s = Variable::new();
+        v_s.set_concretetype(Some(STRPTR.clone()));
+        let v_c = Variable::new();
+        v_c.set_concretetype(Some(LowLevelType::Char));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(STRPTR.clone()));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "add".to_string(),
+                vec![Hlvalue::Variable(v_s), Hlvalue::Variable(v_c)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            crate::annotator::model::SomeValue::String(
+                crate::annotator::model::SomeString::new(false, false),
+            ),
+            crate::annotator::model::SomeValue::Char(crate::annotator::model::SomeChar::new(false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(string_repr() as Arc<dyn Repr>),
+            Some(char_repr() as Arc<dyn Repr>),
+        ]);
+
+        let result = crate::translator::rtyper::pairtype::pair_rtype_add(
+            string_repr().as_ref(),
+            char_repr().as_ref(),
+            &hop,
+        )
+        .unwrap_or_else(|err| panic!("pair add(str, char): {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        let called: Vec<String> = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .map(|op| format!("{:?}", op.args[0]))
+            .collect();
+        assert_eq!(called.len(), 2, "one chr2str coercion, one concat: {called:?}");
+        assert!(
+            called[0].contains("ll_chr2str"),
+            "the char operand coerces first: {called:?}"
+        );
+        assert!(
+            called[1].contains("ll_strconcat"),
+            "then the shared string body runs: {called:?}"
+        );
+    }
+
     /// rstr.py (UnicodeRepr inherited) — UNICODE pair surface
     /// uses distinct helper-cache identity `ll_unicode_concat`.
     #[test]

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -101,7 +101,14 @@ pub fn w_method_new(
         // items block. A nursery shell answers the barrier in its `is_in_nursery`
         // arm, so the call stands for the spill case alone.
         crate::gc_hook::try_gc_write_barrier_managed(raw);
-        for slot in (save_point..save_point + 3).chain(std::iter::once(shell_slot)) {
+        // The four slots are not one contiguous run — `shell_slot` was read
+        // back rather than derived — so walk them by index instead of joining
+        // two iterators. `chain(once(..))` reaches the JIT as four body-less
+        // `core::iter` adapter callees, and an adapter state machine has no
+        // RPython counterpart to lower it to, which drops this graph and every
+        // graph that calls it to the legacy walker.
+        for i in 0..4 {
+            let slot = if i == 3 { shell_slot } else { save_point + i };
             let root = crate::gc_roots::shadow_stack_get(slot);
             let current =
                 crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;


### PR DESCRIPTION
Continues #346. Six changes to the rtyper cutover, one to `pyre-object`, and the
`#346` design doc's census section rewritten around what was actually measured.

## What each change is

**Carry the annotator error across the unwind, instead of a rendering of it.**
`compute_at_fixpoint` and `perform_normalizations` panicked with a formatted
string, so every consumer downcast to `String`. Upstream catches a *typed*
exception and reads its fields — `flowin` attaches `source`, `gottypererror`
attaches `where` — and produces the message text once, at the terminal report.
The unwind now carries the `AnnotatorError` itself, and all five consumers read
it through one reader, `panic_payload_text`. A site that hand-rolls
`downcast_ref::<String>` sees "unrecognised" and turns a routine unported
subject into a hard dual-gate failure, so the reader is the point.

**Port `pairtype(MultipleFrozenPBCRepr, FunctionRepr).convert_from_to`.** A
frozen-PBC pointer feeding a constant-function repr drops its runtime value and
materialises the target's own `s_pbc.const` at Void. Unlike the
`pairtype(FunctionsPBCRepr, FunctionRepr)` sibling, upstream builds that
`Constant` directly rather than through `FunctionRepr.convert_const`, whose
answer is always `None`. The five other frozen-PBC pairs upstream registers are
named in a comment beside it; none of them clears a census record today.

**Attach the missing `#[test]`.** The `checked_add` ovf rewrite test was written
as a test and never ran.

**Lower a family-keyed `IndirectCall` to the pre-rtyper shape.** An
`indirect_call` op has no pre-rtyper spelling — upstream mints it inside
`rtype_simple_call`, and everything the annotator sees is still a `simple_call`.
The flowspace adapter is the entry into annotation, so pyre's internal
`IndirectCall` carrying a `family_key` now lowers to `getattr(receiver, method)`
then `simple_call`, the same shape as its `CallTarget::Indirect` twin.
`CallControl` stops consuming the key at graph discovery, because the prepass
runs after that fill and needs the same identity; the key is still spent where
it is spent, in `rpbc::lower_indirect_calls`.

**Materialise a Void operand as `Constant(None, Void)`.** `lookup_operand` and
`link_arg_to_hlvalue` failed the undefined-operand invariant on a Void-typed
`Variable` with no defining operation, which `front::mir` mints for a field read
that lands on a fieldless enum and says so in its own comment. Void is spelled
as a Constant and not as a Variable upstream: `do_rename` inside
`Transformer.optimize_block` renames every Void var to
`Constant(None, lltype.Void)` before it can be read, and
`pairtype(Repr, VoidRepr).convert_from_to` converts *into* Void as
`inputconst(lltype.Void, None)`. Only Void resolves this way; a missing operand
of any other kind still fails loud.

**Route a char operand to the string add, on both sides.** `SomeChar` is a
`SomeString` subclass and `pairtype(SomeChar, SomeChar)` registers only `union`,
so `chr + chr` resolves through the MRO to `pairtype(SomeString, SomeString).add`
— pyre's `mro()` lacked that edge. The rtyper half is the same rule one level
down: `rtype_add` is defined at exactly one place,
`pairtype(AbstractStringRepr, AbstractStringRepr)`, and a char operand reaches
it through `CharRepr(AbstractCharRepr, StringRepr)` and
`UniCharRepr(AbstractUniCharRepr, UnicodeRepr)`, which is also where
`char_repr.repr` comes from.

**Walk `w_method_new`'s four root slots by index.**
`(save_point..save_point + 3).chain(once(shell_slot))` reaches the JIT as four
body-less `core::iter` adapter callees. An adapter state machine has no RPython
counterpart to lower it to, so the graph and every graph that calls it fell to
the legacy walker. The four slots are not one contiguous run — `shell_slot` is
read back rather than derived — so the loop indexes them.

## What was measured, and how

`PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace`, release
profile, default features, `build/llbc` re-extracted for `majit-rlib
pyre-object pyre-interpreter pyre-jit` at each tree, graded by the build's own
exit status and by the stderr file's mtime against the build start.

The three-change batch (Void constant + char MRO edge + the adapter drop),
against its own baseline on one tree: phase A 1883 → 1848; 48 subjects left the
fail list and 13 entered it, and no graph that previously cleared phase A
stopped clearing it. The 13 entrants appear nowhere in the baseline — not as a
failure and not as a skip — because their caller blocked before they could be
reached; they fail one level deeper, at a merge behind `w_method_new`.

Two results worth keeping:

- **A wall's record count going to zero says nothing on its own.** The
  `IndirectCall` wall was 253 records and the single largest leaf. Closing it
  moved the count to 0 and lifted **not one graph** — all 253 subjects
  relocated. Grade a wall by the per-subject victim map, not by the total.
- **A rule ported at the annotator alone surfaces its rtyper half as a phase-B
  wall.** With only the MRO edge, phase B went from 0 failures to 25, all
  `pair(rtype_add) not implemented for (StringRepr, CharRepr)`, and phase-B
  counts are not in the phase-A histogram. Both halves are in this PR, and
  `CharRepr` appears nowhere in the census afterwards.

## What this deliberately does not do

Recorded in the design doc rather than attempted here:

- **The dead vtable read.** Every `Blocked block` record is a `getattr`, and 68
  of them name a slot on the empty `{vtable}` classdef; 58 of the 68 were
  `IndirectCall` records before that wall was closed. The `IndirectCall` arm
  drops the `funcptr` *operand*, but the ops that defined it stay in the graph
  and are still annotated. The front end cannot stop emitting them — the
  residual path calls through that pointer for real — so the repair is a
  dead-op sweep in the prepass, a design that needs its own census.
- **`is_exception`'s `InstanceRepr → RootClassRepr`.** There is no such
  conversion upstream to port: an instance's vtable is reached by an operation
  (`InstanceRepr.rtype_type`), not by `convert_from_to`.
- **Four phase-B failures the base introduced**, all
  `simple_call(jit_force_virtualizable, frame)` with a `SomeNone` result and no
  concretetype.
- **The five remaining frozen-PBC pairs**, which clear no census record.

## Verification

- `cargo fmt --all -- --check` — clean.
- `scripts/check-new-line-citations.py --base origin/main` — no new
  line-number citations (the 30 this branch had now name their symbol).
- `scripts/check-gc-root-brackets.py`, `scripts/check-majit-boundary.py`,
  `pyre/check.py --check-headers` — exit 0. The bracket script's WARN is a
  backlog rise it attributes itself to interpreter code its baseline never saw.
- `cargo test --all --no-default-features --features dynasm` — **8988 passed**, with
  `build/llbc` re-extracted for `pyre-object pyre-interpreter pyre-jit` at the tree
  being tested. Its first attempt stopped before compiling anything, on
  `pyre-jit-trace`'s `LLBC STALE` guard: a rebase had landed under the branch and
  restaled all three artefacts. Re-extracted rather than relaxed —
  `PYRE_LLBC_STRICT=0` would have graded the wrong bytes.
- `pyre/check.py` was not run locally; it is left to this PR's CI legs.

Assisted-by: Claude
