### PR TITLE
cranelift: the arm COND_CALL_VALUE never called, and a FLOAT_MOD its own blackhole disagreed with

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4058,6 +4058,14 @@ extern "C" fn plain_malloc_zeroed_shim(size: u64) -> u64 {
     unsafe { std::alloc::alloc_zeroed(layout) as u64 }
 }
 
+/// C `fmod` for the `FLOAT_MOD` lowering, which has no native instruction.
+/// The truncated remainder is the whole of this op: the floored `%` a Python
+/// program sees — the sign correction and the signed zero — is applied above
+/// it, so a floored lowering here would apply that correction twice.
+extern "C" fn fmod_shim(a: f64, b: f64) -> f64 {
+    a % b
+}
+
 /// `gc.py:51` malloc-helper OOM signaling — Cranelift counterpart of
 /// `runner::oom_signal_if_zero`.  `do_malloc_fixedsize_clear` raises
 /// `MemoryError` on failure; translation lowers that to "store the
@@ -13737,9 +13745,12 @@ impl CraneliftBackend {
                 }
 
                 // ── Conditional call with value result ──
-                // args[0] = condition, args[1] = func_ptr, args[2..] = call args
-                // If condition != 0: result = call(func_ptr, args...)
-                // Else: result = condition (0)
+                // args[0] = value, args[1] = func_ptr, args[2..] = call args
+                // If value is 0/NULL: result = call(func_ptr, args...)
+                // Else: result = value, and the call is skipped.
+                // The polarity is the opposite of plain COND_CALL above: this
+                // op fills a lazily-computed cache, so a non-zero value is the
+                // already-computed answer and the call is what fills it.
                 OpCode::CondCallValueI | OpCode::CondCallValueR => {
                     let cond = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     let call_block = builder.create_block();
@@ -13753,10 +13764,10 @@ impl CraneliftBackend {
                     let is_zero = builder.ins().icmp(IntCC::Equal, cond, zero);
                     builder.ins().brif(
                         is_zero,
-                        cont_block,
-                        &[BlockArg::from(cond)],
                         call_block,
                         &[],
+                        cont_block,
+                        &[BlockArg::from(cond)],
                     );
 
                     builder.switch_to_block(call_block);
@@ -15309,14 +15320,30 @@ impl CraneliftBackend {
                     builder.def_var(var(vi), r);
                 }
                 OpCode::FloatMod => {
-                    // Python's float mod: a - floor(a/b) * b
+                    // There is no native frem, so call C `fmod` — the bare
+                    // `math_fmod` external, not the `ll_math_fmod` wrapper over
+                    // it, which returns x for a finite x over an infinite y and
+                    // raises EDOM on a NaN result from non-NaN operands.  This
+                    // op is the raw remainder; it cannot collect, so it needs
+                    // neither a gcmap nor a frame reload.
                     let (a, b) = resolve_binop(&mut builder, &constants, op);
                     let fa = coerce_ty(&mut builder, a, cl_types::F64);
                     let fb = coerce_ty(&mut builder, b, cl_types::F64);
-                    let fdiv = builder.ins().fdiv(fa, fb);
-                    let ffloor = builder.ins().floor(fdiv);
-                    let prod = builder.ins().fmul(ffloor, fb);
-                    let fr = builder.ins().fsub(fa, prod);
+                    let callee = builder
+                        .ins()
+                        .iconst(ptr_type, fmod_shim as *const () as i64);
+                    let sig = {
+                        let mut sig = cranelift_codegen::ir::Signature::new(call_conv);
+                        sig.params
+                            .push(cranelift_codegen::ir::AbiParam::new(cl_types::F64));
+                        sig.params
+                            .push(cranelift_codegen::ir::AbiParam::new(cl_types::F64));
+                        sig.returns
+                            .push(cranelift_codegen::ir::AbiParam::new(cl_types::F64));
+                        builder.import_signature(sig)
+                    };
+                    let call = builder.ins().call_indirect(sig, callee, &[fa, fb]);
+                    let fr = builder.inst_results(call)[0];
                     let want = var_types.get(&vi).copied().unwrap_or(cl_types::I64);
                     let r = coerce_ty(&mut builder, fr, want);
                     builder.def_var(var(vi), r);
@@ -22566,6 +22593,37 @@ mod tests {
         assert!((result - 3.25).abs() < 1e-10);
     }
 
+    #[test]
+    fn test_float_mod_keeps_the_dividends_sign() {
+        // `eval_binop_f` executes FLOAT_MOD as `a % b` — C `fmod`, whose
+        // remainder carries the sign of the dividend.  A floored lowering
+        // answers 2.0 here, so a compiled loop and the blackhole it deopts
+        // into would disagree on the same operands.
+        let mut backend = CraneliftBackend::new();
+
+        let inputargs = vec![InputArg::new_float(0), InputArg::new_float(1)];
+        let ops = vec![
+            mk_op(
+                OpCode::Label,
+                &[OpRef::input_arg_float(0), OpRef::input_arg_float(1)],
+                OpRef::NONE.raw(),
+            ),
+            mk_op(
+                OpCode::FloatMod,
+                &[OpRef::input_arg_float(0), OpRef::input_arg_float(1)],
+                2,
+            ),
+            mk_op(OpCode::Finish, &[OpRef::float_op(2)], OpRef::NONE.raw()),
+        ];
+
+        let token = JitCellToken::new(70011);
+        backend.compile_loop(&inputargs, &ops, &token).unwrap();
+
+        let frame = backend.execute_token(&token, &[Value::Float(-7.0), Value::Float(3.0)]);
+        let result = backend.get_float_value(&frame, 0);
+        assert!((result - (-1.0)).abs() < 1e-10, "got {result}");
+    }
+
     // ── Compile bridge test ──
 
     // ── Conditional call tests ──
@@ -22678,8 +22736,17 @@ mod tests {
 
     #[test]
     fn test_cond_call_value_i_nonzero() {
+        static mut COND_CALL_VALUE_CALLS: i64 = 0;
+
         extern "C" fn compute(a: i64) -> i64 {
+            unsafe {
+                COND_CALL_VALUE_CALLS += 1;
+            }
             a * 10
+        }
+
+        unsafe {
+            COND_CALL_VALUE_CALLS = 0;
         }
 
         let mut backend = CraneliftBackend::new();
@@ -22712,8 +22779,13 @@ mod tests {
         let token = JitCellToken::new(42);
         backend.compile_loop(&inputargs, &ops, &token).unwrap();
 
+        // A non-zero args[0] is the already-computed value, so `compute` is
+        // not called and the result is args[0] itself, not `5 * 10`. The
+        // counter is what separates "skipped" from "called and discarded";
+        // the returned value alone cannot.
         let frame = backend.execute_token(&token, &[Value::Int(1), Value::Int(5)]);
-        assert_eq!(backend.get_int_value(&frame, 0), 50);
+        assert_eq!(backend.get_int_value(&frame, 0), 1);
+        assert_eq!(unsafe { COND_CALL_VALUE_CALLS }, 0);
     }
 
     #[test]
@@ -22752,8 +22824,67 @@ mod tests {
         let token = JitCellToken::new(43);
         backend.compile_loop(&inputargs, &ops, &token).unwrap();
 
+        // A zero args[0] is the unfilled cache, so `compute2(5)` runs and its
+        // result — not the zero — is what the op produces.
         let frame = backend.execute_token(&token, &[Value::Int(0), Value::Int(5)]);
-        assert_eq!(backend.get_int_value(&frame, 0), 0);
+        assert_eq!(backend.get_int_value(&frame, 0), 50);
+    }
+
+    #[test]
+    fn test_cond_call_value_r_takes_both_arms() {
+        // The Ref twin shares the arm but returns a GC ref, so the fast path
+        // hands `cont_block` a live reference rather than a scalar.
+        static mut FILL_CACHE_CALLS: i64 = 0;
+
+        extern "C" fn fill_cache(_a: i64) -> i64 {
+            unsafe {
+                FILL_CACHE_CALLS += 1;
+            }
+            0x5678
+        }
+
+        for (value, expected, expected_calls) in [(0x1234i64, 0x1234i64, 0i64), (0, 0x5678, 1)] {
+            unsafe {
+                FILL_CACHE_CALLS = 0;
+            }
+
+            let mut backend = CraneliftBackend::new();
+            let descr = make_call_descr(vec![Type::Ref], Type::Ref);
+
+            let inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
+            let ops = vec![
+                mk_op(
+                    OpCode::Label,
+                    &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
+                    OpRef::NONE.raw(),
+                ),
+                mk_op_with_descr(
+                    OpCode::CondCallValueR,
+                    &[
+                        OpRef::input_arg_ref(0),
+                        OpRef::int_op(100),
+                        OpRef::input_arg_ref(1),
+                    ],
+                    2,
+                    descr,
+                ),
+                mk_op(OpCode::Finish, &[OpRef::ref_op(2)], OpRef::NONE.raw()),
+            ];
+
+            let mut constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+            constants.insert(100, fill_cache as *const () as i64);
+            backend.set_constants(constants);
+
+            let token = JitCellToken::new(70012);
+            backend.compile_loop(&inputargs, &ops, &token).unwrap();
+
+            let frame = backend.execute_token(
+                &token,
+                &[Value::Ref(GcRef(value as usize)), Value::Ref(GcRef(9))],
+            );
+            assert_eq!(backend.get_ref_value(&frame, 0), GcRef(expected as usize));
+            assert_eq!(unsafe { FILL_CACHE_CALLS }, expected_calls);
+        }
     }
 
     // ── Guard variant tests ──


### PR DESCRIPTION
## Summary

Two cranelift lowerings that disagreed with every other spelling of the same op
in the tree. Both are silent wrong answers rather than crashes, which is why
the gates stayed green.

### `COND_CALL_VALUE_I/R` called on the wrong arm

The arm called the function when `args[0]` was **non-zero** and returned
`args[0]` when it was zero. The op is the other way round: `args[0]` is a
lazily-computed value and the call is what fills it, so the call belongs on the
zero/NULL arm and a non-zero `args[0]` is the result. The arm is a copy of the
plain `COND_CALL` arm immediately above it, whose polarity is the opposite —
that one *does* call on non-zero.

Every other spelling in the tree already called on zero, so cranelift was the
only inverted one:

| where | spelling |
| --- | --- |
| `x86/regalloc.py` `consider_cond_call` | "Calls the function when args[0] is equal to 0 or NULL" |
| `pyjitpl.py` `_opimpl_conditional_call_value` | short-circuits on `valuebox.nonnull()` |
| `optimizeopt/rewrite.rs` | folds `value=42` → `value`, `value=0` → `CallPureI` |
| `majit-metainterp` `executor.rs` `execute_varargs` | call-on-zero |
| `blackhole.rs` `handler_cond_call_value_{int,ref}_ext` | call-on-zero |
| dynasm x86 `genop_cond_call_value` | `test rax, rax; jnz skip` |
| dynasm aarch64 | `cbnz x0, skip` |
| wasm `codegen.rs` | `i64.eqz` |

The fix swaps the two block operands of the `brif`. The `cont_block` parameter
is unchanged on both edges — `cond` arrives on the fall-through, the call's
result from `call_block` — and the gcmap discipline is undisturbed, since
`defined_ref_vars.insert(vi)` runs after the match arm, so the result's home is
excluded from the call's map.

`test_cond_call_value_i_nonzero` and `test_cond_call_value_i_zero` asserted the
**inverted** answers, which is why the arm survived. Both now assert the shared
rule. The value-present one also counts calls: the returned value alone cannot
separate a skipped call from one that was made and discarded, and a test that
cannot make that distinction is what let the original pass. `CondCallValueR` —
the edge where the fast-path result is a live GC ref — had no backend test at
all and now exercises both arms.

### `FLOAT_MOD` was floored, not truncated

It was lowered as `a - floor(a/b) * b`. `eval_binop_f` executes the op as
`a % b`, so the two disagreed whenever the operands had unlike signs:
`-7.0 % 3.0` was `2.0` in a compiled trace and `-1.0` in the blackhole
`exec_binop` deopts into. The same trace answered differently before and after
a guard failure.

The floored spelling also belongs to a layer *above* this op:
`trace_helpers::concrete::float_mod` applies the sign correction and the signed
zero on top of the truncated remainder, so a floored lowering here applies that
correction twice.

It now calls C `fmod` — the bare `math_fmod` external, not the `ll_math_fmod`
wrapper over it, which returns `x` for a finite `x` over an infinite `y` and
raises `EDOM` on a NaN result from non-NaN operands. This op is the raw
remainder. The call cannot collect, so it needs neither a gcmap nor a frame
reload, and `call_conv` is `target_config().default_call_conv` (the platform C
convention) rather than the trace body's `CallConv::Tail` — the same shape
`plain_malloc_zeroed_shim` already uses.

The blackhole test covering negative operands only asserted `is_finite()`,
never the value, which is why nothing caught this. The new backend test pins it
by executing the compiled code.

`FloatFloorDiv`, the arm directly above, is consistent with its own oracle —
`eval_binop_f` runs it as `(a / b).floor()` — and is untouched.

### Reachability

Both ops are unreachable in production today, which is why neither gate moved.
`COND_CALL_VALUE` needs a `conditional_call_elidable!` call site and pyre has
none yet, though the lowering machinery in `lower_stmt.rs` is complete.
`FLOAT_MOD` never reaches a backend because `jtransform`'s
`canonical_float_mod_binop` arm lowers float `%` to an `ll_math_fmod` residual
call instead. Neither is a reason to leave a wrong arm in place: the first
becomes a silent wrong answer the moment a call site is added, and the second
already contradicts the executor it shares an opcode with.

### Verification

`cargo test -p majit-backend-cranelift`: 179 tests (143 lib + 35 + 1), 0 failed;
2 rewritten, 2 added. `cargo fmt --all -- --check` and
`scripts/check-majit-boundary.py` clean.

Note: `pyre/check.py` is currently red on `main` for an unrelated reason —
`synth/range_step_one_shapes` has a committed `.dynasm.jitstats` baseline but no
`.wasm.jitstats` one (from #1645), so every `check.py` job fails with
`jit-stats baseline missing` while reporting `dynasm 535/535`. That red predates
this branch and reproduces on `main`'s own tip.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected floating-point remainder calculations to preserve the dividend’s sign.
  * Fixed conditional call behavior so cached non-zero values bypass unnecessary calls, while zero values trigger computation.
  * Improved conditional branching consistency across value and reference operations.

* **Tests**
  * Added coverage for signed floating-point remainder results.
  * Expanded conditional-call tests to verify both execution paths and call behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->