### PR TITLE
jit-trace: give FORMAT_WITH_SPEC's user __format__ an inline route

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -960,6 +960,22 @@ pub enum RuntimeHelperKind {
     /// `guard_class INT` (`~x` always fits an int, so no overflow guard); a
     /// bool / subclass / non-int operand falls through to the generic residual.
     UnaryInvert,
+    /// `bh_format_simple_fn(value)` — the FORMAT_SIMPLE helper
+    /// (`runtime_ops::format_value` with the empty spec).  A user
+    /// `__format__` runs Python here, so the generic residual is opaque for
+    /// the whole method body.  The full-body walker recognises this tag to
+    /// resolve `__format__` on the promoted receiver class and inline the
+    /// resolved body behind a `guard_class` + version-tag guard, the same
+    /// receiver-pinning route [`RuntimeHelperKind::BinaryOp`] takes for a
+    /// user `__add__`.  A builtin `__format__` is not inlinable Python code
+    /// and falls through to the residual unchanged.
+    FormatSimple,
+    /// `bh_format_with_spec_fn(value, spec)` — the FORMAT_WITH_SPEC helper,
+    /// the two-operand sibling of [`RuntimeHelperKind::FormatSimple`] carrying
+    /// the f-string's format spec.  Recognised for the same receiver-pinned
+    /// `__format__` inline; `spec` is threaded to the callee as its second
+    /// parameter.
+    FormatWithSpec,
     /// `bh_unpack_sequence_fn(count, seq)` — the UNPACK_SEQUENCE validator
     /// emitted by the codewriter UNPACK_SEQUENCE arm.  Validates the exact
     /// length and returns the normalized tuple.  The full-body walker

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -10315,6 +10315,144 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     Ok(Some(inlined))
 }
 
+/// Route `f"{x:spec}"` through an app-level `__format__`.
+///
+/// FORMAT_WITH_SPEC lowers to `residual_call_r_r(format_with_spec_fn,
+/// [value, spec])`, and `bh_format_with_spec_fn` reaches the receiver dunder
+/// through `runtime_ops::format_value` → `space.format`. When that dunder is
+/// Python, the whole method body sits behind an opaque MayForce residual and
+/// runs interpreted once per iteration. This is the `__format__` sibling of
+/// [`try_walker_inline_user_binop`]: pin the promoted receiver class, then
+/// enter the ordinary resolved-callee plumbing with the value as `self` and
+/// the spec as the second parameter.
+///
+/// Unlike a binary operator there is no `NotImplemented` escape hatch to hand
+/// back to a wider protocol — `__format__` either returns a string or raises —
+/// so this route needs none of binop's rewind machinery, and a body that
+/// commits an effect is admitted like any other inlined callee.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_inline_format<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor || dst_bank != 'r' || r_args.len() != 2 {
+        return Ok(None);
+    }
+
+    // Name every bail, as the binop route does: a FORMAT_WITH_SPEC that stays
+    // residual costs a full interpreted `__format__` per execution, and
+    // without a reason line the only observable is the runtime.
+    macro_rules! decline {
+        ($why:expr) => {{
+            if fbw_inline_diag_enabled() {
+                eprintln!("[format-inline-decline] pc={} why={}", op.pc, $why);
+            }
+            return Ok(None);
+        }};
+    }
+
+    let value = r_args[0];
+    let spec = r_args[1];
+    let Some(concrete_value) = walker_concrete_ref_object(ctx, value) else {
+        decline!("value has no concrete ref");
+    };
+    let Some(concrete_spec) = walker_concrete_ref_object(ctx, spec) else {
+        decline!("spec has no concrete ref");
+    };
+
+    // A tagged immediate is an exact builtin `int` with C-level slots: no heap
+    // `w_class` to pin, and its `__format__` is not inlinable Python code.
+    // Decline before the deref below, which would fault on the immediate.
+    // Inert behind `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && pyre_object::tagged_int::is_tagged_int(concrete_value)
+    {
+        decline!("tagged immediate receiver");
+    }
+
+    let w_class = unsafe { (*concrete_value).w_class };
+    if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
+        decline!("receiver w_class is not a type");
+    }
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_class) };
+    if version_tag == 0 {
+        decline!(format_args!(
+            "receiver class {} has no version tag",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
+    }
+
+    let Some(method) =
+        (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_class, "__format__") })
+    else {
+        decline!(format_args!("{} has no __format__", unsafe {
+            pyre_object::typeobject::w_type_get_name(w_class)
+        }));
+    };
+    // `object.__format__` and the builtin type overrides are C slots, so this
+    // is also what refuses a receiver that has no app-level `__format__` at
+    // all — no separate comparison against the default is needed.
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
+        decline!(format_args!(
+            "{}.__format__ is not inlinable Python code",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
+    };
+    if nparams != 2 {
+        decline!(format_args!(
+            "{}.__format__ takes {nparams} params",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
+    }
+
+    let method_const = ctx.trace_ctx.const_ref(method as i64);
+    let arg_concretes = vec![
+        ConcreteValue::Ref(method),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_value),
+        ConcreteValue::Ref(concrete_spec),
+    ];
+    try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        method_const,
+        r_args,
+        call_descr,
+        'r',
+        dst,
+        method,
+        method_const,
+        method,
+        arg_concretes,
+        vec![value, spec],
+        vec![
+            ConcreteValue::Ref(concrete_value),
+            ConcreteValue::Ref(concrete_spec),
+        ],
+        true,
+        None,
+        w_code,
+        nparams,
+        has_closure,
+        Some((value, concrete_value, w_class, version_tag)),
+        None,
+        // The abort rewind names this entry, as it does for the property and
+        // exception-override routes that enter through the same plumbing.
+        true,
+        // `__format__` returning a non-string is a TypeError the interpreter
+        // raises; the plumbing guards the inlined result is a string so that
+        // check keeps its meaning on the compiled path.
+        true,
+        None,
+    )
+}
+
 /// Allocate the callee's three symbolic register banks for a sub-walk
 /// entered through any `inline_call_*` arm.
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6736,6 +6736,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         }
     }
 
+    // FORMAT_WITH_SPEC over a receiver whose `__format__` is Python: inline
+    // the resolved body in place of the opaque format residual.  Keyed off
+    // the helper tag, so every other `residual_call_r_r` falls straight
+    // through.
+    if foldable_runtime_helper == majit_ir::RuntimeHelperKind::FormatWithSpec {
+        if let Some(inlined) =
+            try_walker_inline_format(ctx, op, code, &r_args, call_descr, dst, dst_bank)?
+        {
+            return Ok(inlined);
+        }
+    }
+
     // #62: a self-recursive call the inline path declined (e.g. the
     // branchy `fib`) gets a direct `CALL_ASSEMBLER` to its own loop token
     // instead of the heavyweight func-entry

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -6190,7 +6190,7 @@ where
         ctx.format_simple_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::RuntimeHelperKind::None,
+        majit_ir::RuntimeHelperKind::FormatSimple,
         dst_reg,
     ))
 }
@@ -6824,7 +6824,7 @@ where
         ctx.format_with_spec_fn_idx,
         vec![value, spec],
         CallFlavor::MayForce,
-        majit_ir::RuntimeHelperKind::None,
+        majit_ir::RuntimeHelperKind::FormatWithSpec,
         dst_reg,
     ))
 }


### PR DESCRIPTION
`lower_format_with_spec_hlop_to_insn` and its FORMAT_SIMPLE sibling built their
residual with `RuntimeHelperKind::None`. Every walker inline route in
`dispatch_residual_call_iRd_kind` is keyed on that tag, so neither opcode could
reach any of the fifteen routes: a receiver whose `__format__` is Python ran the
whole method body interpreted behind an opaque `MayForce` residual, once per
execution.

`synth/foriter_format_with_spec_user_dunder` already records this gap as the
reason for its ceiling:

> The ceiling is far above `foriter_format_with_spec`'s because the residual
> calls a Python `__format__` every iteration and the trace does not inline it,
> while pypy does

## What this does

* Adds `FormatSimple` / `FormatWithSpec` to `RuntimeHelperKind` and tags both
  lowerings.
* Adds `try_walker_inline_format`, the `__format__` sibling of
  `try_walker_inline_user_binop` — same operand shape (two Refs, no callable).
  It pins the promoted receiver class, resolves `__format__` on it, and enters
  `try_walker_inline_resolved_user_call` with the value as `self` and the spec
  as the second parameter, under `require_str_result`.

The route carries none of binop's rewind machinery: `__format__` has no
`NotImplemented` arm to hand back to a wider protocol, so a body that commits an
effect is admitted like any other inlined callee. It also passes no
`arg_class_guard` for the spec, where binop guards its RHS class — binop needs
that because the RHS type participates in the dispatch decision before the body
is entered, and `__format__` dispatch is always the receiver's.

`resolve_inlinable_callee` requires a `Function` of exactly `FUNCTION_TYPE`,
which is also what refuses a builtin `__format__`, so no separate comparison
against the default is made.

## Evidence

* `synth/foriter_format_with_spec_user_dunder` output matches CPython and PyPy
  byte for byte, including the `calls` counter that is its exactly-once
  assertion and the spec echoed into the result.
* The route was confirmed to fire rather than assumed: under
  `PYRE_FBW_INLINE_DIAG=1` the builtin-format sibling emits exactly
  `[format-inline-decline] pc=586 why=int.__format__ is not inlinable Python code`,
  so the hook is reached and declines correctly; silence on the user-dunder
  fixture is the inline.
* No jit-stats baseline moved.
* `cargo check -p pyre-jit-trace -p pyre-jit -p majit-ir` is clean.

## Numbers, and why CI should be the judge

Locally the fixture read `?12.5x / ?15.8x / ?18.4x` over three runs where its
header records 60-68x/81-89x. Those readings are **not** trustworthy as
magnitudes: they were taken at load 33 against a `?`-thin pypy baseline, and
this worktree was rebased 38 times during the session, so no measure-build-verify
cycle could complete against a stable base. The direction and the jit-stats
stability are what the local runs establish; the header's band was itself
recorded on CI, so CI is the same-conditions comparison.

If the ratio has moved enough that the 165x ceiling wants re-recording, that is
a follow-up commit against whatever CI reads.

## Not included

* `FormatSimple` is tagged but no route consumes it yet. FORMAT_SIMPLE would
  have to synthesize the empty spec operand its callee's second parameter needs
  — `format_value_dispatch` allocates a fresh `str` per call there, and the
  empty spec has its own dispatch arms, so it is not a one-line extension of
  this route.
* A `foriter_format_simple_user_dunder` fixture exists locally and its output is
  verified against both oracles, but it is held back until FORMAT_SIMPLE has a
  route and a measured ceiling to declare.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT optimization for formatted strings by inlining eligible application-defined `__format__` implementations.
  * Formatting with a specification now passes that specification directly to the resolved formatter.
  * Unsupported or non-eligible formatting cases continue through the standard fallback path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->