### PR TITLE
metainterp: review follow-ups, guard-failure and back-edge costs, and the loop header's missing virtualizable normalization

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -260,7 +260,7 @@ cover the condition they diagnose.
 
 - Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
 - Accessor: `guard_resume_refuse_pending_fields()`
-- What it does: Restores `guard_carries_pending_fields`, the refusal to build a guard-resume bridge for a guard whose deferred writes span more than one virtual. Off by default: upstream has no such refusal, and the double-application it once guarded against is answered by siting the decision ahead of `start_bridge_tracing` rather than by declining. Kept so the two answers stay comparable inside one binary, which a second build cannot do.
+- What it does: Restores `guard_carries_pending_fields`, the refusal to build a guard-resume bridge for a guard whose deferred writes span more than one virtual. Off by default: upstream has no such refusal, and the double-application it once guarded against is answered by placing the decision ahead of `start_bridge_tracing` rather than by declining. Kept so the two answers stay comparable inside one binary, which a second build cannot do.
 - Retirement condition: Remove once no consumer needs the refusal restored to attribute a result.
 
 ### `MAJIT_HEAPDBG`
@@ -414,8 +414,8 @@ cover the condition they diagnose.
 ### `MAJIT_SKIP_BRIDGES`
 
 - Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
-- Accessor: `bridge_fuel_skipped()`
-- What it does: `MAJIT_SKIP_BRIDGES=a,b,...`: decline exactly the listed `MAJIT_MAX_BRIDGES` sequence numbers and take every other one, so a bisect can ask whether one numbered bridge corrupts on its own or whether the corruption is cumulative. The fuel limit cannot answer that, because declining number N also declines everything after it.
+- Accessor: `bridge_fuel_skip_set()`, read by `bridge_fuel_skipped()` and by `bridge_fuel_take()`
+- What it does: `MAJIT_SKIP_BRIDGES=a,b,...`: decline exactly the listed bridge sequence numbers and take every other one, so a bisect can ask whether one numbered bridge corrupts on its own or whether the corruption is cumulative. `MAJIT_MAX_BRIDGES` cannot answer that, because declining number N also declines everything after it. The two share one sequence — the n-th bridge `should_bridge` otherwise reaches — and either one alone starts the count, so this gate needs no fuel limit beside it.
 - Retirement condition: Remove with `MAJIT_MAX_BRIDGES`, once a compiled bridge cannot produce a value the same guard's blackhole resume would not.
 
 ### `MAJIT_SMALLIR`

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -372,9 +372,9 @@ pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
         return Arc::new(EffectInfoCell::new(effect_info));
     }
 
-    // `effectinfo.py:14` spells the interner `_cache = {}` and `:147` probes
-    // it with `key in cls._cache`, so one lookup costs one hash of the key
-    // whatever the cache already holds. A sequence answered the same question
+    // `EffectInfo._cache` is a dict and `EffectInfo.__new__` probes it with
+    // `key in cls._cache`, so one lookup costs one hash of the key whatever
+    // the cache already holds. A sequence answered the same question
     // by running `EffectInfo`'s `==` — which compares six descr sets
     // element-wise — against every cell already interned, so the cost of
     // interning the n-th distinct EffectInfo grew with n.

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -305,6 +305,17 @@ pub struct CompileResult<M> {
     /// returns before reaching. A FINISH exit stores one null word here, so the
     /// steady entry path's allocation count is unchanged.
     pub exit_layout: Option<Box<CompiledExitLayout>>,
+    /// `compile.py handle_fail` reads `resumedescr.rd_loop_token` once and
+    /// hands the loop it names to everything downstream. The green key of the
+    /// `JitCellToken` the failing descr belongs to, recovered by walking
+    /// `descr.rd_loop_token_clt() -> clt.upgrade_loop_token()`.
+    ///
+    /// `None` when the walk finds no live owner (memmgr eviction) and on a
+    /// finish or back-edge JUMP exit, neither of which has a guard identity to
+    /// recover: the layout fallback and `must_compile` are the only readers,
+    /// and neither exit reaches either. Readers fall back to the key of the
+    /// entry they came in through.
+    pub rd_loop_token: Option<u64>,
     pub savedata: Option<GcRef>,
     pub exception: ExceptionState,
     /// compile.py: ResumeGuardDescr.status read at guard failure.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5898,11 +5898,24 @@ impl<S: JitState> JitDriver<S> {
         // rebuild the caller's `GreenKey` on a chained bucket, and the whole
         // point of the carry is that the key, the token and the run come from
         // one resolution.
-        let green_key = if carried_procedure_token.is_some() {
-            green_key_hash
-        } else {
-            self.meta
-                .resolve_cell_key(green_key_hash, structured_green_key)
+        //
+        // The cell-owned half of the entry decision is taken from that same
+        // resolution rather than from later walks back to the cell it already
+        // found: `resolve_cell_key`, the token read and the `JC_TEMPORARY` test
+        // are three questions about ONE cell, and upstream asks all three off
+        // the single `cell` its chain walk bound
+        // (`WarmEnterState.maybe_compile_and_run` — "these few lines inline
+        // some logic that is also on the JitCell class, to avoid computing the
+        // hash several times"). The `compiled_loops` conjunct is still taken
+        // below, where the metadata's value is wanted anyway.
+        //
+        // Which shape the gate below takes, recorded before the token is moved
+        // into it, so the amplified gate can take the same one.
+        #[cfg(feature = "__back-edge-stage-probe")]
+        let carried_token = carried_procedure_token.is_some();
+        let (green_key, entry_procedure_token) = match carried_procedure_token {
+            Some(token) => (green_key_hash, Some(token)),
+            None => self.resolved_entry_procedure_token(green_key_hash, structured_green_key),
         };
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
@@ -5948,11 +5961,11 @@ impl<S: JitState> JitDriver<S> {
         // `warmstate.py maybe_compile_and_run`: a cell whose token was
         // `attached by compile_tmp_callback()` is NOT entered — upstream falls
         // straight to `jitcounter.tick(hash, increment_threshold)` and, on
-        // overflow, `bound_reached`. `runnable_procedure_token` reads the
+        // overflow, `bound_reached`. The resolution above reads the
         // cell-owned `JC_TEMPORARY` flag explicitly: a callback token has a
         // body, and pyre may retain frontend metadata for the loop it
         // displaced, so neither token nor metadata presence identifies it.
-        // Binding the token here rather than testing a predicate and
+        // Binding the token rather than testing a predicate and
         // unwrapping afterwards keeps the decision and execution in step — the
         // fall-through below IS the counter processing upstream continues
         // with. Token presence stays one conjunct: it is the
@@ -5973,7 +5986,8 @@ impl<S: JitState> JitDriver<S> {
         // runner receives it and never asks the cell again. This is the same
         // resolve-once discipline the cell key above already follows, one
         // level in: the token the gate said yes about IS the token executed,
-        // and a warm entry pays for one cell lookup rather than two.
+        // and a warm entry pays for one cell lookup, not one per question it
+        // asks about that cell.
         //
         // A caller that already took its own decision on this cell's token
         // hands that same object in, and it is entered unread — the carry
@@ -5986,12 +6000,7 @@ impl<S: JitState> JitDriver<S> {
         // this load nor the loops it feeds.
         #[cfg(feature = "__back-edge-stage-probe")]
         let stage_repeats = back_edge_stage_repeats();
-        // Which shape the gate below takes, recorded before the token is moved
-        // into it, so the amplified gate can take the same one.
-        #[cfg(feature = "__back-edge-stage-probe")]
-        let carried_token = carried_procedure_token.is_some();
-        if let Some(procedure_token) =
-            carried_procedure_token.or_else(|| self.runnable_procedure_token(green_key))
+        if let Some(procedure_token) = entry_procedure_token
             && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
         {
             // warmstate.py `WarmEnterState.make_entry_point` /
@@ -8258,52 +8267,41 @@ impl<S: JitState> JitDriver<S> {
     }
 
     /// See [`MetaInterp::runnable_generation`]: a number that holds while
-    /// [`Self::resolved_runnable_procedure_token`] cannot change its answer
+    /// [`Self::resolved_entry_procedure_token`] cannot change its answer
     /// for any key, and moves when it may.
     #[inline]
     pub fn runnable_generation(&self) -> u64 {
         self.meta.runnable_generation()
     }
 
-    /// [`Self::resolve_cell_key`] and [`Self::runnable_procedure_token`] from
-    /// one walk of the cell chain.
+    /// [`Self::resolve_cell_key`] and the whole CELL-OWNED half of
+    /// [`Self::runnable_procedure_token`] from one walk of the cell chain.
     ///
-    /// The two together are what a door holding a raw bucket hash asks: which
-    /// cell do my greens own, and does that cell have code to enter. Asked
-    /// separately they walk the chain twice for the same cell — see
+    /// The pair is what a door holding a raw bucket hash asks: which cell do my
+    /// greens own, and does that cell have code that may be entered. Asked
+    /// separately they walked the chain three times for the same cell — once to
+    /// resolve, once to read the token, once for `JC_TEMPORARY` — see
     /// [`MetaInterp::resolved_entry_procedure_token`]. The answer is identical
     /// to resolving first and then asking; this only stops paying for the
-    /// second walk.
+    /// repeats.
     ///
-    /// The resolved key travels back with the token because a caller that goes
-    /// on to run needs it, and because the `compiled_loops` half of the
-    /// predicate is keyed by it.
+    /// `JC_TEMPORARY` is part of the answer because retained frontend metadata
+    /// must not make a `compile_tmp_callback` token executable as the loop it
+    /// displaced, matching the flag-first branch of
+    /// `WarmEnterState.maybe_compile_and_run`.
     ///
-    /// The `compiled_loops` half is asked FIRST, as the gate the token read
-    /// sits behind. The resolved cell's `JC_TEMPORARY` flag is then the final
-    /// filter, matching `WarmEnterState.maybe_compile_and_run`; retained
-    /// frontend metadata must not make a callback executable as the displaced
-    /// loop. These are pure reads of the same resolved key. A key with no
-    /// compiled entry — which is every key a door declines on — still stops at
-    /// the cheap map probe before the token's `Weak::upgrade` / `Arc` drop.
+    /// The `compiled_loops` conjunct is NOT part of it, and the resolved key
+    /// travels back so the caller can take it: a door that goes on to run needs
+    /// that map's VALUE, so a presence test here would probe it twice for one
+    /// entry, and a door that declines is answered by the walk alone.
     #[inline]
-    pub fn resolved_runnable_procedure_token(
+    pub fn resolved_entry_procedure_token(
         &self,
         green_key_hash: u64,
-        make_green_key: impl FnOnce() -> GreenKey,
+        make_green_key: Option<&dyn Fn() -> GreenKey>,
     ) -> (u64, Option<std::sync::Arc<majit_backend::JitCellToken>>) {
-        let (cell_key, token) =
-            self.meta
-                .resolved_entry_procedure_token(green_key_hash, make_green_key, |cell_key| {
-                    self.meta.get_compiled_meta(cell_key).is_some()
-                });
-        let token = token.filter(|_| {
-            !self
-                .meta
-                .warm_state_ref()
-                .procedure_token_is_temporary(cell_key)
-        });
-        (cell_key, token)
+        self.meta
+            .resolved_entry_procedure_token(green_key_hash, make_green_key)
     }
 
     /// The token [`Self::has_runnable_compiled_loop`] says yes about, handed

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -856,20 +856,6 @@ fn format_rca_live_values(labels: Option<&[String]>, values: &[Value]) -> String
     out
 }
 
-fn convert_rd_virtuals_for_storage(
-    storage: &crate::resume::ResumeStorage,
-    raw_value_count: usize,
-) -> Vec<crate::resume::VirtualInfo> {
-    let rd_consts = storage.rd_consts();
-    let count = raw_value_count as i32;
-    let num_virtuals = storage.rd_virtuals().len();
-    storage
-        .rd_virtuals()
-        .iter()
-        .map(|rd| crate::resume::rd_virtual_to_virtual_info(rd, rd_consts, count, num_virtuals))
-        .collect()
-}
-
 use crate::TraceAction;
 use crate::blackhole::ExceptionState;
 use crate::jit_state::JitState;
@@ -6510,10 +6496,10 @@ impl<S: JitState> JitDriver<S> {
                 let rd_numb = storage.rd_numb.as_ref();
                 let rd_consts_slice: &[Const] = storage.rd_consts();
 
-                // Convert RdVirtualInfo → VirtualInfo for blackhole resume.
-                let rd_virtuals_converted =
-                    Some(convert_rd_virtuals_for_storage(storage, raw_values.len()));
-                let rd_virtuals_slice = rd_virtuals_converted.as_deref();
+                // `resume.py _prepare_virtuals` — off the guard's own storage,
+                // which builds the reader-shaped virtuals once and hands the
+                // same list to every later resume off this guard.
+                let rd_virtuals_slice = Some(storage.virtual_infos());
 
                 // resume.py:1338-1340: `jitcode = jitcodes[jitcode_pos];
                 // curbh.setposition(jitcode, pc)`.  Per-driver

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7000,22 +7000,31 @@ impl<S: JitState> JitDriver<S> {
             // interpreter has no exception machinery — unreachable for an
             // exception-less interpreter): fall back to crude state recovery and
             // resume the interpreter at the guard pc.
+            //
+            // compile.py:710 recovery_layout header_pc parity: the resume pc
+            // comes from the guard's recovery metadata. Resolved at the head of
+            // this block for two reasons. It sits inside the block because the
+            // block is the only reader — every other exit from the guard arm
+            // returns a pc the bridge or the blackhole reported — and it sits
+            // ahead of the retirement below because the index lookup is keyed on
+            // a compiled loop that `remove_compiled_loop` is about to drop:
+            // asking afterwards finds nothing and silently answers `target_pc`,
+            // which resumes at the loop entry against state the recovery has
+            // already rewound. The failing guard's own layout carries the same
+            // header pc, so reading it first also answers without a lookup.
+            let guard_resume_pc = exit_layout
+                .recovery_layout
+                .as_ref()
+                .and_then(|recovery| recovery.frames.first())
+                .and_then(|frame| frame.header_pc)
+                .or_else(|| self.get_merge_point_pc(owning_key, trace_id, fail_index))
+                .map(|pc| pc as usize)
+                .unwrap_or(target_pc);
             state.recover_after_compiled_run();
             self.meta.invalidate_loop(green_key);
             self.meta.remove_compiled_loop(green_key);
             self.meta.warm_state_mut().abort_tracing(green_key, true);
             self.exit_raw_scratch_out(raw_values);
-            // compile.py:710 recovery_layout header_pc parity:
-            // guard resume_pc comes from the guard's recovery metadata.
-            // Resolved here rather than beside the `must_compile` tick: this
-            // block is the only reader, and every other exit from the guard arm
-            // returns a pc the bridge or the blackhole reported, so the three
-            // index lookups the resolution costs were spent per guard failure
-            // for a value all but this one path discarded.
-            let guard_resume_pc = self
-                .get_merge_point_pc(owning_key, trace_id, fail_index)
-                .map(|pc| pc as usize)
-                .unwrap_or(target_pc);
             return Some(guard_resume_pc);
         }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6394,6 +6394,9 @@ impl<S: JitState> JitDriver<S> {
                 .take()
                 .expect("a guard exit carries its descr");
             let guard_value_operand = result.guard_value_operand;
+            // `compile.py handle_fail` `resumedescr.rd_loop_token`, resolved
+            // once where the run handed the descr back.
+            let descr_owning_key = result.rd_loop_token;
             // blackhole.py `_prepare_resume_from_failure(deadframe)`:
             // the pending exception grabbed at guard failure
             // (cpu.grab_exc_value) must seed the blackhole resume so an
@@ -6442,11 +6445,16 @@ impl<S: JitState> JitDriver<S> {
             } else {
                 green_key
             };
-            let (must_compile, owning_key) = self.meta.must_compile_with_values(
+            // Resolved once for the whole event, where the run handed the descr
+            // back, and carried here: `compile.py handle_fail` reads
+            // `resumedescr.rd_loop_token` once and hands the loop it names to
+            // both the layout it looks up and the `must_compile` call.
+            let owning_key = descr_owning_key.unwrap_or(fallback_green_key);
+            let (must_compile, owning_key) = self.meta.must_compile_with_owning_key(
                 &descr_arc,
                 &raw_values,
                 guard_value_operand,
-                fallback_green_key,
+                owning_key,
             );
             // compile.py: must_compile() and not stack_almost_full().
             // MAJIT_NO_BRIDGE (diagnostic): suppress bridge recording so every
@@ -8084,6 +8092,8 @@ impl<S: JitState> JitDriver<S> {
         // `result` is dropped just below, so the buffer has no reader left.
         let typed_values = std::mem::take(&mut result.typed_values).into_vec();
         let guard_value_operand = result.guard_value_operand;
+        // See the sibling run loop.
+        let descr_owning_key = result.rd_loop_token;
         // llmodel.py grab_exc_value: the pending exception captured at
         // guard failure travels with the GuardFailure outcome so the
         // blackhole resume can seed it (blackhole.py:1794).
@@ -8121,11 +8131,13 @@ impl<S: JitState> JitDriver<S> {
         } else {
             green_key
         };
-        let (must_compile, owning_key) = self.meta.must_compile_with_values(
+        // Carried off the result — see the sibling run loop.
+        let owning_key = descr_owning_key.unwrap_or(fallback_green_key);
+        let (must_compile, owning_key) = self.meta.must_compile_with_owning_key(
             &descr_arc,
             &raw_values,
             guard_value_operand,
-            fallback_green_key,
+            owning_key,
         );
         // compile.py: must_compile() and not stack_almost_full().
         // `no_bridge_enabled()` is the same opt-out the two sibling loops

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6460,13 +6460,6 @@ impl<S: JitState> JitDriver<S> {
                 && !no_bridge_enabled()
                 && bridge_fuel_take();
 
-            // compile.py:710 recovery_layout header_pc parity:
-            // guard resume_pc comes from the guard's recovery metadata.
-            let guard_resume_pc = self
-                .get_merge_point_pc(owning_key, trace_id, fail_index)
-                .map(|pc| pc as usize)
-                .unwrap_or(target_pc);
-
             // compile.py handle_fail. `must_compile() and not
             // stack_almost_full()` → `_trace_and_compile_from_bridge`, else
             // `resume_in_blackhole`; the two are mutually exclusive and
@@ -7009,6 +7002,17 @@ impl<S: JitState> JitDriver<S> {
             self.meta.remove_compiled_loop(green_key);
             self.meta.warm_state_mut().abort_tracing(green_key, true);
             self.exit_raw_scratch_out(raw_values);
+            // compile.py:710 recovery_layout header_pc parity:
+            // guard resume_pc comes from the guard's recovery metadata.
+            // Resolved here rather than beside the `must_compile` tick: this
+            // block is the only reader, and every other exit from the guard arm
+            // returns a pc the bridge or the blackhole reported, so the three
+            // index lookups the resolution costs were spent per guard failure
+            // for a value all but this one path discarded.
+            let guard_resume_pc = self
+                .get_merge_point_pc(owning_key, trace_id, fail_index)
+                .map(|pc| pc as usize)
+                .unwrap_or(target_pc);
             return Some(guard_resume_pc);
         }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7215,26 +7215,21 @@ impl<S: JitState> JitDriver<S> {
         // the same two checks, and folding three doors into one slot would say
         // nothing about any of them.
         crate::mc_diag_bump(61); // mst_entered
-        // warmstate.py `maybe_compile_and_run` consults the cell before
-        // `bound_reached` builds tracing state. Pyre's abort ceiling is the
-        // equivalent permanent refusal. Resolve it through the same typed-key
-        // helper as `on_back_edge_typed_decision` below; the public
-        // hash-only doors fall back through the same u64 arm as that decision.
-        // Keep slot 81 on the same population as the mirrored refusal in
-        // `maybe_compile_decision_with_meta`.
-        let ceiling_latched = match MetaInterp::<S::Meta>::with_typed_decision_key(
-            green_key,
-            (state.code_ptr(), target_pc),
-            |key| self.meta.warm_state.is_ceiling_latched_for_key(key),
-        ) {
-            Some(latched) => latched,
-            None => self.meta.warm_state.is_ceiling_latched(green_key),
-        };
-        if ceiling_latched {
-            crate::mc_diag_bump(81); // abort_ceiling_refused
-            return false;
-        }
-
+        // The abort ceiling is NOT consulted separately here. It is a refusal
+        // the decision below already owns: `maybe_compile_decision_with_key`
+        // takes it in the position `warmstate.py maybe_compile_and_run` gives
+        // `confirm_enter_jit`, above the counter tick and above the
+        // `decay_all_counters` inside `bound_reached`, so a latched cell
+        // reaches neither — which is the whole reason the ceiling decides
+        // early. Asking first resolved the same cell through the same typed
+        // chain walk a second time, for an answer
+        // `is_ceiling_latched_agrees_with_the_decision_it_mirrors` pins equal
+        // to the one the decision reaches; `maybe_compile_and_run` binds its
+        // cell once ("to avoid computing the hash several times") and answers
+        // every question about it off that binding. Slot 81 counts the same
+        // population either way, because only one of the two refusals can fire
+        // for a given edge: every state in which the mirror answered `false`
+        // returns above the decision's ceiling arm or fails its condition.
         match self
             .meta
             .on_back_edge_typed_decision(green_key, (state.code_ptr(), target_pc))

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7001,8 +7001,11 @@ impl<S: JitState> JitDriver<S> {
             // exception-less interpreter): fall back to crude state recovery and
             // resume the interpreter at the guard pc.
             //
-            // compile.py:710 recovery_layout header_pc parity: the resume pc
-            // comes from the guard's recovery metadata. Resolved at the head of
+            // `AbstractResumeGuardDescr.handle_fail` parity: a guard failure
+            // that does not compile is answered by `resume_in_blackhole`, which
+            // rebuilds the frame chain and `setposition`s it at the pc the
+            // guard's own resume data encodes. The header pc of the guard's
+            // recovery frame is that position here. Resolved at the head of
             // this block for two reasons. It sits inside the block because the
             // block is the only reader — every other exit from the guard arm
             // returns a pc the bridge or the blackhole reported — and it sits

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -546,14 +546,17 @@ pub fn no_bridge_enabled() -> bool {
 /// limit cannot draw, because declining N also declines everything after it.
 /// Off by default; an unparsable entry is ignored rather than reported, since
 /// the variable exists only for a bisect the operator is reading anyway.
-fn bridge_fuel_skipped(n: u64) -> bool {
+fn bridge_fuel_skip_set() -> &'static [u64] {
     static SET: std::sync::OnceLock<Vec<u64>> = std::sync::OnceLock::new();
     SET.get_or_init(|| {
         std::env::var("MAJIT_SKIP_BRIDGES")
             .map(|v| v.split(',').filter_map(|p| p.trim().parse().ok()).collect())
             .unwrap_or_default()
     })
-    .contains(&n)
+}
+
+fn bridge_fuel_skipped(n: u64) -> bool {
+    bridge_fuel_skip_set().contains(&n)
 }
 /// `MAJIT_MAX_BRIDGES=N` (diagnostic): allow the first N bridge compilations
 /// and behave as `MAJIT_NO_BRIDGE` from then on.  Bisecting N names the bridge
@@ -562,6 +565,10 @@ fn bridge_fuel_skipped(n: u64) -> bool {
 /// already held, so the count is bridges actually taken — place it last in the
 /// `&&` chain.  `MAJIT_BRIDGE_FUEL_LOG` reports each one taken.
 ///
+/// `MAJIT_SKIP_BRIDGES` names positions in this same sequence, so either gate
+/// alone starts the count: numbering only when a limit is set would leave the
+/// skip list naming positions nothing ever allocates.
+///
 /// Public for the same reason `no_bridge_enabled` is: a frontend with its own
 /// guard-failure entry point spends fuel there too, and a counter that only
 /// half the bridges draw from makes `MAJIT_MAX_BRIDGES=0` disagree with
@@ -569,16 +576,21 @@ fn bridge_fuel_skipped(n: u64) -> bool {
 /// every bridge that entry point reaches.
 pub fn bridge_fuel_take() -> bool {
     static LIMIT: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
-    let Some(limit) = *LIMIT.get_or_init(|| {
+    let limit = *LIMIT.get_or_init(|| {
         std::env::var("MAJIT_MAX_BRIDGES")
             .ok()
             .and_then(|v| v.parse().ok())
-    }) else {
+    });
+    // The sequence number belongs to the pair, not to the limit: the skip list
+    // names positions in this same count, so a run that configures only the
+    // skip list still has to number the bridges it takes. Numbering only when a
+    // limit is set would leave the skip list naming positions nothing allocates.
+    if limit.is_none() && bridge_fuel_skip_set().is_empty() {
         return true;
-    };
+    }
     static USED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let n = USED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    if n >= limit {
+    if limit.is_some_and(|limit| n >= limit) {
         return false;
     }
     if bridge_fuel_skipped(n) {
@@ -6749,13 +6761,19 @@ impl<S: JitState> JitDriver<S> {
                     // actually happened records it.
                     //
                     // A walk that crossed a frame boundary is not judged by one
-                    // frame's registers, so it does not qualify.
+                    // frame's registers, so it does not qualify — and cannot be:
+                    // each pop above rebinds `bh` to its caller, while the spans
+                    // were measured against the bank of the frame the guard
+                    // failed in. The frame-count test therefore has to come
+                    // first, so the comparison is reached only while the spans
+                    // still describe the bank they are indexing.
                     let guard_may_bridge = match &sf_before {
                         Some((before_i, before_r, before_f)) => {
-                            let tail_wrote_state = bh.registers_i[sf_i] != before_i[..]
-                                || bh.registers_r[sf_r] != before_r[..]
-                                || bh.registers_f[sf_f] != before_f[..];
-                            bh_frames_popped == 0 && !bh.called_residual.get() && !tail_wrote_state
+                            bh_frames_popped == 0
+                                && !bh.called_residual.get()
+                                && bh.registers_i[sf_i] == before_i[..]
+                                && bh.registers_r[sf_r] == before_r[..]
+                                && bh.registers_f[sf_f] == before_f[..]
                         }
                         // Only reachable with `should_bridge` false, where the
                         // reader below short-circuits before asking.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -220,7 +220,7 @@ pub use majit_backend::CompiledTraceInfo;
 /// The object a door carries from its entry decision into the run.
 ///
 /// Re-exported because [`JitDriver::runnable_procedure_token`] and
-/// [`JitDriver::resolved_runnable_procedure_token`] hand one to callers
+/// [`JitDriver::resolved_entry_procedure_token`] hand one to callers
 /// outside this crate, which have no other way to name its type.
 pub use majit_backend::JitCellToken;
 #[cfg(feature = "__execute-stage-probe")]

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -448,8 +448,8 @@ pub struct Optimizer {
     /// makes. That one runs `Optimizer.optimize_loop`, whose result is a
     /// `BasicLoopInfo` and the operations; the short-preamble export and the
     /// `ExportedState` it produces belong to `UnrollOptimizer.optimize_preamble`
-    /// alone, and `unroll.py:454-457`'s force-then-flush-then-virtual-state runs
-    /// only there. pyre folds that preview into the shared
+    /// alone, and the force-then-flush-then-virtual-state that opens
+    /// `UnrollOptimizer.export_state` runs only there. pyre folds that preview into the shared
     /// `optimize_with_constants_and_inputs_at`, so a simple compile needs this
     /// flag to reach the same shape: no forcing of the closing JUMP's arguments
     /// for a preamble that is not being built, and no exported state, which no

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -12735,21 +12735,24 @@ impl<M: Clone> MetaInterp<M> {
     /// hands on enters that same cell's code. Asking for them separately walks
     /// the chain twice; see [`WarmState::resolved_cell_procedure_token`].
     ///
-    /// The key comes back because the second conjunct of the runnable predicate
-    /// reads `compiled_loops`, which is indexed by that key and is not a cell
-    /// walk, so the caller still needs it.
-    /// `gate` runs on the resolved key before the token is read — see
-    /// [`WarmState::resolved_cell_procedure_token`] for why a caller would
-    /// want that.
+    /// The key comes back because the remaining conjunct of the runnable
+    /// predicate reads `compiled_loops`, which is indexed by that key and is
+    /// not a cell walk, so the caller still needs it. That conjunct stays with
+    /// the caller rather than being taken here as a gate: a door that enters
+    /// wants the metadata's VALUE, so testing its presence separately would
+    /// probe the same map twice for one entry.
+    ///
+    /// `make_green_key` is consulted only on an ambiguous bucket, and a caller
+    /// that holds no structured key passes `None` — see
+    /// [`Self::resolve_cell_key`], whose key this reports.
     pub fn resolved_entry_procedure_token(
         &self,
         green_key_hash: u64,
-        make_green_key: impl FnOnce() -> majit_ir::GreenKey,
-        gate: impl FnOnce(u64) -> bool,
+        make_green_key: Option<&dyn Fn() -> majit_ir::GreenKey>,
     ) -> (u64, Option<std::sync::Arc<JitCellToken>>) {
-        let (cell_key, token) =
-            self.warm_state
-                .resolved_cell_procedure_token(green_key_hash, make_green_key, gate);
+        let (cell_key, token) = self
+            .warm_state
+            .resolved_cell_procedure_token(green_key_hash, make_green_key);
         (cell_key, token.filter(|token| token.has_compiled_code()))
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11836,8 +11836,20 @@ impl<M: Clone> MetaInterp<M> {
         let exit_types: &[Type] = descr.fail_arg_types();
         let status = descr.get_status();
         let guard_value_operand = self.resolve_guard_value_operand(descr, &frame);
+        // A plain loop back-edge carries neither a guard nor a resume point.
+        // `warmstate.py execute_assembler` never builds a description for one:
+        // the JUMP has already re-entered the loop's own LABEL, and what comes
+        // back out is the loop-carried state, not a failure to recover from.
+        let is_jump_exit = Self::is_jump_exit(is_finish, fail_index);
         // compile.py `descr.rd_loop_token` — see `run_compiled_detailed`.
-        let rd_loop_token = majit_backend::descr_owning_jct(descr).map(|jct| jct.green_key());
+        // Only the layout fallback and the `must_compile` identity read it, and
+        // a JUMP exit reaches neither, so the weakref upgrade the resolution
+        // costs is not paid on the back edge.
+        let rd_loop_token = if is_jump_exit {
+            None
+        } else {
+            majit_backend::descr_owning_jct(descr).map(|jct| jct.green_key())
+        };
         Self::finish_compiled_run_io();
 
         // RPython: guard failure counter tick and bridge compilation happen
@@ -11848,46 +11860,59 @@ impl<M: Clone> MetaInterp<M> {
             self.record_guard_failure_event(green_key, trace_id, fail_index, back_edge_poll);
         }
 
-        // Fresh lookup, and fallible: the run can re-enter the driver through
-        // a residual call and drop this green key (`jitdriver.rs`'s
-        // `remove_compiled_loop` on the unrecoverable-resume path), in which
-        // case the exit falls through to the `rd_loop_token` lookup and then
-        // to the synthesized default layout below.
-        let compiled = self.compiled_loops.get(&green_key);
-        // Only a guard exit reaches here — a final descr returned through the
-        // fast path above — so the layout comes from the failing guard's own
-        // trace, and falls back to a synthesized one per `run_compiled_detailed`
-        // when the green key no longer holds it.
-        let mut exit_layout = compiled
-            .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
-            .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
-            .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
-            .and_then(|(owning_key, resolved_id, trace)| {
-                Self::compiled_exit_layout_from_trace(trace, owning_key, resolved_id, fail_index)
-            })
-            .unwrap_or_else(|| CompiledExitLayout {
-                rd_loop_token: green_key,
-                trace_id,
-                fail_index,
-                source_op_index: None,
-                exit_types: ExitTypes::from_slice(exit_types),
-                is_finish,
-                is_exception_exit: is_exit_frame_with_exception,
-                recovery_layout: None,
-                resume_layout: None,
-                // The green-key index no longer holds this trace, but the
-                // failing descr still carries the resume payload it was
-                // compiled with (`compile.py get_resumestorage`), so a
-                // blackhole resume off this layout stays possible.
-                storage: crate::resume::ResumeStorage::from_fail_descr(descr)
-                    .map(std::sync::Arc::new),
-            });
-        // RPython: deadframe has ALL jitframe slots accessible.
-        // If the backend's descr covers more slots than the trace layout,
-        // extend exit_layout.exit_types to match (conservative Int for extras).
-        if exit_types.len() > exit_layout.exit_types.len() {
-            exit_layout.exit_types.resize(exit_types.len(), Type::Int);
-        }
+        // Built for a guard exit only. Every reader of this field opens it past
+        // its own JUMP arm — the two driver run loops restore the exit values
+        // and return, and the drain loop breaks — so a layout built for a back
+        // edge is a type-vector copy, three refcount pairs and a heap box that
+        // nothing reads.
+        let exit_layout = (!is_jump_exit).then(|| {
+            // Fresh lookup, and fallible: the run can re-enter the driver
+            // through a residual call and drop this green key (`jitdriver.rs`'s
+            // `remove_compiled_loop` on the unrecoverable-resume path), in
+            // which case the exit falls through to the `rd_loop_token` lookup
+            // and then to the synthesized default layout below.
+            let compiled = self.compiled_loops.get(&green_key);
+            // The layout comes from the failing guard's own trace, and falls
+            // back to a synthesized one per `run_compiled_detailed` when the
+            // green key no longer holds it.
+            let mut exit_layout = compiled
+                .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
+                .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
+                .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
+                .and_then(|(owning_key, resolved_id, trace)| {
+                    Self::compiled_exit_layout_from_trace(
+                        trace,
+                        owning_key,
+                        resolved_id,
+                        fail_index,
+                    )
+                })
+                .unwrap_or_else(|| CompiledExitLayout {
+                    rd_loop_token: green_key,
+                    trace_id,
+                    fail_index,
+                    source_op_index: None,
+                    exit_types: ExitTypes::from_slice(exit_types),
+                    is_finish,
+                    is_exception_exit: is_exit_frame_with_exception,
+                    recovery_layout: None,
+                    resume_layout: None,
+                    // The green-key index no longer holds this trace, but the
+                    // failing descr still carries the resume payload it was
+                    // compiled with (`compile.py get_resumestorage`), so a
+                    // blackhole resume off this layout stays possible.
+                    storage: crate::resume::ResumeStorage::from_fail_descr(descr)
+                        .map(std::sync::Arc::new),
+                });
+            // RPython: deadframe has ALL jitframe slots accessible.
+            // If the backend's descr covers more slots than the trace layout,
+            // extend exit_layout.exit_types to match (conservative Int for
+            // extras).
+            if exit_types.len() > exit_layout.exit_types.len() {
+                exit_layout.exit_types.resize(exit_types.len(), Type::Int);
+            }
+            Box::new(exit_layout)
+        });
         let savedata = self.backend.get_savedata_ref(&frame);
         // pyjitpl.py:3119-3123: exc_class = ptr2int(exception_obj.typeptr)
         let exc_value_ref = self.backend.grab_exc_value(&frame);
@@ -11911,7 +11936,7 @@ impl<M: Clone> MetaInterp<M> {
             descr_arc: Some(descr_arc),
             is_finish,
             is_exit_frame_with_exception,
-            exit_layout: Some(Box::new(exit_layout)),
+            exit_layout,
             savedata,
             exception,
             status,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11863,10 +11863,10 @@ impl<M: Clone> MetaInterp<M> {
         }
 
         // Built for a guard exit only. Every reader of this field opens it past
-        // its own JUMP arm — the two driver run loops restore the exit values
-        // and return, and the drain loop breaks — so a layout built for a back
-        // edge is a type-vector copy, three refcount pairs and a heap box that
-        // nothing reads.
+        // its own back-edge arm, because a JUMP exit is answered by restoring
+        // the loop-carried state and re-entering — so a layout built for one is
+        // a type-vector copy, three refcount pairs and a heap box that nothing
+        // reads.
         let exit_layout = (!is_jump_exit).then(|| {
             // Fresh lookup, and fallible: the run can re-enter the driver
             // through a residual call and drop this green key (`jitdriver.rs`'s

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11582,6 +11582,7 @@ impl<M: Clone> MetaInterp<M> {
             is_finish,
             is_exit_frame_with_exception,
             exit_layout: exit_layout.map(Box::new),
+            rd_loop_token,
             savedata,
             exception,
             status,
@@ -11814,6 +11815,7 @@ impl<M: Clone> MetaInterp<M> {
                 is_finish,
                 is_exit_frame_with_exception,
                 exit_layout: None,
+                rd_loop_token: None,
                 savedata: None,
                 exception: ExceptionState {
                     exc_class: 0,
@@ -11937,6 +11939,7 @@ impl<M: Clone> MetaInterp<M> {
             is_finish,
             is_exit_frame_with_exception,
             exit_layout,
+            rd_loop_token,
             savedata,
             exception,
             status,
@@ -12913,6 +12916,34 @@ impl<M: Clone> MetaInterp<M> {
     const TY_REF: u64 = 0x04;
     const TY_FLOAT: u64 = 0x06;
 
+    /// Green key of the loop a failing guard belongs to.
+    ///
+    /// `compile.py _trace_and_compile_from_bridge` walks
+    /// `resumedescr.rd_loop_token.loop_token_wref()` for the owning JCT.  When
+    /// the weakref is dead (memmgr eviction — `compile.py compile.giveup()`
+    /// parity), no other identity is recoverable, so the caller's own outer
+    /// entry key stands in.  RPython has no such fallback because its identity
+    /// is descr-pointer-based, never indirected through a numeric `green_key`.
+    ///
+    /// A JitCellToken invalidated by `QuasiImmut.invalidate()` (quasiimmut.py)
+    /// still resolves here, and the `must_compile` tick that follows still
+    /// fires: warmstate.py:191-196 stops returning the dead token as a
+    /// procedure token, so once the counter fires, the walk reaches
+    /// `reached_loop_header` (pyjitpl.py) with no compiled target, falls
+    /// through to `compile_loop` and installs a live replacement for the key.
+    /// Suppressing that tick strands every later activation of the dead trace
+    /// in blackhole resume forever.
+    pub fn owning_key_for_descr(
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+        fallback_green_key: u64,
+    ) -> u64 {
+        descr_arc
+            .as_fail_descr()
+            .and_then(majit_backend::descr_owning_jct)
+            .map(|jct| jct.green_key())
+            .unwrap_or(fallback_green_key)
+    }
+
     /// compile.py: must_compile — read self.status directly from
     /// the failed descriptor (by descr_addr), compute hash, tick jitcounter.
     ///
@@ -12927,10 +12958,8 @@ impl<M: Clone> MetaInterp<M> {
     /// loop_token_wref()`, `trace_id` mirrors `assembler.py:227
     /// self.faildescr.trace_id`, and `fail_index_per_trace` mirrors
     /// `self.faildescr.index = i`.  The `fallback_green_key` only fires
-    /// when `descr_owning_jct` returns `None` (the JCT was evicted by
-    /// memmgr, equivalent to RPython's `compile.py:725-729 compile.
-    /// giveup()` path), so callers pass their own outer entry key as
-    /// the safe default.
+    /// when the owning-JCT walk returns `None`; see
+    /// [`Self::owning_key_for_descr`].
     ///
     /// Returns (should_compile, owning_green_key).
     pub fn must_compile_with_values(
@@ -12940,6 +12969,25 @@ impl<M: Clone> MetaInterp<M> {
         guard_value_operand: Option<i64>,
         fallback_green_key: u64,
     ) -> (bool, u64) {
+        let owning_key = Self::owning_key_for_descr(descr_arc, fallback_green_key);
+        self.must_compile_with_owning_key(descr_arc, fail_values, guard_value_operand, owning_key)
+    }
+
+    /// [`Self::must_compile_with_values`] for a caller that has already
+    /// resolved the owning loop.
+    ///
+    /// `compile.py handle_fail` reads `resumedescr.rd_loop_token` once per
+    /// failure and `must_compile` never re-derives the loop it belongs to; a
+    /// caller that walked the owning JCT to look the guard's layout up holds
+    /// the same answer and hands it in rather than paying the weakref upgrade
+    /// a second time inside one event.
+    pub fn must_compile_with_owning_key(
+        &mut self,
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+        fail_values: &[i64],
+        guard_value_operand: Option<i64>,
+        owning_key: u64,
+    ) -> (bool, u64) {
         crate::mc_diag_bump(0); // must_compile_with_values entered
         let descr_addr = std::sync::Arc::as_ptr(descr_arc) as *const () as usize;
         let descr_fd = descr_arc
@@ -12947,18 +12995,6 @@ impl<M: Clone> MetaInterp<M> {
             .expect("must_compile_with_values: descr_arc must be a FailDescr");
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
-        // `must_compile` ticks the counter for every reported guard failure,
-        // including one whose owning JitCellToken has since been invalidated by
-        // `QuasiImmut.invalidate()` (quasiimmut.py).  That tick is the
-        // recovery path, not a leak: warmstate.py:191-196 stops returning the
-        // dead token as a procedure token, so once the counter fires, the walk
-        // reaches `reached_loop_header` (pyjitpl.py) with no compiled
-        // target, falls through to `compile_loop` and installs a live
-        // replacement for the key.  Suppressing the tick strands every later
-        // activation of the dead trace in blackhole resume forever.
-        let owning_key = majit_backend::descr_owning_jct(descr_fd)
-            .map(|jct| jct.green_key())
-            .unwrap_or(fallback_green_key);
         // A guard whose bridge was refused by a terminal-declining backend
         // (`bridge_decline_is_terminal()`, currently wasm) or by a structural
         // full-body-walk decline must not re-fire: re-tracing rebuilds the same
@@ -12969,14 +13005,6 @@ impl<M: Clone> MetaInterp<M> {
             crate::mc_diag_bump(1); // guard-descr terminal-decline short-circuit
             return (false, owning_key);
         }
-        // compile.py `_trace_and_compile_from_bridge` walks
-        // `resumedescr.rd_loop_token.loop_token_wref()` for the owning
-        // JCT.  When the weakref is dead (memmgr eviction —
-        // `compile.py compile.giveup()` parity), no other
-        // identity is recoverable, so we fall back to the caller's
-        // outer entry key.  RPython doesn't have this fallback because
-        // its identity is descr-pointer-based, never indirected through
-        // a numeric `green_key`.
         if descr_addr == 0 {
             crate::mc_diag_bump(2); // descr_addr==0 skip
             crate::debug::log_one("jit-tracing", "must_compile: descr_addr=0, skip");

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9887,11 +9887,6 @@ impl<M: Clone> MetaInterp<M> {
         self.clear_retrace_state();
         if let Some(ctx) = self.tracing.take() {
             let green_key = ctx.green_key;
-            // A recorder panic settles the question the `MAX_TRACE_ABORT_COUNT`
-            // ceiling would otherwise take that many attempts to reach: the walk
-            // stopped on something about the jitcode it was reading, so every
-            // later attempt at this key reads it again. Ban the key here.
-            let permanent = permanent || ctx.recorder_panicked;
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] abort trace at key={} (permanent={})",

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3163,7 +3163,6 @@ where
                     // The unwind left `code_cursor` inside the panicking
                     // instruction, so the frames name no resumable position.
                     ctx.abort_after_panic = true;
-                    ctx.recorder_panicked = true;
                     sym.abort_portal_op();
                     return TraceAction::Abort;
                 }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6531,6 +6531,51 @@ where
                     // box handling in between, neither of which reads the
                     // heapcache, so reset-then-guard is the faithful order.
                     ctx.heap_cache_mut().reset();
+                    // pyjitpl.py reached_loop_header, its second statement:
+                    //
+                    //     self.remove_consts_and_duplicates(
+                    //         self.virtualizable_boxes,
+                    //         len(self.virtualizable_boxes) - 1, duplicates)
+                    //     live_arg_boxes += self.virtualizable_boxes
+                    //
+                    // The normalization is IN PLACE on `virtualizable_boxes`
+                    // and runs on EVERY visit, before the list is spliced into
+                    // the loop-carried args — so the args a merge point carries
+                    // never hold a constant and never repeat a box.  The two
+                    // merge-point registration sites below normalize their own
+                    // COPY, which leaves the closing JUMP — built by
+                    // `collect_jump_args_with_boxes` out of `sym` plus a fresh
+                    // splice of `virtualizable_boxes` — splicing the raw list.
+                    // A guard-origin bridge reaches here with that list still
+                    // holding whatever `seed_bridge_virtualizable_boxes`
+                    // decoded, and a `TAGCONST` element decodes to a constant
+                    // `OpRef`, so the JUMP into the parent loop carried a bare
+                    // literal in an element position: a value read off ONE
+                    // guard failure, frozen into an edge every later entry
+                    // takes.  Normalizing here, and handing the result back so
+                    // the splice sees it, is what upstream's in-place rewrite
+                    // does.
+                    //
+                    // The identity sits outside the `endindex = len - 1`
+                    // window and is never rewritten: it is a live red input box
+                    // that `standard_virtualizable_jitcode_argbox` and the
+                    // resume reader both index by position.
+                    //
+                    // Upstream shares one `duplicates` set with the reds it
+                    // normalized first; the reds here live in `sym`'s scalar
+                    // fields, which this expansion cannot rewrite, so the
+                    // element block gets its own set.  The registration sites
+                    // below still run the combined pass over their copy, and
+                    // `remove_consts_and_duplicates` is idempotent on an
+                    // already-normalized list.
+                    if let Some(mut typed) = ctx.collect_virtualizable_typed_boxes() {
+                        if let Some(end) = typed.len().checked_sub(1) {
+                            ctx.remove_consts_and_duplicates(&mut typed[..end]);
+                            let elements: Vec<OpRef> =
+                                typed[..end].iter().map(|(opref, _)| *opref).collect();
+                            ctx.adopt_normalized_virtualizable_elements(&elements);
+                        }
+                    }
                     // pyjitpl.py reached_loop_header: generate a dummy
                     // GUARD_FUTURE_CONDITION just before the implicit JUMP so
                     // unroll's `jump_to_existing_trace` has a `patchguardop`

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -660,6 +660,9 @@ pub struct ResumeStorage {
     /// resume.py:468 `storage.rd_pendingfields` — pending field writes
     /// replayed during blackhole resume.
     pub rd_pendingfields: SharedResumeSlice<majit_ir::GuardPendingFieldEntry>,
+    /// `rd_virtuals` in the shape `ResumeDataDirectReader` consumes, built
+    /// once — see [`ResumeStorage::virtual_infos`].
+    virtual_infos: std::sync::OnceLock<Vec<VirtualInfo>>,
 }
 
 impl ResumeStorage {
@@ -683,6 +686,7 @@ impl ResumeStorage {
             rd_consts: descr.rd_consts_arc()?,
             rd_virtuals: descr.rd_virtuals_arc().into(),
             rd_pendingfields: descr.rd_pendingfields_arc().into(),
+            virtual_infos: std::sync::OnceLock::new(),
         })
     }
 }
@@ -717,6 +721,7 @@ impl ResumeStorage {
             rd_consts: majit_ir::SharedConstPool::new(rd_consts),
             rd_virtuals: rd_virtuals.into(),
             rd_pendingfields: rd_pendingfields.into(),
+            virtual_infos: std::sync::OnceLock::new(),
         })
     }
 
@@ -751,6 +756,32 @@ impl ResumeStorage {
         self.rd_pendingfields.as_slice()
     }
 
+    /// `resume.py ResumeDataReader._prepare_virtuals`: `self.virtuals =
+    /// storage.rd_virtuals` — a bare assignment, because upstream builds the
+    /// `AbstractVirtualInfo` objects once, at compile time, in
+    /// `ResumeDataVirtualAdder.finish`.
+    ///
+    /// Pyre records `RdVirtualInfo` on the guard and reshapes it for the
+    /// reader, so the reshape lands here instead. It is a pure function of
+    /// `rd_virtuals` — the tagged `fieldnums` stay tagged and every descriptor
+    /// is cloned as-is — and `rd_virtuals` is immutable once the guard owns it,
+    /// so the result is built on the first resume off this guard and shared by
+    /// every later one rather than rebuilt per failure.
+    ///
+    /// Nothing in the result is a GC reference: the field sources are
+    /// numbering tags, and the descriptors, type ids, known-class vtable words
+    /// and raw-buffer function pointers are all immortal. The minor-collection
+    /// root walker therefore has nothing to rewrite here, and visits
+    /// `rd_consts` alone as before.
+    pub fn virtual_infos(&self) -> &[VirtualInfo] {
+        self.virtual_infos.get_or_init(|| {
+            self.rd_virtuals()
+                .iter()
+                .map(|rd| virtual_info_from_rd(rd))
+                .collect()
+        })
+    }
+
     pub fn with_shared_consts(
         rd_numb: Arc<[u8]>,
         rd_consts: Arc<majit_ir::SharedConstPool>,
@@ -762,6 +793,7 @@ impl ResumeStorage {
             rd_consts,
             rd_virtuals: rd_virtuals.into(),
             rd_pendingfields: rd_pendingfields.into(),
+            virtual_infos: std::sync::OnceLock::new(),
         })
     }
 }
@@ -1556,6 +1588,19 @@ pub fn rd_virtual_to_virtual_info(
     _count: i32,
     _num_virtuals: usize,
 ) -> VirtualInfo {
+    virtual_info_from_rd(rd)
+}
+
+/// The conversion itself.
+///
+/// It reads nothing but `rd`: the tagged `fieldnums` stay tagged for
+/// `ResumeDataDirectReader` to resolve against the live pool, so the constant
+/// pool, the deadframe width and the virtual count that a reader would need to
+/// resolve them play no part here. Callers holding those may go through
+/// `rd_virtual_to_virtual_info`, which names them for the reader-shaped call
+/// sites; the purity is what lets `ResumeStorage::virtual_infos` build the
+/// result once.
+pub fn virtual_info_from_rd(rd: &majit_ir::RdVirtualInfo) -> VirtualInfo {
     match rd {
         majit_ir::RdVirtualInfo::VirtualInfo {
             descr,
@@ -5820,7 +5865,7 @@ mod tests {
             offset: 0,
             fieldnums: vec![],
         };
-        let virtuals = [rd_virtual_to_virtual_info(&rd, &[], 0, 1)];
+        let virtuals = [virtual_info_from_rd(&rd)];
         let mut reader = ResumeDataDirectReader::new(
             &[0, 0],
             &[],
@@ -5859,7 +5904,7 @@ mod tests {
             fieldnums: vec![tagged],
         };
         let mut consts = vec![majit_ir::Const::Ref(majit_ir::GcRef(0x1000))];
-        let virtual_info = rd_virtual_to_virtual_info(&rd, &consts, 0, 1);
+        let virtual_info = virtual_info_from_rd(&rd);
         let VirtualInfo::VRawSlice { parent, .. } = virtual_info else {
             panic!("expected VRawSlice");
         };

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -556,14 +556,6 @@ pub struct TraceCtx {
     /// instruction boundary).  RPython has no counterpart: it has no panic arm
     /// here.
     pub abort_after_panic: bool,
-    /// Set alongside [`Self::abort_after_panic`], and never consumed before the
-    /// abort reaches the warm-state cell, so `abort_trace_live` can ban the
-    /// green key on the first panic instead of retrying it.  What the recorder
-    /// panicked on is a property of the jitcode it is walking, not of the values
-    /// this attempt happened to see, so every later attempt at the same key
-    /// reads the same thing and panics again.  RPython has no counterpart: it
-    /// has no panic arm here.
-    pub recorder_panicked: bool,
     /// Set when the walk refused a residual call whose target was still a
     /// symbolic path hash.  A dispatch-arm sub-JitCode may contain an earlier
     /// residual call that already executed concretely, so neither replaying
@@ -1784,7 +1776,6 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
-            recorder_panicked: false,
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
@@ -1884,7 +1875,6 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
-            recorder_panicked: false,
             symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -7123,6 +7123,65 @@ mod tests {
         );
     }
 
+    /// The one-walk resolve answers an ambiguous bucket with no greens exactly
+    /// as the two readers it replaced did.
+    ///
+    /// [`WarmEnterState::resolved_cell`] folds
+    /// [`WarmEnterState::cell_keys_at`] and [`WarmEnterState::cell_by_key`]
+    /// into a single traversal, and its `(count > 1, make_key: None)` arm is
+    /// the one that cannot be checked against a caller's greens: it reports the
+    /// raw hash and whatever cell that hash names. That arm reaches the cell
+    /// through `by_key`, a candidate noted DURING the walk, where the readers
+    /// it replaced reached it by walking back from the key — so the two can
+    /// only be shown to agree on a bucket that actually holds more than one
+    /// candidate, which is the fixture below.
+    #[test]
+    fn an_ambiguous_bucket_resolved_without_greens_names_the_cell_its_key_names() {
+        let mut ws = WarmEnterState::new(100);
+        let first = GreenKey::new(vec![4100, 4200]);
+        let second = GreenKey::new(vec![4300, colliding_last_green(&first, 4300)]);
+        let bucket = first.get_uhash();
+
+        // A procedure token keeps the first cell non-removable so the second
+        // install chains it rather than pruning it — the same shape
+        // `a_chained_bucket_reached_without_greens_answers_the_first_occupant`
+        // builds, because a single-candidate bucket takes the `(1, _)` arm and
+        // never reaches the branch under test.
+        let token = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        attach_alive_for_key(&mut ws, &first, token);
+        let first_key = ws
+            .cell_key_for(&first)
+            .expect("the first key owns the cell it just installed");
+        let _second_key = ws.ensure_cell_key(&second);
+
+        let (count, first_found) = ws.cell_keys_at(bucket);
+        assert!(
+            count > 1,
+            "fixture: the bucket must own two candidates, or the resolve takes              its single-candidate arm and the branch under test never runs",
+        );
+        assert_eq!(
+            first_found,
+            Some(first_key),
+            "fixture: and the first of them is the occupant that kept the raw              hash",
+        );
+
+        let (cell_key, cell) = ws.resolved_cell(bucket, None);
+        assert_eq!(
+            cell_key, bucket,
+            "with no greens to settle the bucket, the resolve reports the raw              hash, exactly as `sole_cell_key` declines and `resolve_cell_key`              falls back",
+        );
+
+        let by_key = ws
+            .cell_by_key(bucket)
+            .expect("the raw hash names the bucket's original occupant");
+        let cell = cell.expect("and the resolve hands that same cell back");
+        assert!(
+            std::ptr::eq(cell, by_key),
+            "the cell noted during the walk must BE the one a walk back from              the key finds, not merely one with equal fields",
+        );
+        assert_eq!(cell.cell_key, Some(first_key));
+    }
+
     /// The number of cells linked at `hash`'s table slot, counting the
     /// neighbours the index truncation put there as well as `hash`'s own.
     fn chain_len(ws: &WarmEnterState, hash: u64) -> usize {

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -3278,7 +3278,7 @@ impl WarmEnterState {
         }
     }
 
-    /// [`Self::resolve_cell_key`] and [`Self::get_procedure_token`] answered
+    /// [`Self::resolve_cell_key`] and the resolved cell's ENTRY TOKEN answered
     /// from ONE walk of the bucket.
     ///
     /// A door that resolves a hash and then reads the resolved key's token
@@ -3288,29 +3288,51 @@ impl WarmEnterState {
     /// holds exactly this key's cell — has the cell in hand at the moment the
     /// count reaches one, so the token is read there.
     ///
+    /// `JC_TEMPORARY` is read off that same borrow, and a cell carrying it
+    /// reports no token: `warmstate.py maybe_compile_and_run` tests the flag
+    /// before it considers a token executable, and a `compile_tmp_callback`
+    /// token has a body like any other, so nothing about the token itself
+    /// answers that question. Folding it in here is what lets the whole
+    /// cell-owned half of an entry decision cost one walk — asked separately it
+    /// was a third walk of the same chain for the same cell.
+    ///
     /// The other two cases are the second walk, unchanged. On a miss the key a
     /// later install would take is `hash`, but `hash` may itself be a minted
-    /// key filed under a different bucket, so the token read has to go through
-    /// [`Self::get_procedure_token`], which maps it. On an ambiguous bucket the
-    /// greens are what settle it, exactly as [`Self::resolve_cell_key`] says.
-    /// `gate` runs on the resolved key, BEFORE the token is read.
+    /// key filed under a different bucket, so the cell has to be looked up
+    /// through [`Self::cell_by_key`], which maps it. On an ambiguous bucket the
+    /// greens are what settle it, exactly as [`Self::resolve_cell_key`] says —
+    /// and a caller that cannot build them (`make_key` is `None`) gets the raw
+    /// hash back, naming that bucket's original occupant or nothing, which is
+    /// the same answer [`Self::sole_cell_key`] gives such a caller.
     ///
-    /// Reading a token is a `Weak::upgrade` and the `Arc` drop that answers it
-    /// — one atomic each. A caller whose real question is a conjunction of that
-    /// read and something cheaper about the same key wants the cheap half
-    /// first, and cannot have it while the resolve and the read are one step:
-    /// the cheap half needs the resolved key, which only the walk produces.
-    ///
-    /// The resolve is unaffected — the key comes back whatever `gate` answers,
-    /// and a refused gate reports no token, which is what the conjunction was
-    /// going to conclude anyway. A caller with no second conjunct passes a gate
-    /// that always accepts.
+    /// The resolve is unaffected by the token: the key comes back whether or
+    /// not one is found, because every consumer downstream is keyed by it.
     pub fn resolved_cell_procedure_token(
         &self,
         hash: u64,
-        make_key: impl FnOnce() -> GreenKey,
-        gate: impl FnOnce(u64) -> bool,
+        make_key: Option<&dyn Fn() -> GreenKey>,
     ) -> (u64, Option<Arc<JitCellToken>>) {
+        let (cell_key, cell) = self.resolved_cell(hash, make_key);
+        let token = cell.and_then(|cell| {
+            if cell.flags.contains(JcFlags::JC_TEMPORARY) {
+                return None;
+            }
+            cell.get_procedure_token()
+        });
+        (cell_key, token)
+    }
+
+    /// [`Self::resolve_cell_key`]'s answer together with the cell it names,
+    /// from the one walk that produces both.
+    ///
+    /// The key alone is what `resolve_cell_key` reports, and every arm here
+    /// hands back exactly the key that function would; a caller that needs
+    /// anything OFF the cell would otherwise walk back to it.
+    fn resolved_cell(
+        &self,
+        hash: u64,
+        make_key: Option<&dyn Fn() -> GreenKey>,
+    ) -> (u64, Option<&BaseJitCell>) {
         let mut count = 0usize;
         let mut found: Option<(&BaseJitCell, u64)> = None;
         let mut cell = self.lookup_chain(hash);
@@ -3326,23 +3348,15 @@ impl WarmEnterState {
             cell = c.next.as_deref();
         }
         match (count, found) {
-            (1, Some((cell, cell_key))) => (
-                cell_key,
-                gate(cell_key).then(|| cell.get_procedure_token()).flatten(),
-            ),
-            (0, _) => (
-                hash,
-                gate(hash).then(|| self.get_procedure_token(hash)).flatten(),
-            ),
-            _ => {
-                let cell_key = self.cell_key_for(&make_key()).unwrap_or(hash);
-                (
-                    cell_key,
-                    gate(cell_key)
-                        .then(|| self.get_procedure_token(cell_key))
-                        .flatten(),
-                )
-            }
+            (1, Some((cell, cell_key))) => (cell_key, Some(cell)),
+            (0, _) => (hash, self.cell_by_key(hash)),
+            _ => match make_key {
+                Some(make_key) => {
+                    let cell_key = self.cell_key_for(&make_key()).unwrap_or(hash);
+                    (cell_key, self.cell_by_key(cell_key))
+                }
+                None => (hash, self.cell_by_key(hash)),
+            },
         }
     }
 

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -3335,27 +3335,48 @@ impl WarmEnterState {
     ) -> (u64, Option<&BaseJitCell>) {
         let mut count = 0usize;
         let mut found: Option<(&BaseJitCell, u64)> = None;
+        // The cell this slot holds under `hash` ITSELF, whatever bucket filed
+        // it. A key naming no cell of this bucket still names one when `hash`
+        // was minted for a cell of another bucket, and the miss arm below
+        // would otherwise walk back for it; noting it here costs one compare
+        // per chain node instead of a second traversal.
+        let mut by_key: Option<&BaseJitCell> = None;
         let mut cell = self.lookup_chain(hash);
         while let Some(c) = cell {
-            if let Some(cell_key) = c.cell_key
-                && c.cell_bucket == hash
-            {
-                count += 1;
-                if found.is_none() {
-                    found = Some((c, cell_key));
+            if let Some(cell_key) = c.cell_key {
+                if c.cell_bucket == hash {
+                    count += 1;
+                    if found.is_none() {
+                        found = Some((c, cell_key));
+                    }
+                }
+                if cell_key == hash {
+                    by_key = Some(c);
                 }
             }
             cell = c.next.as_deref();
         }
+        // `bucket_of(hash) == hash` says [`Self::cell_by_key`] would search
+        // THIS slot for `hash`, so the walk above has already decided it: a key
+        // is routed to another slot only when [`Self::mint_cell_key`] recorded
+        // it for another bucket, and a cell key names at most one live cell
+        // wherever that cell sits.
+        let cell_named_by_hash = || {
+            if self.bucket_of(hash) == hash {
+                by_key
+            } else {
+                self.cell_by_key(hash)
+            }
+        };
         match (count, found) {
             (1, Some((cell, cell_key))) => (cell_key, Some(cell)),
-            (0, _) => (hash, self.cell_by_key(hash)),
+            (0, _) => (hash, cell_named_by_hash()),
             _ => match make_key {
                 Some(make_key) => {
                     let cell_key = self.cell_key_for(&make_key()).unwrap_or(hash);
                     (cell_key, self.cell_by_key(cell_key))
                 }
-                None => (hash, self.cell_by_key(hash)),
+                None => (hash, cell_named_by_hash()),
             },
         }
     }


### PR DESCRIPTION
Two batches. The first carries the three changes #1649's review produced after its merge snapshot; the second removes four per-event costs from the guard-failure path, each a divergence from the upstream shape that the fix closes.

## Review follow-ups to #1649

### `metainterp: test the frame count before indexing the banks it was measured against, and start the bridge sequence for MAJIT_SKIP_BRIDGES alone`

**A panic reachable from the blackhole resume loop.** `guard_may_bridge` compared `bh.registers_i[sf_i]` and its two siblings against spans captured before the resume walk. The resume loop rebinds `bh` to the caller on every pop, so once a frame boundary was crossed the spans described a bank that is no longer the one being indexed — and if the caller's bank is shorter, the slice access panics before `bh_frames_popped == 0` gets to reject the bridge. The frame-count test now comes first inside the arm, so `&&` short-circuits the three indexings unless `bh` is still the frame the spans were measured against.

**`MAJIT_SKIP_BRIDGES` did nothing on its own.** `bridge_fuel_take` returned early whenever `MAJIT_MAX_BRIDGES` was unset, so no sequence number was ever allocated and the skip list named positions nothing allocated. Either gate alone now starts the count. Verified — `MAJIT_SKIP_BRIDGES=0` alone prints `@@@FUEL bridge #0 SKIPPED` followed by `@@@FUEL bridge #1`.

### `metainterp: stop banning the green key on the first recorder panic`

Reverts the `permanent || ctx.recorder_panicked` promotion added in #1649. The `catch_unwind` that produces the flag documents its own class as value-dependent ("Catch panics from BigInt overflow in runtime stack operations"), so the same key can panic on one set of values and record cleanly on the next.

### `ir, metainterp: cite two upstream references by symbol`

`effectinfo.rs` now cites `EffectInfo._cache` and the `key in cls._cache` probe in `EffectInfo.__new__`; `optimizer.rs` names the force-then-flush-then-virtual-state sequence that opens `UnrollOptimizer.export_state`.

## Guard-failure path: four per-event costs removed

An audit of the path from a compiled guard's failure through blackhole resume found four costs paid on every event (~250 of 251 events never bridge) that upstream does not pay. Each fix moves the code toward the upstream shape; all JIT counters are byte-for-byte unchanged (verified against a control build on 8 workloads — loops/bridges/aborts/guard_failures identical, outputs byte-identical).

### `metainterp: compute the guard resume pc inside its only reader`

`guard_resume_pc` was resolved through `get_merge_point_pc` — three IndexMap lookups — on every guard failure, and read only in the fallback reached when the resume chain raised and `deliver_blackhole_exception` answered `None`. `handle_fail` has no such lookup; the resolution now happens in that block alone.

### `metainterp: build the exit layout for guard exits only`

`execute_assembler_at_dispatch_key` built a `CompiledExitLayout` — an `ExitTypes` copy, three `Arc` clones, and a `Box` — for every non-finish exit, including a plain loop back-edge JUMP whose callers never read it. The layout build and the `descr_owning_jct` resolution feeding its fallback now run on the guard arm only. (Plus a comment-only follow-up removing a caller name from the new comment.)

### `metainterp: carry the failing guard's owning loop key out of the run`

The exit gathering walked `descr_owning_jct` (registry lock + `Weak::upgrade` + `Arc` clone) and `must_compile_with_values` walked it again on the same descr in the same event. `compile.py handle_fail` reads `resumedescr.rd_loop_token` once and `must_compile` never re-derives identity. `CompileResult` now carries the resolved key; `must_compile_with_values` remains as the resolving wrapper for callers that hold only the descr.

### `metainterp: build a guard's reader-shaped virtuals once`

The blackhole resume arm converted every `RdVirtualInfo` on the failing guard's storage into a reader-shaped `VirtualInfo` on each event — `2N+1` allocations plus descr `Arc` bumps — although the conversion is a pure function of the storage (`rd_virtual_to_virtual_info` ignores three of its four parameters). `ResumeDataVirtualAdder.finish` builds the reader's virtuals at compile time and `_prepare_virtuals` is a bare assignment; `ResumeStorage::virtual_infos` now builds the list once behind a `OnceLock` and shares it.

### Verification

- `cargo test -p majit-metainterp -p majit-ir --features majit-metainterp/dynasm` — 0 failed.
- aheui gates: logo byte-exact (exit 42, 996310 bytes, md5 `7fcdbff…`); self-interpreted quine/40col/99bottles `--jit` ≡ `--no-jit` byte-for-byte.
- MAJIT_STATS on 8 workloads identical to a control build of the base commit.

## Back-edge path: cell questions answered from one chain walk

A guest interpreter whose merge point sits on every guest branch pays the back-edge door on every taken branch. `maybe_compile_and_run` inlines its cell walk precisely "to avoid computing the hash several times"; the port had grown three chain walks and two map probes per warm edge.

### `metainterp: answer a back edge's cell questions from one chain walk`

`back_edge_internal` resolved the cell key, walked back for the procedure token, walked back again for the `JC_TEMPORARY` filter, and probed `compiled_loops` for presence right before fetching its value. `WarmEnterState::resolved_cell_procedure_token` now reads the token and applies the temporary filter off the borrow its own walk produced, and the presence probe becomes the fetch. Warm entry: 3 walks + 2 probes → 1 walk + 1 probe.

### `metainterp: decide a resolve's miss arm inside the walk that found it`

The resolve's miss arm re-entered `cell_by_key(hash)`, re-traversing the chain just walked — on the arm a never-compiled green key takes on every back edge. The walk now notes the cell filed under the hash itself as it passes.

### `metainterp: let the counter decision own the abort-ceiling refusal`

`maybe_start_tracing` pre-tested the abort ceiling and then delegated to the typed decision, which resolves the same cell and re-tests the same condition. The decision's ceiling arm already sits above its counter tick, which is the ordering the early refusal existed to preserve; the mirror was pure duplication. Slot counters are unchanged — only one of the two refusals could ever fire per edge.

### Verification

Same gates as above (2380 tests / 0 failed; logo + self-interpreted quine and 99bottles byte-exact, `--jit` ≡ `--no-jit`; the full stats dict — every counter — byte-identical to a control build). Child-CPU on the arm that isolates the door (`MAJIT_THRESHOLD=1e9`, compilation off): 0.95–0.96x across four independent interleaved runs; the fully-jitted arms sit inside host-load noise.

## A silent wrong answer: the loop header never normalized the virtualizable elements

A guest interpreter driving its virtualizable through the state-field model produced deterministic wrong answers (and one hang) across a wide band of bridge-threshold settings — silently, with stable counters. The root cause is one upstream statement the port never ran: `reached_loop_header` rewrites `virtualizable_boxes` in place through `remove_consts_and_duplicates`, so no element position holds a Const (or a repeated box) by the time `compile_trace` closes a bridge. The port had faithful implementations of both halves — `TraceCtx::remove_consts_and_duplicates`, and `adopt_normalized_virtualizable_elements`, whose own doc comment states the write-back requirement — but the adopter had zero callers, so the closing JUMP spliced the raw decoded list and a `TAGCONST` element landed as an unguarded literal in the jump into the parent loop. `cut_trace_from_with_consts`'s `remap_ref` short-circuits on constants, so the literal was never rewritten to the LABEL's inputarg.

### `metainterp: normalize the virtualizable element boxes at every loop header`

Runs the normalization over the element block (identity excluded, upstream's `endindex`) at the loop header, before `GUARD_FUTURE_CONDITION`, and hands the result back through the adopter. Alternatives measured and rejected: emitting a live array read would read stale memory (nothing writes a token-less state vable back on the guard-failure path — 236 box slots also disagreed with the heap across 93 seeds), and a `GUARD_VALUE` would never fire (the decoded const values are correct; only the bridge's use of them was wrong). A mode switch isolating the two halves showed the constant half is causal; both are kept, as upstream.

Verification: the self-interpreted quine is byte-correct at every bridge threshold in 12..120 (109 values, previously wrong or hanging across 15..110) and at the default; logo and the self-interpreted 99bottles byte-exact, `--jit` ≡ `--no-jit`; 77-program corpus differential clean (the five divergent rows are byte-identical to the pre-fix control — non-terminating or `undefined/` family); loops/bridges/guard-failure counters unchanged, ops-after-opt unchanged (the added `SAME_AS` ops fold away).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after tracing interruptions, allowing affected traces to be retried instead of being permanently blocked.
  - Improved handling of loop exits and guard failures for more reliable execution.
  - Corrected bridge numbering and skip behavior when bridge limits are configured.
  - Improved loop processing by removing duplicate or constant values from carried state.
  - Improved resume handling for virtualized values across repeated guard exits.

- **Documentation**
  - Clarified bridge-skipping behavior and updated terminology in configuration guidance.
  - Updated technical references for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->