### PR TITLE
jit-trace, majit: a struct descr's tid and size from one cache entry, the symbolic finish payload rooted, an overwritten vable register, and a callee-only resume image

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -2403,10 +2403,23 @@ impl GcCache {
     /// keys a `_cache_size` slot, so a miss reports the value was already a
     /// tid and the caller keeps it verbatim.
     pub fn resolve_struct_tid(&self, cache_key: u64) -> Option<u32> {
+        self.resolve_struct_layout(cache_key).map(|(tid, _)| tid)
+    }
+
+    /// Resolve both halves that make a typed struct allocation sound: the
+    /// collector `tid` and the payload size owned by the same cached
+    /// `SizeDescr`.  RPython's `GcCache._cache_size[STRUCT]` hands allocation
+    /// and header emission one descriptor object, so these values cannot come
+    /// from different structs.  Pyre's frozen `BhDescr` wire value carries a
+    /// structural key and a size separately; its runtime resolver
+    /// uses this pair to reject a key that lands on a differently-sized cache
+    /// entry instead of stamping the foreign entry's tid on the requested
+    /// block.
+    pub fn resolve_struct_layout(&self, cache_key: u64) -> Option<(u32, usize)> {
         self._cache_size
             .get(&LLType::Struct(cache_key))
             .and_then(|d| d.as_size_descr())
-            .map(|sd| sd.type_id())
+            .map(|sd| (sd.type_id(), sd.size()))
     }
 
     /// Array counterpart of [`resolve_struct_tid`] keyed on

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -2118,7 +2118,10 @@ impl BhDescr {
     /// `:348-378` structural identity).  A `_cache_size`/`_cache_array` hit
     /// maps a `cache_key` back to the allocated tid (`gc.py:536-542`); a
     /// miss means the value was already the dense tid (a real tid never keys
-    /// a struct/array cache slot).  Backends call this instead of
+    /// a struct/array cache slot). A cache hit whose payload size disagrees
+    /// with this descr fails loudly: using that tid would make the collector
+    /// trace the cached struct's fields past this allocation. Backends call
+    /// this instead of
     /// `get_type_id() as u32` so a materialized object carries a header the
     /// collector can trace.
     ///
@@ -2130,22 +2133,28 @@ impl BhDescr {
     /// descr — and the collector then walks the foreign type's GC offsets
     /// straight off the end of the block.
     pub fn resolve_gc_tid(&self) -> u32 {
-        if let BhDescr::Array { gc_type_id, .. } = self
-            && *gc_type_id != 0
-        {
-            return *gc_type_id;
-        }
-        let raw = self.get_type_id();
-        let resolved = if raw == 0 {
-            None
-        } else {
-            match self {
-                BhDescr::Size { .. } => majit_ir::descr::gc_cache().lock().resolve_struct_tid(raw),
-                BhDescr::Array { .. } => majit_ir::descr::gc_cache().lock().resolve_array_tid(raw),
-                _ => None,
+        if let BhDescr::Size { size, .. } = self {
+            let raw = self.get_type_id();
+            if raw == 0 {
+                return 0;
             }
-        };
-        resolved.unwrap_or(raw as u32)
+            // Keep the cache lookup and size decision under one lock.  The
+            // registry is process-global (as upstream's GcCache is), so two
+            // independent lookups would allow a concurrent publication to
+            // turn a checked hit into an unchecked truncated-key fallback.
+            match majit_ir::descr::gc_cache()
+                .lock()
+                .resolve_struct_layout(raw)
+            {
+                Some((tid, cached_size)) if cached_size == *size => return tid,
+                Some((_tid, _cached_size)) => {
+                    panic!("BhDescr GC identity resolves to a foreign allocation layout: {self:?}");
+                }
+                None => return raw as u32,
+            }
+        }
+        self.resolved_gc_tid_checked()
+            .unwrap_or_else(|| self.get_type_id() as u32)
     }
 
     /// Resolve the GC type id without truncating an unresolved serialized
@@ -2163,7 +2172,22 @@ impl BhDescr {
             None
         } else {
             match self {
-                BhDescr::Size { .. } => majit_ir::descr::gc_cache().lock().resolve_struct_tid(raw),
+                BhDescr::Size { size, .. } => {
+                    let resolved = majit_ir::descr::gc_cache()
+                        .lock()
+                        .resolve_struct_layout(raw);
+                    match resolved {
+                        Some((tid, cached_size)) if cached_size == *size => Some(tid),
+                        // `descr.py get_size_descr` returns one descriptor
+                        // object for STRUCT, so allocation size and tid are
+                        // inseparable upstream.  A disagreement here means
+                        // pyre's serialized key named a foreign cache entry;
+                        // adopting its tid makes the collector scan that
+                        // entry's fields past this allocation.
+                        Some((_tid, _cached_size)) => return None,
+                        None => None,
+                    }
+                }
                 BhDescr::Array { .. } => majit_ir::descr::gc_cache().lock().resolve_array_tid(raw),
                 _ => None,
             }
@@ -2678,5 +2702,20 @@ mod tests {
         };
 
         assert_eq!(bh.resolved_gc_tid_checked(), Some(17));
+    }
+
+    #[test]
+    fn checked_gc_tid_rejects_a_foreign_sized_struct_cache_entry() {
+        let key = 0xd15a_6eed_5a1e_0001;
+        let foreign = majit_ir::descr::make_size_descr_full(0, 328, 31);
+        majit_ir::descr::gc_cache()
+            .lock()
+            .register_keyed_size(majit_ir::descr::LLType::Struct(key), foreign);
+
+        let bh = size_descr_with_key(24, key);
+        assert_eq!(bh.resolved_gc_tid_checked(), None);
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| bh.resolve_gc_tid())).is_err()
+        );
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -483,6 +483,19 @@ pub fn capture_fbw_finish_concrete_root_area() -> *const () {
     FBW_FINISH_CONCRETE.with(|value| value as *const _ as *const ())
 }
 
+/// `history.py ConstPtr` parity for the symbolic FINISH payload.  RPython's
+/// box remains in the translated GC graph while compilation allocates; pyre's
+/// inline `GcRef` lives in this TLS cell instead, so it must be registered as
+/// an explicit root and updated when the collector forwards it.
+pub fn fbw_finish_payload_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let data = capture_fbw_finish_payload_root_area();
+    unsafe { fbw_finish_payload_root_walker_area(data, visitor) };
+}
+
+pub fn capture_fbw_finish_payload_root_area() -> *const () {
+    FBW_FINISH_PAYLOAD.with(|value| value as *const _ as *const ())
+}
+
 /// Record that `op` is a walker-built inline exception (construction fold).
 pub(crate) fn fbw_built_exc_insert(op: OpRef) {
     FBW_BUILT_EXC.with(|s| {
@@ -4125,6 +4138,15 @@ pub(crate) fn fbw_callee_body_replay_scan(
             let Some(&dst) = body_code.get(d.next_pc.saturating_sub(1)) else {
                 replay_unscannable!("ResultRegisterByteMissing", d.pc, d.opname);
             };
+            // `vable_reg` proves the identity of the value in this register,
+            // not permanent ownership of the register number.  RPython keeps
+            // the virtualizable on the live MIFrame box; when this SSA bank
+            // slot is overwritten, the replacement cannot inherit that
+            // identity (the freshness lattices below are invalidated here for
+            // the same reason).
+            if vable_reg == Some(dst) {
+                vable_reg = None;
+            }
             fresh_ref_regs[dst as usize] = d.key == "new_with_vtable/d>r"
                 || d.opname.starts_with("new_array")
                 || (d.key == "ref_copy/r>r"

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6810,6 +6810,23 @@ pub unsafe fn fbw_finish_concrete_root_walker_area(
     }
 }
 
+/// # Safety
+/// `data` must come from [`capture_fbw_finish_payload_root_area`], and the
+/// owning thread must be quiesced.
+pub unsafe fn fbw_finish_payload_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let cell = unsafe { &*(data as *const std::cell::Cell<Option<(OpRef, Type)>>) };
+    let Some((payload, ty)) = cell.get() else {
+        return;
+    };
+    if let OpRef::ConstPtr(mut gcref) = payload {
+        visitor(&mut gcref);
+        cell.set(Some((OpRef::ConstPtr(gcref), ty)));
+    }
+}
+
 /// One in-flight FOR_ITER continuation entry (#57 Option C): the item the
 /// FOR_ITER `for_iter_next` residual consumed on the authoritative walk, the
 /// body coordinate to resume at (the FOR_ITER `py_pc + 1` continue-arm

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -253,8 +253,7 @@ fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
     // `rebuild_from_resumedata` rebuilds every encoded jitcode header and
     // `pyjitpl.py capture_resumedata` starts from the portal MIFrame; a lone
     // callee with no captured parent is therefore not a complete resume chain.
-    // Stamp
-    // the last *guard* op, not the last op: `emit_force_virtualizable` records
+    // Stamp the last *guard* op, not the last op: `emit_force_virtualizable` records
     // GETFIELD_GC / PTR_NE / COND_CALL after the promote.  A chain that skips an
     // intermediate inline frame still falls through to the sentinel below:
     // never a wrong resume.
@@ -349,7 +348,7 @@ pub(crate) fn walker_inline_guard_resumes_in_callee<Sym: WalkSym>(
         .iter()
         .filter(|frame| !frame.parents.is_empty())
         .count();
-    n_parents > 0 && n_parents == session.framestack.len()
+    inline_snapshot_has_complete_parent_chain(n_parents, session.framestack.len())
 }
 
 pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -249,8 +249,11 @@ fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
     // `generate_guard(GUARD_VALUE, resumepc=orgpc)` (pyjitpl.py),
     // and `capture_resumedata(resumepc)` (pyjitpl.py) walking the full MIFrame chain
     // (opencoder.py:819). Publish the callee's own coordinate when the inline
-    // chain is either the single callee frame or is fully covered by paused
-    // callers; both shapes are directly represented by the frame list.  Stamp
+    // chain is fully covered by paused callers.  `resume.py`
+    // `rebuild_from_resumedata` rebuilds every encoded jitcode header and
+    // `pyjitpl.py capture_resumedata` starts from the portal MIFrame; a lone
+    // callee with no captured parent is therefore not a complete resume chain.
+    // Stamp
     // the last *guard* op, not the last op: `emit_force_virtualizable` records
     // GETFIELD_GC / PTR_NE / COND_CALL after the promote.  A chain that skips an
     // intermediate inline frame still falls through to the sentinel below:
@@ -271,8 +274,7 @@ fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
                 .collect::<Vec<_>>(),
         )
     };
-    let publish_inline_frames =
-        (n_parents == 0 && n_callees == 1) || (n_parents > 0 && n_parents == n_callees);
+    let publish_inline_frames = inline_snapshot_has_complete_parent_chain(n_parents, n_callees);
     if publish_inline_frames {
         for from_end in (0..minted).rev() {
             walker_capture_multi_frame_inline_snapshot(
@@ -323,6 +325,10 @@ fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
             );
     }
     Ok(())
+}
+
+fn inline_snapshot_has_complete_parent_chain(n_parents: usize, n_callees: usize) -> bool {
+    n_parents > 0 && n_parents == n_callees
 }
 
 /// Whether a guard emitted at the current inline depth resumes at its own

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -648,6 +648,13 @@ fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
     let session = std::cell::RefCell::new(WalkSession::default());
     session.borrow_mut().framestack.push(InlineFrame {
         w_code: w_code as usize,
+        // What `InlineFrameGuard::new` stamps on the first Python portal frame
+        // pushed onto an empty framestack: `MetaInterp.newframe` consumes
+        // `call_id` 0, no `DEBUG_MERGE_POINT` has been emitted yet, and a
+        // forward inline call carries the portal greenkey.
+        recursion_greenkey: true,
+        call_id: 0,
+        debug_merge_point_py_pc: None,
         parents: Vec::new(),
         entry_executed_effects: 0,
     });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -6,6 +6,23 @@ use majit_metainterp::{JitCodeSym, TraceAction, VableArrayStore, make_fail_descr
 static STATIC_REFUSAL_PREFIX_CALLS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+#[test]
+fn finish_payload_root_walker_writes_back_forwarded_const_ptr() {
+    fbw_finish_payload_reset();
+    fbw_terminate_with_raise(
+        OpRef::const_ptr(majit_ir::GcRef(0x1000)),
+        ConcreteValue::Ref(std::ptr::null_mut()),
+    );
+
+    fbw_finish_payload_root_walker(&mut |gcref| gcref.0 = 0x2000);
+
+    assert_eq!(
+        fbw_finish_payload_take(),
+        Some((OpRef::const_ptr(majit_ir::GcRef(0x2000)), Type::Ref))
+    );
+    fbw_finish_payload_reset();
+}
+
 extern "C" fn count_static_refusal_prefix() {
     STATIC_REFUSAL_PREFIX_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
@@ -588,6 +605,99 @@ fn exact_py_pc_preserves_a_later_disjoint_emission_region() {
 fn fresh_trace_ctx() -> TraceCtx {
     let _ = test_outer_resume_jitcode_index();
     TraceCtx::for_test_types(&[Type::Ref])
+}
+
+#[test]
+fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
+    use crate::state::PyreSym;
+    use pyre_interpreter::{compile_exec, w_code_get_ptr, w_code_new};
+
+    // Give the callee a real, permanently-live CodeObject and a populated
+    // `-live-`-anchored JitCode.  This deliberately crosses the old
+    // `code_ptr.is_null()` fixture bail: the assertion is about the publish
+    // path, not merely its parent-count predicate.
+    let code = compile_exec("None").expect("test code should compile");
+    let w_code = w_code_new(Box::into_raw(Box::new(code)) as *const ()) as *const ();
+    let raw_code = unsafe {
+        w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const pyre_interpreter::CodeObject
+    };
+    let mut builder = majit_metainterp::JitCodeBuilder::default();
+    let live_patch = builder.live_placeholder();
+    builder.patch_live_offset(live_patch, 0);
+    let mut insns = indexmap::IndexMap::new();
+    insns.insert(
+        "live/".to_string(),
+        majit_metainterp::jitcode::insns::BC_LIVE,
+    );
+    crate::assembler::publish_state(&insns, &[0, 0, 0], 3, 1);
+    let mut pyjit = crate::PyJitCode::skeleton(raw_code);
+    pyjit.jitcode = std::sync::Arc::new(builder.finish());
+    pyjit.metadata.is_drained = true;
+    pyjit.metadata.forward_py_pc_marker_by_jit_pc = vec![(0, 0)];
+    let installed = crate::state::install_jitcode_for(w_code, std::sync::Arc::new(pyjit))
+        as *const crate::state::JitCode;
+    assert!(!installed.is_null());
+
+    let mut tc = fresh_trace_ctx();
+    let cond = tc.const_int(1);
+    tc.record_guard(majit_ir::OpCode::GuardTrue, &[cond], 0);
+    let mut snapshot_sym = PyreSym::new_uninit(OpRef::NONE);
+    let mut mode = test_fbw_mode();
+    mode.snapshot_sym = &snapshot_sym;
+    mode.inline_subwalk = true;
+    let session = std::cell::RefCell::new(WalkSession::default());
+    session.borrow_mut().framestack.push(InlineFrame {
+        w_code: w_code as usize,
+        parents: Vec::new(),
+        entry_executed_effects: 0,
+    });
+    let mut regs_r = Vec::new();
+    let mut regs_i = Vec::new();
+    let mut regs_f = Vec::new();
+    let mut concrete_r = Vec::new();
+    let mut concrete_i = Vec::new();
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        inline_poison_pcs: None,
+        fbw_mode: mode,
+        session: &session,
+        registers_r: &mut regs_r,
+        registers_i: &mut regs_i,
+        registers_f: &mut regs_f,
+        concrete_registers_r: &mut concrete_r,
+        concrete_registers_i: &mut concrete_i,
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: false,
+        trace_ctx: &mut tc,
+        is_top_level: false,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        vstack_reorder_saved: None,
+        vstack_handler_landing_py: None,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+
+    assert_eq!(
+        super::resume_snapshot::walker_capture_inline_nonstandard_vable_guard(&mut wc, 0, 0, None,),
+        Err(DispatchError::GuardResumeCoordinateUnavailable { pc: 0 }),
+        "a callee-only image would make frames[0] disagree between the two resume decoders",
+    );
+    // Keep the pointer live through the call; PyCode itself is intentionally
+    // permanent, matching the production `w_code_new` ownership contract.
+    std::hint::black_box(&mut snapshot_sym);
 }
 
 /// The `ec` recovery every unseeded portal red falls back on
@@ -3809,6 +3919,31 @@ fn replay_scan_treats_callee_frame_bookkeeping_as_call_owned() {
     let scan = fbw_callee_body_replay_scan(&code, &[], 0, &[0], 6, &[], &descrs, false);
     assert_eq!(scan.verdict(), CalleeReplaySafety::Clean);
     assert!(scan.poison.is_empty());
+}
+
+#[test]
+fn replay_scan_does_not_transfer_frame_identity_across_register_overwrite() {
+    let get_vable = *insns_opname_to_byte()
+        .get("getarrayitem_vable_r/ridd>r")
+        .unwrap();
+    let copy = *insns_opname_to_byte().get("ref_copy/r>r").unwrap();
+    let setfield = *insns_opname_to_byte().get("setfield_gc_i/rid").unwrap();
+    let ret = *insns_opname_to_byte().get("ref_return/r").unwrap();
+    // r4 initially names the callee frame.  Loading a slot into r5 and then
+    // overwriting r4 with r5 must revoke that identity before the mutable
+    // store; the new value is an arbitrary non-fresh heap reference.
+    let code = [
+        get_vable, 4, 0, 0, 0, 1, 0, 5, copy, 5, 4, setfield, 4, 0, 2, 0, ret, 5,
+    ];
+    let descrs = vec![
+        make_fail_descr(0),
+        make_fail_descr(1),
+        field_descr_with_index(2),
+    ];
+
+    let scan = fbw_callee_body_replay_scan(&code, &[], 0, &[0], 6, &[], &descrs, false);
+
+    assert_eq!(scan.poison, vec![11]);
 }
 
 #[test]

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5167,6 +5167,11 @@ fn register_thread_root_areas() {
             "fbw_finish_concrete",
         );
         register(
+            fbw_finish_payload_root_walker_area,
+            pyre_jit_trace::jitcode_dispatch::capture_fbw_finish_payload_root_area(),
+            "fbw_finish_payload",
+        );
+        register(
             walk_end_root_walker_area,
             pyre_jit_trace::trace::capture_walk_end_root_area(),
             "walk_end",
@@ -6063,6 +6068,13 @@ unsafe fn fbw_finish_concrete_root_walker_area(
     unsafe {
         pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_root_walker_area(data, visitor)
     };
+}
+
+unsafe fn fbw_finish_payload_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe { pyre_jit_trace::jitcode_dispatch::fbw_finish_payload_root_walker_area(data, visitor) };
 }
 
 /// The recording walk's own reference register banks, whose inline `ConstPtr`


### PR DESCRIPTION
Four independent correctness gaps, each found by reading and each carrying its own
unit test. Split out of `perf-memory`, which also holds an unrelated
cranelift-codegen pin that is not ready.

### 1. A struct descr's tid and payload size come from one cache entry

`descr.py get_size_descr` hands allocation and header emission **one** descriptor
object per STRUCT, so upstream cannot get a tid from one struct and a size from
another. Pyre's frozen `BhDescr::Size` wire value carries a structural key and a
size separately, and `resolve_gc_tid` resolved the key against
`GcCache._cache_size` without ever asking whether the entry it landed on
described a block of this size. A truncated or colliding key stamped the foreign
entry's tid on the allocation, and the collector then walked that type's GC
offsets past the end of the block.

`GcCache::resolve_struct_layout` now returns `(tid, size)` from the same
`SizeDescr` under one lock — the registry is process-global, so two separate
lookups would let a concurrent publication turn a checked hit into an unchecked
fallback. On disagreement `resolved_gc_tid_checked` returns `None` (the caller
declines) and the unchecked `resolve_gc_tid` panics rather than emitting a
header that mis-describes the block.

The unchecked variant fails loudly on purpose, and that is the part worth
reviewing: `register_keyed_size` already documents that two producers can
publish under one key and that genuinely different layouts mean "the key itself
is the defect" (the struct-identity spelling collision `identity_collision_census`
counts). If that collision is live at runtime this panics where it previously
mis-stamped a header — a loud failure replacing a silent one, but a new failure
either way. The gate is where that shows up.

### 2. The symbolic FINISH payload is a GC root

`FBW_FINISH_PAYLOAD` holds an `OpRef::ConstPtr` from the walk's terminate arm
(`fbw_terminate_with_finish`, `fbw_terminate_void_with_finish`,
`fbw_terminate_with_raise`) until `full_body_walk_trace` takes it. Upstream's
`history.py ConstPtr` box sits in the translated GC graph for that whole window;
pyre's copy sits in a TLS `Cell` that nothing walked, so a collection inside the
window left a stale ref behind. Its concrete sibling `FBW_FINISH_CONCRETE` is
already registered at `register_thread_root_areas`; the symbolic half now is
too, and the walker writes the forwarded ref back into the cell.

### 3. `vable_reg` is an identity, not ownership of a register number

In `fbw_callee_body_replay_scan`, `callee_owned_frame` exempts a `setfield_gc`
whose target register is the virtualizable from the freshness/immutability
poison. `vable_reg` was latched at the first `*_vable_r*` and never cleared,
while `fresh_ref_regs` beside it is recomputed on every ref-producing
instruction. Latch register R, overwrite R with a non-fresh ref (a
`getfield_gc` result, a residual call result), then `setfield_gc` R on a mutable
field, and the store escaped `SetfieldGcTargetNotFreshOrMutable` — a store to an
arbitrary live-heap object inside a body the walk may replay from the caller's
CALL.

RPython keeps the virtualizable on the live `MIFrame` box, so the identity dies
with the register's old value. Clearing `vable_reg` at the site that already
recomputes `fresh_ref_regs[dst]` is strictly conservative: it can only add
poison, never remove it.

### 4. A callee-only inline image is not a complete resume chain

`resume.py rebuild_from_resumedata` rebuilds one frame per encoded jitcode
header and `pyjitpl.py capture_resumedata` starts from the portal MIFrame, so a
lone callee with no captured parent is not a resume chain. The
`n_parents == 0 && n_callees == 1` arm of `publish_inline_frames` published one
anyway, which makes `frames[0]` disagree between the two resume decoders. That
shape now falls through to the existing `GuardResumeCoordinateUnavailable`
sentinel like every other incomplete chain.

### Tests

- `checked_gc_tid_rejects_a_foreign_sized_struct_cache_entry`
- `finish_payload_root_walker_writes_back_forwarded_const_ptr`
- `replay_scan_does_not_transfer_frame_identity_across_register_overwrite`
- `parentless_populated_callee_does_not_publish_a_lone_resume_frame` — deliberately
  installs a real `CodeObject` and a populated `-live-`-anchored JitCode so it
  crosses the old `code_ptr.is_null()` fixture bail

### What ran locally, and what did not

- `cargo fmt --check` over the four touched crates — clean.
- `cargo test -p majit-translate --lib codewriter::jitcode` — 12 passed, including
  the new descr test.
- `pyre-jit-trace` / `pyre-jit` **were not compiled in this session**: the box hit
  load 104 with six sibling builds and the job was killed. The non-test code in
  both did compile earlier today, as the Charon extraction over `pyre-jit` on this
  exact tree completed; the three new `#[test]` functions have not been built.
- `pyre/check.py` did not run: the branch was rebased onto main after that
  extraction, so all four `.ullbc` artefacts are stale and re-extracting on this
  box was not viable.

CI is the gate. Items 3 and 4 are tightenings — they can only add declines — so a
moved counter or a SNAPDIFF is the expected shape of a red, and the baseline gets
re-recorded rather than the fix relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F69vGeNqTgKVSNqY8WiR4X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime type resolution to reject mismatched cached layouts, preventing incorrect type assignments.
  - Fixed garbage collection handling for inline finish payloads so references continue to be updated safely when objects move.
  - Prevented stale register information from causing later stores to be misclassified.
  - Strengthened snapshot validation to prevent incomplete frame chains from being published.
- **Tests**
  - Added regression coverage for pointer forwarding, snapshot validation, cache mismatches, and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->