### PR TITLE
jit-trace, interp: name the unpaired-address disarm; extra_tests: the getsizeof ABI split, an exact module-name oracle, and a slice script that runs

### DIFF
--- a/pyre/extra_tests/snippets/builtin_slice.py
+++ b/pyre/extra_tests/snippets/builtin_slice.py
@@ -1,3 +1,4 @@
+# pyre-check: gate=1
 from testutils import assert_raises
 
 a = slice(10)
@@ -165,41 +166,3 @@ class CustomIndex:
 
 assert c[CustomIndex(1) : CustomIndex(3)] == [1, 2]
 assert d[CustomIndex(1) : CustomIndex(3)] == "23"
-
-
-def test_all_slices():
-    """
-    test all possible slices except big number
-    """
-
-    mod = __import__("cpython_generated_slices")
-
-    ll = mod.LL
-    start = mod.START
-    end = mod.END
-    step = mod.STEP
-    slices_res = mod.SLICES_RES
-
-    count = 0
-    failures = []
-    for s in start:
-        for e in end:
-            for t in step:
-                lhs = ll[s:e:t]
-                try:
-                    assert lhs == slices_res[count]
-                except AssertionError:
-                    failures.append(
-                        "start: {} ,stop: {}, step {}. Expected: {}, found: {}".format(
-                            s, e, t, lhs, slices_res[count]
-                        )
-                    )
-                count += 1
-
-    if failures:
-        for f in failures:
-            print(f)
-        print(len(failures), "slices failed")
-
-
-test_all_slices()

--- a/pyre/extra_tests/snippets/stdlib_sys.py
+++ b/pyre/extra_tests/snippets/stdlib_sys.py
@@ -184,11 +184,20 @@ with assert_raises(TypeError):
 with assert_raises(TypeError):
     sys.getsizeof("x", 1, 2)
 
-# CPython 3.14 adds a two-word PyGC_Head according to the type's GC flag, not
-# the object's current tracked state, plus two managed-prefix words for heap
-# instances with a managed dict or weakref slot.
+# `sys.getsizeof` adds a pre-header the object's type asks for, read off the
+# type's flags rather than off the object's current tracked state: two
+# managed-prefix words for a heap instance with a managed dict or weakref slot,
+# and a two-word PyGC_Head for a type the collector tracks.
+#
+# The PyGC_Head half exists only in a build that has a global interpreter lock.
+# Without one the collector keeps its bits in the object header, so the header
+# a tracked type already carries covers it and the pre-header charges nothing;
+# `Py_GIL_DISABLED` is the config var that names which of the two layouts the
+# running build was compiled with.
+import sysconfig
+
 pointer_size = (sys.maxsize.bit_length() + 7) // 8
-gc_head = 2 * pointer_size
+gc_head = 0 if sysconfig.get_config_var("Py_GIL_DISABLED") else 2 * pointer_size
 managed_prefix = 2 * pointer_size
 
 
@@ -261,4 +270,7 @@ def test_getframemodulename():
 
 test_getframemodulename.__module__ = "awesome_module"
 
+# `sys__getframemodulename_impl` reads the module off the frame's function
+# object (`PyFunction_GetModule`), so a `__module__` reassigned after definition
+# is what the call answers.
 assert test_getframemodulename() == "awesome_module"

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -4598,8 +4598,9 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
 /// appears in the first and not the second.  A name bound at build time and
 /// missing at run time keeps the build-process address baked in the constant
 /// pool, because `runtime_fnaddr_patch::patch_static_addr_constants` re-pairs
-/// only names present in both; `reject_unpaired_build_addrs` refuses the load
-/// once such an address actually reaches a constant pool.
+/// only names present in both; `disarm_unpaired_build_addrs` writes zero over
+/// such an address, which is the "no address" value every call site already
+/// declines.
 pub fn pyre_class_pytype_addrs() -> Vec<(&'static str, i64)> {
     let mut rows = Vec::new();
     pyre_object::lltype::for_each_class_descriptor(|d| {

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -1117,8 +1117,8 @@ fn real_main() {
     // an unmatched name keeps this process's address.  The `#[pyre_class]`
     // registry populates on every target for that reason; where the two pools
     // can still disagree is the module set, which this process cannot read for
-    // another target, and `reject_unpaired_build_addrs` refuses the load if
-    // one of those names reaches a constant pool.
+    // another target, and `disarm_unpaired_build_addrs` writes zero over an
+    // address of that kind so the call sites reading it decline.
     let registry_rows = pyre_interpreter::pyre_class_pytype_addrs();
     let registry_keys: std::collections::HashSet<&str> =
         registry_rows.iter().map(|&(key, _)| key).collect();

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -294,12 +294,19 @@ static UNPAIRED_BUILD_ADDRS: LazyLock<HashMap<i64, String>> = LazyLock::new(|| {
 ///
 /// Such a value is a pointer into the build-script process, and every use the
 /// pools have for one is wrong with it: as a residual call target it enters
-/// whatever this process holds at that address, as a `PyType` operand it is
-/// dereferenced by a type test, and as a pointer-`eq` operand it answers "not
-/// this type" for every object.  Zero is the substitute because it is the one
-/// value none of those can mistake for a real target — a call through it faults
-/// on the first instruction, a dereference faults at the first field, and a
-/// comparison never matches.
+/// whatever this process holds at that address, and as a `PyType` operand it is
+/// dereferenced by a type test or compared against every object's type.
+///
+/// Zero is not a chosen poison, it is the spelling this already has for "no
+/// address" — `jitcode.py JitCode.__init__ fnaddr=None` — and both consumers
+/// test for it before they branch.  A call target goes through
+/// `is_callable_fnaddr`, so the blackhole's `residual_call_*` and
+/// `inline_call_*` handlers decline it and hand the continuation back to the
+/// interpreter, and the walker's residual path declines the same value as
+/// `ResidualDecline::Symbolic`.  A type operand is only ever compared, and a
+/// comparison against zero matches no object, so the guard reading it fails
+/// and the path leaves the JIT before anything can dereference it.  That is
+/// what makes zero an answer here rather than a trap laid for later.
 ///
 /// All three pools are cleared, `constants_r` included: that pool already
 /// carries words that are not gcrefs — patched host statics and pre-patch


### PR DESCRIPTION
Re-lands the part of #1651 that outlived it. That PR's merge commit `557d6de9db5` is not an ancestor of `main`; of the last fourteen merged PRs it is the only one whose merge is missing, so the drop was specific to it rather than a history rewrite. Two of its four subjects should not come back, and do not:

- the 2563-line `cpython_generated_slices.py` table. Every question `test_all_slices` asks is answered more widely by `test.test_slice`'s `test_indices`, which the CPython suite gate runs and records as PASS, and which walks `itertools.product` over twelve start/stop/step values against six lengths -- including `2**100` bounds -- against a reference implementation. The function is deleted instead of given its table.
- the two `max-pypy-ratio` refits. #1653 changed what a ratio measures: every pyre backend now subtracts pypy's startup rather than its own, so `ratio_new = ratio_old + Δ / pypy_exec` with Δ = 0.053s-0.110s. Both refits were fitted from readings taken under the previous subtrahend, which that PR's own message rules out as evidence, and both pointed against the correction's sign. `loop_callee_shared_mutation` and `load_name_builtin_cell_fold` are left exactly as `main` has them, and #1653 already recorded the two `range_step_one_shapes` jit-stats baselines byte-for-byte identically.

What remains is three doc comments and two snippets. `git diff main..HEAD -- '*.rs'` contains no non-comment line, so nothing here can move a benchmark.

### One reading this leaves open

`load_name_builtin_cell_fold` is not among the eight ceilings #1653 refitted, and the same arithmetic moves it toward its own. Its readings were 0.4x-2.4x against a ceiling of 2.5 and a derived floor of 0.417, with pyre's execution flat at 0.28s-0.37s and pypy's spanning 0.15s-0.54s -- the spread is the denominator's. Under the new subtraction the low reading pairs with the slow pypy and rises to 0.50x-0.60x, clearing the floor, while the high reading pairs with the fast pypy and rises to 2.75x-3.13x, over the ceiling. `main`'s own run at 6aabe927ce1 was cancelled, so no measurement of this exists yet. It is named here rather than refitted, because refitting a gate from a prediction is the error this PR removes.