### PR TITLE
super: move _super_check's apparent-class arm into baseobjspace, fix the branch-resume gate inside a helper sub-walk, and price the descent

### DIFF
--- a/pyre/bench/synth/zero_arg_super_attr.py
+++ b/pyre/bench/synth/zero_arg_super_attr.py
@@ -34,12 +34,28 @@
 # 1.7x on cranelift, carried with room for a slower host.
 # `load_super_attr.py` carries the same 3 for the same family.
 #
-# `load_super_attr_descent` is not among them.  The descent walks the MRO
-# suffix and reaches `wtf8_key_is_utf8`, whose `&Wtf8` argument is two machine
-# words against the residual ABI's one, so the sub-walk declines at that call
-# rather than run it: the fold is consulted once per trace and fires zero
-# times.  Naming it here would gate on a fold that cannot fire until the
-# wtf8-keyed dict family takes a key that is one word wide.
+# `load_super_attr_descent` is not among them, and adding it is not the
+# improvement it looks like.  The descent walks the MRO suffix and declines at
+# `pyre_object::function::w_method_new`, the unpublished descriptor bind that
+# ends the walk, so it is consulted once per trace and fires zero times.  The
+# earlier `wtf8_key_is_utf8` wall this comment used to name is gone; that one
+# moved rather than resolved anything.
+#
+# The wall has since been lifted experimentally, and what is behind it is a
+# regression.  With the descent firing on this body it read 7.71s against
+# 0.06s for the hand-written `load_super_attr` fold at N=2,000,000 -- 128x,
+# A/B'd on ONE binary with `PYRE_FBW_NO_SPECIALIZE=load_super_attr_descent`,
+# with identical output and with both arms reporting `loops_compiled=2
+# loops_aborted=0`.  No abort, no bailout, no compile failure: the compiled
+# trace itself is what is worse, and nothing explains why yet.
+#
+# The preference is what makes that reachable.
+# `try_walker_specialize_load_super_attr` consults the descent first and
+# returns on success, so a firing descent takes a site AWAY from the fold
+# rather than adding one.  On
+# `extra_tests/snippets/class_super_zero_arg_inlined_callee.py` the fold alone
+# covers 5 of 5 super sites; with the descent firing, coverage splits 3+2,
+# `loops_compiled` drops 6 -> 4 and `loops_aborted` rises 0 -> 6.
 #
 try:
     import pypyjit

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10471,7 +10471,11 @@ pub(crate) unsafe fn w_type_getdictvalue(
     // process-global `STRING_INTERN_TABLE` mutex once per lookup, which is the
     // cost `lookup_in_type_where_wtf8` documents paying for the same ABI.
     let w_value = _pure_getdictvalue_no_unwrapping(w_type, w_name, version_tag);
-    if w_value.is_null() { None } else { Some(w_value) }
+    if w_value.is_null() {
+        None
+    } else {
+        Some(w_value)
+    }
 }
 
 /// `lookup` value projection of [`lookup_where_with_method_cache`]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11115,6 +11115,57 @@ pub unsafe fn bound_method_attr_fast_path(
     Some((w_type, version_tag, w_descr, owes_shadow_guard))
 }
 
+/// `_super_check`'s third arm for a receiver whose `__class__` read settles
+/// without running Python (descriptor.py:139-146).
+///
+/// [`crate::builtins::super_check_python_free`] answers the first two arms,
+/// which consult installed MROs alone.  The third asks the receiver itself for
+/// `__class__`, and a property answers that with arbitrary code, which is why
+/// that function stops before it.  A mapdict instance whose type installs the
+/// default `__getattribute__` and whose map does not shadow the name is the
+/// case where the read is instead a plain class-attribute fetch:
+/// `class_attr_fast_path` both proves that and reports the three pins holding
+/// the proof -- the receiver's type, that type's version tag, and its map.
+///
+/// The tracer consults this rather than recomputing the arm, for the reason
+/// [`super_attr_fast_path`] gives: the interpreter and the tracer must agree on
+/// which receivers take the reduced shape, or the recorded and the concrete
+/// stacks desync.
+///
+/// Returns `class_attr_fast_path`'s own tuple,
+/// `(receiver_type, receiver_version_tag, receiver_map, objtype)`, with
+/// `objtype` the apparent class the arm yields.
+///
+/// # Safety
+/// `start_type` and `obj` must be valid object pointers (null tolerated).
+pub unsafe fn super_check_apparent_fast_path(
+    start_type: PyObjectRef,
+    obj: PyObjectRef,
+) -> Option<(
+    PyObjectRef,
+    u64,
+    crate::objspace::std::mapdict::MapRef,
+    PyObjectRef,
+)> {
+    if start_type.is_null() || obj.is_null() || !is_type(start_type) {
+        return None;
+    }
+    // `None` is a singleton with no mapdict, and the two arms above have
+    // already answered for it; keep the map read off it entirely.
+    if pyre_object::is_none(obj) {
+        return None;
+    }
+    let (receiver_type, receiver_version_tag, receiver_map, objtype) =
+        crate::objspace::std::mapdict::class_attr_fast_path(obj, "__class__")?;
+    // descriptor.py:145 `if space.issubtype_w(w_type, w_starttype)`.  The arm
+    // yields the apparent class only when that holds; otherwise `_super_check`
+    // raises, which is not an answer this predicate offers.
+    if !is_type(objtype) || !issubtype_w(objtype, start_type) {
+        return None;
+    }
+    Some((receiver_type, receiver_version_tag, receiver_map, objtype))
+}
+
 /// The Python-free prefix of `super(C, self).name`: validate the pair and find
 /// the first descriptor in the MRO suffix after `C`.
 ///

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5890,7 +5890,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
     // builtin slot is handled in the generic dispatch below.
     unsafe {
         if pyre_object::is_exact_type(obj, &pyre_object::descriptor::SUPER_TYPE) {
-            return super_getattribute_str(obj, name);
+            // Only the unwrapped name here, so the walk takes the raw
+            // dict probe rather than the elidable (see `w_type_getdictvalue`).
+            return super_getattribute_str(obj, name, PY_NULL);
         }
     }
 
@@ -6333,7 +6335,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
                     // `object_getattr_miss` would skip the post-starttype MRO
                     // walk, while re-entering `getattr` would recurse.
                     if pyre_object::descriptor::is_super(obj) {
-                        return match super_getattribute_str(obj, name) {
+                        return match super_getattribute_str(obj, name, PY_NULL) {
                             Ok(value) => Ok(value),
                             Err(err) if call_getattr && err.kind == PyErrorKind::AttributeError => {
                                 instance_getattr_hook_or_err(w_type, obj, name, err)
@@ -6526,6 +6528,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
 unsafe fn super_getattribute_wtf8(
     obj: PyObjectRef,
     name: &Wtf8,
+    w_name: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, PyError> {
     unsafe {
         if !pyre_object::descriptor::is_super(obj)
@@ -6564,9 +6567,13 @@ unsafe fn super_getattribute_wtf8(
             if !past_super || !is_type(t) {
                 continue;
             }
-            // This class's own dict only — the full MRO is already being
-            // walked here.
-            if let Some(attr) = crate::type_dict_lookup_wtf8(t, name) {
+            // typeobject.py:468 `w_value = w_class.getdictvalue(space, name)`
+            // — this class's own namespace only, since the walk above is the
+            // MRO traversal.  `getdictvalue` and not the raw dict probe: the
+            // former routes the read through an `@elidable` keyed on the
+            // version tag, which both folds it and keeps every argument inside
+            // the residual call ABI's one machine word.
+            if let Some(attr) = w_type_getdictvalue(t, name, w_name) {
                 // W_Super.getattribute binds every descriptor rather than only
                 // the three builtin method-wrapper shapes, which also covers
                 // property, getset, member and user-defined descriptors.
@@ -6594,10 +6601,10 @@ unsafe fn super_getattribute_wtf8(
 /// is what that selected builtin slot executes.  Keeping the two levels apart
 /// lets a `super` subclass override the slot without making an inherited or
 /// explicit `super.__getattribute__(obj, name)` call recurse.
-fn super_getattribute_str(obj: PyObjectRef, name: &str) -> PyResult {
+fn super_getattribute_str(obj: PyObjectRef, name: &str, w_name: PyObjectRef) -> PyResult {
     unsafe {
         if name != "__class__"
-            && let Some(value) = super_getattribute_wtf8(obj, Wtf8::new(name))?
+            && let Some(value) = super_getattribute_wtf8(obj, Wtf8::new(name), w_name)?
         {
             return Ok(value);
         }
@@ -6618,13 +6625,15 @@ pub(crate) fn super_getattribute(obj: PyObjectRef, w_name: PyObjectRef) -> PyRes
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
     if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(name) } {
-        super_getattribute_str(obj, unsafe {
-            pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name)
-        })
+        super_getattribute_str(
+            obj,
+            unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name) },
+            w_name,
+        )
     } else {
         unsafe {
             if name.as_str() != Ok("__class__")
-                && let Some(value) = super_getattribute_wtf8(obj, name)?
+                && let Some(value) = super_getattribute_wtf8(obj, name, w_name)?
             {
                 return Ok(value);
             }
@@ -6648,9 +6657,11 @@ pub(crate) unsafe fn super_getattribute_code_name(
     w_name: PyObjectRef,
 ) -> PyResult {
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    super_getattribute_str(obj, unsafe {
-        pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name)
-    })
+    super_getattribute_str(
+        obj,
+        unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name) },
+        w_name,
+    )
 }
 
 // ─── `w_name`-taking attribute API ───
@@ -10202,6 +10213,42 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
     _cached_lookup_where(w_type, w_name, version_tag).0
 }
 
+/// `typeobject.py _pure_getdictvalue_no_unwrapping` — the `@elidable` read of
+/// a type's *own* namespace, keyed on `(version_tag, name)`.  `getdictvalue`
+/// consults it whenever the type carries a version tag
+/// (typeobject.py:389-396), so the trace records a `CALL_PURE_R` and folds
+/// repeated same-key reads instead of probing the dict storage per iteration.
+///
+/// Elidability rests on the version tag: a namespace write runs `mutated()`
+/// before it stores, so a tag that is still current witnesses a namespace that
+/// has not changed since the folded read.  Unlike
+/// [`_pure_lookup_where_with_method_cache`] this consults one type rather than
+/// the MRO, which is what `typeobject.py:460-471 lookup_starting_at` needs: it
+/// walks `mro_w` itself and reads each class past `w_starttype` with
+/// `w_class.getdictvalue(space, name)` (typeobject.py:468).
+///
+/// `name` arrives as `w_name`, an interned immortal str object
+/// (`box_str_constant`), for the reason it does on that sibling: the residual
+/// call ABI carries one machine word per argument and a `&Wtf8` is two.  The
+/// result is a raw pointer because the same ABI cannot carry an `Option`; null
+/// is the absent attribute.  The `is_type` / `version_tag == 0` guards live in
+/// the front door, so this is only entered with a valid promoted tag.
+#[majit_macros::elidable]
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn _pure_getdictvalue_no_unwrapping(
+    w_type: *mut PyObject,
+    w_name: *mut PyObject,
+    version_tag: u64,
+) -> *mut PyObject {
+    // The tag is the elidable's key, not an input its body reads — upstream's
+    // body is likewise just `self._getdictvalue_no_unwrapping(space, attr)`.
+    let _ = version_tag;
+    let name = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(w_name) };
+    crate::type_dict_lookup_wtf8(w_type, name).unwrap_or(PY_NULL)
+}
+
 /// The `MethodCache` probe/fill shared by the `@elidable` JIT surface
 /// and the interpreter front door.  Probes the `(version_tag, name)`
 /// slot; on a miss runs the raw MRO walk (`typeobject.py:478-489
@@ -10378,6 +10425,53 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
         let w_class = _pure_lookup_class_with_method_cache(w_type, w_name, version_tag);
         Some((w_class, w_value))
     }
+}
+
+/// `typeobject.py W_TypeObject.getdictvalue` — the read of a type's own
+/// namespace.  One path for interpreter and JIT (upstream branches only on
+/// `version_tag is None`, never on `we_are_jitted()`): promote the type and
+/// its `version_tag`, then read through the `@elidable`
+/// [`_pure_getdictvalue_no_unwrapping`].  Without a tag the read is
+/// uncacheable and runs raw (typeobject.py:393-395).
+///
+/// The raw probe this replaces on the traced path reaches `w_dict_getitem_wtf8`
+/// with a `&Wtf8`, whose two machine words exceed the residual call ABI's one,
+/// so a sub-walk declines at that call rather than run it.  Routing the read
+/// through an elidable whose every argument is one word keeps the descent
+/// going, and folds the probe besides.
+///
+/// pyre's type namespaces hold plain values (no `MutableCell` strategy yet), so
+/// the `unwrap_cell` boundary either side of the elidable has nothing to
+/// unwrap.
+pub(crate) unsafe fn w_type_getdictvalue(
+    w_type: PyObjectRef,
+    name: &Wtf8,
+    w_name: PyObjectRef,
+) -> Option<PyObjectRef> {
+    if w_type.is_null() || !is_type(w_type) {
+        return None;
+    }
+    // No `promote(self)` here: `lookup_where_with_method_cache` promotes
+    // because it keys a shared cache on the pair, whereas `getdictvalue` reads
+    // the one type it was handed (typeobject.py:390 is just
+    // `version_tag = self.version_tag()`).
+    let version_tag = w_type_version_tag(w_type);
+    if version_tag == 0 || w_name.is_null() || !majit_metainterp::jit::we_are_jitted() {
+        // No tag means uncacheable (typeobject.py:393-395).  The interpreter
+        // takes the same raw arm, as does any caller that reached this walk
+        // holding only the unwrapped name -- see the `w_name` note below.
+        return crate::type_dict_lookup_wtf8(w_type, name);
+    }
+    // `w_name` is the caller's own wrapped name, not a fresh
+    // `box_str_constant`.  `LOAD_SUPER_ATTR` already carries it
+    // (`super_getattribute_code_name`), and boxing it again would put a
+    // `box_str_constant` residual on the traced path -- which is a symbolic
+    // fnaddr the sub-walk cannot name, so the descent declines there instead.
+    // Threading the wrapper down also spares the ordinary interpreter the
+    // process-global `STRING_INTERN_TABLE` mutex once per lookup, which is the
+    // cost `lookup_in_type_where_wtf8` documents paying for the same ABI.
+    let w_value = _pure_getdictvalue_no_unwrapping(w_type, w_name, version_tag);
+    if w_value.is_null() { None } else { Some(w_value) }
 }
 
 /// `lookup` value projection of [`lookup_where_with_method_cache`]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6567,9 +6567,9 @@ unsafe fn super_getattribute_wtf8(
             if !past_super || !is_type(t) {
                 continue;
             }
-            // typeobject.py:468 `w_value = w_class.getdictvalue(space, name)`
-            // — this class's own namespace only, since the walk above is the
-            // MRO traversal.  `getdictvalue` and not the raw dict probe: the
+            // `lookup_starting_at`'s `w_value = w_class.getdictvalue(space,
+            // name)` — this class's own namespace only, since the walk above
+            // is the MRO traversal.  `getdictvalue` and not the raw dict probe: the
             // former routes the read through an `@elidable` keyed on the
             // version tag, which both folds it and keeps every argument inside
             // the residual call ABI's one machine word.
@@ -10216,16 +10216,17 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
 /// `typeobject.py _pure_getdictvalue_no_unwrapping` — the `@elidable` read of
 /// a type's *own* namespace, keyed on `(version_tag, name)`.  `getdictvalue`
 /// consults it whenever the type carries a version tag
-/// (typeobject.py:389-396), so the trace records a `CALL_PURE_R` and folds
-/// repeated same-key reads instead of probing the dict storage per iteration.
+/// (`W_TypeObject.getdictvalue`), so the trace records a `CALL_PURE_R` and
+/// folds repeated same-key reads instead of probing the dict storage per
+/// iteration.
 ///
 /// Elidability rests on the version tag: a namespace write runs `mutated()`
 /// before it stores, so a tag that is still current witnesses a namespace that
 /// has not changed since the folded read.  Unlike
 /// [`_pure_lookup_where_with_method_cache`] this consults one type rather than
-/// the MRO, which is what `typeobject.py:460-471 lookup_starting_at` needs: it
+/// the MRO, which is what `typeobject.py lookup_starting_at` needs: it
 /// walks `mro_w` itself and reads each class past `w_starttype` with
-/// `w_class.getdictvalue(space, name)` (typeobject.py:468).
+/// `w_class.getdictvalue(space, name)`.
 ///
 /// `name` arrives as `w_name`, an interned immortal str object
 /// (`box_str_constant`), for the reason it does on that sibling: the residual
@@ -10432,7 +10433,7 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
 /// `version_tag is None`, never on `we_are_jitted()`): promote the type and
 /// its `version_tag`, then read through the `@elidable`
 /// [`_pure_getdictvalue_no_unwrapping`].  Without a tag the read is
-/// uncacheable and runs raw (typeobject.py:393-395).
+/// uncacheable and runs raw, through `_getdictvalue_no_unwrapping`.
 ///
 /// The raw probe this replaces on the traced path reaches `w_dict_getitem_wtf8`
 /// with a `&Wtf8`, whose two machine words exceed the residual call ABI's one,
@@ -10453,13 +10454,21 @@ pub(crate) unsafe fn w_type_getdictvalue(
     }
     // No `promote(self)` here: `lookup_where_with_method_cache` promotes
     // because it keys a shared cache on the pair, whereas `getdictvalue` reads
-    // the one type it was handed (typeobject.py:390 is just
+    // the one type it was handed (`W_TypeObject.getdictvalue` opens with just
     // `version_tag = self.version_tag()`).
     let version_tag = w_type_version_tag(w_type);
-    if version_tag == 0 || w_name.is_null() || !majit_metainterp::jit::we_are_jitted() {
-        // No tag means uncacheable (typeobject.py:393-395).  The interpreter
-        // takes the same raw arm, as does any caller that reached this walk
-        // holding only the unwrapped name -- see the `w_name` note below.
+    if version_tag == 0 || w_name.is_null() {
+        // No tag means uncacheable: `W_TypeObject.getdictvalue`'s untagged
+        // arm reads raw.  A caller that reached this walk holding only the
+        // unwrapped name takes that same arm, because the elidable's ABI needs
+        // the wrapper -- see the `w_name` note below.
+        //
+        // Both are tests on what this call was handed, not on
+        // `we_are_jitted()`: the tagged read has one owner for interpreter and
+        // JIT alike, which is what the doc above claims and what upstream
+        // does.  Nothing is lost by routing the interpreter through the
+        // elidable, whose body is the same `type_dict_lookup_wtf8` this arm
+        // calls directly.
         return crate::type_dict_lookup_wtf8(w_type, name);
     }
     // `w_name` is the caller's own wrapped name, not a fresh
@@ -11119,8 +11128,8 @@ pub unsafe fn bound_method_attr_fast_path(
     Some((w_type, version_tag, w_descr, owes_shadow_guard))
 }
 
-/// `_super_check`'s third arm for a receiver whose `__class__` read settles
-/// without running Python (descriptor.py:139-146).
+/// `_super_check`'s third arm (pypy/module/__builtin__/descriptor.py), for a
+/// receiver whose `__class__` read settles without running Python.
 ///
 /// [`crate::builtins::super_check_python_free`] answers the first two arms,
 /// which consult installed MROs alone.  The third asks the receiver itself for
@@ -11161,7 +11170,7 @@ pub unsafe fn super_check_apparent_fast_path(
     }
     let (receiver_type, receiver_version_tag, receiver_map, objtype) =
         crate::objspace::std::mapdict::class_attr_fast_path(obj, "__class__")?;
-    // descriptor.py:145 `if space.issubtype_w(w_type, w_starttype)`.  The arm
+    // `_super_check`'s `if space.issubtype_w(w_type, w_starttype)`.  The arm
     // yields the apparent class only when that holds; otherwise `_super_check`
     // raises, which is not an answer this predicate offers.
     if !is_type(objtype) || !issubtype_w(objtype, start_type) {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1855,6 +1855,17 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         "pyre_interpreter::_pure_lookup_class_with_method_cache",
         pure_lookup_class_with_method_cache,
     );
+    // `W_Super.getattribute` walks the MRO itself and reads each class's own
+    // namespace, so it needs the single-type elidable rather than the
+    // method-cache pair above.
+    let pure_getdictvalue_no_unwrapping: extern "C" fn(i64, i64, i64) -> i64 =
+        crate::baseobjspace::__majit_call_target__pure_getdictvalue_no_unwrapping;
+    cpa3(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::_pure_getdictvalue_no_unwrapping",
+        "pyre_interpreter::_pure_getdictvalue_no_unwrapping",
+        pure_getdictvalue_no_unwrapping,
+    );
     // #346: null-collapsing stable-alloc primitive residualised via
     // `#[dont_look_inside]`, keeping the thread-local GC hook dispatch out of
     // the trace.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10928,7 +10928,35 @@ fn guarded_branch_core<Sym: WalkSym>(
             let n_callees = session.framestack.len();
             !(n_parents > 0 && n_parents == n_callees)
         };
-        let gate_frame = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym);
+        // A canonical helper body (`run_sub_jitcode_walk`) walks its OWN
+        // jitcode over its OWN register bank and pushes no `InlineFrame`, so
+        // `current()` resolves to the Python frame BELOW it instead -- the
+        // innermost inlined callee, or the portal.  Every read taken through
+        // that frame is then cross-bank: `other_target` is a helper offset,
+        // and `depth_trivia` / `pcdep_trivia` answer a foreign offset through
+        // a predecessor scan rather than failing, so the depth and the color
+        // list come back plausible and wrong.  `kept_stack_has_boxed_int_hazard`
+        // finishes the sequence by dereferencing whatever word the foreign
+        // color lands on in `ctx.concrete_registers_r` as a `PyObjectRef`,
+        // which is an unmapped address rather than a wrong answer.
+        //
+        // Depth 0 is the right answer, not merely the safe one: a helper frame
+        // owns no Python operand stack, and its guards resume at the paused
+        // parents' CALL coordinates
+        // (`walker_capture_transparent_helper_snapshot`), re-executing the call
+        // -- exactly the reasoning `single_frame_collapse` above already
+        // applies to the helper walk whose framestack is empty.  This closes
+        // the same case when it is not.
+        //
+        // `transparent_helper_subwalk` and not `inline_subwalk`: the latter is
+        // also set for a Python-callee sub-walk, where the bank and the target
+        // DO belong to the frame `current()` returns and the gate must keep
+        // working.
+        let gate_frame = if ctx.fbw_mode.transparent_helper_subwalk {
+            None
+        } else {
+            ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym)
+        };
         let resume_depth = if single_frame_collapse {
             None
         } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2988,16 +2988,16 @@ fn walker_bare_super_frame_slots<Sym: WalkSym>(
     Some((self_op, cell_op, layout.self_is_cell))
 }
 
-/// The third arm of PyPy's `descriptor.py:_super_check`, when its
-/// `space.getattr(obj, '__class__')` is the ordinary class-attribute read the
-/// mapdict tracer already knows how to fold.
+/// The walker's holder for
+/// [`pyre_interpreter::baseobjspace::super_check_apparent_fast_path`] -- the
+/// third arm of `descriptor.py:_super_check`, admitted for the receivers whose
+/// `space.getattr(obj, '__class__')` is the ordinary class-attribute read.
 ///
-/// `class_attr_fast_path` is deliberately the whole admission predicate: a
-/// property, custom `__getattribute__`, heap-type descriptor, devolved map or
-/// instance shadow stays on the traceable/residual Python path.  For an
-/// admitted read these four values are exactly the guards an ordinary
-/// `LOAD_ATTR __class__` emits, so super construction can consume the same
-/// answer without inventing a stronger receiver-class equality.
+/// The predicate is the interpreter's so that both engines answer the same
+/// receivers; what stays here is the three pins it reports, which are exactly
+/// the guards an ordinary `LOAD_ATTR __class__` emits.  Super construction can
+/// therefore consume the answer without inventing a stronger receiver-class
+/// equality.
 #[derive(Clone, Copy)]
 pub(crate) struct ApparentSuperClass {
     pub(crate) objtype: pyre_object::PyObjectRef,
@@ -3010,21 +3010,9 @@ pub(crate) fn walker_apparent_super_class(
     start_type: pyre_object::PyObjectRef,
     obj: pyre_object::PyObjectRef,
 ) -> Option<ApparentSuperClass> {
-    if start_type.is_null()
-        || obj.is_null()
-        || !unsafe { pyre_object::is_type(start_type) }
-        || unsafe { pyre_object::is_none(obj) }
-    {
-        return None;
-    }
     let (receiver_type, receiver_version_tag, receiver_map, objtype) = unsafe {
-        pyre_interpreter::objspace::std::mapdict::class_attr_fast_path(obj, "__class__")
+        pyre_interpreter::baseobjspace::super_check_apparent_fast_path(start_type, obj)
     }?;
-    if !unsafe { pyre_object::is_type(objtype) }
-        || !unsafe { pyre_interpreter::baseobjspace::jit_issubtype_w(objtype, start_type) }
-    {
-        return None;
-    }
     Some(ApparentSuperClass {
         objtype,
         receiver_type,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3010,9 +3010,8 @@ pub(crate) fn walker_apparent_super_class(
     start_type: pyre_object::PyObjectRef,
     obj: pyre_object::PyObjectRef,
 ) -> Option<ApparentSuperClass> {
-    let (receiver_type, receiver_version_tag, receiver_map, objtype) = unsafe {
-        pyre_interpreter::baseobjspace::super_check_apparent_fast_path(start_type, obj)
-    }?;
+    let (receiver_type, receiver_version_tag, receiver_map, objtype) =
+        unsafe { pyre_interpreter::baseobjspace::super_check_apparent_fast_path(start_type, obj) }?;
     Some(ApparentSuperClass {
         objtype,
         receiver_type,
@@ -5065,6 +5064,18 @@ pub(crate) fn try_walker_specialize_load_super_attr<Sym: WalkSym>(
     if ctx.fbw_mode.inline_subwalk && !walker_inline_guard_resumes_in_callee(ctx) {
         return Ok(None);
     }
+    // Tried before the hand-written fold below, and returning here takes the
+    // site away from it rather than adding one.  That ordering is only
+    // harmless while the descent declines, which it does today at
+    // `w_method_new`.  Lifting that wall was measured: the descent then
+    // compiled `bench/synth/zero_arg_super_attr.py` 128x slower than the fold
+    // (7.71s against 0.06s at N=2,000,000, one binary A/B'd with
+    // `PYRE_FBW_NO_SPECIALIZE`, identical output, both arms
+    // `loops_compiled=2 loops_aborted=0`), and on
+    // `extra_tests/snippets/class_super_zero_arg_inlined_callee.py` it took 2
+    // of the fold's 5 sites while `loops_aborted` went 0 -> 6.  Publishing
+    // `w_method_new` therefore needs that deficit explained and this
+    // preference reconsidered, not just the wall removed.
     if spec_gate(SpecFold::LoadSuperAttrDescent, || {
         try_walker_orthodox_load_super_attr(
             ctx,


### PR DESCRIPTION
Four commits on the super/LOAD_SUPER_ATTR line, plus a negative result that
closes the "make `load_super_attr_descent` fire" thread.

## What landed

**`interp: read the super MRO walk's per-class namespace through an elidable`**
Ports `typeobject.py:460-471 lookup_starting_at`'s `@elidable`
`_pure_getdictvalue_no_unwrapping` route beside
`_pure_lookup_where_with_method_cache`, with a `w_type_getdictvalue` front door
that takes the caller's own wrapped name. Besides the parity, it keeps a
`box_str_constant` residual off the traced path and spares the interpreter the
process-global `STRING_INTERN_TABLE` mutex once per super lookup.

**`interp: move _super_check's third arm out of the walker into baseobjspace`**
Behaviour-preserving move. `walker_apparent_super_class` held the
null/`is_type`/`is_none` screens, the `class_attr_fast_path` read of
`__class__`, and the `issubtype_w` check that `descriptor.py:139-146` spells;
those are now `baseobjspace::super_check_apparent_fast_path`, next to
`super_check_python_free` which answers the same function's first two arms. The
walker keeps the adapter that packs the tuple into `ApparentSuperClass`; its
four call sites are untouched. Coverage for the moved path is existing and
gated: `bench/synth/super_descriptor_shapes.py` drives it through
`ApparentChild` under `selfcheck-compiles`.

**`jit-trace: take no resume frame for a guard inside a transparent helper sub-walk`**
A latent segfault, independent of super. `guarded_branch_core` resolved its
branch-resume gate through `ActiveResumeFrame::current`. A canonical helper body
walks its own jitcode over its own register bank and pushes no `InlineFrame`, so
`current` returns the Python frame *below* it. `other_target` is then a helper
offset read against a foreign jitcode, and `depth_trivia` / `pcdep_trivia`
answer it through a predecessor scan instead of failing — so the resume depth
and the kept-slot colours come back plausible and wrong, and
`kept_stack_has_boxed_int_hazard` dereferences the word the foreign colour names
as a `PyObjectRef`. Depth 0 is the right answer and not merely the safe one: a
helper frame owns no Python operand stack and its guards resume at the paused
parents' CALL coordinates, which is what `single_frame_collapse` already
computes for the empty-framestack case.

Gated on `transparent_helper_subwalk` and deliberately not on `inline_subwalk`
— the latter is also set for Python-callee sub-walks, where the bank and the
target *do* belong to the frame `current` returns.

**`bench, jit-trace: record what a firing load_super_attr_descent measured`**
Documentation only; see below.

## The negative result

`zero_arg_super_attr.py` used to blame `wtf8_key_is_utf8` for the descent firing
zero times. That wall moved rather than resolved — the sub-walk now declines at
`pyre_object::function::w_method_new`, the unpublished descriptor bind the walk
ends in.

That wall was cleared experimentally (an emit registry virtualizing the bind as
`NewWithVtable` + `SetfieldGc` rather than publishing a residual), the descent
fired as designed, and then it was measured. **Firing it is a regression:**

- `bench/synth/zero_arg_super_attr.py` at N=2,000,000: **7.71s with the descent
  against 0.06s without** — 128x. One binary, A/B'd with
  `PYRE_FBW_NO_SPECIALIZE=load_super_attr_descent`, identical output, and *both*
  arms reporting `loops_compiled=2 loops_aborted=0`. No abort, no bailout, no
  compile failure: the compiled trace itself is what is worse.
- `extra_tests/snippets/class_super_zero_arg_inlined_callee.py` — the pluggy
  shape this whole line of work targeted: the hand-written `load_super_attr`
  fold alone covers **5 of 5** super sites. With the descent firing, coverage
  splits 3+2, `loops_compiled` drops 6 -> 4 and `loops_aborted` rises **0 -> 6**.

`try_walker_specialize_load_super_attr` consults the descent *before* the
hand-written fold and returns on success, so a firing descent takes a site away
from the fold rather than adding one. That ordering was harmless only for as
long as the descent always declined.

So the experiment is reverted and the measurement is committed in its place —
at the `spec_gate` call site and in the fixture header — so the next attempt
starts from the number rather than from the wall. The `#1643` per-fold
framestack mitigation is also kept rather than removed: the commit above fixes
that crash at its true site, but the mitigation's only behavioural benefit was
letting the descent fire, which is what these numbers price.

What is still unexplained is the 128x itself, and it should be explained before
`w_method_new` is published.

## Gates

Re-run on the current base (`78501667f`), from this exact tree — both binaries
built after the last source edit:

| gate | result |
| --- | --- |
| `cargo test --all --no-default-features --features dynasm` | 9006 passed, 0 failed, 0 panics |
| `check.py --backend dynasm` | **537/537 ALL PASSED** |
| `check.py --backend cranelift` | **537/537 ALL PASSED** |
| `extra_tests/run.py --gated-only` | 178/178 on cpython, dynasm, cranelift |

An earlier revision of this description claimed
`synth/range_step_one_shapes` had no committed cranelift jit-stats baseline and
called that a defect owed to `main`. **That was wrong on both counts**: the
verifying probe asked for `pyre/bench/jitstats/...` when the baselines live in
`pyre/bench/synth/...`, and a path that does not exist reports "absent" for
everything, so the probe confirmed the conclusion regardless of the truth. The
reading was also taken against the base the branch then sat on; `6aabe927ce1`
(#1653) had already recorded the missing baselines. All three siblings exist on
the current `main`, and the fixture passes here.

### The CI cranelift ratio reds

`pyre/check.py cranelift (ubuntu-24.04)` is red on CI. It is also red on `main`
**at this branch's exact base commit** (`78501667f`, run 33691104038), which is
the control:

| | fixtures over their pypy-ratio gate |
| --- | --- |
| `main` @ 78501667f | `synth/exception_loop_warmup` 4.8x>4.1x, `synth/pure_tupleload` **8.6x**>6x |
| this branch @ 98235d4 | `inline_helper` 1.6x>1.5x, `synth/for_iter_conditional_store_bridge` 4.5x>4x, `synth/for_iter_nested_method_inline` 3.5x>3.3x, `synth/pure_tupleload` **8.2x**>6x |

The one large overrun, `pure_tupleload`, fails on both and is *lower* here than
on `main`. The rest are 6-12% over their gates and the two sets do not overlap,
which is the shape of ratio noise on a shared runner rather than a regression.
None of these fixtures are touched by this branch, all pass locally, and
check.py reported no jit-stats mismatch for any of them — so compilation is
unchanged and only wall-clock differs.

That said, one change here (the branch-resume gate) does reach helper sub-walks
and could in principle touch an inlining fixture, so this is stated as the
current reading rather than a closed question; the re-run on this push is the
test.

The wasm backend was not run locally; CI covers `wasm32` on its Linux job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZKxAmCTcGFbJssJrbPSfV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved the speed of `super` attribute lookups in eligible cases.
  - Added optimized handling for type-based namespace reads and apparent-class checks.
  - Improved JIT support for these lookup paths.

- **Bug Fixes**
  - Improved consistency between interpreter and JIT behavior when resolving `super` attributes.
  - Fixed frame handling during transparent helper walks to avoid incorrect cross-context resolution.
  - Improved handling of wrapped attribute names during `super` lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

