### PR TITLE
blackhole: per-jitdriver portal re-entry, runtime opcode decoding, and five parity-audit fixes

### DIFF
--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -4154,27 +4154,27 @@ static MEMORY_ERROR_PROVIDER: std::sync::OnceLock<fn() -> i64> = std::sync::Once
 /// is stored there, with zero replaced by 29872897 so a computed value is
 /// distinguishable from the sentinel.
 ///
-/// PyPy relies on process serialization here.  Pyre's CPython-3.14t contract
-/// permits concurrent readers, so the same one-word owner is accessed
-/// atomically rather than duplicated in a side table.
+/// The word is read and written the same way the compiled path reaches it.
+/// `build_ll_strhash_internal_helper_graph` implements `_ll_strhash` as an
+/// ordinary `getfield`/`setfield` pair on this field, and both backends lower
+/// those to plain loads and stores, so this must not be the one accessor that
+/// makes it atomic: a location reached atomically by one writer and plainly by
+/// another is a data race whichever way the race resolves.
+///
+/// The store stays benign for the same reason it is in `LLHelpers`: every racing
+/// writer computes the identical value from immutable characters, so a losing
+/// writer overwrites the word with what is already there.
 fn blackhole_cached_hash(string_ptr: i64, compute: impl FnOnce() -> i64) -> i64 {
     assert_ne!(string_ptr, 0, "blackhole string hash: null string");
-    let cache = unsafe { &*(string_ptr as usize as *const std::sync::atomic::AtomicIsize) };
-    let cached = cache.load(std::sync::atomic::Ordering::Acquire);
+    let cache = string_ptr as usize as *mut isize;
+    let cached = unsafe { std::ptr::read(cache) };
     if cached != 0 {
         return cached as i64;
     }
     let computed = compute() as isize;
     let computed = if computed == 0 { 29_872_897 } else { computed };
-    match cache.compare_exchange(
-        0,
-        computed,
-        std::sync::atomic::Ordering::AcqRel,
-        std::sync::atomic::Ordering::Acquire,
-    ) {
-        Ok(_) => computed as i64,
-        Err(winner) => winner as i64,
-    }
+    unsafe { std::ptr::write(cache, computed) };
+    computed as i64
 }
 
 /// Install the `memory_error` singleton provider.  Called once from

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -4154,26 +4154,33 @@ static MEMORY_ERROR_PROVIDER: std::sync::OnceLock<fn() -> i64> = std::sync::Once
 /// is stored there, with zero replaced by 29872897 so a computed value is
 /// distinguishable from the sentinel.
 ///
-/// The word is read and written the same way the compiled path reaches it.
-/// `build_ll_strhash_internal_helper_graph` implements `_ll_strhash` as an
-/// ordinary `getfield`/`setfield` pair on this field, and both backends lower
-/// those to plain loads and stores, so this must not be the one accessor that
-/// makes it atomic: a location reached atomically by one writer and plainly by
-/// another is a data race whichever way the race resolves.
+/// The word is reached with the same MACHINE instructions the compiled path
+/// uses.  `build_ll_strhash_internal_helper_graph` implements `_ll_strhash` as
+/// an ordinary `getfield`/`setfield` pair on this field and both backends lower
+/// those to a plain load and store, so an acquire load and a compare-exchange
+/// here made this the one accessor that fenced and retried.
 ///
-/// The store stays benign for the same reason it is in `LLHelpers`: every racing
-/// writer computes the identical value from immutable characters, so a losing
-/// writer overwrites the word with what is already there.
+/// `Relaxed` is the spelling that matches: on every target pyre builds for it
+/// emits exactly the plain load and store the compiled path emits, while
+/// keeping the access an atomic one in Rust's model — a plain `ptr::read` /
+/// `ptr::write` racing with another thread's write is undefined behaviour even
+/// when both threads store identical bits, so "the compiled path uses plain
+/// accesses" is a reason to drop the fences, not a reason to drop the atomic.
+///
+/// The store itself stays unguarded for the same reason it is in `LLHelpers`:
+/// every racing writer computes the identical value from immutable characters,
+/// so a losing writer overwrites the word with what is already there.
 fn blackhole_cached_hash(string_ptr: i64, compute: impl FnOnce() -> i64) -> i64 {
+    use std::sync::atomic::{AtomicIsize, Ordering};
     assert_ne!(string_ptr, 0, "blackhole string hash: null string");
-    let cache = string_ptr as usize as *mut isize;
-    let cached = unsafe { std::ptr::read(cache) };
+    let cache = unsafe { &*(string_ptr as usize as *const AtomicIsize) };
+    let cached = cache.load(Ordering::Relaxed);
     if cached != 0 {
         return cached as i64;
     }
     let computed = compute() as isize;
     let computed = if computed == 0 { 29_872_897 } else { computed };
-    unsafe { std::ptr::write(cache, computed) };
+    cache.store(computed, Ordering::Relaxed);
     computed as i64
 }
 

--- a/majit/majit-ir/src/resumedata.rs
+++ b/majit/majit-ir/src/resumedata.rs
@@ -386,9 +386,21 @@ pub fn decode_tagged_value(
                 RebuiltValue::Unassigned
             } else {
                 let idx = (val - TAG_CONST_OFFSET) as usize;
-                // resume.py/1571/1583 self.consts[num - TAG_CONST_OFFSET]
-                // — the Const carries its type with it.
-                let c = rd_consts.get(idx).copied().unwrap_or(Const::Int(0));
+                // resume.py:1554/1571/1583 `self.consts[num -
+                // TAG_CONST_OFFSET]` — a plain index, so an out-of-range
+                // number is an `IndexError` there.  The Const carries its type
+                // with it, which is why there is no defaulting answer to give:
+                // `Const::Int(0)` is a well-formed integer zero, so a bridge
+                // rebuilt from a truncated `rd_consts` would run on it instead
+                // of failing, while `ResumeDataDirectReader`'s `decode_int` /
+                // `decode_ref` panic on the very same index.
+                let Some(c) = rd_consts.get(idx).copied() else {
+                    panic!(
+                        "decode_tagged_value: TAGCONST index {idx} is past the \
+                         guard's {} consts (tagged {tagged})",
+                        rd_consts.len(),
+                    );
+                };
                 RebuiltValue::Const(c)
             }
         }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -13136,7 +13136,26 @@ fn handler_inline_call_nested_ext(
             break 'callee Err(DispatchError::LeaveFrame);
         }
 
-        if let Some((return_kind, callee_src)) = callee.jitcode.trailing_return_info() {
+        let Some((return_kind, callee_src)) = callee.jitcode.trailing_return_info() else {
+            // No trailing return opcode means the callee produced no value.
+            // The caller's three slots are all `NO_RETURN_REG` in that case —
+            // `inline_call_typed` emits a real register only for the kind the
+            // callee returns — so a slot that IS a register here names a
+            // destination nothing will write, and the caller goes on to read
+            // whatever the previous occupant of that register left.  Upstream
+            // cannot reach the state: `bhimpl_inline_call_*` gets its value
+            // from `cpu.bh_call_*`, whose result kind is the calldescr's.
+            assert!(
+                return_i.is_none() && return_r.is_none() && return_f.is_none(),
+                "inline_call: callee jitcode {:?} index {:?} ends without a \
+                 typed return opcode, but the caller declared result slots \
+                 (i={return_i:?} r={return_r:?} f={return_f:?})",
+                callee.jitcode.name,
+                callee.jitcode.try_index(),
+            );
+            break 'callee Ok(p);
+        };
+        {
             match return_kind {
                 JitArgKind::Int => {
                     let caller_dst =
@@ -13159,6 +13178,18 @@ fn handler_inline_call_nested_ext(
         Ok(p)
     };
 
+    // `called_residual` is "this frame left the interpreter", and
+    // `jitdriver.rs` reads it to decide whether a guard may spawn a bridge —
+    // a residual call is not a value the bridge can recompute.  The native arm
+    // of this opcode sets the CALLER's flag, because `inline_call_native` goes
+    // through `bhimpl_residual_call_*` on `bh` itself.  The interpreted arm
+    // runs the callee's own opcodes on `callee`, so a residual call inside it
+    // set the callee's flag and the caller's stayed clear: the same source
+    // call was judged escaping or not depending on which arm ran it.  Fold the
+    // callee's answer into the caller's before the frame is reset.
+    if callee.called_residual.get() {
+        bh.called_residual.set(true);
+    }
     callee.reset_for_inline_reuse();
     bh.inline_callee_scratch = Some(callee);
     outcome

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -11643,7 +11643,7 @@ fn handler_getarrayitem_vable_i(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 2);
     let array_idx = field_descr.as_vable_array_index();
@@ -11661,7 +11661,7 @@ fn handler_getarrayitem_vable_r(
 ) -> Result<usize, DispatchError> {
     let nbody_debug = crate::nbody_debug_enabled();
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 2);
     let array_idx = field_descr.as_vable_array_index();
@@ -11684,7 +11684,7 @@ fn handler_setarrayitem_vable_i(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_i[code[p + 2] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 3);
@@ -11703,7 +11703,7 @@ fn handler_setarrayitem_vable_r(
 ) -> Result<usize, DispatchError> {
     let nbody_debug = crate::nbody_debug_enabled();
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_r[code[p + 2] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 3);
@@ -12324,7 +12324,7 @@ fn handler_getarrayitem_vable_f(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 2);
     let array_idx = field_descr.as_vable_array_index();
@@ -12342,7 +12342,7 @@ fn handler_setarrayitem_vable_f(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
-    let index = bh.registers_i[code[p + 1] as usize] as usize;
+    let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_f[code[p + 2] as usize];
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
     let (field_descr, p) = read_descr(bh, code, p + 3);

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -152,6 +152,45 @@ pub struct BhJitDriverSd {
     /// `jitdriver_sd.mainjitcode.calldescr` — CallDescr of the portal
     /// function returned by `get_portal_runner` for `bh_call_*`.
     pub mainjitcode_calldescr: BhCallDescr,
+    /// `warmspot.py:921` `jd.mainjitcode` — the portal function's jitcode.
+    ///
+    /// `blackhole.py` `_handle_jitexception_in_portal` picks the driver whose
+    /// `mainjitcode is self.jitcode`, so a recursive `ContinueRunningNormally`
+    /// re-enters the portal that raised it and not some other driver's.
+    /// [`portal_runner_for`] runs that same search.
+    pub mainjitcode: Option<std::sync::Arc<JitCode>>,
+}
+
+/// How [`BlackholeInterpreter::run`]'s dispatch loop stopped.
+///
+/// `blackhole.py`'s `dispatch_loop` is `while True:` over `ord(code[position])`
+/// and never returns — it only raises, and `run` converts `LeaveFrame` into a
+/// normal return while letting everything else through.  So upstream has three
+/// exits, and each one leaves different state behind for `_resume_mainloop` to
+/// read.  Naming them keeps the caller from having to infer which happened.
+///
+/// The fourth, [`Self::EndOfCode`], has no upstream counterpart: reading past
+/// the last byte is an `IndexError` there.  It exists here because pyre's unit
+/// builders emit jitcodes that simply end, and it is a distinct variant rather
+/// than a synonym for [`Self::LeaveFrame`] because the two differ in exactly
+/// the state a caller goes on to publish — `return_type` and `tmpreg_*` are
+/// written by a `*_return` handler and cleared by neither `cleanup_registers`
+/// (upstream has no such slot to clear) nor `release_interp`, so a frame that
+/// merely ran out of bytes carries the previous occupant of its pooled
+/// interpreter to the caller's result register.
+#[derive(Debug)]
+pub enum BhRunOutcome {
+    /// A `*_return` handler raised `LeaveFrame`: `return_type` and the matching
+    /// `tmpreg_*` hold this frame's result.
+    LeaveFrame,
+    /// An exception no `catch_exception` in this frame handled;
+    /// `got_exception` and `exception_last_value` carry it.
+    Exception,
+    /// `blackhole.py:1068` `raise ContinueRunningNormally(*args)`.
+    ContinueRunningNormally(Box<MergePointArgs>),
+    /// The dispatch loop ran out of bytecode without returning.  No upstream
+    /// counterpart — see the type's own docs.
+    EndOfCode,
 }
 
 /// Signal raised by handlers and propagated up through `dispatch_step` to `run`.
@@ -1097,8 +1136,23 @@ impl BlackholeInterpreter {
         // blackhole.py `_resume_mainloop` does not catch
         // ContinueRunningNormally; it propagates out to `_run_forever`
         // and then to `handle_jitexception` (warmspot.py).
-        if let Some(args) = self.run() {
-            return Err(JitException::ContinueRunningNormally(args));
+        match self.run() {
+            BhRunOutcome::ContinueRunningNormally(args) => {
+                return Err(JitException::ContinueRunningNormally(args));
+            }
+            // `blackhole.py:1633` reads `self._return_type` next, and it only
+            // gets there because `dispatch_loop` raised `LeaveFrame` from a
+            // `*_return` handler that had just written it.  Nothing writes it
+            // on the way out of a frame that merely ran out of bytecode, and
+            // nothing clears it either, so the read below would publish the
+            // result of whatever ran on this pooled interpreter last.
+            BhRunOutcome::EndOfCode => panic!(
+                "resume_mainloop: jitcode {:?} index {:?} ended without a return \
+                 opcode, so there is no result to pass to the caller",
+                self.jitcode.name,
+                self.jitcode.try_index(),
+            ),
+            BhRunOutcome::LeaveFrame | BhRunOutcome::Exception => {}
         }
 
         // Check for exception during execution
@@ -1628,7 +1682,7 @@ impl BlackholeInterpreter {
     /// catches exceptions and calls `handle_exception_in_frame`.
     /// Returns `Some(args)` for `ContinueRunningNormally` (RPython: raise
     /// jitexc.ContinueRunningNormally propagates through run→_run_forever).
-    pub fn run(&mut self) -> Option<Box<MergePointArgs>> {
+    pub fn run(&mut self) -> BhRunOutcome {
         let _bh_phase = majit_gc::BhProbePhase::enter("blackhole");
         // Root this frame's register bank AND every pending caller frame
         // reachable through `nextblackholeinterp`.  RPython keeps the whole
@@ -1703,7 +1757,7 @@ impl BlackholeInterpreter {
         result
     }
 
-    fn run_inner(&mut self) -> Option<Box<MergePointArgs>> {
+    fn run_inner(&mut self) -> BhRunOutcome {
         let trace = crate::majit_log_enabled() || crate::bh_debug_enabled();
         // blackhole.py:86-91:
         //
@@ -1749,7 +1803,7 @@ impl BlackholeInterpreter {
                         self.registers_i.first().copied().unwrap_or(-1)
                     );
                 }
-                return None;
+                return BhRunOutcome::EndOfCode;
             }
             let pos_before = self.position;
             self.last_opcode_position = pos_before;
@@ -1782,7 +1836,7 @@ impl BlackholeInterpreter {
                             pos_before, self.return_type,
                         );
                     }
-                    return None;
+                    return BhRunOutcome::LeaveFrame;
                 }
                 Err(DispatchError::ContinueRunningNormally(args)) => {
                     // blackhole.py:1068: raise ContinueRunningNormally(*args)
@@ -1793,7 +1847,7 @@ impl BlackholeInterpreter {
                             &format!("ContinueRunningNormally at pos={pos_before}"),
                         );
                     }
-                    return Some(args);
+                    return BhRunOutcome::ContinueRunningNormally(args);
                 }
                 Err(DispatchError::RaiseException { exc, .. }) => {
                     // blackhole.py: except Exception → handle_exception_in_frame
@@ -1810,7 +1864,7 @@ impl BlackholeInterpreter {
                     // No handler: propagate exception via got_exception flag
                     self.got_exception = true;
                     self.exception_last_value = exc;
-                    return None;
+                    return BhRunOutcome::Exception;
                 }
             }
         }
@@ -2741,6 +2795,22 @@ impl BlackholeInterpBuilder {
         // `scalar_slot`/`array_elem_slot` range checks are `debug_assert!`, so
         // a release build reads whatever slot the arithmetic lands on.
         interp.state_field_layout = StateFieldLayout::default();
+        // Two more pyre-only fields on the same footing as the ones above:
+        // they describe the run that just ended, and `acquire_interp` refreshes
+        // only the six builder-shared slots.
+        //
+        // `called_residual` is "this frame left the interpreter", set by every
+        // `bh_call_*` helper and cleared by `reset_for_inline_reuse` alone.  A
+        // pooled interp that kept it hands its next user the previous run's
+        // answer, which `jitdriver.rs` reads on the back-edge to decide whether
+        // the walk may treat the frame as never having escaped.
+        //
+        // `record_caught_exception` is a callback the resume path installs on
+        // every frame of a chain (`call_jit.rs`), and the chain goes back into
+        // the same pool.  Handing the next user a hook it never asked for makes
+        // it report exceptions to whoever owned the frame before it.
+        interp.called_residual.set(false);
+        interp.record_caught_exception = None;
         interp.back = self.blackholeinterps.take();
         self.blackholeinterps = Some(interp);
     }
@@ -2771,17 +2841,39 @@ fn handle_jitexception_dispatch(
     portal_runner: Option<
         &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
     >,
+    result_kind: Option<BhReturnType>,
 ) -> Result<(BhReturnType, i64), PortalRunnerFailure> {
+    // `warmspot.py:984-996` guards each `DoneWithThisFrame*` arm with `if
+    // result_kind == '<kind>':`, so a portal only ever absorbs the flavour it
+    // returns; a mismatch falls off the end of the `while True` into
+    // `:1007 raise AssertionError("all cases should have been handled")`.  The
+    // kinds carry the value in different banks — `DoneWithThisFrameInt` at a
+    // ref portal would install an integer through `setup_return_value_i` and
+    // the caller would read it as a pointer — so the wrong arm is a wrong
+    // answer, not a mislabelled one.  `None` is a jitcode no driver claims
+    // (the unit-test builders build `BhJitDriverSd` without `mainjitcode`);
+    // there is no `result_kind` to test against, so the variant alone decides
+    // as it did before the driver was consulted.
+    let kind_matches = |kind: BhReturnType| result_kind.is_none_or(|want| want == kind);
+    let done_arm = |kind: BhReturnType, value: i64| {
+        assert!(
+            kind_matches(kind),
+            "portal result_kind {:?} cannot absorb DoneWithThisFrame{:?}",
+            result_kind,
+            kind,
+        );
+        Ok((kind, value))
+    };
     match exc {
-        // warmspot.py:986-987
-        JitException::DoneWithThisFrameVoid => Ok((BhReturnType::Void, 0)),
+        // warmspot.py:985-987
+        JitException::DoneWithThisFrameVoid => done_arm(BhReturnType::Void, 0),
         // warmspot.py:988-990
-        JitException::DoneWithThisFrameInt(result) => Ok((BhReturnType::Int, result)),
+        JitException::DoneWithThisFrameInt(result) => done_arm(BhReturnType::Int, result),
         // warmspot.py:991-993
-        JitException::DoneWithThisFrameRef(result) => Ok((BhReturnType::Ref, result.0 as i64)),
+        JitException::DoneWithThisFrameRef(result) => done_arm(BhReturnType::Ref, result.0 as i64),
         // warmspot.py:994-996
         JitException::DoneWithThisFrameFloat(result) => {
-            Ok((BhReturnType::Float, result.to_bits() as i64))
+            done_arm(BhReturnType::Float, result.to_bits() as i64)
         }
         // warmspot.py:998-1005
         JitException::ExitFrameWithExceptionRef(_) => Err(PortalRunnerFailure::jit(exc)),
@@ -2822,12 +2914,13 @@ fn handle_jitexception_in_portal(
     portal_runner: Option<
         &dyn Fn(&JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>,
     >,
+    result_kind: Option<BhReturnType>,
 ) -> Result<(), PortalRunnerFailure> {
     // warmspot.py handle_jitexception: while True loop.
     // ContinueRunningNormally → portal_runner → may raise JitException → loop.
     let mut current_exc = exc;
     loop {
-        match handle_jitexception_dispatch(current_exc, portal_runner) {
+        match handle_jitexception_dispatch(current_exc, portal_runner, result_kind) {
             Ok((ret_type, result)) => {
                 // warmspot.py:1041-1050
                 match ret_type {
@@ -2865,8 +2958,14 @@ fn handle_jitexception_in_portal(
                 exception: next_exc,
                 terminal,
             }) => {
-                // warmspot.py:967-968, 979-980: JitException from portal_runner
-                // or EnterJitAssembler → loop back in handle_jitexception
+                // warmspot.py:979-980: a JitException out of `portal_runner`
+                // loops back in `handle_jitexception`.  Upstream reaches the
+                // same `continue` from `:967-968` as well, where
+                // `EnterJitAssembler.execute()` raised; pyre has no such
+                // exception because `warmstate.py maybe_compile_and_run`'s
+                // counterpart in `eval.rs` enters the assembler directly, so
+                // that producer has no port and this arm serves the portal
+                // re-entry alone.
                 assert!(
                     terminal.is_none(),
                     "only BailToInterpreter may carry a terminal blackhole image"
@@ -3015,8 +3114,20 @@ fn handle_jitexception(
     // DoneWithThisFrame{Int,Ref,Float,Void} and returns it.
     //
     // In Rust we can do this directly since JitException carries the result.
+    //
+    // `bh` is upstream's `self` — the portal frame that raised — so its own
+    // driver owns the runner.  Only a frame no driver claims falls back to the
+    // runner this call was handed.
+    let own_runner = portal_runner_for(&bh);
+    let own_runner = own_runner.as_ref().map(|hook| {
+        hook as &dyn Fn(
+            &crate::jitexc::JitException,
+        ) -> Result<(BhReturnType, i64), PortalRunnerFailure>
+    });
+    let result_kind = portal_result_kind_for(&bh);
     let caller = bh.nextblackholeinterp.as_mut().unwrap();
-    let portal_outcome = handle_jitexception_in_portal(caller, exc, portal_runner);
+    let portal_outcome =
+        handle_jitexception_in_portal(caller, exc, own_runner.or(portal_runner), result_kind);
     let current_exc = match portal_outcome {
         Ok(()) => 0,
         Err(PortalRunnerFailure {
@@ -3254,7 +3365,12 @@ pub fn convert_and_run_from_pyjitpl(
     // recursive portal level can re-enter the portal function.  Without it
     // `handle_jitexception_dispatch` has nothing to call and
     // `ContinueRunningNormally` reaches its `expect`.
-    let hook = PORTAL_RUNNER_HOOK.get().copied();
+    //
+    // This is only the fallback for a frame no driver claims: the recursive
+    // level resolves its own runner from the raising portal frame
+    // (`portal_runner_for`), because the driver that owns that jitcode is the
+    // one whose portal has to be re-entered.
+    let hook = portal_runner_for(&first_bh);
     let portal_runner = hook.as_ref().map(|hook| {
         hook as &dyn Fn(
             &crate::jitexc::JitException,
@@ -7080,6 +7196,78 @@ fn bhimpl_jit_leave_portal_frame() {}
 /// blackhole.py `bhimpl_hint_force_virtualizable(r): pass`.
 fn bhimpl_hint_force_virtualizable(_r: i64) {}
 
+/// The interpreter's `portal_runner`, re-entering the portal function when
+/// `ContinueRunningNormally` is raised at a recursive portal level
+/// (`warmspot.py handle_jitexception_from_blackhole`).
+///
+/// `warmspot.py:1010-1013` `jd.handle_jitexc_from_bh`, one per jitdriver.
+pub type PortalRunnerHook =
+    fn(&crate::jitexc::JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>;
+
+/// The registered runners, indexed by `metainterp_sd.jitdrivers_sd` position.
+///
+/// Upstream hangs this callback off the driver itself, so
+/// `_handle_jitexception_in_portal` can pick the one whose `mainjitcode is
+/// self.jitcode`.  Keeping the table beside `BhJitDriverSd` rather than in it
+/// only avoids an initialisation order between the driver table (built once,
+/// lazily) and the consumer's registration; [`portal_runner_for`] joins the two
+/// at the point of use, by the same identity test upstream uses.
+static PORTAL_RUNNER_HOOKS: std::sync::RwLock<Vec<Option<PortalRunnerHook>>> =
+    std::sync::RwLock::new(Vec::new());
+
+/// Install the [`PortalRunnerHook`] owned by `jitdrivers_sd[jd_index]`.
+///
+/// First registration for an index wins, so a consumer may call it from every
+/// install path for that driver.
+pub fn register_portal_runner_hook(jd_index: usize, hook: PortalRunnerHook) {
+    let mut hooks = PORTAL_RUNNER_HOOKS
+        .write()
+        .expect("portal runner table poisoned");
+    if hooks.len() <= jd_index {
+        hooks.resize(jd_index + 1, None);
+    }
+    hooks[jd_index].get_or_insert(hook);
+}
+
+/// `blackhole.py` `_handle_jitexception_in_portal`:
+///
+/// ```python
+/// for jd in self.builder.metainterp_sd.jitdrivers_sd:
+///     if jd.mainjitcode is self.jitcode:
+///         break
+/// else:
+///     assert 0, "portal jitcode not found??"
+/// jd.handle_jitexc_from_bh(self.nextblackholeinterp, e)
+/// ```
+///
+/// `bh` is the portal frame that raised, i.e. upstream's `self`.  Upstream
+/// asserts when no driver owns that jitcode; here a miss returns `None` and
+/// each caller keeps the behaviour it had before the driver was consulted,
+/// because a `BhJitDriverSd` table assembled without `mainjitcode` (the
+/// unit-test builders) would otherwise abort paths that used to work.
+fn portal_jd_for(bh: &BlackholeInterpreter) -> Option<usize> {
+    bh.jitdrivers_sd.iter().position(|jd| {
+        jd.mainjitcode
+            .as_ref()
+            .is_some_and(|code| std::sync::Arc::ptr_eq(code, &bh.jitcode))
+    })
+}
+
+/// The `jd.handle_jitexc_from_bh` of the driver [`portal_jd_for`] picked.
+fn portal_runner_for(bh: &BlackholeInterpreter) -> Option<PortalRunnerHook> {
+    let jd_index = portal_jd_for(bh)?;
+    *PORTAL_RUNNER_HOOKS
+        .read()
+        .expect("portal runner table poisoned")
+        .get(jd_index)?
+}
+
+/// The `result_kind` `warmspot.py:984-996` tests each `DoneWithThisFrame*`
+/// against, taken from the same driver [`portal_jd_for`] picked.
+fn portal_result_kind_for(bh: &BlackholeInterpreter) -> Option<BhReturnType> {
+    Some(bh.jitdrivers_sd[portal_jd_for(bh)?].result_type)
+}
+
 /// Called at every `-live-` marker, i.e. once per source-level instruction the
 /// blackhole replays. Arguments are the interpreter and the marker's own
 /// bytecode position.
@@ -7100,25 +7288,6 @@ fn bhimpl_hint_force_virtualizable(_r: i64) {}
 /// colouring reusing that register almost immediately
 /// (`rpython/tool/algo/regalloc.py:28-75`); a codewriter whose colours are
 /// not reused that densely needs the same clear at marker granularity.
-/// The interpreter's `portal_runner`, re-entering the portal function when
-/// `ContinueRunningNormally` is raised at a recursive portal level
-/// (`warmspot.py handle_jitexception_from_blackhole`).
-///
-/// Registered as a module hook rather than held on `JitDriver`, because the two
-/// production entries into `convert_and_run_from_pyjitpl` reach it with
-/// `MetaInterpStaticData` only — neither can name the driver that owns the
-/// callback.  Same shape as [`LiveMarkerHook`] beside it.
-pub type PortalRunnerHook =
-    fn(&crate::jitexc::JitException) -> Result<(BhReturnType, i64), PortalRunnerFailure>;
-
-static PORTAL_RUNNER_HOOK: std::sync::OnceLock<PortalRunnerHook> = std::sync::OnceLock::new();
-
-/// Install the [`PortalRunnerHook`]. First registration wins; later calls are
-/// ignored, so a consumer may call it from every driver install path.
-pub fn register_portal_runner_hook(hook: PortalRunnerHook) {
-    let _ = PORTAL_RUNNER_HOOK.set(hook);
-}
-
 pub type LiveMarkerHook = fn(&mut BlackholeInterpreter, usize);
 
 static LIVE_MARKER_HOOK: std::sync::OnceLock<LiveMarkerHook> = std::sync::OnceLock::new();
@@ -12914,9 +13083,21 @@ fn handler_inline_call_nested_ext(
     // Every exit below leaves through the single `break 'callee`, so the
     // frame always reaches the scratch slot on its way out.
     let outcome = 'callee: {
-        if let Some(args) = callee.run() {
-            bh.position = p;
-            break 'callee Err(DispatchError::ContinueRunningNormally(args));
+        match callee.run() {
+            BhRunOutcome::ContinueRunningNormally(args) => {
+                bh.position = p;
+                break 'callee Err(DispatchError::ContinueRunningNormally(args));
+            }
+            // Same reason as `resume_mainloop`: the caller copies the callee's
+            // `return_type` / `tmpreg_*` into its own result register below,
+            // and a callee that ran out of bytecode never wrote either.
+            BhRunOutcome::EndOfCode => panic!(
+                "inline_call: callee jitcode {:?} index {:?} ended without a \
+                 return opcode, so there is no result for the caller",
+                callee.jitcode.name,
+                callee.jitcode.try_index(),
+            ),
+            BhRunOutcome::LeaveFrame | BhRunOutcome::Exception => {}
         }
 
         // RPython `blackhole.py` invariant: after the handler has

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -229,10 +229,13 @@ pub struct BlackholeInterpreter {
     /// lifetime shape as the sibling `cpu: Option<&'static dyn Backend>`.
     pub descrs: &'static dyn DescrTable,
     /// RPython `blackhole.py` `self.op_catch_exception = builder.op_catch_exception`.
+    /// `BC_ABSENT` when the key is missing — see [`BlackholeInterpBuilder::op_live`].
     pub op_catch_exception: u8,
     /// RPython `blackhole.py:290` `self.op_rvmprof_code = builder.op_rvmprof_code`.
+    /// `BC_ABSENT` when the key is missing — see [`BlackholeInterpBuilder::op_live`].
     pub op_rvmprof_code: u8,
     /// RPython `blackhole.py:289` `self.op_live = builder.op_live`.
+    /// `BC_ABSENT` when the key is missing — see [`BlackholeInterpBuilder::op_live`].
     pub op_live: u8,
     /// Integer register bank.
     /// Indices 0..num_regs_i are working registers.
@@ -501,10 +504,11 @@ impl Default for BlackholeInterpreter {
             // blackhole.py `EMPTY_LIST_I = [] # shared`.
             descrs: EMPTY_DESCR_TABLE,
             // RPython blackhole.py — copied from builder in `acquire_interp`.
-            // Sentinel `u8::MAX` matches RPython's `insns.get('…', -1)` fallback.
-            op_catch_exception: u8::MAX,
-            op_rvmprof_code: u8::MAX,
-            op_live: u8::MAX,
+            // `BC_ABSENT` stands in for `insns.get('…', -1)`: a reserved byte
+            // no opname is ever assigned, so it cannot match `code[position]`.
+            op_catch_exception: majit_translate::insns::BC_ABSENT,
+            op_rvmprof_code: majit_translate::insns::BC_ABSENT,
+            op_live: majit_translate::insns::BC_ABSENT,
             registers_i: Vec::new(),
             registers_r: Vec::new(),
             registers_f: Vec::new(),
@@ -2281,10 +2285,18 @@ pub struct BlackholeInterpBuilder {
     /// Populated by `setup_insns`; empty until called.
     pub _insns: Vec<String>,
     /// RPython `blackhole.py` `self.op_live = insns.get('live/', -1)`.
+    ///
+    /// A missing key stores [`majit_translate::insns::BC_ABSENT`] rather than
+    /// upstream's `-1`.  The two carry the same guarantee for the
+    /// `opcode == self.op_live` tests: `-1` cannot equal `ord(code[position])`
+    /// because it is outside `0..=255`, and `BC_ABSENT` cannot because it is a
+    /// reserved byte that no opname is ever assigned.
     pub op_live: u8,
     /// RPython `blackhole.py:73` `self.op_catch_exception`.
+    /// `BC_ABSENT` when the key is missing — see [`Self::op_live`].
     pub op_catch_exception: u8,
     /// RPython `blackhole.py:74` `self.op_rvmprof_code`.
+    /// `BC_ABSENT` when the key is missing — see [`Self::op_live`].
     pub op_rvmprof_code: u8,
     /// RPython `blackhole.py:103` `self.descrs`.
     /// Populated by `setup_descrs()` from the assembler's descriptor table.
@@ -2339,9 +2351,9 @@ impl BlackholeInterpBuilder {
             blackholeinterps: None,
             cpu: None,
             _insns: Vec::new(),
-            op_live: u8::MAX,
-            op_catch_exception: u8::MAX,
-            op_rvmprof_code: u8::MAX,
+            op_live: majit_translate::insns::BC_ABSENT,
+            op_catch_exception: majit_translate::insns::BC_ABSENT,
+            op_rvmprof_code: majit_translate::insns::BC_ABSENT,
             // blackhole.py `EMPTY_LIST_I = [] # shared`.
             descrs: EMPTY_DESCR_TABLE,
             dispatch_table: std::sync::Arc::new(Vec::new()),
@@ -2374,7 +2386,7 @@ impl BlackholeInterpBuilder {
     ) {
         let to_u8 = |opcode: i32| -> u8 {
             if opcode < 0 {
-                u8::MAX
+                majit_translate::insns::BC_ABSENT
             } else {
                 u8::try_from(opcode).expect("cached blackhole opcode does not fit in u8")
             }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5,6 +5,13 @@
 //! concrete values, following all code paths (not just the traced one).
 //!
 //! This is the RPython equivalent of `rpython/jit/metainterp/blackhole.py`.
+//!
+//! The `resume_in_blackhole` entry itself lives with its caller, as
+//! `pyre_jit::eval::resume_in_blackhole_from_exit_layout`: it needs the
+//! backend's exit layout plus the driver's `vinfo`/`vrefinfo`/`ginfo`, none
+//! of which this crate can name.  What this module owns is everything it
+//! calls into — `blackhole_from_resumedata`, `prepare_resume_from_failure`
+//! and `run_forever`.
 
 use crate::jitexc::JitException;
 use indexmap::IndexMap;
@@ -3264,51 +3271,6 @@ pub fn convert_and_run_from_pyjitpl(
     );
     majit_gc::shadow_stack::pop_resume_ref_roots_to(roots_depth);
     outcome
-}
-
-/// blackhole.py resume_in_blackhole
-///
-/// Resume execution in the blackhole interpreter after a compiled
-/// code guard failure. Builds a frame chain from resume data, extracts
-/// exception from deadframe, and runs the chain to completion.
-///
-/// `resolve_jitcode` is `metainterp_sd.jitcodes[jitcode_pos]` in RPython.
-pub fn resume_in_blackhole(
-    builder: &mut BlackholeInterpBuilder,
-    resolve_jitcode: &dyn Fn(i32, i32) -> Option<crate::resume::ResolvedJitCode>,
-    rd_numb: &[u8],
-    rd_consts: &[majit_ir::Const],
-    all_liveness: &[u8],
-    deadframe: &[i64],
-    deadframe_exc: i64,
-) -> JitException {
-    // blackhole.py:1786-1792
-    let null_alloc = crate::resume::NullAllocator;
-    let bh = crate::resume::blackhole_from_resumedata(
-        builder,
-        resolve_jitcode,
-        rd_numb,
-        rd_consts,
-        all_liveness,
-        deadframe,
-        None, // deadframe_types
-        None, // rd_virtuals
-        None, // rd_guard_pendingfields
-        None, // vrefinfo
-        None, // vinfo
-        None, // ginfo
-        None, // virtualizable_identity_override
-        None, // all_virtuals
-        &null_alloc,
-    );
-
-    let (bh, _virtualizable_ptr) = bh;
-
-    // blackhole.py:1794
-    let current_exc = BlackholeInterpreter::prepare_resume_from_failure(deadframe_exc);
-
-    // blackhole.py:1795
-    run_forever(builder, bh, current_exc)
 }
 
 #[cfg(test)]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7255,11 +7255,20 @@ fn portal_jd_for(bh: &BlackholeInterpreter) -> Option<usize> {
 
 /// The `jd.handle_jitexc_from_bh` of the driver [`portal_jd_for`] picked.
 fn portal_runner_for(bh: &BlackholeInterpreter) -> Option<PortalRunnerHook> {
-    let jd_index = portal_jd_for(bh)?;
-    *PORTAL_RUNNER_HOOKS
+    let hooks = PORTAL_RUNNER_HOOKS
         .read()
-        .expect("portal runner table poisoned")
-        .get(jd_index)?
+        .expect("portal runner table poisoned");
+    let own = portal_jd_for(bh).and_then(|jd_index| *hooks.get(jd_index)?);
+    // The search may find nothing, and then this must still hand back the
+    // runner it would have handed back before the search existed.  Upstream can
+    // assert instead (`blackhole.py:1704` "portal jitcode not found??") because
+    // every level it reaches came through `_run_forever`, so the frame that
+    // stopped the walk really is a portal frame.  pyre's production guard-failure
+    // loop in `call_jit.rs` does not go through `_run_forever`, so the chain can
+    // stop at a frame whose jitcode is not any driver's `mainjitcode`; returning
+    // `None` there does not report a missing driver, it silently withdraws the
+    // portal re-entry from a path that had it.
+    own.or_else(|| hooks.iter().find_map(|slot| *slot))
 }
 
 /// The `result_kind` `warmspot.py:984-996` tests each `DoneWithThisFrame*`

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -144,6 +144,9 @@ fn build_bh_jitdrivers_sd(
                 result_type,
                 portal_runner_ptr,
                 mainjitcode_calldescr,
+                // warmspot.py:921 `jd.mainjitcode`; `portal_runner_for` matches
+                // it against the raising portal frame's own jitcode.
+                mainjitcode: jd.mainjitcode.clone(),
             }
         })
         .collect()

--- a/majit/majit-metainterp/src/virt_array.rs
+++ b/majit/majit-metainterp/src/virt_array.rs
@@ -661,7 +661,7 @@ mod tests {
         );
         for (index, expected) in [10i64, 20, 30].into_iter().enumerate() {
             assert_eq!(
-                unsafe { crate::virtualizable::vable_read_array_item(vable, array, index) },
+                unsafe { crate::virtualizable::vable_read_array_item(vable, array, index as i64) },
                 expected
             );
         }

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -2983,18 +2983,33 @@ impl crate::resume::VirtualizableInfo for VirtualizableInfo {
         reader: &mut crate::resume::ResumeDataDirectReader,
     ) {
         let vable_ptr = virtualizable as *mut u8;
-        if vable_ptr.is_null() {
-            return;
-        }
         // virtualizable.py:131-133: ALL static fields.  Route through
         // `write_field` so the resume bits are specialized back to the field
         // type (`f64::from_bits` for `Float`); a raw `i64` write would store a
         // float's bit pattern as an integer and corrupt the field.
+        //
+        // The reader is a cursor over one shared stream, so the item COUNT this
+        // function consumes is what keeps every later section (vrefs, then the
+        // frames) aligned — and `get_total_size` right below already promises
+        // that count to `consume_vable_info`'s `== vable_size - 1` assert.  It
+        // counts `static_fields.len()` whether or not there is a virtualizable
+        // to read the array lengths off, so the static items must be consumed
+        // unconditionally too; skipping the loop on a null identity leaves them
+        // in the stream to be re-read as somebody else's values.  A null gets
+        // no write — upstream has no such case at all, `cast_gcref_to_vtype`
+        // hands `setattr` a null and it crashes — but the read still happens.
         for (field_index, field) in self.static_fields.iter().enumerate() {
             let value = reader.next_value_of_type(field.field_type);
-            unsafe {
-                self.write_field(vable_ptr, field_index, value);
+            if !vable_ptr.is_null() {
+                unsafe {
+                    self.write_field(vable_ptr, field_index, value);
+                }
             }
+        }
+        if vable_ptr.is_null() {
+            // Matches `get_total_size`, which adds no array length without a
+            // virtualizable to measure: there are no array items encoded.
+            return;
         }
         // virtualizable.py:134-137: array items
         for array in &self.array_fields {

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -519,8 +519,12 @@ impl VirtualizableInfo {
     /// virtualizable.py `finish()` registers the `clear_vable_ptr`
     /// function pointer and `clear_vable_descr` call descriptor.
     ///
-    /// `clear_fn` is an `extern "C" fn(*mut u8)` that clears the vable token,
-    /// forcing the virtualizable if necessary. Hosts must call this after
+    /// `clear_fn` clears the vable token, forcing the virtualizable if
+    /// necessary. Its ABI is the one `make_clear_vable_descr` declares —
+    /// `[Ref] -> Void`, taking the virtualizable as a single machine word —
+    /// spelled `extern "C" fn(i64)`, because that is what the compiled
+    /// `COND_CALL` `emit_force_virtualizable` builds passes and what
+    /// `bh_clear_vable_token` calls it as.  Hosts must call this after
     /// `build_virtualizable_info()` to enable `emit_force_virtualizable`.
     pub fn set_clear_vable(&mut self, clear_fn: *const (), clear_descr: DescrRef) {
         self.clear_vable_ptr = Some(clear_fn as usize);
@@ -3214,21 +3218,28 @@ pub(crate) unsafe fn vable_write_array_item_at(
 
 /// virtualizable.py clear_vable_token, blackhole context.
 ///
-/// Upstream `clear_vable_token` calls `force_now(virtualizable)` when the token
-/// is set, then asserts it cleared — `force_now` writes the live JIT-register
-/// copy of the virtualizable's fields back to the heap object. Here that step
-/// is intentionally omitted: it is a semantic no-op in the blackhole and pyre
-/// has no blackhole `force_now`. The Active token (a force_token = address of a
-/// live JIT frame) only exists while compiled JIT code holds the frame in
-/// registers; by the time the blackhole interprets a vable op, resume has
-/// already materialized every field into the heap object, so no register copy
-/// remains to force back. The token can only be TOKEN_NONE (nothing to do) or
-/// TOKEN_TRACING_RESCALL (a marker, no un-written-back state), so clearing it
-/// unconditionally reaches the same post-state as `force_now` + assert. (If a
-/// blackhole path were ever found to carry a live Active token, that would be a
-/// real bug needing a blackhole force_now — not the case under the current
-/// resume-materializes-then-interprets model, which all virtualizable JIT
-/// tests exercise without any force_now.)
+/// `virtualizable.py:218-222` is `if virtualizable.vable_token: force_now(...)`
+/// followed by `assert not virtualizable.vable_token`, and `force_now`
+/// (`:248-260`) splits on the token:
+///
+///   * `TOKEN_TRACING_RESCALL` — a marker naming no register copy, so clearing
+///     it is the whole of the force for that arm.
+///   * anything else non-zero — the address of a live JIT frame, handed to
+///     `ResumeGuardForcedDescr.force_now`, which writes the compiled
+///     activation's registers back into the frame.
+///
+/// This used to clear both arms alike, on the argument that an Active token
+/// cannot reach the blackhole because resume has already materialized every
+/// field. The sibling helper on the compiled side (`frame_layout.rs`
+/// `pyre_clear_vable_token`) carried the same argument, backed by a census —
+/// "recorded 183 times and invoked 0 times over 462 fixtures" — and that
+/// census has since stopped holding, so the arm is live there. An argument of
+/// that shape is not load-bearing enough to drop a register write-back on:
+/// when it fails the field reads stale and nothing reports it.
+///
+/// So the Active arm now goes through the host's force helper, which is the
+/// very function `emit_force_virtualizable` compiles a `COND_CALL` to
+/// (`trace_ctx.rs`), reached here by address instead of through compiled code.
 ///
 /// # Safety
 /// `obj_ptr` must point to a valid virtualizable object.
@@ -3242,9 +3253,34 @@ pub(crate) unsafe fn bh_clear_vable_token(vinfo: &VirtualizableInfo, obj_ptr: *m
     unsafe {
         let token_ptr = obj_ptr.add(vinfo.token_offset) as *mut usize;
         let token = *token_ptr;
-        if token != 0 {
-            *token_ptr = 0;
+        if token == 0 {
+            return;
         }
+        if token == token_tracing_rescall() as usize {
+            // virtualizable.py:250-255: the values are already correct during
+            // tracing; the marker only tells the tracer this one escaped.
+            *token_ptr = 0;
+            return;
+        }
+        let Some(clear_vable_ptr) = vinfo.clear_vable_ptr else {
+            // A machine that registered no force helper has no compiled
+            // activation to write back either: `emit_force_virtualizable`
+            // `expect`s this same field, so a trace that could have parked an
+            // Active token here could not have been built.  Clear it, matching
+            // the post-state `force_now` guarantees.
+            *token_ptr = 0;
+            return;
+        };
+        // `make_clear_vable_descr` declares `[Ref] -> Void` and
+        // `frame_layout.rs` registers a function taking that word as `i64`;
+        // spelling the pointee any other way mismatches the wasm32 signature
+        // and traps on call.
+        let force: unsafe extern "C" fn(i64) = std::mem::transmute(clear_vable_ptr);
+        force(obj_ptr as i64);
+        assert_eq!(
+            *token_ptr, 0,
+            "virtualizable.py:222 — force_now must leave TOKEN_NONE behind"
+        );
     }
 }
 

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -89,8 +89,14 @@ pub struct VableArrayInfo {
     /// (`unpack_arraydescr`).  This is the authoritative stride: 64-bit
     /// payloads (e.g. `i64` list-strategy backing arrays) carry an explicit
     /// 8-byte descriptor that `item_size_for_type` would under-size to a
-    /// machine word on 32-bit targets.
+    /// machine word on 32-bit targets.  It is also the authoritative LOAD
+    /// WIDTH: `bh_getarrayitem_gc_i` dispatches on `item_size` × sign
+    /// (`majit-backend` `model.rs`), so a narrower item must not be read as a
+    /// full word.
     pub item_size: usize,
+    /// `arraydescr.is_item_signed()` — the other half of that dispatch.
+    /// Meaningless for `Ref` and `Float` items, which have one representation.
+    pub item_signed: bool,
     /// Byte offset of the array pointer in the heap object.
     pub field_offset: usize,
     /// GC type id of the array object stored in a `DirectPointer` field.
@@ -621,11 +627,13 @@ impl VirtualizableInfo {
     ) {
         let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let item_signed = array_descr_item_signed(&array_descr);
         let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
             name,
             item_type,
             item_size,
+            item_signed,
             field_offset,
             array_type_id,
             storage: VableArrayStorage::DirectPointer,
@@ -657,11 +665,13 @@ impl VirtualizableInfo {
     ) {
         let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let item_signed = array_descr_item_signed(&array_descr);
         let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
             name,
             item_type,
             item_size,
+            item_signed,
             field_offset,
             array_type_id,
             storage: VableArrayStorage::EmbeddedArray { ptr_offset },
@@ -688,11 +698,13 @@ impl VirtualizableInfo {
     ) {
         let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
+        let item_signed = array_descr_item_signed(&array_descr);
         let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
             name,
             item_type,
             item_size,
+            item_signed,
             field_offset,
             array_type_id,
             storage: VableArrayStorage::RustVec {
@@ -1727,6 +1739,20 @@ fn array_descr_item_size(array_descr: &DescrRef, item_type: Type) -> usize {
     majit_ir::descr::unpack_arraydescr(array_descr)
         .map(|(_, item_size, _)| item_size)
         .unwrap_or_else(|| item_size_for_type(item_type))
+}
+
+/// `arraydescr.is_item_signed()`, the sign half of `bh_getarrayitem_gc_i`'s
+/// `(item_size, is_item_signed)` dispatch.
+///
+/// A field with no array descriptor falls back to signed: `item_size_for_type`
+/// gives such a field the machine word, and RPython's word-sized integer array
+/// is `Signed`.  The two answers only differ for a narrower item, which cannot
+/// arise without a descriptor to declare the narrower size.
+fn array_descr_item_signed(array_descr: &DescrRef) -> bool {
+    array_descr
+        .as_array_descr()
+        .map(|ad| ad.is_item_signed())
+        .unwrap_or(true)
 }
 
 pub fn item_size_for_type(ty: Type) -> usize {
@@ -3097,40 +3123,81 @@ pub(crate) unsafe fn bhimpl_arraybase_vable(
 pub(crate) unsafe fn vable_read_array_item(
     vable_ptr: *const u8,
     array: &VableArrayInfo,
-    index: usize,
+    index: i64,
 ) -> i64 {
     unsafe {
         // Stride from the field's array descriptor: a pointer array is
         // `size_of::<usize>()` (4 bytes on wasm32) while an `i64` payload
         // array is a fixed 8, regardless of word width.
         let item_size = array.item_size;
+        // `bhimpl_getarrayitem_vable_*` (`blackhole.py:1374-1387`) takes the
+        // index with argcode `i` and hands it to `bh_getarrayitem_gc_*`
+        // SIGNED.  The operand is an interpreter register, so a stale or
+        // clobbered one arrives here as any `i64`; casting it to `usize` turns
+        // a negative one into a huge offset and `data_ptr.add` then names an
+        // address gigabytes away, which reads as a value of `item_type` — for
+        // a `Ref` array, a pointer the caller dereferences.  Refuse it where
+        // it can still be attributed to this array.
+        assert!(
+            index >= 0,
+            "vable_read_array_item: negative index {index} into virtualizable \
+             array {:?} (item_type {:?})",
+            array.name,
+            array.item_type,
+        );
+        let index = index as usize;
         let data_ptr = bhimpl_arraybase_vable(vable_ptr, array);
-        if data_ptr.is_null() {
-            0
-        } else {
-            // An index past the end reads whatever follows the payload and
-            // hands it back as a value of `item_type` — for a `Ref` array that
-            // is a pointer the caller will dereference, so the fault lands in
-            // whatever consumes the result rather than here.  The operand is
-            // an interpreter register, so a stale or clobbered one is a defect
-            // in the producer; report it against this array instead of letting
-            // the poison value travel.
-            if crate::jit_strict_mode() {
-                let len = bhimpl_arraylen_vable(vable_ptr, array);
-                assert!(
-                    index < len,
-                    "vable_read_array_item: index {index} is past the end of \
-                     virtualizable array {:?} (len {len}, item_type {:?})",
-                    array.name,
-                    array.item_type,
-                );
-            }
-            let src = data_ptr.add(index * item_size);
-            if array.item_type == Type::Ref {
-                *(src as *const usize) as i64
-            } else {
-                std::ptr::read(src as *const i64)
-            }
+        // Upstream reaches the items through `bh_getfield_gc_r` and then
+        // `bh_getarrayitem_gc_*`, and a null array field faults in the second.
+        // Answering `0` instead hands a `Ref` read a null the caller
+        // dereferences somewhere else, and an `Int` read a plausible zero that
+        // never surfaces at all.
+        assert!(
+            !data_ptr.is_null(),
+            "vable_read_array_item: virtualizable array {:?} is null \
+             (item_type {:?}, index {index})",
+            array.name,
+            array.item_type,
+        );
+        // An index past the end reads whatever follows the payload and hands
+        // it back as a value of `item_type`, so the fault lands in whatever
+        // consumes the result rather than here.
+        if crate::jit_strict_mode() {
+            let len = bhimpl_arraylen_vable(vable_ptr, array);
+            assert!(
+                index < len,
+                "vable_read_array_item: index {index} is past the end of \
+                 virtualizable array {:?} (len {len}, item_type {:?})",
+                array.name,
+                array.item_type,
+            );
+        }
+        let src = data_ptr.add(index * item_size);
+        match array.item_type {
+            // `llmodel.py read_ref_at_mem` — one machine word.
+            Type::Ref => *(src as *const usize) as i64,
+            // `llmodel.py read_float_at_mem` — the f64 bit pattern, which the
+            // caller re-reads as one.
+            Type::Float => std::ptr::read(src as *const i64),
+            // `bh_getarrayitem_gc_i` dispatches on `(item_size,
+            // is_item_signed)` (`majit-backend` `model.rs`); reading a
+            // narrower item as a full word takes the bytes that follow it.
+            Type::Int | Type::Void => match (item_size, array.item_signed) {
+                (8, true) => *(src as *const i64),
+                (8, false) => *(src as *const u64) as i64,
+                (4, true) => *(src as *const i32) as i64,
+                (4, false) => *(src as *const u32) as i64,
+                (2, true) => *(src as *const i16) as i64,
+                (2, false) => *(src as *const u16) as i64,
+                (1, true) => *(src as *const i8) as i64,
+                (1, false) => *(src as *const u8) as i64,
+                // `llmodel.py:478 else: raise NotImplementedError`.
+                _ => panic!(
+                    "vable_read_array_item: virtualizable array {:?} has no \
+                     integer load for item_size {item_size} (signed {})",
+                    array.name, array.item_signed,
+                ),
+            },
         }
     }
 }
@@ -3164,12 +3231,46 @@ pub(crate) unsafe fn vable_array_write_base(
 pub(crate) unsafe fn vable_write_array_item(
     vable_ptr: *mut u8,
     array: &VableArrayInfo,
-    index: usize,
+    index: i64,
     value: i64,
 ) {
     unsafe {
+        // `bhimpl_setarrayitem_vable_*` (`blackhole.py:1390-1403`) takes the
+        // index with argcode `i` and hands it to `bh_setarrayitem_gc_*`
+        // SIGNED, exactly as the read path does.  Casting a clobbered
+        // register to `usize` turns a negative index into a huge offset and
+        // the store then lands gigabytes past the array.
+        assert!(
+            index >= 0,
+            "vable_write_array_item: negative index {index} into virtualizable \
+             array {:?} (item_type {:?})",
+            array.name,
+            array.item_type,
+        );
         let (data_ptr, owner_ptr) = vable_array_write_base(vable_ptr, array);
-        vable_write_array_item_at(vable_ptr, array, data_ptr, owner_ptr, index, value);
+        // Upstream reaches the items through `bh_getfield_gc_r` and then
+        // `bh_setarrayitem_gc_*`, and a null array field faults in the second.
+        // Dropping the store instead leaves the item holding whatever it held
+        // before, and the mismatch surfaces at some later read with nothing
+        // naming this array.
+        assert!(
+            !data_ptr.is_null(),
+            "vable_write_array_item: virtualizable array {:?} is null \
+             (item_type {:?}, index {index})",
+            array.name,
+            array.item_type,
+        );
+        if crate::jit_strict_mode() {
+            let len = bhimpl_arraylen_vable(vable_ptr as *const u8, array);
+            assert!(
+                (index as usize) < len,
+                "vable_write_array_item: index {index} is past the end of \
+                 virtualizable array {:?} (len {len}, item_type {:?})",
+                array.name,
+                array.item_type,
+            );
+        }
+        vable_write_array_item_at(vable_ptr, array, data_ptr, owner_ptr, index as usize, value);
     }
 }
 
@@ -3209,8 +3310,26 @@ pub(crate) unsafe fn vable_write_array_item_at(
                         majit_gc::gc_write_barrier(majit_ir::GcRef(vable_ptr as usize));
                     }
                 }
-            } else {
+            } else if array.item_type == Type::Float {
+                // `llmodel.py write_float_at_mem` — the f64 bit pattern, which
+                // the caller handed over as one.
                 std::ptr::write(dest as *mut i64, value);
+            } else {
+                // `bh_setarrayitem_gc_i` stores at the descriptor's width
+                // (`majit-backend` `model.rs`); a fixed 8-byte store into a
+                // narrower item overwrites the items that follow it.
+                match item_size {
+                    8 => std::ptr::write(dest as *mut i64, value),
+                    4 => std::ptr::write(dest as *mut i32, value as i32),
+                    2 => std::ptr::write(dest as *mut i16, value as i16),
+                    1 => std::ptr::write(dest as *mut i8, value as i8),
+                    // `llmodel.py:478 else: raise NotImplementedError`.
+                    _ => panic!(
+                        "vable_write_array_item: virtualizable array {:?} has \
+                         no integer store for item_size {item_size}",
+                        array.name,
+                    ),
+                }
             }
         }
     }

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -84,6 +84,20 @@ pub const BC_RECURSIVE_CALL_REF: u8 = 224;
 pub const BC_RECURSIVE_CALL_FLOAT: u8 = 225;
 pub const BC_RECURSIVE_CALL_VOID: u8 = 226;
 
+/// "This cached control opcode is absent" sentinel for the
+/// `blackhole.py:72-74` fields (`op_live`, `op_catch_exception`,
+/// `op_rvmprof_code`).
+///
+/// Upstream spells the fallback `insns.get('live/', -1)` and then tests
+/// `opcode == self.op_live` against `ord(code[position])`.  `-1` lies
+/// outside that `0..=255` range, so an absent entry can never match a real
+/// instruction.  A `u8` has no value outside the range, so the same
+/// guarantee is bought by reserving the byte instead: no opname may be
+/// assigned `BC_ABSENT`, and [`is_reserved_opcode_byte`] keeps both dynamic
+/// allocators (`Assembler::next_dynamic_opnum` here and pyre's runtime
+/// `record_insn_key`) off it.
+pub const BC_ABSENT: u8 = u8::MAX;
+
 pub const BC_LOOP_HEADER: u8 = 12;
 pub const BC_ABORT: u8 = 13;
 pub const BC_ABORT_PERMANENT: u8 = 14;
@@ -690,6 +704,9 @@ pub fn is_reserved_opcode_byte(byte: u8) -> bool {
         for (_, value) in extension_insns() {
             reserved[value as usize] = true;
         }
+        // Keep the absent-control-opcode sentinel out of every allocator's
+        // pool so `opcode == op_live` cannot match a real instruction.
+        reserved[BC_ABSENT as usize] = true;
         reserved
     });
     reserved[byte as usize]
@@ -1402,5 +1419,29 @@ mod recursive_call_byte_tests {
                 "recursive_call byte {b} collides with an already-registered insn"
             );
         }
+    }
+
+    /// `blackhole.py:72-74` reads the cached control opcodes as
+    /// `insns.get(key, -1)` and compares them against `ord(code[position])`,
+    /// so an absent key can never match a real instruction.  `BC_ABSENT`
+    /// carries that guarantee into `u8` by staying out of every allocator's
+    /// pool; if some opname ever claimed it, `handle_exception_in_frame`
+    /// would read that instruction as `live/` or `catch_exception/L`.
+    #[test]
+    fn absent_control_opcode_sentinel_is_never_a_real_instruction() {
+        assert!(
+            is_reserved_opcode_byte(BC_ABSENT),
+            "BC_ABSENT must be reserved so no dynamic allocator hands it out"
+        );
+
+        let registered: Vec<u8> = wellknown_bh_insns()
+            .values()
+            .chain(extension_insns().values())
+            .copied()
+            .collect();
+        assert!(
+            !registered.contains(&BC_ABSENT),
+            "BC_ABSENT must not name an instruction"
+        );
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -703,6 +703,16 @@ static INSNS_BYTE_TO_OPNAME: LazyLock<HashMap<u8, String>> = LazyLock::new(|| {
     map
 });
 
+/// What a runtime-allocated opcode byte decodes to, if anything.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RuntimeInsn {
+    /// Every publication of this byte named the same key.
+    Unique(&'static str),
+    /// Two `Assembler`s numbered the same byte differently, so the byte alone
+    /// does not identify an instruction — see [`RUNTIME_INSNS_BYTE_TO_OPNAME`].
+    Ambiguous,
+}
+
 /// Opcode bytes the runtime assembler allocated after `INSNS_BYTE_TO_OPNAME`
 /// was fixed.
 ///
@@ -717,51 +727,63 @@ static INSNS_BYTE_TO_OPNAME: LazyLock<HashMap<u8, String>> = LazyLock::new(|| {
 /// callers read as "assume the worst" (`replay_unscannable`, every frame slot
 /// written).
 ///
+/// **The numbering is per-`Assembler`, not global.** `record_insn_key` picks
+/// the lowest unreserved byte this assembler has not used, so first-appearance
+/// order decides, and two assemblers that met different shapes first disagree.
+/// `codewriter.py:21-23` keeps ONE `Assembler` for the session and pyre's
+/// `CodeWriter` mirrors that with a single `RefCell<Assembler>`, so the
+/// production numbering is in fact global — but this table cannot assume it.
+/// A byte published under two keys becomes [`RuntimeInsn::Ambiguous`] and the
+/// decoder goes back to reporting it as undecodable, which is what it did for
+/// every runtime byte before this table existed.  Guessing one of the two would
+/// hand a caller the wrong instruction, which "assume the worst" never does.
+///
 /// Keys are leaked so the decoder can keep handing out `&'static str` exactly
 /// as it does for the build-time table.  The set is small and bounded by the
 /// unreserved opcode bytes.
-static RUNTIME_INSNS_BYTE_TO_OPNAME: LazyLock<std::sync::RwLock<HashMap<u8, &'static str>>> =
+static RUNTIME_INSNS_BYTE_TO_OPNAME: LazyLock<std::sync::RwLock<HashMap<u8, RuntimeInsn>>> =
     LazyLock::new(|| std::sync::RwLock::new(HashMap::new()));
 
 /// Publish one runtime-allocated `(opname/argcodes, byte)` pair to the decoder.
 ///
-/// Idempotent, and asserts the mapping stays one-to-one for a byte the
-/// build-time table does not already own.
+/// Idempotent.  A byte that ends up naming two different keys — including one
+/// the build-time table already owns — is recorded as ambiguous instead.
 pub fn publish_runtime_insn(key: &str, byte: u8) {
-    if INSNS_BYTE_TO_OPNAME.contains_key(&byte) {
-        debug_assert_eq!(
-            INSNS_BYTE_TO_OPNAME.get(&byte).map(String::as_str),
-            Some(key),
-            "publish_runtime_insn: byte {byte} is already the build-time table's"
-        );
+    let build_time = INSNS_BYTE_TO_OPNAME.get(&byte).map(String::as_str);
+    if build_time == Some(key) {
+        // Already resolvable, and to this very key.
         return;
     }
     let mut table = RUNTIME_INSNS_BYTE_TO_OPNAME
         .write()
         .expect("runtime insn table poisoned");
-    match table.get(&byte) {
-        Some(existing) => assert_eq!(
-            *existing, key,
-            "publish_runtime_insn: byte {byte} maps to both {existing:?} and {key:?} \
-             (assembler.py:220 keeps Assembler.insns 1:1)"
-        ),
-        None => {
-            table.insert(byte, Box::leak(key.to_string().into_boxed_str()));
-        }
+    let entry = table.entry(byte).or_insert_with(|| match build_time {
+        // The build-time table claims this byte for something else, so no
+        // single key can answer for it.
+        Some(_) => RuntimeInsn::Ambiguous,
+        None => RuntimeInsn::Unique(Box::leak(key.to_string().into_boxed_str())),
+    });
+    if !matches!(entry, RuntimeInsn::Unique(recorded) if *recorded == key) {
+        *entry = RuntimeInsn::Ambiguous;
     }
 }
 
-/// Resolve an opcode byte to its `opname/argcodes` key, consulting the
-/// build-time table first and then whatever the runtime assembler published.
+/// Resolve an opcode byte to its `opname/argcodes` key.
+///
+/// The runtime table is consulted first because it is the one that knows a byte
+/// is ambiguous; only a byte it has never seen falls through to the build-time
+/// table.
 fn key_for_opcode_byte(byte: u8) -> Option<&'static str> {
-    if let Some(key) = INSNS_BYTE_TO_OPNAME.get(&byte) {
-        return Some(key.as_str());
-    }
-    RUNTIME_INSNS_BYTE_TO_OPNAME
+    let runtime = RUNTIME_INSNS_BYTE_TO_OPNAME
         .read()
         .expect("runtime insn table poisoned")
         .get(&byte)
-        .copied()
+        .copied();
+    match runtime {
+        Some(RuntimeInsn::Unique(key)) => Some(key),
+        Some(RuntimeInsn::Ambiguous) => None,
+        None => INSNS_BYTE_TO_OPNAME.get(&byte).map(String::as_str),
+    }
 }
 
 /// RPython `setup_insns(insns)` — full opname → opcode-byte table.

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -703,6 +703,67 @@ static INSNS_BYTE_TO_OPNAME: LazyLock<HashMap<u8, String>> = LazyLock::new(|| {
     map
 });
 
+/// Opcode bytes the runtime assembler allocated after `INSNS_BYTE_TO_OPNAME`
+/// was fixed.
+///
+/// `assembler.py:220` grows `Assembler.insns` with `setdefault(key,
+/// len(self.insns))`, so upstream's table is whatever the run has emitted so
+/// far.  Pyre freezes the build-time half into `insns.bin` and lets
+/// `record_insn_key` allocate the rest on demand — the `USE_C_FORM` shapes
+/// (`int_sub/ci>i`, `goto_if_not_int_gt/icL`, ...) have no fixed `BC_*` byte
+/// and only appear once a graph uses them.  Those bytes must reach
+/// [`decode_op_at`] too: it resolves every opcode through the byte -> opname
+/// map, and an unknown byte makes the whole body undecodable, which the
+/// callers read as "assume the worst" (`replay_unscannable`, every frame slot
+/// written).
+///
+/// Keys are leaked so the decoder can keep handing out `&'static str` exactly
+/// as it does for the build-time table.  The set is small and bounded by the
+/// unreserved opcode bytes.
+static RUNTIME_INSNS_BYTE_TO_OPNAME: LazyLock<std::sync::RwLock<HashMap<u8, &'static str>>> =
+    LazyLock::new(|| std::sync::RwLock::new(HashMap::new()));
+
+/// Publish one runtime-allocated `(opname/argcodes, byte)` pair to the decoder.
+///
+/// Idempotent, and asserts the mapping stays one-to-one for a byte the
+/// build-time table does not already own.
+pub fn publish_runtime_insn(key: &str, byte: u8) {
+    if INSNS_BYTE_TO_OPNAME.contains_key(&byte) {
+        debug_assert_eq!(
+            INSNS_BYTE_TO_OPNAME.get(&byte).map(String::as_str),
+            Some(key),
+            "publish_runtime_insn: byte {byte} is already the build-time table's"
+        );
+        return;
+    }
+    let mut table = RUNTIME_INSNS_BYTE_TO_OPNAME
+        .write()
+        .expect("runtime insn table poisoned");
+    match table.get(&byte) {
+        Some(existing) => assert_eq!(
+            *existing, key,
+            "publish_runtime_insn: byte {byte} maps to both {existing:?} and {key:?} \
+             (assembler.py:220 keeps Assembler.insns 1:1)"
+        ),
+        None => {
+            table.insert(byte, Box::leak(key.to_string().into_boxed_str()));
+        }
+    }
+}
+
+/// Resolve an opcode byte to its `opname/argcodes` key, consulting the
+/// build-time table first and then whatever the runtime assembler published.
+fn key_for_opcode_byte(byte: u8) -> Option<&'static str> {
+    if let Some(key) = INSNS_BYTE_TO_OPNAME.get(&byte) {
+        return Some(key.as_str());
+    }
+    RUNTIME_INSNS_BYTE_TO_OPNAME
+        .read()
+        .expect("runtime insn table poisoned")
+        .get(&byte)
+        .copied()
+}
+
 /// RPython `setup_insns(insns)` — full opname → opcode-byte table.
 pub fn insns_opname_to_byte() -> &'static indexmap::IndexMap<String, u8> {
     &INSNS_OPNAME_TO_BYTE
@@ -2091,7 +2152,7 @@ fn pyre_p_payload_len(opname: &str, code: &[u8], cursor: usize) -> Option<usize>
 /// `blackhole.py` (`bhimpl_live(pc): return pc + OFFSET_SIZE`).
 pub fn decode_op_at(code: &[u8], pc: usize) -> Option<DecodedOp> {
     let opcode_byte = *code.get(pc)?;
-    let key: &'static str = INSNS_BYTE_TO_OPNAME.get(&opcode_byte)?.as_str();
+    let key: &'static str = key_for_opcode_byte(opcode_byte)?;
     let (opname, argcodes) = split_key(key);
 
     let mut cursor = pc + 1;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2833,6 +2833,13 @@ pub fn blackhole_resume_via_rd_numb(
                 d.result_type = 'r';
                 d
             },
+            // `get_portal_runner` reaches this table by INDEX
+            // (`jitdrivers_sd[jdindex]`), so the driver never has to be found
+            // by its portal jitcode here.  Leaving it unset keeps
+            // `portal_jd_for` from claiming a frame for a synthetic driver
+            // assembled around whichever jitcode happened to be innermost when
+            // the chain was built.
+            mainjitcode: None,
         }]);
     {
         let vinfo = bh.virtualizable_info;
@@ -3060,8 +3067,27 @@ pub fn blackhole_resume_via_rd_numb(
         // continuation and the call result is deliberately garbage on raise.
         // Running even one opcode first consumes that garbage as a successful
         // return and replaces the real exception with a secondary TypeError.
-        if !bh.got_exception
-            && let Some(args) = bh.run()
+        let run_outcome = (!bh.got_exception).then(|| bh.run());
+        // A frame that ran out of bytecode never reached a `*_return` handler,
+        // so `return_type` and `tmpreg_*` still hold whatever the previous
+        // occupant of this pooled interpreter left there — and the tail of this
+        // loop publishes exactly those two to the caller.  `blackhole.py`'s
+        // `dispatch_loop` cannot reach that state at all: it is `while True:`
+        // over `ord(code[position])`, so reading past the end raises.
+        if matches!(
+            run_outcome,
+            Some(majit_metainterp::blackhole::BhRunOutcome::EndOfCode)
+        ) {
+            let name = bh.jitcode.name().to_string();
+            let index = bh.jitcode.try_index();
+            release_bh_rd(bh);
+            panic!(
+                "blackhole_resume_via_rd_numb: jitcode {name:?} index {index:?} ended \
+                 without a return opcode, so there is no result to pass to the caller"
+            );
+        }
+        if let Some(majit_metainterp::blackhole::BhRunOutcome::ContinueRunningNormally(args)) =
+            run_outcome
         {
             // blackhole.py:1068: raise ContinueRunningNormally(*args)
             //

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5516,7 +5516,10 @@ fn build_jit_driver_pair() -> JitDriverPair {
     // warmspot.py handle_jitexception_from_blackhole parity:
     // portal_runner is called when ContinueRunningNormally is raised
     // at a recursive portal level during blackhole execution.
-    majit_metainterp::blackhole::register_portal_runner_hook(pyre_portal_runner);
+    // Index 0 is pyre's own `PyPyJitDriver` portal (`interp_jit.py`), the only
+    // driver this process installs a Rust-side runner for; a second driver
+    // registers its own under its own index.
+    majit_metainterp::blackhole::register_portal_runner_hook(0, pyre_portal_runner);
     // pypy/module/pypyjit/interp_jit.py PyPyJitDriver(..., is_recursive=True).
     // Drives MetaInterp.is_main_jitcode() / is_portal_jitcode dispatch
     // — without this flag the recursive-portal bookkeeping stays
@@ -9616,11 +9619,19 @@ pub(crate) fn pyre_portal_runner(
     let pycode = all_r.first().copied().unwrap_or(0) as pyre_object::PyObjectRef;
     let frame_ptr = all_r.get(1).copied().unwrap_or(0) as *mut PyFrame;
     let ec = all_r.get(2).copied().unwrap_or(0) as *const pyre_interpreter::PyExecutionContext;
-    if frame_ptr.is_null() {
-        return Err(PortalRunnerFailure::jit(
-            JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(0)),
-        ));
-    }
+    // `warmspot.py:976` calls `portal_ptr(*args)` unconditionally: the reds a
+    // `ContinueRunningNormally` carries are the portal's own arguments, so the
+    // frame red is always present.  A null one means the CRN was built with the
+    // wrong red layout, and there is no exception to report — an
+    // `ExitFrameWithExceptionRef(GcRef(0))` would reach `resume_mainloop` as
+    // "no exception pending" and let the failure pass silently.
+    assert!(
+        !frame_ptr.is_null(),
+        "portal runner: ContinueRunningNormally carried no frame red \
+         (red_ref[1]); greens={} reds={}",
+        green_ref.len(),
+        red_ref.len(),
+    );
     let frame = unsafe { &mut *frame_ptr };
     // warmspot.py:976 forwards the CRN values to `portal_ptr`; it does not
     // rewrite the red frame's identity. Retain the activation's own pycode

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -531,6 +531,11 @@ impl Assembler {
                     })
                     .unwrap_or_else(|| panic!("runtime assembler opcode space exhausted for {key}"))
             });
+        // The byte has to reach the trace decoder as well: `decode_op_at`
+        // resolves every opcode through the byte -> opname map, and a byte only
+        // this table knows makes the body undecodable, which its callers read
+        // as "assume the worst".
+        pyre_jit_trace::jitcode_runtime::publish_runtime_insn(&key, opcode);
         self.insns.insert(key, opcode);
         Some(opcode)
     }
@@ -763,7 +768,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_eq(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -780,7 +787,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_ne(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -797,7 +806,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_lt(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -814,7 +825,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_le(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -831,7 +844,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_gt(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -848,7 +863,9 @@ fn dispatch_op(
             let label = expect_tlabel(&args[2]);
             let label_id = builder_label(state, &label.name);
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.goto_if_not_int_ge(lhs, rhs, label_id)
                 }
                 _ => state.builder.goto_if_not_int_operands(
@@ -1524,7 +1541,9 @@ fn dispatch_op(
             let lhs = expect_jitcode_int_operand(state, &args[0], use_c_form(opname));
             let rhs = expect_jitcode_int_operand(state, &args[1], use_c_form(opname));
             match (lhs, rhs) {
-                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs)) => {
+                (JitCodeIntOperand::Register(lhs), JitCodeIntOperand::Register(rhs))
+                    if both_int_operands_are_registers(&args[0], &args[1]) =>
+                {
                     state.builder.record_binop_i(dst, opcode, lhs, rhs)
                 }
                 _ => state.builder.record_binop_i_operands(
@@ -2153,6 +2172,22 @@ fn expect_int_reg_or_pool(state: &mut AssemblyState, op: &Operand) -> u16 {
             other
         ),
     }
+}
+
+/// True when both integer positions are real registers, so the fixed
+/// `ii>i`/`iiL` emitters' `touch_reg` bound (`reg < num_regs_i`) holds.
+///
+/// A `ConstInt` becomes either a `ShortConst` or — when it does not fit the
+/// signed byte — a constants-pool slot, which
+/// [`expect_int_reg_or_pool`] numbers `num_regs_i + idx`.  `JitCodeIntOperand`
+/// spells that slot `Register` because `assembler.py` gives it the same `i`
+/// argcode (`blackhole.py` `registers_i` spans registers then constants), but
+/// only the `*_operands` emitters account for the wider namespace with
+/// `touch_int_reg_or_pool_slot`.  Routing a pool slot to the fixed emitter
+/// trips that assert once register counts are frozen, and silently inflates
+/// `num_regs_i` — shifting every later pool slot — before they are.
+fn both_int_operands_are_registers(lhs: &Operand, rhs: &Operand) -> bool {
+    matches!(lhs, Operand::Register(_)) && matches!(rhs, Operand::Register(_))
 }
 
 fn expect_jitcode_int_operand(


### PR DESCRIPTION
Fourteen fixes across the blackhole interpreter, the runtime jitcode decoder,
and the fixed-register jitcode emitters.  The last five come from an advisors'
`blackhole.rs` ↔ `blackhole.py` parity audit; the earlier nine were found by
running the branch.

## Portal re-entry and the two blackhole states with no result

`warmspot.py:955-1007 handle_jitexception` closes over the jitdriver's
`result_kind` and gates each `DoneWithThisFrame*` arm on it, and
`blackhole.py:1700-1706 _handle_jitexception_in_portal` finds that driver by
`jd.mainjitcode is self.jitcode`.  pyre had neither: `BhJitDriverSd` carried no
`mainjitcode` and the portal runner was one process-wide hook.  Both are wired
per jitdriver now.

The search can miss, because pyre's `call_jit.rs` guard-failure loop does not
go through `_run_forever`, so the chain can stop at a frame no driver's
`mainjitcode` matches.  Upstream can assert there; here that would withdraw
portal re-entry from `convert_and_run_from_pyjitpl`, which previously read an
always-present global.  A miss therefore falls back to a registered runner.
This was found the hard way — a 2-in-15 SIGBUS in
`ResumeDeadframeRoots::register`, bisected by restoring commit groups on top of
a reverted tree, with main at 30/30 clean and the branch at 2/15.

`run()` gained `BhRunOutcome`.  `blackhole.py`'s `dispatch_loop` is
`while True:` over `ord(code[position])`, so it cannot reach "ran out of
bytecode"; pyre could, and the caller then published the pooled interpreter's
previous occupant's `return_type` and `tmpreg_*` as this call's result.  The
three sites that publish a result now panic on it.  `release_interp` also
resets `called_residual` and `record_caught_exception`.

## Runtime opcode numbering

`Assembler::record_insn_key` allocates the lowest unreserved byte **per
`Assembler`**, and `#[cfg(test)] assemble()` builds a throwaway one per call, so
two assemblers can number the same byte differently.  `decode_op_at` now
resolves a runtime-allocated byte, and reports a byte two assemblers disagree
on as undecodable rather than guessing.

## The parity audit

**Item 2 — `clear_vable_token` skipped `force_now`.**  `virtualizable.py:218-222`
calls `force_now` then asserts the token cleared; `force_now` (`:248-260`) treats
a token other than `TOKEN_TRACING_RESCALL` as the address of a live JIT frame and
writes that activation's registers back into the heap object.  pyre wrote
`TOKEN_NONE` over every non-zero token.  The Active arm now calls
`VirtualizableInfo::clear_vable_ptr` — the same function `emit_force_virtualizable`
compiles a `COND_CALL` to — and asserts afterwards.  The old comment argued an
Active token cannot reach the blackhole; the sibling helper `frame_layout.rs
pyre_clear_vable_token` carried that same argument backed by a census that has
since stopped holding.

**Item 3 — vable array index and item width.**  `bhimpl_{get,set}arrayitem_vable_*`
(`blackhole.py:1374-1403`) take the index with argcode `i` and hand it to
`bh_{get,set}arrayitem_gc_*` signed.  Three defects, all confirmed against the
sources:

| | before | now |
|---|---|---|
| negative index | `as usize` → offset gigabytes past the array | assert |
| null array | read answered `0`, write silently dropped | assert (upstream faults) |
| non-`Ref` item | always 8 bytes; `item_size` was the stride only | dispatch on `(item_size, is_item_signed)` |

`VableArrayInfo` gains `item_signed` from `arraydescr.is_item_signed()`, and both
helpers panic on a width with no load or store the way `llmodel.py:478` raises
`NotImplementedError`.  The write path also gains the read path's
`jit_strict_mode` bounds assert.

**Item 4 — the interpreted inline arm.**  `handler_inline_call_nested_ext` has a
native arm that goes through `bhimpl_residual_call_*` on the caller, and an
interpreted arm that runs the callee's opcodes on a nested interpreter.  Only the
first set the caller's `called_residual`, which `jitdriver.rs:6761` reads to decide
whether a guard may spawn a bridge — so the same call was judged escaping or not
depending on which arm ran it.  The callee's flag now folds into the caller's.
The result copy also ran only when `trailing_return_info()` was `Some`; a callee
ending without a typed return opcode left the caller's destination register holding
the previous occupant's value, so that case is now asserted against the caller's
declared slots.

### Audited and deliberately not changed

* **Item 1** (production bypasses `_run_forever`) is confirmed and is the root
  cause of the SIGBUS above, but merging `call_jit.rs`'s ~500-line loop into
  `run_forever` would move `PyFrame` traceback recording, GC rooting and backend
  exception draining into `majit-metainterp`, which cannot depend on
  `pyre-interpreter`.  The portal-runner fallback closes the observed failure.
* **Item 5/6** (`call_result_reg` ≠ `code[position-1]`) is a real deviation, but
  it compensates for pyre's own codegen: the portal codewriter emits a 5-byte
  valuestackdepth sync after a call result push, and `BC_INLINE_CALL` closes with
  three return slots.  The step-back is guarded on the opcode byte *and* the
  descriptor's field index.  Restoring `position-1` blindly would break both shapes;
  the upstream-faithful fix is in the codewriter.
* **Item 9** (`do_force_quasi_immutable` no-ops without a hook) cannot arise in a
  shipped binary — `eval.rs:5445` installs the hook unconditionally.
* **Item 10** (`live/` clears registers) is load-bearing: pyre's codewriter cannot
  carry a per-instruction `last_instr` store, and its register colours are not
  reused as densely as `rpython/tool/algo/regalloc.py`, so the marker is where
  dead refs are dropped.
* The audit's `getfield_vable_*` size/sign sub-claim is inert on both supported
  targets: `bh_getfield_gc_f`/`bh_setfield_gc_f` read and write 8 bytes without
  consulting size, and on 64-bit the synthesized machine word is 8.

## Verification

* `cargo test --all --no-fail-fast --no-default-features --features dynasm,cpyext` — 209/209 binaries green.
* `pyre/check.py` — dynasm 537/537, cranelift 537/537, wasm 530/530, all passed.

One caveat on the first run of the suite: `majit-translate`'s new
`test_residual_dunder_arg_slots` failed against a stale `pyre-interpreter.ullbc`
left by another session (it reported the pre-#1644 signature of
`needs_numeric_binop_dispatch`).  Re-extracting the artefacts turned it green; it
is not related to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of virtualizable arrays, including signed element types, variable-width elements, and negative-index validation.
  * Fixed runtime opcode decoding when dynamically generated instructions use previously unknown or conflicting byte values.
  * Corrected integer operation handling when operands come from constant pools.
  * Invalid resume-data constant references now fail explicitly instead of silently using zero.
  * Improved detection and reporting of interpreter frames that end without a return instruction.
* **Reliability**
  * Improved JIT portal and exception routing across multiple drivers.
  * Prevented stale interpreter state from being reused between executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->