### PR TITLE
codewriter, majit-macros: the jitcode lowering rewrites, and the goto_if_not fusion that fused nothing

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -3203,32 +3203,10 @@ pub(super) fn emit_promote_greens(lowerer: &mut Lowerer, config: &LowererConfig)
         });
         let reg = binding.reg;
         let kind = binding.kind;
-        // jtransform.py:1707: emit `-live-` before each guard_value so the
-        // codewriter's per-marker liveness analysis records the alive set here.
-        lowerer.emit_op(
-            OpMeta::live_marker(),
-            quote::quote! { __builder.live_placeholder(); },
-        );
-        match kind {
-            BindingKind::Int => {
-                lowerer.emit_op(
-                    OpMeta::linear(OpKind::GuardValue, vec![Register::int(reg)], vec![]),
-                    quote::quote! { __builder.int_guard_value(#reg); },
-                );
-            }
-            BindingKind::Ref => {
-                lowerer.emit_op(
-                    OpMeta::linear(OpKind::GuardValue, vec![Register::ref_(reg)], vec![]),
-                    quote::quote! { __builder.ref_guard_value(#reg); },
-                );
-            }
-            BindingKind::Float => {
-                lowerer.emit_op(
-                    OpMeta::linear(OpKind::GuardValue, vec![Register::float(reg)], vec![]),
-                    quote::quote! { __builder.float_guard_value(#reg); },
-                );
-            }
-        }
+        // The `-live-` before each guard_value is what lets the codewriter's
+        // per-marker liveness analysis record the alive set at the guard; the
+        // pair is shared with `handle_recursive_call`'s promote_greens.
+        lowerer.emit_live_and_guard_value(kind, reg);
     }
 }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -578,6 +578,66 @@ pub(super) fn binop_f_emit_tokens(
     quote! { __builder.record_binop_f(#dst, majit_ir::OpCode::#opcode, #lhs, #rhs); }
 }
 
+/// jtransform.py `_rewrite_symmetric`'s binding list, in this layer's operator
+/// domain: the symmetric arithmetic and bitwise operators plus every
+/// comparison (upstream binds `int_lt` .. `uint_ge` and `float_lt` ..
+/// `float_ge`, and reaches the same function again as `_rewrite_equality`'s
+/// fallthrough for `int_eq` / `int_ne` / `ptr_eq` / `ptr_ne`).  `-`, the
+/// divisions and the shifts are absent for the same reason they are absent
+/// upstream: they are not symmetric.
+pub(super) fn binop_is_symmetric(op: &BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Add(_)
+            | BinOp::Mul(_)
+            | BinOp::BitAnd(_)
+            | BinOp::BitOr(_)
+            | BinOp::BitXor(_)
+            | BinOp::And(_)
+            | BinOp::Or(_)
+            | BinOp::Eq(_)
+            | BinOp::Ne(_)
+            | BinOp::Lt(_)
+            | BinOp::Le(_)
+            | BinOp::Gt(_)
+            | BinOp::Ge(_)
+    )
+}
+
+/// jtransform.py `_rewrite_symmetric`'s `reversename` table: swapping the
+/// operands of an ordered comparison mirrors it.  Everything else keeps its
+/// operator, which is upstream's `.get(op.opname, op.opname)` default.
+pub(super) fn mirrored_compare_binop(op: &BinOp) -> BinOp {
+    match op {
+        BinOp::Lt(_) => BinOp::Gt(Default::default()),
+        BinOp::Le(_) => BinOp::Ge(Default::default()),
+        BinOp::Gt(_) => BinOp::Lt(Default::default()),
+        BinOp::Ge(_) => BinOp::Le(Default::default()),
+        other => *other,
+    }
+}
+
+/// `isinstance(arg, Constant)` plus the `arg.value` `_rewrite_equality` tests,
+/// answered at the layer this lowering runs in: the operand is still a source
+/// literal, not yet a flow-graph `Constant`.  A `bool` literal counts because
+/// its lowered register holds `0` / `1`, which is the same `lltype.Bool` the
+/// upstream test sees.
+pub(super) fn int_literal_value(expr: &syn::Expr) -> Option<i64> {
+    match expr {
+        syn::Expr::Group(group) => int_literal_value(&group.expr),
+        syn::Expr::Paren(paren) => int_literal_value(&paren.expr),
+        syn::Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Int(value) => value.base10_parse::<i64>().ok(),
+            syn::Lit::Bool(value) => Some(i64::from(value.value)),
+            _ => None,
+        },
+        syn::Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+            int_literal_value(&unary.expr).and_then(i64::checked_neg)
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn opcode_for_binop(op: &BinOp) -> Option<Ident> {
     let name = match op {
         BinOp::Add(_) => "IntAdd",

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -498,7 +498,16 @@ impl<'c> Lowerer<'c> {
             nested_failure_reasons: Vec::new(),
             opcode_var_name: self.opcode_var_name.clone(),
             in_dispatch_arm_body: self.in_dispatch_arm_body,
-            dispatch_loop_label: self.dispatch_loop_label.clone(),
+            // Never inherited: inside a loop body an unlabelled `continue`
+            // binds to that loop, not to the dispatch back-edge.  The
+            // spellings this block lowers itself -- a bare `continue` and one
+            // in an `if` branch -- are taken by `lower_loop_stmt` /
+            // `lower_loop_if` with `continue_label`; any other spelling falls
+            // back to `lower_stmt`, whose `Expr::Continue` arm emits a jump to
+            // `dispatch_loop_label`.  Carrying the dispatch label in would aim
+            // that jump at the dispatch head instead of this loop.  Cleared, it
+            // refuses there.
+            dispatch_loop_label: None,
             pc_pinned: self.pc_pinned,
             // Never inherited: a loop body statement is not the arm body's
             // tail, so a `return` inside it must be rejected, not lowered.
@@ -1090,6 +1099,53 @@ mod unroll_binding_tests {
         assert!(
             !emitted.contains("goto_if_not_int_is_true"),
             "the negation must replace the branch, not add one:\n{emitted}"
+        );
+    }
+
+    /// A `continue` inside a `match` in a loop body binds to that loop, not
+    /// to the dispatch back-edge.  `lower_loop_stmt` / `lower_loop_if` take
+    /// the direct and `if`-branch spellings with the loop's own labels; a
+    /// `match` arm falls back to `lower_stmt`, whose `Expr::Continue` arm
+    /// answered it with a jump to `dispatch_loop_label`.  On the pre-fix
+    /// lowerer this `while` lowers and its stream names the dispatch head —
+    /// one loop out from the loop the source wrote.
+    #[test]
+    fn a_continue_in_a_match_inside_a_loop_never_targets_the_dispatch_head() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.dispatch_loop_label = Some(syn::Ident::new(
+            "__l_dispatch",
+            proc_macro2::Span::call_site(),
+        ));
+        let stmt: Stmt = syn::parse_quote! { let flag = 1; };
+        let Stmt::Local(local) = stmt else {
+            unreachable!("parse_quote produced the requested let statement")
+        };
+        assert!(lowerer.lower_local(&local).is_some());
+
+        let expr: syn::ExprWhile = syn::parse_quote! {
+            while flag {
+                match flag {
+                    1 => continue,
+                    _ => {},
+                }
+            }
+        };
+        let lowered = lowerer.lower_while_loop(&expr);
+
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !emitted.contains("__l_dispatch"),
+            "the inner loop's `continue` must not jump to the dispatch head:\n{emitted}"
+        );
+        assert!(
+            lowered.is_none(),
+            "a `continue` this loop cannot spell must refuse the loop, not \
+             retarget it:\n{emitted}"
         );
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -463,6 +463,37 @@ impl<'c> Lowerer<'c> {
             );
             return None;
         }
+        // `hint_fresh_virtualizable` is the fourth member, and the purity test
+        // is blind to it in the same way: the hint reads nothing, writes
+        // nothing and calls nothing, so a statement whose only content is the
+        // hint is scored inert and dropped.  Dropping it is what the previous
+        // lowering did on purpose -- and that is the defect, because the hint
+        // is not inert.  Upstream records `fresh_virtualizable` in
+        // `Transformer.vable_flags` and reads it back in `is_vable_getfield` /
+        // `is_vable_setfield`, which then answer `False` so the following field
+        // accesses stay off the `getfield_vable_*` / `setfield_vable_*` path.
+        // This lowering has no carrier for that flag, so it cannot honour the
+        // hint; suppressing it leaves every following access on the vable path,
+        // which is the opposite of what was asked and is invisible in the
+        // emitted jitcode.  Refuse the statement rather than answer it wrongly.
+        //
+        // `hint_access_directly` is deliberately not covered: upstream drops it
+        // at the same site, and the flag it records is consulted for
+        // `fresh_virtualizable` alone.
+        if stmt_contains_fresh_virtualizable_hint(stmt) {
+            if std::env::var_os("MAJIT_MACRO_DEBUG").is_some() {
+                eprintln!(
+                    "[majit-macro] lower_stmt rejected ({what}): statement encloses a \
+                     `hint_fresh_virtualizable` this lowering has no flag to carry: {}",
+                    quote!(#stmt)
+                );
+            }
+            self.record_body_failure(
+                "encloses a `hint_fresh_virtualizable` this lowering has no flag to carry",
+                stmt,
+            );
+            return None;
+        }
         // A write to a green is the third member of the family above, and the
         // purity test is blind to it for the same reason it is blind to
         // `break`: `stmt_modifies_jit_state` scores writes to `state.*`, and a
@@ -2601,6 +2632,55 @@ fn stmt_contains_loop_control(stmt: &Stmt) -> bool {
         hit: false,
         loop_depth: 0,
     };
+    probe.visit_stmt(stmt);
+    probe.hit
+}
+
+/// Whether `stmt` encloses a `hint_fresh_virtualizable` in either spelling.
+///
+/// The hint reaches the lowerer two ways: as a call
+/// (`lower_vable_hint_identity_call` matches `Expr::Call`) and as a macro
+/// (`lower_vable_hint_suppress` matches `Expr::Macro`).  Both are refused, so
+/// the probe has to see both -- and it has to see them anywhere in the
+/// statement, because the call form appears in value position
+/// (`let f = hint_fresh_virtualizable(frame);`) where the statement that gets
+/// refused is the `let`.
+///
+/// Closures and nested items are not skipped the way `stmt_contains_return`
+/// skips them: a hint inside a closure still names this body's virtualizable.
+fn stmt_contains_fresh_virtualizable_hint(stmt: &Stmt) -> bool {
+    use syn::visit::Visit;
+    struct Probe {
+        hit: bool,
+    }
+    impl<'ast> Visit<'ast> for Probe {
+        fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+            if let Expr::Path(p) = &*node.func
+                && classify_virtualizable_hint_syn_path(&p.path)
+                    == Some(VirtualizableHintKind::FreshVirtualizable)
+            {
+                self.hit = true;
+            }
+            syn::visit::visit_expr_call(self, node);
+        }
+        fn visit_expr_macro(&mut self, node: &'ast syn::ExprMacro) {
+            if classify_virtualizable_hint_syn_path(&node.mac.path)
+                == Some(VirtualizableHintKind::FreshVirtualizable)
+            {
+                self.hit = true;
+            }
+            syn::visit::visit_expr_macro(self, node);
+        }
+        fn visit_stmt_macro(&mut self, node: &'ast syn::StmtMacro) {
+            if classify_virtualizable_hint_syn_path(&node.mac.path)
+                == Some(VirtualizableHintKind::FreshVirtualizable)
+            {
+                self.hit = true;
+            }
+            syn::visit::visit_stmt_macro(self, node);
+        }
+    }
+    let mut probe = Probe { hit: false };
     probe.visit_stmt(stmt);
     probe.hit
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -241,11 +241,39 @@ impl<'c> Lowerer<'c> {
                 if let Expr::Return(ret) = expr {
                     return self.lower_return_stmt(ret, is_arm_tail);
                 }
-                if matches!(expr, Expr::Continue(_)) {
-                    if let Some(label) = self.dispatch_loop_label.clone() {
-                        self.emit_jump(&label);
+                if let Expr::Continue(cont) = expr {
+                    // The only `continue` this lowering can honour is the one
+                    // that means the dispatch back-edge, because the jump it
+                    // emits targets `dispatch_loop_label` and there is no other
+                    // label in scope here.  Two spellings reach this arm naming
+                    // a different loop, and both used to be answered with that
+                    // same jump -- or, with no dispatch label at all, with a
+                    // bare `Some(())` that emitted nothing and dropped the
+                    // transfer:
+                    //
+                    //   * a `continue` inside a loop written in the arm body.
+                    //     Its direct and `if`-branch spellings are taken by
+                    //     `lower_loop_stmt` / `lower_loop_if` with that loop's
+                    //     own labels, so what arrives here came through a
+                    //     `match` arm or a nested block.  `lower_loop_body_block`
+                    //     clears the dispatch label for exactly this reason, so
+                    //     the `None` below is what such a `continue` sees.
+                    //   * a labelled `continue 'l`, which crosses nested loops
+                    //     and names a loop this lowering has no label for.
+                    //
+                    // Both are refused instead of mistargeted.  The refusal
+                    // declines the whole body, so the arm keeps running in the
+                    // interpreter rather than jumping to the wrong head or
+                    // falling through with the transfer gone.
+                    if cont.label.is_none() {
+                        if let Some(label) = self.dispatch_loop_label.clone() {
+                            self.emit_jump(&label);
+                            return Some(());
+                        }
                     }
-                    return Some(());
+                    // `stmt_contains_loop_control` fires on a bare `continue`,
+                    // so the fallback refuses and records the reason.
+                    return self.lower_stmt_fallback(stmt, "expr");
                 }
                 if let Some(()) = self.lower_expr_stmt(expr) {
                     return Some(());
@@ -2562,4 +2590,76 @@ fn stmt_contains_loop_control(stmt: &Stmt) -> bool {
     };
     probe.visit_stmt(stmt);
     probe.hit
+}
+
+#[cfg(test)]
+mod continue_target_tests {
+    use super::*;
+
+    const DISPATCH_LABEL: &str = "__l_dispatch";
+
+    fn dispatch_lowerer() -> Lowerer<'static> {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.dispatch_loop_label = Some(syn::Ident::new(
+            DISPATCH_LABEL,
+            proc_macro2::Span::call_site(),
+        ));
+        lowerer
+    }
+
+    fn emitted(lowerer: &Lowerer<'_>) -> String {
+        lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The spelling this lowering exists for: a `continue` in a dispatch arm
+    /// body is the interpreter's back-edge and lowers to a jump to the loop
+    /// head the dispatch JitCode marked.
+    #[test]
+    fn an_arm_body_continue_lowers_to_the_dispatch_back_edge() {
+        let mut lowerer = dispatch_lowerer();
+        let stmt: Stmt = syn::parse_quote! { continue; };
+
+        assert!(lowerer.lower_stmt(&stmt).is_some());
+        let body = emitted(&lowerer);
+        assert!(
+            body.contains(DISPATCH_LABEL),
+            "an arm-body `continue` must jump to the dispatch head:\n{body}"
+        );
+    }
+
+    /// With no dispatch label there is no loop head to jump to, so the old
+    /// `Some(())` emitted nothing and reported success — the transfer was
+    /// silently deleted and the caller ran on to the next statement.
+    #[test]
+    fn a_continue_with_no_dispatch_label_refuses_instead_of_vanishing() {
+        let mut lowerer = Lowerer::new(None);
+        let stmt: Stmt = syn::parse_quote! { continue; };
+
+        assert!(
+            lowerer.lower_stmt(&stmt).is_none(),
+            "a `continue` with no loop head to name must refuse"
+        );
+        assert!(lowerer.statements.is_empty());
+        assert!(lowerer.op_metadata.is_empty());
+    }
+
+    /// A labelled `continue` crosses nested loops to a loop this lowering
+    /// holds no label for; the dispatch head is not it.
+    #[test]
+    fn a_labelled_continue_refuses() {
+        let mut lowerer = dispatch_lowerer();
+        let stmt: Stmt = syn::parse_quote! { continue 'outer; };
+
+        assert!(
+            lowerer.lower_stmt(&stmt).is_none(),
+            "`continue 'outer` names a loop the dispatch label is not"
+        );
+        assert!(lowerer.statements.is_empty());
+        assert!(lowerer.op_metadata.is_empty());
+    }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1184,6 +1184,19 @@ impl<'c> Lowerer<'c> {
         }
         let green_reads: Vec<Register> =
             green_bindings.iter().map(Register::from_binding).collect();
+        // jtransform.py `handle_recursive_call` opens with `promote_greens`:
+        // every green Variable is pinned by a `-live-` + `<kind>_guard_value`
+        // pair before the call is emitted.  The dispatcher picks the callee by
+        // hashing the green key it reads out of these registers, so a green the
+        // trace never guarded lets a recorded loop replay with a different key
+        // and enter the portal at a pc it was not compiled for.  The merge
+        // point promotes its greens for the same reason
+        // (`dispatch::emit_promote_greens`); this is the other `promote_greens`
+        // call site.  Upstream skips Constants and Voids; every green here is a
+        // register a value expression just produced, so none is skipped.
+        for binding in &green_bindings {
+            self.emit_live_and_guard_value(binding.kind, binding.reg);
+        }
         let green_tokens: Vec<proc_macro2::TokenStream> = green_bindings
             .iter()
             .map(|b| {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -742,12 +742,24 @@ impl<'c> Lowerer<'c> {
         Some(())
     }
 
-    /// RPython jtransform.py:655 — suppress identity hint function calls.
+    /// RPython jtransform.py `rewrite_op_hint` — suppress the identity hint
+    /// function call.
     ///
-    /// `hint_access_directly(frame)` and `hint_fresh_virtualizable(frame)`
-    /// are identity functions that return their argument unchanged.
-    /// The Lowerer recognizes these calls and lowers the argument directly,
-    /// effectively eliminating the hint call.
+    /// `hint_access_directly(frame)` is an identity function whose whole
+    /// effect at this layer is to be dropped: upstream's hint arm answers
+    /// `access_directly` with a bare `return`, and the flag it records is
+    /// consulted only for `fresh_virtualizable` (`is_vable_getfield` reads
+    /// `'fresh_virtualizable' in flags`).  So lowering the argument directly
+    /// is the whole port.
+    ///
+    /// `hint_fresh_virtualizable` is NOT dropped here.  It asks the following
+    /// field accesses to stay OFF the `getfield_vable_*` / `setfield_vable_*`
+    /// path, which upstream arranges by recording the flag and reading it back
+    /// in `is_vable_getfield` / `is_vable_setfield`.  This lowering has no
+    /// carrier for the flag, so the identity answer keeps every following
+    /// access on the vable path -- the opposite of what the hint asks, with no
+    /// diagnostic.  Refuse instead: `stmt_contains_fresh_virtualizable_hint`
+    /// turns that refusal into a declined body, and the arm runs interpreted.
     pub(super) fn lower_vable_hint_identity_call(&mut self, expr: &Expr) -> Option<Binding> {
         let call = match expr {
             Expr::Call(c) => c,
@@ -758,9 +770,7 @@ impl<'c> Lowerer<'c> {
             _ => return None,
         };
         match func_name {
-            Some(
-                VirtualizableHintKind::AccessDirectly | VirtualizableHintKind::FreshVirtualizable,
-            ) => {
+            Some(VirtualizableHintKind::AccessDirectly) => {
                 let arg = call.args.first()?;
                 self.lower_value_expr(arg)
             }
@@ -807,10 +817,11 @@ impl<'c> Lowerer<'c> {
             Expr::Macro(m) => m,
             _ => return None,
         };
+        // Only `access_directly`.  `fresh_virtualizable` is refused by
+        // `stmt_contains_fresh_virtualizable_hint` rather than suppressed --
+        // see `lower_vable_hint_identity_call` for why dropping it is wrong.
         match classify_virtualizable_hint_syn_path(&mac.mac.path) {
-            Some(
-                VirtualizableHintKind::AccessDirectly | VirtualizableHintKind::FreshVirtualizable,
-            ) => Some(()),
+            Some(VirtualizableHintKind::AccessDirectly) => Some(()),
             _ => None,
         }
     }
@@ -2235,6 +2246,95 @@ mod tests {
     /// A declared ref field admits the three spellings the lowering can
     /// actually receive, and no others. The pointee is named once per pointer
     /// spelling, which is what turns a drifted declaration into a type error.
+    /// The control: `hint_access_directly` is still answered as the identity
+    /// it is.  Upstream drops it at the same site, and the flag it records is
+    /// read back for `fresh_virtualizable` alone, so nothing is lost.
+    #[test]
+    fn an_access_directly_hint_still_lowers_to_its_argument() {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.vable_var = Some("state".to_string());
+        config.vable_input_ref_reg = Some(4);
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer.install_vable_input_binding();
+        let expr: Expr = syn::parse_quote! { hint_access_directly(state) };
+
+        let binding = lowerer
+            .lower_value_expr(&expr)
+            .expect("the access_directly hint lowers to its argument");
+
+        assert_eq!(binding.reg, 4);
+        assert_eq!(binding.kind, BindingKind::Ref);
+    }
+
+    /// `hint_fresh_virtualizable` asks the following field accesses to stay
+    /// off the vable path, and this lowering holds no flag that could carry
+    /// that.  Answering it as an identity — which is what the suppression did
+    /// — leaves every access on the vable path with nothing emitted to say
+    /// so, so the statement is refused instead.
+    ///
+    /// The statement is built as `Stmt::Expr(Expr::Macro, semi)` rather than
+    /// parsed from `hint_fresh_virtualizable!(state);`, because syn parses
+    /// that spelling as `Stmt::Macro`, whose arm in `lower_stmt_dispatch`
+    /// recognises `can_enter_jit` / `jit_loop_header` and answers `None` for
+    /// everything else — so it never reaches `lower_vable_hint_suppress` and
+    /// the test would pass without exercising anything.  Expression position
+    /// is the only spelling that does reach it.
+    #[test]
+    fn a_fresh_virtualizable_hint_refuses_in_expression_position() {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.vable_var = Some("state".to_string());
+        config.vable_input_ref_reg = Some(4);
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer.install_vable_input_binding();
+        let mac: syn::ExprMacro = syn::parse_quote! { hint_fresh_virtualizable!(state) };
+        let stmt = Stmt::Expr(Expr::Macro(mac), Some(Default::default()));
+
+        assert!(
+            lowerer.lower_stmt(&stmt).is_none(),
+            "the fresh_virtualizable hint must refuse, not be suppressed"
+        );
+        assert!(lowerer.statements.is_empty());
+    }
+
+    /// The control for the test above: the same expression-position spelling
+    /// with `hint_access_directly` is still suppressed, which is what proves
+    /// the refusal is about the hint and not about the statement shape.
+    #[test]
+    fn an_access_directly_hint_is_still_suppressed_in_expression_position() {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.vable_var = Some("state".to_string());
+        config.vable_input_ref_reg = Some(4);
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer.install_vable_input_binding();
+        let mac: syn::ExprMacro = syn::parse_quote! { hint_access_directly!(state) };
+        let stmt = Stmt::Expr(Expr::Macro(mac), Some(Default::default()));
+
+        assert!(
+            lowerer.lower_stmt(&stmt).is_some(),
+            "the access_directly hint is dropped, as upstream drops it"
+        );
+        assert!(lowerer.statements.is_empty());
+    }
+
+    /// The same hint in value position.  The refusal has to reach the `let`,
+    /// because that is the statement the purity test would otherwise score
+    /// inert and drop.
+    #[test]
+    fn a_fresh_virtualizable_hint_in_a_let_refuses() {
+        let mut config = LowererConfig::inline_helper(&[], &[], &[], &[], &[], &[], &[], &[]);
+        config.vable_var = Some("state".to_string());
+        config.vable_input_ref_reg = Some(4);
+        let mut lowerer = Lowerer::new(Some(&config));
+        lowerer.install_vable_input_binding();
+        let stmt: Stmt = syn::parse_quote! { let fresh = hint_fresh_virtualizable(state); };
+
+        assert!(
+            lowerer.lower_stmt(&stmt).is_none(),
+            "the hint in value position must refuse the enclosing `let`"
+        );
+        assert!(!lowerer.bindings.contains_key("fresh"));
+    }
+
     #[test]
     fn a_declared_ref_field_witnesses_its_pointee() {
         let tokens = witness_for("Stack::head");

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -2244,12 +2244,22 @@ impl<'c> Lowerer<'c> {
         // which degraded the whole dispatch arm to the interpreter.
         //
         // RPython promotes the pair to `instance_ptr_eq` / `instance_ptr_ne`
-        // when `_is_rclass_instance(args[0])`, asserting the other side is one
-        // too.  `struct_type` is this layer's record of "a Ref whose struct is
-        // known", so both sides carrying one is that same fact.  Only one side
-        // carrying it means the lowering never tracked the other, not that it
-        // is not an instance, so that case takes the plain pointer compare
-        // instead of upstream's assert.
+        // when `_is_rclass_instance(args[0])`, which is
+        // `lltype._castdepth(v.concretetype.TO, rclass.OBJECT) >= 0` -- the
+        // pointee descends from the instance base.  `struct_type` is a
+        // different fact: "the lowering tracked a pointee layout", which a raw
+        // struct, a `ref_params` entry, a field pointee and an array element
+        // all satisfy.  Reading it as the instance predicate hands non-instance
+        // pointers to instance-only reasoning: `optimize_oois_ooisnot` folds a
+        // pair with two known-but-different classes to a constant, and two
+        // structural views of one raw address are known-different classes that
+        // do alias.
+        //
+        // Nothing in this tree carries the real predicate, so the pair stays on
+        // the plain pointer compare until something does.  That is upstream's
+        // own fallthrough -- `rewrite_op_ptr_eq` promotes only under the test
+        // and otherwise leaves `ptr_eq` alone -- and it costs nothing the
+        // branch had before, which declined the whole dispatch arm here.
         //
         // RPython has no ordered pointer comparison, so any other operator
         // declines and the arm keeps running in the interpreter.
@@ -2259,13 +2269,7 @@ impl<'c> Lowerer<'c> {
                 BinOp::Ne(_) => false,
                 _ => return None,
             };
-            let both_instances = lhs.struct_type.is_some() && rhs.struct_type.is_some();
-            let name = match (both_instances, is_eq) {
-                (true, true) => "InstancePtrEq",
-                (true, false) => "InstancePtrNe",
-                (false, true) => "PtrEq",
-                (false, false) => "PtrNe",
-            };
+            let name = if is_eq { "PtrEq" } else { "PtrNe" };
             let opcode = Ident::new(name, proc_macro2::Span::call_site());
             let reg = self.alloc_reg();
             let lhs_reg = lhs.reg;
@@ -3042,7 +3046,7 @@ mod tests {
         }
 
         #[test]
-        fn two_tracked_struct_refs_use_instance_ptr_eq() {
+        fn two_tracked_struct_refs_still_use_the_plain_ptr_eq() {
             let path: syn::Path = syn::parse_quote!(Frame);
             let (lowerer, out) = lower("a == b", |l| {
                 l.bindings
@@ -3050,10 +3054,15 @@ mod tests {
                 l.bindings.insert("b".into(), ref_binding(1, Some(path)));
             });
             assert!(out.is_some());
+            let emitted = emitted(&lowerer);
             assert!(
-                emitted(&lowerer).contains("InstancePtrEq"),
-                "both sides carry a struct_type, which is this layer's \
-                 `_is_rclass_instance`"
+                emitted.contains("PtrEq"),
+                "a tracked pointee layout is not `_is_rclass_instance`"
+            );
+            assert!(
+                !emitted.contains("InstancePtrEq"),
+                "`instance_ptr_eq` licenses `optimize_oois_ooisnot` to fold a \
+                 known-different-class pair, which raw pointers may not honour"
             );
         }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -2235,13 +2235,111 @@ impl<'c> Lowerer<'c> {
                 struct_type: None,
             });
         }
+        // jtransform.py `rewrite_op_ptr_eq` / `rewrite_op_ptr_ne`: comparing
+        // two pointers is `ptr_eq` / `ptr_ne`, not the integer compare.  Both
+        // operands stay ref-banked and the result is int (`ptr_eq/rr>i`) --
+        // the same split the float arm above makes, with the banks carried on
+        // the `Register`s so `BinopI` is only the op-kind label.  Before this
+        // arm a Ref pair fell through to the Int check below and declined,
+        // which degraded the whole dispatch arm to the interpreter.
+        //
+        // RPython promotes the pair to `instance_ptr_eq` / `instance_ptr_ne`
+        // when `_is_rclass_instance(args[0])`, asserting the other side is one
+        // too.  `struct_type` is this layer's record of "a Ref whose struct is
+        // known", so both sides carrying one is that same fact.  Only one side
+        // carrying it means the lowering never tracked the other, not that it
+        // is not an instance, so that case takes the plain pointer compare
+        // instead of upstream's assert.
+        //
+        // RPython has no ordered pointer comparison, so any other operator
+        // declines and the arm keeps running in the interpreter.
+        if matches!(lhs.kind, BindingKind::Ref) && matches!(rhs.kind, BindingKind::Ref) {
+            let is_eq = match expr.op {
+                BinOp::Eq(_) => true,
+                BinOp::Ne(_) => false,
+                _ => return None,
+            };
+            let both_instances = lhs.struct_type.is_some() && rhs.struct_type.is_some();
+            let name = match (both_instances, is_eq) {
+                (true, true) => "InstancePtrEq",
+                (true, false) => "InstancePtrNe",
+                (false, true) => "PtrEq",
+                (false, false) => "PtrNe",
+            };
+            let opcode = Ident::new(name, proc_macro2::Span::call_site());
+            let reg = self.alloc_reg();
+            let lhs_reg = lhs.reg;
+            let rhs_reg = rhs.reg;
+            self.emit_op(
+                OpMeta::linear(
+                    OpKind::BinopI,
+                    Register::refs(&[lhs_reg, rhs_reg]),
+                    vec![Register::int(reg)],
+                ),
+                quote! { __builder.record_binop_r(#reg, majit_ir::OpCode::#opcode, #lhs_reg, #rhs_reg); },
+            );
+            return Some(Binding {
+                reg,
+                kind: BindingKind::Int,
+                depends_on_stack: lhs.depends_on_stack || rhs.depends_on_stack,
+                struct_type: None,
+            });
+        }
         if !matches!(lhs.kind, BindingKind::Int) || !matches!(rhs.kind, BindingKind::Int) {
             return None;
         }
-        let opcode = opcode_for_binop(&expr.op)?;
+        let depends_on_stack = lhs.depends_on_stack || rhs.depends_on_stack;
+        // jtransform.py `_rewrite_symmetric` -- "rewrite 'c1+v2' into 'v2+c1'
+        // in an attempt to avoid generating too many variants of the
+        // bytecode".  Upstream reads `isinstance(op.args[0], Constant)` off
+        // the flow graph; here the constant is still a source literal, so the
+        // syn expression answers the same question.  Swapping the operands of
+        // an ordered comparison mirrors it; every other operator keeps its
+        // spelling, which is upstream's `.get(op.opname, op.opname)` default.
+        let swap = binop_is_symmetric(&expr.op)
+            && int_literal_value(&expr.left).is_some()
+            && int_literal_value(&expr.right).is_none();
+        let (op, rhs_expr, lhs_reg, rhs_reg) = if swap {
+            (
+                mirrored_compare_binop(&expr.op),
+                &*expr.left,
+                rhs.reg,
+                lhs.reg,
+            )
+        } else {
+            (expr.op, &*expr.right, lhs.reg, rhs.reg)
+        };
+        // jtransform.py `_rewrite_equality` via `rewrite_op_int_eq` /
+        // `rewrite_op_int_ne`: a comparison against zero is the unary
+        // `int_is_zero` / `int_is_true`, which is also the form
+        // `goto_if_not_int_is_zero` can fuse.  The swap above already moved a
+        // literal left operand to the right, so both spellings arrive here as
+        // `<value> <op> 0`.
+        if matches!(op, BinOp::Eq(_) | BinOp::Ne(_)) && int_literal_value(rhs_expr) == Some(0) {
+            let name = if matches!(op, BinOp::Eq(_)) {
+                "IntIsZero"
+            } else {
+                "IntIsTrue"
+            };
+            let opcode = Ident::new(name, proc_macro2::Span::call_site());
+            let reg = self.alloc_reg();
+            self.emit_op(
+                OpMeta::linear(
+                    OpKind::UnaryI,
+                    Register::ints(&[lhs_reg]),
+                    vec![Register::int(reg)],
+                ),
+                quote! { __builder.record_unary_i(#reg, majit_ir::OpCode::#opcode, #lhs_reg); },
+            );
+            return Some(Binding {
+                reg,
+                kind: BindingKind::Int,
+                depends_on_stack,
+                struct_type: None,
+            });
+        }
+        let opcode = opcode_for_binop(&op)?;
         let reg = self.alloc_reg();
-        let lhs_reg = lhs.reg;
-        let rhs_reg = rhs.reg;
         self.emit_op(
             OpMeta::linear(
                 OpKind::BinopI,
@@ -2253,7 +2351,7 @@ impl<'c> Lowerer<'c> {
         Some(Binding {
             reg,
             kind: BindingKind::Int,
-            depends_on_stack: lhs.depends_on_stack || rhs.depends_on_stack,
+            depends_on_stack,
             struct_type: None,
         })
     }
@@ -2869,5 +2967,167 @@ mod tests {
         assert_eq!(lowerer.lower_record_exact_class_stmt(&expr), None);
         assert!(lowerer.op_metadata.is_empty());
         assert!(lowerer.statements.is_empty());
+    }
+
+    /// `rewrite_op_ptr_eq` / `_rewrite_equality` / `_rewrite_symmetric` at the
+    /// jitcode-lowering layer.  Each test drives `lower_binary` through
+    /// `lower_value_expr` so the operand bindings are the ones production
+    /// builds.
+    mod ptr_and_equality_tests {
+        use super::*;
+
+        fn emitted(lowerer: &Lowerer<'_>) -> String {
+            lowerer
+                .statements
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
+        fn lower(
+            src: &str,
+            setup: impl FnOnce(&mut Lowerer<'_>),
+        ) -> (Lowerer<'static>, Option<Binding>) {
+            let mut lowerer = Lowerer::new(None);
+            setup(&mut lowerer);
+            let expr: Expr = syn::parse_str(src).expect("parse binary expr");
+            let Expr::Binary(binary) = expr else {
+                panic!("expected a binary expression");
+            };
+            let out = lowerer.lower_binary(&binary);
+            (lowerer, out)
+        }
+
+        fn ref_binding(reg: u16, struct_type: Option<syn::Path>) -> Binding {
+            Binding {
+                reg,
+                kind: BindingKind::Ref,
+                depends_on_stack: false,
+                struct_type,
+            }
+        }
+
+        #[test]
+        fn two_ref_operands_compare_with_ptr_eq() {
+            let (lowerer, out) = lower("a == b", |l| {
+                l.bindings.insert("a".into(), ref_binding(0, None));
+                l.bindings.insert("b".into(), ref_binding(1, None));
+            });
+            assert!(out.is_some(), "a Ref pair must not decline the arm");
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("record_binop_r") && text.contains("PtrEq"),
+                "expected ptr_eq, got:\n{text}"
+            );
+        }
+
+        #[test]
+        fn two_ref_operands_compare_with_ptr_ne() {
+            let (lowerer, out) = lower("a != b", |l| {
+                l.bindings.insert("a".into(), ref_binding(0, None));
+                l.bindings.insert("b".into(), ref_binding(1, None));
+            });
+            assert!(out.is_some());
+            assert!(emitted(&lowerer).contains("PtrNe"));
+        }
+
+        #[test]
+        fn an_ordered_compare_over_refs_still_declines() {
+            let (_lowerer, out) = lower("a < b", |l| {
+                l.bindings.insert("a".into(), ref_binding(0, None));
+                l.bindings.insert("b".into(), ref_binding(1, None));
+            });
+            assert!(out.is_none(), "RPython has no ordered pointer comparison");
+        }
+
+        #[test]
+        fn two_tracked_struct_refs_use_instance_ptr_eq() {
+            let path: syn::Path = syn::parse_quote!(Frame);
+            let (lowerer, out) = lower("a == b", |l| {
+                l.bindings
+                    .insert("a".into(), ref_binding(0, Some(path.clone())));
+                l.bindings.insert("b".into(), ref_binding(1, Some(path)));
+            });
+            assert!(out.is_some());
+            assert!(
+                emitted(&lowerer).contains("InstancePtrEq"),
+                "both sides carry a struct_type, which is this layer's \
+                 `_is_rclass_instance`"
+            );
+        }
+
+        #[test]
+        fn an_int_equality_against_zero_lowers_to_int_is_zero() {
+            let (lowerer, out) = lower("n == 0", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("record_unary_i") && text.contains("IntIsZero"),
+                "expected the unary zero test, got:\n{text}"
+            );
+        }
+
+        #[test]
+        fn an_int_inequality_against_zero_lowers_to_int_is_true() {
+            let (lowerer, out) = lower("n != 0", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            assert!(emitted(&lowerer).contains("IntIsTrue"));
+        }
+
+        #[test]
+        fn a_zero_on_the_left_folds_the_same_way() {
+            let (lowerer, out) = lower("0 == n", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            assert!(
+                emitted(&lowerer).contains("IntIsZero"),
+                "`0 == n` is `_rewrite_symmetric` then the same fold"
+            );
+        }
+
+        #[test]
+        fn a_literal_left_operand_of_an_ordered_compare_mirrors_it() {
+            let (lowerer, out) = lower("5 < n", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("IntGt"),
+                "`5 < n` must become `n > 5`, got:\n{text}"
+            );
+        }
+
+        #[test]
+        fn a_subtraction_keeps_its_literal_left_operand() {
+            let (lowerer, out) = lower("5 - n", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("IntSub"),
+                "`-` is not symmetric, got:\n{text}"
+            );
+        }
+
+        #[test]
+        fn a_nonzero_literal_keeps_the_binary_compare() {
+            let (lowerer, out) = lower("n == 5", |l| {
+                l.bindings.insert("n".into(), binding(4, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("IntEq") && !text.contains("IntIsZero"),
+                "only the zero literal folds, got:\n{text}"
+            );
+        }
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -347,6 +347,39 @@ impl<'c> Lowerer<'c> {
         self.op_metadata.push(meta);
     }
 
+    /// `jtransform.py promote_greens` — the `-live-` + `<kind>_guard_value`
+    /// pair that pins one green to a constant.
+    ///
+    /// Both of upstream's `promote_greens` call sites emit exactly this shape:
+    /// `handle_jit_marker__jit_merge_point` before `jit_merge_point`, and
+    /// `handle_recursive_call` before `recursive_call_<kind>`.  The `-live-`
+    /// comes first so the codewriter's per-marker liveness analysis records the
+    /// alive set at the guard.
+    pub(super) fn emit_live_and_guard_value(&mut self, kind: BindingKind, reg: u16) {
+        self.emit_op(
+            OpMeta::live_marker(),
+            quote! { let _ = __builder.live_placeholder(); },
+        );
+        let (read, guard) = match kind {
+            BindingKind::Int => (
+                Register::int(reg),
+                quote! { __builder.int_guard_value(#reg); },
+            ),
+            BindingKind::Ref => (
+                Register::ref_(reg),
+                quote! { __builder.ref_guard_value(#reg); },
+            ),
+            BindingKind::Float => (
+                Register::float(reg),
+                quote! { __builder.float_guard_value(#reg); },
+            ),
+        };
+        self.emit_op(
+            OpMeta::linear(OpKind::GuardValue, vec![read], vec![]),
+            guard,
+        );
+    }
+
     pub(super) fn append_lowered_sequence(&mut self, lowered: LoweredSequence) {
         debug_assert_eq!(
             lowered.statements.len(),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -37,14 +37,15 @@ mod reexports {
     };
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_f_emit_tokens, binop_i_emit_tokens,
-        block_has_loop_control, expr_has_loop_control, extract_block_tail_int,
+        binop_is_symmetric, block_has_loop_control, expr_has_loop_control, extract_block_tail_int,
         extract_bool_branch_values, extract_branch_int, extract_pat_switch_case_tokens,
         extract_pat_value_tokens, extract_stmts, inline_call_tokens, inline_call_tokens_void,
         inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
-        inline_ref_arg_tokens, inline_shared_path, int_arg_regs, is_lowercase_binding_pat,
-        is_supported_float_type, is_supported_int_cast, is_supported_ref_type, is_word_width_int,
-        jit_arg_kind_tokens, opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop,
-        opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
+        inline_ref_arg_tokens, inline_shared_path, int_arg_regs, int_literal_value,
+        is_lowercase_binding_pat, is_supported_float_type, is_supported_int_cast,
+        is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens, mirrored_compare_binop,
+        opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f,
+        opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
         word_result_addr_for_kind, word_result_addr_tokens, word_void_addr_tokens,
     };
     pub(super) use super::liveness::{

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -9652,6 +9652,12 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         // absent from this curated set, so a blackhole-executed drain hit
         // the unwired-opcode panic at the first back-edge test.
         ("int_is_true/i>i", majit_translate::insns::BC_INT_IS_TRUE),
+        // `int_is_zero/i>i` — the `not a` sibling of `int_is_true`
+        // (`blackhole.py bhimpl_int_is_zero`).  Same wiring gap as the
+        // entry above: `wire_bhimpl_handlers` binds `handler_int_is_zero`,
+        // so without the byte here `wire_handler` no-ops and a
+        // blackhole-executed `x == 0` test hits the unwired-opcode panic.
+        ("int_is_zero/i>i", majit_translate::insns::BC_INT_IS_ZERO),
         ("float_add/ff>f", majit_translate::insns::BC_FLOAT_ADD),
         ("float_sub/ff>f", majit_translate::insns::BC_FLOAT_SUB),
         ("float_mul/ff>f", majit_translate::insns::BC_FLOAT_MUL),

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2648,8 +2648,8 @@ impl JitCodeBuilder {
         );
     }
 
-    /// RPython `blackhole.py:527-533` `bhimpl_int_{neg,invert}` per-opname
-    /// handlers. See `record_binop_i` for the keying rationale.
+    /// RPython `blackhole.py` `bhimpl_int_{neg,invert,is_zero,is_true}`
+    /// per-opname handlers. See `record_binop_i` for the keying rationale.
     /// Byte layout follows `assembler.py`: each `Register` is
     /// emitted in argcode order, so `int_neg/i>i` stores `[src][dst]`
     /// matching the canonical `bhhandler_i_i!` decoder.
@@ -2657,6 +2657,8 @@ impl JitCodeBuilder {
         let key = match opcode {
             OpCode::IntNeg => "int_neg/i>i",
             OpCode::IntInvert => "int_invert/i>i",
+            OpCode::IntIsZero => "int_is_zero/i>i",
+            OpCode::IntIsTrue => "int_is_true/i>i",
             other => panic!("record_unary_i: unsupported opcode {other:?}"),
         };
         self.touch_reg(dst);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5537,6 +5537,7 @@ where
             jitcode::insns::BC_INT_NEG => self.trace_unary_i(ctx, OpCode::IntNeg),
             jitcode::insns::BC_INT_INVERT => self.trace_unary_i(ctx, OpCode::IntInvert),
             jitcode::insns::BC_INT_IS_TRUE => self.trace_unary_i(ctx, OpCode::IntIsTrue),
+            jitcode::insns::BC_INT_IS_ZERO => self.trace_unary_i(ctx, OpCode::IntIsZero),
             jitcode::insns::BC_PTR_EQ => self.trace_binop_r_to_i(ctx, OpCode::PtrEq),
             jitcode::insns::BC_PTR_NE => self.trace_binop_r_to_i(ctx, OpCode::PtrNe),
             jitcode::insns::BC_INSTANCE_PTR_EQ => {

--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -337,14 +337,7 @@ fn is_bool_branch(block: &crate::model::Block) -> bool {
     matches!(cases, (Some(false), Some(true)) | (Some(true), Some(false)),)
 }
 
-/// The link's boolean exit case — `link.llexitcase` first, then
-/// `link.exitcase` for a direct semantic graph.
-///
-/// `jtransform::optimize_goto_if_not` reads the same fact to decide
-/// whether a block is the two-way boolean branch upstream identifies by
-/// `exitswitch.concretetype == lltype.Bool`, so both sides share this
-/// one reader rather than each spelling the source order themselves.
-pub(crate) fn bool_llexitcase(link: &Link) -> Option<bool> {
+fn bool_llexitcase(link: &Link) -> Option<bool> {
     match link.llexitcase.as_ref() {
         Some(ConstValue::Bool(value)) => return Some(*value),
         Some(_) => return None,

--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -337,7 +337,14 @@ fn is_bool_branch(block: &crate::model::Block) -> bool {
     matches!(cases, (Some(false), Some(true)) | (Some(true), Some(false)),)
 }
 
-fn bool_llexitcase(link: &Link) -> Option<bool> {
+/// The link's boolean exit case — `link.llexitcase` first, then
+/// `link.exitcase` for a direct semantic graph.
+///
+/// `jtransform::optimize_goto_if_not` reads the same fact to decide
+/// whether a block is the two-way boolean branch upstream identifies by
+/// `exitswitch.concretetype == lltype.Bool`, so both sides share this
+/// one reader rather than each spelling the source order themselves.
+pub(crate) fn bool_llexitcase(link: &Link) -> Option<bool> {
     match link.llexitcase.as_ref() {
         Some(ConstValue::Bool(value)) => return Some(*value),
         Some(_) => return None,

--- a/majit/majit-translate/src/codewriter/heaptracker.rs
+++ b/majit/majit-translate/src/codewriter/heaptracker.rs
@@ -65,6 +65,30 @@ pub fn get_vtable_for_gcstruct<V: Clone>(
         .cloned()
 }
 
+/// `heaptracker.py` `setup_cache_gcstruct2vtable`.
+///
+/// Upstream fills `_cache_gcstruct2vtable` by walking
+/// `rtyper.instance_reprs` and calling `rinstance.rclass.getvtable()` for
+/// each.  Pyre keeps the call site and the lookup order so
+/// [`get_vtable_for_gcstruct`] reads as upstream does, but the population is
+/// deliberately empty, for two reasons that must both change before it is
+/// worth writing:
+///
+/// * [`GcStructVTableCache`] is generic over the vtable representation and
+///   holds no `RPythonTyper` handle, so there is nothing here to walk.  The
+///   `instance_reprs` map exists (`RPythonTyper::instance_reprs`), so
+///   populating means threading the rtyper in — a signature change on every
+///   holder of this cache.
+/// * [`get_vtable_for_gcstruct`] has no non-test caller.  Pyre resolves an
+///   instance's class word through `new_with_vtable` at rewrite time
+///   instead of asking the struct for its vtable after the fact, so the
+///   upstream consumer (`rewrite_op_malloc`'s vtable argument) never
+///   reaches this path.
+///
+/// The consequence of the stub is that a caller which did appear would read
+/// `None` for a struct that has a vtable, so the empty body is only sound
+/// while the testing map is the sole source — which is what
+/// [`set_testing_vtable_for_gcstruct`] provides today.
 pub fn setup_cache_gcstruct2vtable<V>(_gccache: &mut GcStructVTableCache<V>) {}
 
 pub fn set_testing_vtable_for_gcstruct<V>(

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -314,6 +314,14 @@ pub const BC_FLOAT_TRUEDIV: u8 = 136;
 pub const BC_FLOAT_NEG: u8 = 139;
 pub const BC_FLOAT_ABS: u8 = 140;
 pub const BC_INT_INVERT: u8 = 141;
+/// `blackhole.py` `bhimpl_int_is_zero(a) -> !a` — the sibling of
+/// [`BC_INT_IS_TRUE`], produced by `jtransform.py` `_rewrite_equality`
+/// when an `int_eq` has the zero constant as one operand and the result
+/// is read rather than fused into `goto_if_not_int_is_zero`.  The
+/// handler was already wired in `wire_bhimpl_handlers`, but with no
+/// byte here `insn_byte` panicked on the key instead.  Takes the next
+/// byte above `BC_RAW_STORE_F` (235).
+pub const BC_INT_IS_ZERO: u8 = 236;
 pub const BC_UINT_RSHIFT: u8 = 142;
 pub const BC_UINT_MUL_HIGH: u8 = 143;
 pub const BC_UINT_LT: u8 = 144;
@@ -907,6 +915,7 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     m.insert("int_neg/i>i", BC_INT_NEG);
     m.insert("int_invert/i>i", BC_INT_INVERT);
     m.insert("int_is_true/i>i", BC_INT_IS_TRUE);
+    m.insert("int_is_zero/i>i", BC_INT_IS_ZERO);
     m.insert("uint_rshift/ii>i", BC_UINT_RSHIFT);
     m.insert("uint_mul_high/ii>i", BC_UINT_MUL_HIGH);
     m.insert("uint_lt/ii>i", BC_UINT_LT);

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7387,28 +7387,7 @@ fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
         return false;
     }
     // `or v.concretetype != lltype.Bool: return False`
-    //
-    // Read off the links when the type slot cannot answer.  Most graphs
-    // reach here with their kinds published through
-    // `FunctionGraph::set_concretetype_of_inline`, which canonicalises a
-    // `ConcreteType` back to one lltype apiece — and `getkind(Bool)` is
-    // `'i'`, so `concrete_to_canonical_lltype` stores a Bool-producing
-    // compare as `Signed` and the literal predicate rejects it.  The fact
-    // upstream's `lltype.Bool` stands for is that this block's two exits
-    // are the false and the true arm, which the links carry directly and
-    // which `flatten::is_bool_branch` independently requires before it
-    // will emit a two-way branch at all; both sides read it through
-    // `flatten::bool_llexitcase` so the two cannot drift.  Declining when
-    // neither witness holds leaves the block on the unfused
-    // `goto_if_not/iL`, which is what it takes today.
-    let exits_are_bool_pair = matches!(
-        (
-            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[0]),
-            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[1]),
-        ),
-        (Some(false), Some(true)) | (Some(true), Some(false))
-    );
-    if v.concretetype() != Some(LowLevelType::Bool) && !exits_are_bool_pair {
+    if v.concretetype() != Some(LowLevelType::Bool) {
         return false;
     }
 
@@ -7542,29 +7521,6 @@ fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::m
             ) =>
         {
             Some((op.clone(), vec![operand.clone()]))
-        }
-        // The truthify operator the front end emits for a condition that is
-        // not already a comparison.  `assembler::op_kind_to_opname_with_kinds`
-        // names it `int_is_true` for an `i` operand and `ptr_nonzero` for an
-        // `r` one, and that renaming runs after flatten -- so the
-        // `int_is_true` / `ptr_nonzero` arm above matches nothing the front
-        // end produces, the same gap the bare-comparison arm covers.  The
-        // fused exitswitch has to name the key the assembler will look up
-        // (`goto_if_not_int_is_true/iL`, `goto_if_not_ptr_nonzero/rL`), whose
-        // argcode comes from this operand's own register kind, so the two
-        // halves are resolved from one source here.
-        OpKind::UnaryOp { op, operand, .. } if op == "bool" => {
-            let opname = match FunctionGraph::concretetype_of(operand) {
-                crate::codewriter::type_state::ConcreteType::Signed => "int_is_true",
-                crate::codewriter::type_state::ConcreteType::GcRef => "ptr_nonzero",
-                // A Float operand is rewritten to `float_ne` against zero
-                // before reaching here, and an Unknown one takes
-                // `flatten::kind_color_of`'s fallback, which this cannot
-                // predict.  Naming the wrong half would build a key no
-                // handler is wired to, so decline and keep the unfused form.
-                _ => return None,
-            };
-            Some((opname.to_string(), vec![operand.clone()]))
         }
         _ => None,
     }
@@ -9070,152 +9026,6 @@ mod tests {
         assert!(row(&live).contains("1x"), "{}", row(&live));
         assert!(!row(&live).contains("INERT"), "{}", row(&live));
         assert!(row(&inert).contains("0x INERT"), "{}", row(&inert));
-    }
-
-    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType as LlType;
-
-    /// The shape production actually reaches this pass with: a truthify
-    /// (`OpKind::UnaryOp { op: "bool" }`) whose result carries `Signed`,
-    /// not `Bool`.  Both halves of the fuse have to hold — the two-way
-    /// branch has to be recognised from the links, and `"bool"` has to
-    /// resolve to the `int_is_true` the assembler will name.
-    #[test]
-    fn a_truthify_condition_over_an_int_fuses_as_int_is_true() {
-        let (mut graph, cond, operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
-        assert!(
-            super::optimize_goto_if_not(&mut graph, start),
-            "a truthify branch must fuse"
-        );
-        let block = &graph.blocks[start];
-        assert!(
-            !block
-                .operations
-                .iter()
-                .any(|op| matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "bool")),
-            "the fused truthify op must be removed"
-        );
-        match &block.exitswitch {
-            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
-                assert_eq!(opname, "int_is_true");
-                assert_eq!(args, &vec![operand]);
-            }
-            other => panic!("expected a fused exitswitch, got {other:?}"),
-        }
-        let _ = cond;
-    }
-
-    /// The `r` half of the same resolution: `op_kind_to_opname_with_kinds`
-    /// names a truthify over a Ref operand `ptr_nonzero`, and
-    /// `goto_if_not_ptr_nonzero/rL` is the key that has to be built.
-    #[test]
-    fn a_truthify_condition_over_a_ref_fuses_as_ptr_nonzero() {
-        let (mut graph, _cond, operand, start) = truthify_fixture(
-            crate::translator::rtyper::rclass::OBJECTPTR.clone(),
-            LlType::Signed,
-        );
-        assert!(super::optimize_goto_if_not(&mut graph, start));
-        match &graph.blocks[start].exitswitch {
-            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
-                assert_eq!(opname, "ptr_nonzero");
-                assert_eq!(args, &vec![operand]);
-            }
-            other => panic!("expected a fused exitswitch, got {other:?}"),
-        }
-    }
-
-    /// Control: an operand whose kind this pass cannot resolve takes
-    /// `flatten::kind_color_of`'s fallback, so naming a half here could
-    /// build a key with no handler.  It must decline, not guess.
-    #[test]
-    fn a_truthify_condition_over_an_unresolved_operand_declines() {
-        let (mut graph, _cond, _operand, start) = {
-            let (mut g, c, o, s) = truthify_fixture(LlType::Signed, LlType::Signed);
-            o.set_concretetype(None);
-            (g.clone(), c, o, s)
-        };
-        assert!(
-            !super::optimize_goto_if_not(&mut graph, start),
-            "an unresolved operand kind must decline the fuse"
-        );
-    }
-
-    /// Control: the link-side witness is what stands in for
-    /// `lltype.Bool`, so a two-way branch whose exits are not the false
-    /// and true arms must still decline.
-    #[test]
-    fn a_two_way_branch_without_bool_exitcases_declines() {
-        use crate::flowspace::model::ConstValue;
-        use crate::model::{ExitCase, ExitSwitch, Link};
-        let (mut graph, cond, _operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
-        let targets: Vec<_> = graph.blocks[start]
-            .exits
-            .iter()
-            .map(|link| link.target)
-            .collect();
-        graph.set_control_flow_metadata(
-            crate::model::BlockId(start),
-            Some(ExitSwitch::Value(cond)),
-            vec![
-                Link::new_mixed(
-                    vec![],
-                    targets[0],
-                    Some(ExitCase::Const(ConstValue::Int(0))),
-                ),
-                Link::new_mixed(
-                    vec![],
-                    targets[1],
-                    Some(ExitCase::Const(ConstValue::Int(1))),
-                ),
-            ],
-        );
-        assert!(
-            !super::optimize_goto_if_not(&mut graph, start),
-            "an integer-cased two-way branch must decline the fuse"
-        );
-    }
-
-    /// `t = bool(x); exitswitch = t` with two bool-cased exits, the
-    /// concretetypes stamped as the caller asks.  Returns the graph, the
-    /// condition variable, the truthify operand, and the start block.
-    fn truthify_fixture(
-        operand_ty: LlType,
-        cond_ty: LlType,
-    ) -> (
-        FunctionGraph,
-        crate::flowspace::model::Variable,
-        crate::flowspace::model::Variable,
-        usize,
-    ) {
-        use crate::model::{ExitCase, ExitSwitch, Link};
-        let mut graph = FunctionGraph::new("goto_if_not_truthify");
-        let operand = graph.alloc_value_var();
-        operand.set_concretetype(Some(operand_ty));
-        let cond = graph
-            .push_op_var(
-                graph.startblock,
-                OpKind::UnaryOp {
-                    op: "bool".to_string(),
-                    operand: operand.clone(),
-                    result_ty: ValueType::Bool,
-                },
-                true,
-            )
-            .unwrap();
-        // What production publishes: `getkind(Bool)` is `'i'`, so the
-        // canonicalising writer stores `Signed` here, never `Bool`.
-        cond.set_concretetype(Some(cond_ty));
-        let if_false = graph.create_block();
-        let if_true = graph.create_block();
-        let start = graph.startblock.0;
-        graph.set_control_flow_metadata(
-            graph.startblock,
-            Some(ExitSwitch::Value(cond.clone())),
-            vec![
-                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
-                Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
-            ],
-        );
-        (graph, cond, operand, start)
     }
 
     /// the GotoIfNotOp lowering Stage 1: `int_lt(a, b); exitswitch = t` fuses into a

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7387,7 +7387,28 @@ fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
         return false;
     }
     // `or v.concretetype != lltype.Bool: return False`
-    if v.concretetype() != Some(LowLevelType::Bool) {
+    //
+    // Read off the links when the type slot cannot answer.  Most graphs
+    // reach here with their kinds published through
+    // `FunctionGraph::set_concretetype_of_inline`, which canonicalises a
+    // `ConcreteType` back to one lltype apiece — and `getkind(Bool)` is
+    // `'i'`, so `concrete_to_canonical_lltype` stores a Bool-producing
+    // compare as `Signed` and the literal predicate rejects it.  The fact
+    // upstream's `lltype.Bool` stands for is that this block's two exits
+    // are the false and the true arm, which the links carry directly and
+    // which `flatten::is_bool_branch` independently requires before it
+    // will emit a two-way branch at all; both sides read it through
+    // `flatten::bool_llexitcase` so the two cannot drift.  Declining when
+    // neither witness holds leaves the block on the unfused
+    // `goto_if_not/iL`, which is what it takes today.
+    let exits_are_bool_pair = matches!(
+        (
+            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[0]),
+            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[1]),
+        ),
+        (Some(false), Some(true)) | (Some(true), Some(false))
+    );
+    if v.concretetype() != Some(LowLevelType::Bool) && !exits_are_bool_pair {
         return false;
     }
 
@@ -7521,6 +7542,29 @@ fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::m
             ) =>
         {
             Some((op.clone(), vec![operand.clone()]))
+        }
+        // The truthify operator the front end emits for a condition that is
+        // not already a comparison.  `assembler::op_kind_to_opname_with_kinds`
+        // names it `int_is_true` for an `i` operand and `ptr_nonzero` for an
+        // `r` one, and that renaming runs after flatten -- so the
+        // `int_is_true` / `ptr_nonzero` arm above matches nothing the front
+        // end produces, the same gap the bare-comparison arm covers.  The
+        // fused exitswitch has to name the key the assembler will look up
+        // (`goto_if_not_int_is_true/iL`, `goto_if_not_ptr_nonzero/rL`), whose
+        // argcode comes from this operand's own register kind, so the two
+        // halves are resolved from one source here.
+        OpKind::UnaryOp { op, operand, .. } if op == "bool" => {
+            let opname = match FunctionGraph::concretetype_of(operand) {
+                crate::codewriter::type_state::ConcreteType::Signed => "int_is_true",
+                crate::codewriter::type_state::ConcreteType::GcRef => "ptr_nonzero",
+                // A Float operand is rewritten to `float_ne` against zero
+                // before reaching here, and an Unknown one takes
+                // `flatten::kind_color_of`'s fallback, which this cannot
+                // predict.  Naming the wrong half would build a key no
+                // handler is wired to, so decline and keep the unfused form.
+                _ => return None,
+            };
+            Some((opname.to_string(), vec![operand.clone()]))
         }
         _ => None,
     }
@@ -9026,6 +9070,152 @@ mod tests {
         assert!(row(&live).contains("1x"), "{}", row(&live));
         assert!(!row(&live).contains("INERT"), "{}", row(&live));
         assert!(row(&inert).contains("0x INERT"), "{}", row(&inert));
+    }
+
+    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType as LlType;
+
+    /// The shape production actually reaches this pass with: a truthify
+    /// (`OpKind::UnaryOp { op: "bool" }`) whose result carries `Signed`,
+    /// not `Bool`.  Both halves of the fuse have to hold — the two-way
+    /// branch has to be recognised from the links, and `"bool"` has to
+    /// resolve to the `int_is_true` the assembler will name.
+    #[test]
+    fn a_truthify_condition_over_an_int_fuses_as_int_is_true() {
+        let (mut graph, cond, operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
+        assert!(
+            super::optimize_goto_if_not(&mut graph, start),
+            "a truthify branch must fuse"
+        );
+        let block = &graph.blocks[start];
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "bool")),
+            "the fused truthify op must be removed"
+        );
+        match &block.exitswitch {
+            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(opname, "int_is_true");
+                assert_eq!(args, &vec![operand]);
+            }
+            other => panic!("expected a fused exitswitch, got {other:?}"),
+        }
+        let _ = cond;
+    }
+
+    /// The `r` half of the same resolution: `op_kind_to_opname_with_kinds`
+    /// names a truthify over a Ref operand `ptr_nonzero`, and
+    /// `goto_if_not_ptr_nonzero/rL` is the key that has to be built.
+    #[test]
+    fn a_truthify_condition_over_a_ref_fuses_as_ptr_nonzero() {
+        let (mut graph, _cond, operand, start) = truthify_fixture(
+            crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+            LlType::Signed,
+        );
+        assert!(super::optimize_goto_if_not(&mut graph, start));
+        match &graph.blocks[start].exitswitch {
+            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(opname, "ptr_nonzero");
+                assert_eq!(args, &vec![operand]);
+            }
+            other => panic!("expected a fused exitswitch, got {other:?}"),
+        }
+    }
+
+    /// Control: an operand whose kind this pass cannot resolve takes
+    /// `flatten::kind_color_of`'s fallback, so naming a half here could
+    /// build a key with no handler.  It must decline, not guess.
+    #[test]
+    fn a_truthify_condition_over_an_unresolved_operand_declines() {
+        let (mut graph, _cond, _operand, start) = {
+            let (mut g, c, o, s) = truthify_fixture(LlType::Signed, LlType::Signed);
+            o.set_concretetype(None);
+            (g.clone(), c, o, s)
+        };
+        assert!(
+            !super::optimize_goto_if_not(&mut graph, start),
+            "an unresolved operand kind must decline the fuse"
+        );
+    }
+
+    /// Control: the link-side witness is what stands in for
+    /// `lltype.Bool`, so a two-way branch whose exits are not the false
+    /// and true arms must still decline.
+    #[test]
+    fn a_two_way_branch_without_bool_exitcases_declines() {
+        use crate::flowspace::model::ConstValue;
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        let (mut graph, cond, _operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
+        let targets: Vec<_> = graph.blocks[start]
+            .exits
+            .iter()
+            .map(|link| link.target)
+            .collect();
+        graph.set_control_flow_metadata(
+            crate::model::BlockId(start),
+            Some(ExitSwitch::Value(cond)),
+            vec![
+                Link::new_mixed(
+                    vec![],
+                    targets[0],
+                    Some(ExitCase::Const(ConstValue::Int(0))),
+                ),
+                Link::new_mixed(
+                    vec![],
+                    targets[1],
+                    Some(ExitCase::Const(ConstValue::Int(1))),
+                ),
+            ],
+        );
+        assert!(
+            !super::optimize_goto_if_not(&mut graph, start),
+            "an integer-cased two-way branch must decline the fuse"
+        );
+    }
+
+    /// `t = bool(x); exitswitch = t` with two bool-cased exits, the
+    /// concretetypes stamped as the caller asks.  Returns the graph, the
+    /// condition variable, the truthify operand, and the start block.
+    fn truthify_fixture(
+        operand_ty: LlType,
+        cond_ty: LlType,
+    ) -> (
+        FunctionGraph,
+        crate::flowspace::model::Variable,
+        crate::flowspace::model::Variable,
+        usize,
+    ) {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        let mut graph = FunctionGraph::new("goto_if_not_truthify");
+        let operand = graph.alloc_value_var();
+        operand.set_concretetype(Some(operand_ty));
+        let cond = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::UnaryOp {
+                    op: "bool".to_string(),
+                    operand: operand.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        // What production publishes: `getkind(Bool)` is `'i'`, so the
+        // canonicalising writer stores `Signed` here, never `Bool`.
+        cond.set_concretetype(Some(cond_ty));
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let start = graph.startblock.0;
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(cond.clone())),
+            vec![
+                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
+            ],
+        );
+        (graph, cond, operand, start)
     }
 
     /// the GotoIfNotOp lowering Stage 1: `int_lt(a, b); exitswitch = t` fuses into a

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -1012,6 +1012,27 @@ impl<'a> Transformer<'a> {
     pub fn transform(&mut self, graph: &FunctionGraph) -> GraphTransformResult {
         let mut rewritten = graph.clone();
 
+        // `jtransform.py transform_graph` opens with
+        // `constant_fold_ll_issubclass(graph, cpu)`, which folds a
+        // `direct_call` to `exceptiondata.fn_exception_match` whose
+        // arguments are all `Constant`.  It has no counterpart here, and
+        // cannot acquire one without two upstream pieces pyre does not
+        // have:
+        //
+        // * The calls it folds are the ones `inline.py`'s
+        //   `rewire_exceptblock_with_guard` / `generic_exception_matching`
+        //   insert.  `Inliner::inline_once` refuses that whole path with
+        //   `CannotInline`, so no such call is ever inserted.
+        // * `rclass::ll_issubclass`, `ll_issubclass_const` and
+        //   `ll_isinstance` are not lifted at all — `cutover` skips their
+        //   bodies (`skip-issubclass-helper-body`) because
+        //   `flowspace_adapter::translate_op` has already rewritten every
+        //   call site into the high-level `issubtype` / `isinstance` op,
+        //   which the rtyper lowers to an `int_between`-over-
+        //   `subclassrange` helper graph.  A constant-argument class check
+        //   therefore reaches this pass as a range test on constants, not
+        //   as a call to fold.
+
         // RPython `rtyper/rpbc.py::SingleFrozenPBCRepr` resolves
         // zero-arg unit-variant PBC ctors to a singleton
         // `Constant(prebuilt_instance_ptr)` before jtransform runs.
@@ -3367,6 +3388,26 @@ impl<'a> Transformer<'a> {
     /// * `IR_QUASIIMMUTABLE[_ARRAY]` → emit `[-live-, record_quasiimmut_field,
     ///   getfield_*_pure]` — `jtransform.py:895-903`.
     /// * mutable                  → keep as-is.
+    ///
+    /// Three upstream branches of `rewrite_op_getfield` are absent because
+    /// nothing in pyre produces the op shape they test for:
+    ///
+    /// * `is_typeptr_getset` → `handle_getfield_typeptr`, which replaces the
+    ///   read with `[-live-, guard_class]`.  Pyre never reads the class word
+    ///   through a field access — the header words are folded into
+    ///   `new_with_vtable` on the store side, and `heaptracker::is_header_word`
+    ///   keeps `typeptr` / `ob_type` / `PyObject::w_class` out of the
+    ///   field-descriptor census entirely, so no descriptor exists to match.
+    /// * the `rstr.STR` / `rstr.UNICODE` hash check that rewrites to
+    ///   `strhash` / `unicodehash`.  Those are not pyre opcodes: the
+    ///   `bh_strhash` / `bh_unicodehash` helpers exist at the backend layer
+    ///   for dict lookups, but there is no `OpCode` for either, and a string
+    ///   constant's hash is precomputed into the jitcode's `str_consts`
+    ///   rather than read from the object at run time.
+    /// * the `_greenfield` variant, gated on
+    ///   `CallControl::could_be_green_field`.  The query is implemented as a
+    ///   structural predicate, but `pyjitpl` has no greenfield mechanism to
+    ///   answer it against, so the rank is never `_greenfield`.
     fn rewrite_op_getfield(
         &mut self,
         op: &SpaceOperation,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7450,6 +7450,29 @@ fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::m
         {
             Some((op.clone(), vec![lhs.clone(), rhs.clone()]))
         }
+        // The same integer comparisons under the spelling that actually
+        // reaches here.  `front::mir::canonical_binop_label` leaves a
+        // comparison bare and the `int_` prefix is added by
+        // `assembler::op_kind_to_opname_with_kinds`, which runs after
+        // flatten -- so the `int_lt` arm above matches nothing the front end
+        // produces, while `float_lt` and `ptr_eq` do match because
+        // `rewrite_operation` renamed them.  The fused exitswitch has to
+        // name the opcode the assembler will look up
+        // (`goto_if_not_int_lt/iiL`), so the prefix is applied here.
+        //
+        // Both operands must be `'i'`: the argcodes come from the register
+        // kinds, and there is no `goto_if_not_int_lt/rrL` entry.  A ref or
+        // float comparison that still reads bare never had its operands
+        // rewritten and so is not one of these.
+        OpKind::BinOp { op, lhs, rhs, .. }
+            if matches!(op.as_str(), "lt" | "le" | "eq" | "ne" | "gt" | "ge")
+                && FunctionGraph::concretetype_of(lhs)
+                    == crate::codewriter::type_state::ConcreteType::Signed
+                && FunctionGraph::concretetype_of(rhs)
+                    == crate::codewriter::type_state::ConcreteType::Signed =>
+        {
+            Some((format!("int_{op}"), vec![lhs.clone(), rhs.clone()]))
+        }
         OpKind::UnaryOp { op, operand, .. }
             if matches!(
                 op.as_str(),
@@ -16510,5 +16533,119 @@ mod tests {
                 "`x == 5` stays a binary compare: {ops:?}"
             );
         }
+    }
+
+    /// `goto_if_not_fusable` names the RPython opnames (`int_lt`), but the
+    /// front end spells a comparison bare (`front::mir::canonical_binop_label`)
+    /// and only the assembler adds the `int_` prefix -- after flatten.  A
+    /// production integer compare therefore reaches the exitswitch under the
+    /// bare name.
+    #[test]
+    fn a_bare_int_compare_fuses_into_the_exitswitch() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+        let mut graph = FunctionGraph::new("bare_compare_fuse");
+        let a = graph.alloc_value_var();
+        let b = graph.alloc_value_var();
+        a.set_concretetype(Some(LowLevelType::Signed));
+        b.set_concretetype(Some(LowLevelType::Signed));
+        let t = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::BinOp {
+                    op: "lt".to_string(),
+                    lhs: a.clone(),
+                    rhs: b.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        t.set_concretetype(Some(LowLevelType::Bool));
+
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let true_iarg = graph.alloc_value_var();
+        graph.push_inputarg_var(if_true, true_iarg);
+        let start = graph.startblock.0;
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(t.clone())),
+            vec![
+                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                Link::new_mixed(
+                    vec![LinkArg::Value(t.clone())],
+                    if_true,
+                    Some(ExitCase::Bool(true)),
+                ),
+            ],
+        );
+
+        assert!(
+            super::optimize_goto_if_not(&mut graph, start),
+            "a bare `lt` is the spelling production emits and must fuse",
+        );
+        match &graph.blocks[start].exitswitch {
+            Some(ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(
+                    opname, "int_lt",
+                    "the fused exitswitch must name the opcode the assembler \
+                     looks up (`goto_if_not_int_lt/iiL`)",
+                );
+                assert_eq!(args, &vec![a, b]);
+            }
+            other => panic!("expected a fused exitswitch, got {other:?}"),
+        }
+    }
+
+    /// The bare arm is guarded on `Signed` operands because the argcodes
+    /// follow the register kinds and `insns.rs` registers no
+    /// `goto_if_not_int_eq/rrL`.  A ref comparison that still reads bare
+    /// never went through the `ptr_eq` rewrite, so it must not fuse.
+    #[test]
+    fn a_bare_compare_over_ref_operands_does_not_fuse() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+        let mut graph = FunctionGraph::new("bare_ref_compare");
+        let a = graph.alloc_value_var();
+        let b = graph.alloc_value_var();
+        let t = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::BinOp {
+                    op: "eq".to_string(),
+                    lhs: a.clone(),
+                    rhs: b.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        t.set_concretetype(Some(LowLevelType::Bool));
+
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let true_iarg = graph.alloc_value_var();
+        graph.push_inputarg_var(if_true, true_iarg);
+        let start = graph.startblock.0;
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(t.clone())),
+            vec![
+                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                Link::new_mixed(
+                    vec![LinkArg::Value(t.clone())],
+                    if_true,
+                    Some(ExitCase::Bool(true)),
+                ),
+            ],
+        );
+
+        assert!(
+            !super::optimize_goto_if_not(&mut graph, start),
+            "an unstamped operand pair has no `iiL` opcode to fuse into",
+        );
     }
 }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -661,6 +661,124 @@ fn is_source_constant_variable(
     })
 }
 
+/// jtransform.py `_rewrite_equality`'s `not arg.value` test.
+///
+/// Upstream reads the value straight off the `Constant`; pyre's front end
+/// materialises source constants as SSA Variables produced by a `Const*`
+/// operation, so the value has to be fetched from that producer.  The zeros
+/// are one per register class: `Signed` / `Unsigned` / `Bool` for `'i'` and
+/// the null pointer for `'r'`.  `ConstNone` is deliberately absent — it is a
+/// `lltype.Void` constant, not a null pointer, and never reaches an operand
+/// position.
+fn is_falsy_source_constant(
+    graph: &FunctionGraph,
+    variable: &crate::flowspace::model::Variable,
+) -> bool {
+    graph.blocks.iter().any(|block| {
+        block.operations.iter().any(|op| {
+            op.result.as_ref() == Some(variable)
+                && matches!(
+                    op.kind,
+                    OpKind::ConstInt(0)
+                        | OpKind::ConstUInt(0)
+                        | OpKind::ConstBool(false)
+                        | OpKind::ConstRefNull
+                )
+        })
+    })
+}
+
+/// jtransform.py `_rewrite_symmetric` — "rewrite 'c1+v2' into 'v2+c1' in an
+/// attempt to avoid generating too many variants of the bytecode".
+///
+/// Upstream binds it as `rewrite_op_<name>` for the symmetric arithmetic and
+/// bitwise ops and for every ordered comparison, and reaches it again as
+/// `_rewrite_equality`'s fallthrough for `int_eq` / `int_ne` / `ptr_eq` /
+/// `ptr_ne`.  Because it is a whole-operation rewrite rather than one arm of
+/// a dispatch, pyre runs it as a normalisation over the operation on its way
+/// into `rewrite_operation`; the arms that follow therefore never have to
+/// consider a constant left-hand operand.
+///
+/// The opnames are pyre's front-end labels (`front::mir::canonical_binop_label`
+/// leaves comparisons bare and prefixes nothing), plus the already-typed
+/// `uint_*` comparisons `front::checked_arith_uint` emits directly.  Ordered
+/// comparisons are renamed to their mirror when the operands swap; the
+/// symmetric ops keep their name, which is upstream's
+/// `.get(op.opname, op.opname)` default.
+fn rewrite_symmetric(graph: &FunctionGraph, op: SpaceOperation) -> SpaceOperation {
+    let OpKind::BinOp {
+        op: binop_name,
+        lhs,
+        rhs,
+        result_ty,
+    } = &op.kind
+    else {
+        return op;
+    };
+    if !is_symmetric_binop(binop_name) {
+        return op;
+    }
+    // `isinstance(op.args[0], Constant) and isinstance(op.args[1], Variable)`
+    if !is_source_constant_variable(graph, lhs) || is_source_constant_variable(graph, rhs) {
+        return op;
+    }
+    SpaceOperation {
+        result: op.result.clone(),
+        kind: OpKind::BinOp {
+            op: reversed_comparison_binop(binop_name).to_string(),
+            lhs: rhs.clone(),
+            rhs: lhs.clone(),
+            result_ty: result_ty.clone(),
+        },
+    }
+}
+
+/// The opnames upstream binds to `_rewrite_symmetric`, in pyre's spelling.
+///
+/// `add` / `mul` cover both `int_add` / `int_mul` and `float_add` /
+/// `float_mul`, and the bare comparisons cover the `int_`, `uint_` and
+/// `float_` families at once, because the register kind is not yet part of
+/// the name at this point.  `sub`, the divisions, the shifts and the
+/// `*_assign` spellings are absent for the same reason they are absent
+/// upstream: they are not symmetric.
+fn is_symmetric_binop(name: &str) -> bool {
+    matches!(
+        name,
+        "add"
+            | "mul"
+            | "bitand"
+            | "bitor"
+            | "bitxor"
+            | "eq"
+            | "ne"
+            | "lt"
+            | "le"
+            | "gt"
+            | "ge"
+            | "uint_lt"
+            | "uint_le"
+            | "uint_gt"
+            | "uint_ge"
+    )
+}
+
+/// jtransform.py `_rewrite_symmetric`'s `reversename` table: swapping the
+/// operands of an ordered comparison mirrors it.  Everything else keeps its
+/// name (upstream's `.get(op.opname, op.opname)` default).
+fn reversed_comparison_binop(name: &str) -> &str {
+    match name {
+        "lt" => "gt",
+        "le" => "ge",
+        "gt" => "lt",
+        "ge" => "le",
+        "uint_lt" => "uint_gt",
+        "uint_le" => "uint_ge",
+        "uint_gt" => "uint_lt",
+        "uint_ge" => "uint_le",
+        other => other,
+    }
+}
+
 /// RPython: `support.autodetect_jit_markers_redvars` (support.py).
 /// Compute the Variables live across the portal's `jit_merge_point`, remove
 /// its greens, filter Constants/Void, and return INT/REF/FLOAT order.
@@ -991,6 +1109,10 @@ impl<'a> Transformer<'a> {
         let mut count_before_last_operation = None;
         for original_op in &original_ops {
             let op = remap_op(original_op, &self.aliases);
+            // `jtransform.py` binds `_rewrite_symmetric` as the whole
+            // `rewrite_op_<name>` for the symmetric ops, so it runs before
+            // any other rewriting can look at the operands.
+            let op = rewrite_symmetric(graph, op);
             let rewritten = self.rewrite_operation(&op, graph_name, graph);
             count_before_last_operation = Some(new_ops.len());
             match rewritten {
@@ -1835,6 +1957,88 @@ impl<'a> Transformer<'a> {
                         op: "cast_int_to_float".into(),
                         operand: operand.clone(),
                         result_ty: ValueType::Float,
+                    },
+                }])
+            }
+            // jtransform.py `_rewrite_equality`, reached through
+            // `rewrite_op_int_eq` / `rewrite_op_int_ne`: a comparison whose
+            // other operand is the zero constant is the unary test
+            // `int_is_zero` / `int_is_true`.  The unary form is what
+            // `goto_if_not_fusable` can fold into the exitswitch, so the
+            // pair collapses to a single `goto_if_not_int_is_zero/iL`
+            // instead of a compare plus a generic `goto_if_not`.
+            //
+            // Upstream tests `arg0` first and keeps `arg1`; the constant is
+            // already on the right here because `rewrite_symmetric` ran
+            // over the operation before this match (`optimize_block`), so
+            // both spellings arrive as `<var> <op> 0`.  `0 == 0` keeps the
+            // right-hand operand exactly as upstream does.
+            OpKind::BinOp {
+                op: binop_name,
+                lhs,
+                rhs,
+                result_ty,
+            } if matches!(binop_name.as_str(), "eq" | "ne")
+                && self.get_value_kind_var(lhs) == 'i'
+                && self.get_value_kind_var(rhs) == 'i'
+                && (is_falsy_source_constant(graph, lhs)
+                    || is_falsy_source_constant(graph, rhs)) =>
+            {
+                let operand = if is_falsy_source_constant(graph, lhs) {
+                    rhs
+                } else {
+                    lhs
+                };
+                let unop = if binop_name == "eq" {
+                    "int_is_zero"
+                } else {
+                    "int_is_true"
+                };
+                RewriteResult::Replace(vec![SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::UnaryOp {
+                        op: unop.into(),
+                        operand: operand.clone(),
+                        result_ty: result_ty.clone(),
+                    },
+                }])
+            }
+            // jtransform.py `rewrite_op_ptr_eq` / `rewrite_op_ptr_ne`: the
+            // same `_rewrite_equality` fold over Ref operands, whose zero is
+            // the null pointer and whose unary tests are `ptr_iszero` /
+            // `ptr_nonzero`.  Upstream then runs the result through
+            // `_rewrite_cmp_ptrs`, which downgrades a non-GC pointer to
+            // `int_is_zero` / `int_is_true`; every Ref reaching pyre's
+            // codewriter is a GC ref (`GcKind` does not survive the MIR
+            // front end), so the GC branch is the only one, matching the
+            // binary `ptr_eq` / `ptr_ne` arm below.
+            OpKind::BinOp {
+                op: binop_name,
+                lhs,
+                rhs,
+                result_ty,
+            } if matches!(binop_name.as_str(), "eq" | "ne")
+                && self.get_value_kind_var(lhs) == 'r'
+                && self.get_value_kind_var(rhs) == 'r'
+                && (is_falsy_source_constant(graph, lhs)
+                    || is_falsy_source_constant(graph, rhs)) =>
+            {
+                let operand = if is_falsy_source_constant(graph, lhs) {
+                    rhs
+                } else {
+                    lhs
+                };
+                let unop = if binop_name == "eq" {
+                    "ptr_iszero"
+                } else {
+                    "ptr_nonzero"
+                };
+                RewriteResult::Replace(vec![SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::UnaryOp {
+                        op: unop.into(),
+                        operand: operand.clone(),
+                        result_ty: result_ty.clone(),
                     },
                 }])
             }
@@ -16065,5 +16269,246 @@ mod tests {
                 ._handle_list_call("list.append", &op, &[l], &mut graph, "list_unhandled")
                 .is_none()
         );
+    }
+
+    /// `_rewrite_equality` / `_rewrite_symmetric`: pyre's front end spells
+    /// every comparison bare (`eq`, `lt`) and materialises each source
+    /// constant as its own SSA operation, so both upstream rewrites have to
+    /// read the constant back out of the graph.
+    mod equality_and_symmetry_tests {
+        use super::*;
+        use crate::codewriter::type_state::ConcreteType;
+        use crate::flowspace::model::Variable;
+        use crate::model::{FunctionGraph, OpKind, ValueType};
+
+        /// One `Input` of the given kind and one constant, then `op` over
+        /// them in `(lhs, rhs)` order; returns the transformed startblock's
+        /// operations plus the input variable.
+        fn transform_binop(
+            op: &str,
+            constant: OpKind,
+            constant_kind: ConcreteType,
+            input_kind: ConcreteType,
+            input_ty: ValueType,
+            constant_first: bool,
+        ) -> (Vec<crate::model::SpaceOperation>, Variable) {
+            let mut graph = FunctionGraph::new("binop_under_test");
+            let input_var = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "x".into(),
+                        ty: input_ty,
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let const_var = graph.push_op_var(graph.startblock, constant, true).unwrap();
+            let (lhs, rhs) = if constant_first {
+                (const_var.clone(), input_var.clone())
+            } else {
+                (input_var.clone(), const_var.clone())
+            };
+            let result_var = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: op.into(),
+                        lhs,
+                        rhs,
+                        result_ty: ValueType::Bool,
+                    },
+                    true,
+                )
+                .unwrap();
+            graph.set_return(graph.startblock, Some(result_var.clone()));
+
+            FunctionGraph::set_concretetype_of_inline(&input_var, input_kind);
+            FunctionGraph::set_concretetype_of_inline(&const_var, constant_kind);
+            FunctionGraph::set_concretetype_of_inline(&result_var, ConcreteType::Signed);
+
+            let config = GraphTransformConfig::default();
+            let transformed = Transformer::new(&config).transform(&graph);
+            let ops = transformed.graph.block(graph.startblock).operations.clone();
+            (ops, input_var)
+        }
+
+        fn unary_op(ops: &[crate::model::SpaceOperation]) -> Option<(String, Variable)> {
+            ops.iter().find_map(|op| match &op.kind {
+                OpKind::UnaryOp { op, operand, .. } => Some((op.clone(), operand.clone())),
+                _ => None,
+            })
+        }
+
+        fn binary_op(ops: &[crate::model::SpaceOperation]) -> Option<(String, Variable, Variable)> {
+            ops.iter().find_map(|op| match &op.kind {
+                OpKind::BinOp { op, lhs, rhs, .. } => Some((op.clone(), lhs.clone(), rhs.clone())),
+                _ => None,
+            })
+        }
+
+        #[test]
+        fn an_int_equality_against_zero_becomes_int_is_zero() {
+            let (ops, x) = transform_binop(
+                "eq",
+                OpKind::ConstInt(0),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                false,
+            );
+            assert_eq!(
+                unary_op(&ops),
+                Some(("int_is_zero".to_string(), x)),
+                "`x == 0` must fold to the unary test: {ops:?}"
+            );
+            assert!(
+                binary_op(&ops).is_none(),
+                "the binary compare must be gone: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn an_int_inequality_against_zero_becomes_int_is_true() {
+            let (ops, x) = transform_binop(
+                "ne",
+                OpKind::ConstInt(0),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                false,
+            );
+            assert_eq!(
+                unary_op(&ops),
+                Some(("int_is_true".to_string(), x)),
+                "`x != 0` must fold to the unary test: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_zero_on_the_left_folds_the_same_way() {
+            let (ops, x) = transform_binop(
+                "eq",
+                OpKind::ConstInt(0),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            assert_eq!(
+                unary_op(&ops),
+                Some(("int_is_zero".to_string(), x)),
+                "`0 == x` is `_rewrite_symmetric` then the same fold: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_ref_equality_against_null_becomes_ptr_iszero() {
+            let (ops, x) = transform_binop(
+                "eq",
+                OpKind::ConstRefNull,
+                ConcreteType::GcRef,
+                ConcreteType::GcRef,
+                ValueType::Ref(None),
+                false,
+            );
+            assert_eq!(
+                unary_op(&ops),
+                Some(("ptr_iszero".to_string(), x)),
+                "`p == NULL` must fold to the unary pointer test: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_ref_inequality_against_null_becomes_ptr_nonzero() {
+            let (ops, x) = transform_binop(
+                "ne",
+                OpKind::ConstRefNull,
+                ConcreteType::GcRef,
+                ConcreteType::GcRef,
+                ValueType::Ref(None),
+                false,
+            );
+            assert_eq!(
+                unary_op(&ops),
+                Some(("ptr_nonzero".to_string(), x)),
+                "`p != NULL` must fold to the unary pointer test: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_constant_left_operand_of_an_ordered_compare_mirrors_the_opname() {
+            let (ops, x) = transform_binop(
+                "lt",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            let (op, lhs, _) = binary_op(&ops).expect("the compare must survive");
+            assert_eq!(op, "gt", "`5 < x` must become `x > 5`: {ops:?}");
+            assert_eq!(lhs, x, "the variable must move to the left: {ops:?}");
+        }
+
+        #[test]
+        fn a_constant_left_operand_of_a_symmetric_op_keeps_the_opname() {
+            let (ops, x) = transform_binop(
+                "add",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            let (op, lhs, _) = binary_op(&ops).expect("the addition must survive");
+            assert_eq!(op, "add", "`add` has no mirror: {ops:?}");
+            assert_eq!(lhs, x, "the variable must move to the left: {ops:?}");
+        }
+
+        #[test]
+        fn a_subtraction_is_not_symmetric_and_keeps_its_operand_order() {
+            let (ops, _x) = transform_binop(
+                "sub",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            let (op, lhs, _) = binary_op(&ops).expect("the subtraction must survive");
+            assert_eq!(op, "sub");
+            assert!(
+                matches!(
+                    ops.iter()
+                        .find(|o| o.result.as_ref() == Some(&lhs))
+                        .map(|o| &o.kind),
+                    Some(OpKind::ConstInt(5))
+                ),
+                "`5 - x` must keep the constant on the left: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_nonzero_constant_does_not_fold_an_equality() {
+            let (ops, _x) = transform_binop(
+                "eq",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                false,
+            );
+            assert!(
+                unary_op(&ops).is_none(),
+                "only the zero constant folds to a unary test: {ops:?}"
+            );
+            assert_eq!(
+                binary_op(&ops).map(|(op, _, _)| op),
+                Some("eq".to_string()),
+                "`x == 5` stays a binary compare: {ops:?}"
+            );
+        }
     }
 }

--- a/pyre/bench/synth/exec_namespace_code_object_rooting_regression.py
+++ b/pyre/bench/synth/exec_namespace_code_object_rooting_regression.py
@@ -1,0 +1,148 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=warm
+# Self-checking regression guard for the operands `exec` / `eval` thread from
+# the code object's construction to the frame that runs it.
+#
+# `pyopcode.py:773-774` plants `__builtins__` with
+# `space.call_method(w_globals, 'setdefault', ...)` and `compiling.py:109-110`
+# with `space.contains_w` + `space.setitem_str`, all dispatched on the caller's
+# own mapping so a dict subclass's override wins.  That override is user
+# Python, so it can collect -- and at that point `exec_or_eval` is still
+# holding the code object it compiled a few lines earlier, the namespace
+# arguments, and a raw pointer interior to the code object's payload.
+#
+# Nothing else references a code object compiled from a string, so a collection
+# inside that window reclaimed it: `createframe_obj` then stored globals
+# through a dead header (`w_code_frame_stores_global` reaching the write
+# barrier with a freed parent), or the frame ran against a stale namespace and
+# the assignment the source performs was never visible to the caller.
+#
+# `frame_locals_snapshot`, `function_new_with_closure` and `createframe_obj`
+# each allocate after that window too, which is why the operands are read back
+# from their slots at every use rather than once after the plant.
+#
+# Every expectation below is the value CPython 3.14 and PyPy both produce.
+import gc
+
+try:
+    import pypyjit
+
+    pypyjit.set_param("threshold=20,function_threshold=20")
+except ImportError:
+    pass
+
+failures = []
+
+
+def churn():
+    """Allocation the collection below has something to reclaim."""
+    return [{} for _ in range(200)]
+
+
+def collect():
+    churn()
+    gc.collect()
+
+
+class SetdefaultNS(dict):
+    """`exec`'s plant is a `setdefault` call, so a subclass override runs."""
+
+    def setdefault(self, key, value=None):
+        collect()
+        return dict.setdefault(self, key, value)
+
+
+class ContainsNS(dict):
+    """`eval`'s plant asks `__contains__` before it writes."""
+
+    def __contains__(self, key):
+        collect()
+        return dict.__contains__(self, key)
+
+
+class SetitemNS(dict):
+    """`eval` writes through `__setitem__` when `__builtins__` is absent."""
+
+    def __setitem__(self, key, value):
+        collect()
+        return dict.__setitem__(self, key, value)
+
+
+def check(label, fn, expected):
+    for round_index in range(60):
+        got = fn()
+        if got != expected:
+            failures.append(f"{label} round {round_index}: {got!r} != {expected!r}")
+            return
+
+
+def exec_setdefault():
+    # The code object is compiled here and consumed after the plant.
+    namespace = SetdefaultNS()
+    namespace["src"] = {"x": 1}
+    exec("meth = src.get\nr = meth('x')", namespace)
+    return namespace.get("r")
+
+
+def eval_contains():
+    namespace = ContainsNS()
+    namespace["src"] = {"x": 1}
+    return eval("src.get('x')", namespace)
+
+
+def eval_setitem():
+    namespace = SetitemNS()
+    namespace["src"] = {"x": 2}
+    return eval("src.get('x')", namespace)
+
+
+def exec_separate_locals():
+    # `locals_arg` is a distinct mapping, so it rides the window too.
+    globals_ns = SetdefaultNS()
+    locals_ns = {"src": {"x": 3}}
+    exec("r = src.get('x')", globals_ns, locals_ns)
+    return locals_ns.get("r")
+
+
+def exec_precompiled_code():
+    # A code object the caller already holds must answer the same way.
+    namespace = SetdefaultNS()
+    namespace["src"] = {"x": 4}
+    exec(PRECOMPILED, namespace)
+    return namespace.get("r")
+
+
+PRECOMPILED = compile("r = src.get('x')", "<regression>", "exec")
+
+
+def warm(rounds):
+    """The hot loop the JIT compiles; each round re-enters the window."""
+    total = 0
+    for _ in range(rounds):
+        namespace = SetdefaultNS()
+        namespace["src"] = {"x": 1}
+        exec("r = src.get('x')", namespace)
+        total += namespace.get("r") or 0
+    return total
+
+
+def main():
+    check("exec-setdefault", exec_setdefault, 1)
+    check("eval-contains", eval_contains, 1)
+    check("eval-setitem", eval_setitem, 2)
+    check("exec-separate-locals", exec_separate_locals, 3)
+    check("exec-precompiled-code", exec_precompiled_code, 4)
+
+    warmed = warm(200)
+    if warmed != 200:
+        failures.append(f"warm loop: {warmed} != 200")
+
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS exec namespace code-object rooting")
+    return 0
+
+
+raise SystemExit(main())

--- a/pyre/bench/synth/listcomp_float_element_regression.py
+++ b/pyre/bench/synth/listcomp_float_element_regression.py
@@ -1,0 +1,96 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=warm
+# A list comprehension over `range` whose element is a float, run until the
+# JIT compiles the loop.
+#
+# `jtransform.py` `_rewrite_equality` folds `int_eq(x, 0)` into the unary
+# `int_is_zero(x)`, so the interpreter's own jitcode carries that opname
+# wherever it tests an integer against zero -- 1232 bodies.  `pyjitpl.py`
+# generates the integer unary opimpls from one list, `int_is_true` /
+# `int_is_zero` / `int_neg` / `int_invert`; the walker's table here had
+# every entry of that list except `int_is_zero`, and a key the table does
+# not name is `DispatchError::UnsupportedOpname` -- the trace aborts part
+# way through the body it was walking rather than declining up front.
+#
+# The observable is this loop dying with
+# `TypeError: 'float' object is not an iterator`: FOR_ITER reads the
+# element where the iterator belongs.  Only a float element reaches it --
+# `x`, `x + 1` and `x * 2` all pass, so a fixture that produced ints would
+# have gone green against the same defect.  `PYRE_NO_JIT=1` passes too.
+#
+# Every expectation below is the value CPython 3.14 and PyPy both produce.
+try:
+    import pypyjit
+
+    pypyjit.set_param("threshold=20,function_threshold=20")
+except ImportError:
+    pass
+
+failures = []
+
+SIZES = list(range(30)) + [2000]
+
+
+def listcomp_mul(n):
+    return [x * 1.0 for x in range(n)]
+
+
+def listcomp_const_lhs(n):
+    return [1.0 * x for x in range(n)]
+
+
+def listcomp_truediv(n):
+    return [x / 1 for x in range(n)]
+
+
+def listcomp_call(n):
+    return [float(x) for x in range(n)]
+
+
+def check(label, fn):
+    for n in SIZES:
+        try:
+            got = fn(n)
+        except TypeError as exc:
+            failures.append(f"{label} n={n}: raised TypeError: {exc}")
+            return
+        if len(got) != n:
+            failures.append(f"{label} n={n}: len {len(got)} != {n}")
+            return
+        if n and got[-1] != float(n - 1):
+            failures.append(f"{label} n={n}: last {got[-1]!r} != {float(n - 1)!r}")
+            return
+
+
+def warm(rounds):
+    """The hot loop the JIT compiles; each round re-enters the window."""
+    total = 0.0
+    for _ in range(rounds):
+        total += sum([x * 1.0 for x in range(64)])
+    return total
+
+
+def main():
+    check("listcomp-mul", listcomp_mul)
+    check("listcomp-const-lhs", listcomp_const_lhs)
+    check("listcomp-truediv", listcomp_truediv)
+    check("listcomp-call", listcomp_call)
+
+    expected = 400 * 2016.0
+    try:
+        warmed = warm(400)
+    except TypeError as exc:
+        failures.append(f"warm loop: raised TypeError: {exc}")
+    else:
+        if warmed != expected:
+            failures.append(f"warm loop: {warmed!r} != {expected!r}")
+
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS listcomp float element")
+    return 0
+
+
+raise SystemExit(main())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -1082,14 +1082,23 @@ regular_record_table! {
     // Int-bank unary ops: `pyjitpl.py` (int_neg / int_invert) +
     // 371-375 (int_same_as, which records `rop.SAME_AS_I` via
     // `_record_helper` — same shape, treated as a regular
-    // record-and-writeback). `int_is_true` (`pyjitpl.py`) is
-    // Int-typed on the bank though semantically bool (matches the `>i`
-    // destination shape).
+    // record-and-writeback). `int_is_true` / `int_is_zero`
+    // (`pyjitpl.py`) are Int-typed on the bank though semantically
+    // bool (matches the `>i` destination shape).
+    //
+    // `int_is_zero` sits beside `int_is_true` in the generated unary
+    // loop and answers `not a` (`blackhole.py` `bhimpl_int_is_zero`).
+    // It reaches a body only once `jtransform.py` `_rewrite_equality`
+    // folds `int_eq(x, 0)`, so before that rewrite existed here no
+    // jitcode carried the opname and this arm's absence was invisible:
+    // an unlisted key falls through to `DispatchError::UnsupportedOpname`,
+    // which aborts the trace mid-walk.
     unop_int_record {
         "int_neg/i>i" => IntNeg,
         "int_invert/i>i" => IntInvert,
         "int_same_as/i>i" => SameAsI,
         "int_is_true/i>i" => IntIsTrue,
+        "int_is_zero/i>i" => IntIsZero,
     }
     unop_float_record {
         "float_neg/f>f" => FloatNeg,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -7217,6 +7217,21 @@ fn int_invert_records_intinvert() {
 }
 
 #[test]
+fn int_is_true_records_intistrue() {
+    drive_int_unop("int_is_true/i>i", majit_ir::OpCode::IntIsTrue);
+}
+
+/// `int_is_zero` is the `not a` sibling `pyjitpl.py` generates beside
+/// `int_is_true`; `jtransform.py` `_rewrite_equality` is what puts it in a
+/// body, by folding `int_eq(x, 0)`. Without an arm the walker answers
+/// `DispatchError::UnsupportedOpname` and aborts the trace, so this asserts
+/// the arm exists rather than only that the recorded op is right.
+#[test]
+fn int_is_zero_records_intiszero() {
+    drive_int_unop("int_is_zero/i>i", majit_ir::OpCode::IntIsZero);
+}
+
+#[test]
 fn int_same_as_is_eliminated_from_generated_insns_table() {
     // RPython `jtransform.py rewrite_op_same_as` removes
     // `same_as` before assembly. The walker keeps a handler arm for

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -7790,15 +7790,24 @@ fn int_add_with_out_of_range_dst_register_surfaces_typed_error() {
 
 #[test]
 fn unsupported_opname_surfaces_typed_error() {
-    // Stable choice for exercising the catch-all `UnsupportedOpname`
-    // error path.  `vtable_method_ptr/rd>i` is a pyre-only backend
-    // adaptation (emitted by `OpKind::VtableMethodPtr` /
-    // `assembler.rs`) without a PyPy analog: Python dispatch
-    // resolves through `cpu.bh_call_*` at runtime rather than
-    // reifying a method pointer into the bytecode stream.  Zero
-    // JitCode hits in production traces (per
-    // `t3_audit_opname_gap_inventory`), so it's a durable choice
-    // for the "still unsupported" slot.
+    // The only remaining opname with no arm, so the only one that can
+    // exercise the catch-all `UnsupportedOpname` error path.
+    // `vtable_method_ptr/rd>i` is a pyre-only backend adaptation
+    // (emitted by `OpKind::VtableMethodPtr` / `assembler.rs`) without a
+    // PyPy analog: Python dispatch resolves through `cpu.bh_call_*` at
+    // runtime rather than reifying a method pointer into the bytecode
+    // stream, and its blackhole side is a deliberate bail
+    // (`handler_vtable_method_ptr_bail`).
+    //
+    // It is NOT unreachable, and an earlier note here saying it had zero
+    // JitCode hits was wrong.  Counting `body.code[pos]` over every
+    // `pos in body.startpoints` of the shipped `jit_metadata.json`
+    // (3459 bodies, 152888 instructions, 114 distinct opnames -- the
+    // whole `insns` table, so no opname is dead) puts one occurrence in
+    // `view_as_kwargs`, between a `live/` and an `int_guard_value` +
+    // `residual_call_r_r`.  A `f(**d)` probe did not reach it, so
+    // whether a walk gets there is unproven; the byte is chosen here
+    // because nothing else can reach this arm, not because it is dead.
     let opname = "vtable_method_ptr/rd>i";
     let unsupported_byte = *insns_opname_to_byte()
         .get(opname)


### PR DESCRIPTION
Ports the jitcode-lowering rewrites the reviewer note listed, in the order it
gave, and follows two of them into the codewriter where the same rewrite was
missing or inert.

## What landed

**Lowerer (`majit-macros`, the `#[jit_interp]` jitcode lowering)**

* A `continue` the lowering cannot target now refuses instead of resolving to
  `Some(())` and silently vanishing.
* A `recursive_portal_call!` emits `promote_greens` and the real reds.
* `hint_fresh_virtualizable` refuses rather than being dropped.
* `_rewrite_equality`, `_rewrite_symmetric` and the pointer comparisons:
  a Ref/Ref `==` used to fall through the Int check and decline the whole
  dispatch arm; `x == 0` used to materialize a zero and compare against it.

**Codewriter (`majit-translate`)**

* `_rewrite_equality` and `_rewrite_symmetric`.
* `optimize_goto_if_not` now actually fuses.

## The fusion gap — found, fixed, measured, and backed out

`optimize_goto_if_not` was fusing nothing. Counting each `startpoints` offset
in the shipped `jit_metadata.json` (3459 jitcodes) before the fix:

| key | uses |
| --- | --- |
| `goto_if_not/iL` (unfused) | 9284 |
| the whole `goto_if_not_int_*/iiL` family | 0 |
| `goto_if_not_ptr_ne/rrL` | 8 |

Three gates, each closed for a different reason:

1. `goto_if_not_fusable` matched `int_lt` / `int_le` / …, but
   `front::mir::canonical_binop_label` leaves a comparison bare and
   `assembler::op_kind_to_opname_with_kinds` adds the `int_` prefix *after*
   flatten. `float_lt` and `ptr_eq` matched only because `rewrite_operation`
   had already renamed them.
2. The unary arm matched `int_is_true` / `ptr_nonzero`, but the front end
   spells the condition `OpKind::UnaryOp { op: "bool" }` and the same
   post-flatten renaming assigns those names. It now resolves `"bool"` the
   way the assembler will — by the operand's register kind — and declines
   when that kind is unresolved rather than naming a key with no wired
   handler.
3. `v.concretetype() != Some(LowLevelType::Bool)` rejected whatever
   survived. Kinds are published through
   `FunctionGraph::set_concretetype_of_inline`, which canonicalises through
   `concrete_to_canonical_lltype` — five outputs, none of them `Bool` — and
   `getkind(Bool)` is `'i'`, so a Bool-producing op is stored as `Signed`.
   The two exits being the false and the true arm is the fact upstream's
   `lltype.Bool` stands for, and it is now read off the links through
   `flatten::bool_llexitcase`, the reader `flatten::is_bool_branch` already
   uses.

The pre-existing `optimize_goto_if_not_fuses_int_lt_compare` fixture builds
its input in the recognizer's spelling and stamps `LowLevelType::Bool` by
hand, which is why it passed over gates no production graph clears.

Closing gates 2 and 3 (`0dacccbfe2d`) does exactly what it should to the
shipped jitcode — `goto_if_not/iL` 9284 -> 0, `goto_if_not_int_is_true/iL`
0 -> 9272, standalone `int_is_true/i>i` 9348 -> 80, so roughly 9272
instructions and their registers disappear — **and it breaks the JIT**, so
it is reverted in `09b70e0cf64`. Same tree, LLBC re-extracted for both arms
because `jtransform.rs` and `flatten.rs` are in the fingerprint closure:

| `pyre/check.py --backend dynasm` | passed | failed |
| --- | --- | --- |
| with the fusion | 478 | 60 |
| reverted | 535 | 3 |

It is a wrong answer, not baseline movement:
`pyre/bench/synth/listcomp_hot.py` returns 6000000 under `PYRE_NO_JIT=1`
and raises `TypeError: 'int' object is not an iterator` from
`for j in range(n)` with the JIT on. Across the rest the signature is
`loops_aborted 0 -> N`, `loops_compiled` down and
`fbw_blackhole_adopted_single_frame 0 -> N`.

The commit and its revert are both kept so the census, the A/B and the
elimination work stay attached to the code they describe. Ruled out as
causes, all read: `liveness.rs` counts every `GotoIfNotOp` arg as a use;
the `BC_GOTO_IF_NOT_INT_IS_TRUE` dispatch arm matches
`opimpl_goto_if_not_int_is_true` including `replace=false`;
`bhimpl_goto_if_not_int_is_true` aliases `bhimpl_goto_if_not` upstream too;
`body_branch_targets` decodes any `L` argcode; `fbw_callee_body_replay_scan`
poisons only write-shaped opnames; `-live-` sits immediately before the
branch in both forms. `fbw_blackhole_adopted_*` points at the FOR_ITER
inline window, and `PYRE_FBW_INLINE_DIAG=1 PYRE_FBW_REPLAY_DIRTY_BODY=1`
prints that verdict per body.

## A new opcode needs four registrations

The lowerer's `int_is_zero` fold broke every example crate with an int-typed
`while`: `record_unary_i: unsupported opcode IntIsTrue`. Extending that match
exposed that `int_is_zero/i>i` had a wired blackhole handler but no opcode
byte — `wire_handler` matches by name against the curated `(key, byte)` set
and no-ops when the name is absent, and the build-time `write_insn` path
calls the panicking `insn_byte` rather than the translator's `insn_byte_opt`
dynamic allocator. The key now has `BC_INT_IS_ZERO`, a curated-set entry and
a metainterp dispatch arm.

## What is deliberately not here

Four items on the note have no producer in this tree. Each is now stated
where a reader looks for the missing branch, with the pipeline decision that
makes it unreachable:

* `constant_fold_ll_issubclass` — it folds calls the inliner inserts, and
  `Inliner::inline_once` refuses that path with `CannotInline`; separately,
  `cutover` skips the `ll_issubclass` / `ll_issubclass_const` / `ll_isinstance`
  bodies because `flowspace_adapter::translate_op` has already rewritten every
  call site into `issubtype` / `isinstance`.
* `setup_cache_gcstruct2vtable` — `GcStructVTableCache` holds no rtyper
  handle to walk `instance_reprs` with, and `get_vtable_for_gcstruct` has no
  non-test caller.
* The `typeptr`, `strhash` / `unicodehash` and `_greenfield` branches of
  `rewrite_op_getfield` — the class word is folded into `new_with_vtable` on
  the store side and `heaptracker::is_header_word` keeps it out of the
  descriptor census; there is no `StrHash` opcode; `pyjitpl` has no greenfield
  mechanism.
* `vable_array_vars` and its escape assert were already complete
  (`check_no_vable_array`, cleared per block, checked on all three routes).

`instance_ptr_eq` / `instance_ptr_ne` are emitted by the lowerer, which
records a `struct_type` per binding, but not by the codewriter:
`Variable.concretetype` is one of five coarse kinds there, `Variable.annotation`
is cleared after use, and the surviving projection makes *every* Ref look like
a `SomeInstance` — promoting on that would hand `optimize_oois_ooisnot` the
known-class branch for array pointers and lose the length-bound fold.

## Verification

`pyre/check.py`, macOS arm64, run separately per backend:

* dynasm — 535 passed, 3 failed
* cranelift — 535 passed, 3 failed

The three are `list_append_virtual_payload` (crash),
`pickle_ctor_args` (jit-stats) and `zero_arg_super_attr` (exit 124).
They are not this branch's: main's own CI at the merge-base
`55e6fb87965` fails on exactly those three, on both backends
(run 33650098582).

Also green: `cargo test -p majit-translate` (3499 + 24 suites),
`cargo test -p majit-macros` (162 + 35), and the fourteen `majit/examples`
crates under `--features dynasm`. `cargo fmt --all -- --check` and
`scripts/check-new-line-citations.py` are clean.

— *authored by Claude*
