### PR TITLE
majit-ir: state that no route consumes the FormatSimple tag

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -963,12 +963,14 @@ pub enum RuntimeHelperKind {
     /// `bh_format_simple_fn(value)` — the FORMAT_SIMPLE helper
     /// (`runtime_ops::format_value` with the empty spec).  A user
     /// `__format__` runs Python here, so the generic residual is opaque for
-    /// the whole method body.  The full-body walker recognises this tag to
-    /// resolve `__format__` on the promoted receiver class and inline the
-    /// resolved body behind a `guard_class` + version-tag guard, the same
-    /// receiver-pinning route [`RuntimeHelperKind::BinaryOp`] takes for a
-    /// user `__add__`.  A builtin `__format__` is not inlinable Python code
-    /// and falls through to the residual unchanged.
+    /// the whole method body.
+    ///
+    /// No walker route consumes this tag, so a FORMAT_SIMPLE stays residual.
+    /// The receiver-pinning inline [`RuntimeHelperKind::FormatWithSpec`]
+    /// takes needs a spec operand for the callee's second parameter, and
+    /// FORMAT_SIMPLE carries none: `format_value_dispatch` allocates a fresh
+    /// empty `str` per call, which a route would have to synthesize.  The tag
+    /// is what such a route would key on.
     FormatSimple,
     /// `bh_format_with_spec_fn(value, spec)` — the FORMAT_WITH_SPEC helper,
     /// the two-operand sibling of [`RuntimeHelperKind::FormatSimple`] carrying


### PR DESCRIPTION
Follow-up to #1656, acting on the one actionable review comment it received.

`RuntimeHelperKind::FormatSimple`'s doc said, in the present tense, that the
full-body walker resolves `__format__` on the promoted receiver class and
inlines the resolved body for this tag. That is true of `FormatWithSpec`, which
has a branch in `dispatch_residual_call_iRd_kind`; nothing matches on
`FormatSimple`, so a FORMAT_SIMPLE stays residual.

On current main the tag appears only at the site that *produces* it:

```
pyre/pyre-jit/src/jit/flatten.rs:6193:  RuntimeHelperKind::FormatSimple,      # lowering
```

against `FormatWithSpec`'s producer *and* consumer:

```
pyre/pyre-jit/src/jit/flatten.rs:6827:                    RuntimeHelperKind::FormatWithSpec,
pyre/pyre-jit-trace/.../residual_call.rs:6762:  if foldable_runtime_helper == RuntimeHelperKind::FormatWithSpec {
```

The replacement says no route consumes the tag, and records what blocks one:
the inline needs a spec operand for the callee's second parameter and
FORMAT_SIMPLE carries none — `format_value_dispatch` allocates a fresh empty
`str` per call, which a route would have to synthesize.

Comment-only; no behaviour change.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the behavior and limitations of the `FormatSimple` runtime helper.
  * Documented that simple formatting remains residual and does not use the same inlining path as formatting with a specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->