### PR TITLE
bench/synth: refit four pypy ceilings the startup subtraction moved, and retire a fifth

### DIFF
--- a/pyre/bench/synth/condexpr_heap_const_merge.py
+++ b/pyre/bench/synth/condexpr_heap_const_merge.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4.2
+# pyre-check: max-pypy-ratio=9
 # The trip count answers two ends at once.  The loop has to run long enough to
 # reach the JIT, or the merge this fixture exists for never happens; and pypy's
 # own execution has to clear FLOOR_GATE_MIN_BASELINE_S, or the ratio divides

--- a/pyre/bench/synth/exception_loop_warmup.py
+++ b/pyre/bench/synth/exception_loop_warmup.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4.1
+# pyre-check: max-pypy-ratio=6.5
 # Warm-up-then-raise exception handling: the loop runs cleanly long enough to
 # compile, then a nested try/(try-finally)/except starts raising only after the
 # warm-up window. The post-warm-up raise is therefore NOT in the recorded trace,

--- a/pyre/bench/synth/for_iter_conditional_store_bridge.py
+++ b/pyre/bench/synth/for_iter_conditional_store_bridge.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4
+# pyre-check: max-pypy-ratio=7
 def loop_with_two_backedges(n):
     high = 0
     for i in range(n):

--- a/pyre/bench/synth/for_iter_method_branch_inline.py
+++ b/pyre/bench/synth/for_iter_method_branch_inline.py
@@ -1,4 +1,3 @@
-# pyre-check: max-pypy-ratio=3.7
 # A FOR_ITER caller should inline a method-form callee whose body branches on a
 # field.  The callee body carries a `truth` residual before trace-time folding;
 # the replay-safety scan must defer it so the walker can erase it instead of

--- a/pyre/bench/synth/for_iter_nested_method_inline.py
+++ b/pyre/bench/synth/for_iter_nested_method_inline.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=3.3
+# pyre-check: max-pypy-ratio=4.4
 # A FOR_ITER caller should inline a method-form callee whose body performs a
 # nested method-form call.  The nested `LOAD_METHOD` path emits a
 # `load_method_self` residual after the attribute lookup; deferring it lets the


### PR DESCRIPTION
`6aabe927ce1` (#1653) made every pyre backend subtract pypy's startup rather than its own, so what a pyre process spends above pypy to reach the first bytecode now stays in the numerator. It refitted 8 ceilings and lengthened 41 fixtures; these five were in neither list, and each sits where 0.053s-0.110s lands on a baseline of comparable size.

Refitting one at a time does not converge — it relocates. `exception_loop_warmup` was fixed first, and the same job then failed `for_iter_conditional_store_bridge`, which is what `gate` and `jit-gc-resume-gaps` had been failing on all along.

### Method

Every number here is read from CI. Nothing was measured locally, and readings from runs created before `6aabe927ce1` are excluded: they subtracted a different quantity and are not evidence about these gates. That leaves **12 runs**, pooled across ubuntu/macos/windows and dynasm/cranelift/wasm.

**Only unmarked rows are fitted.** A `?` row carries a granularity buffer worth `EXEC_TIME_FLOOR_S` over its baseline, which is precisely what lets it print a ratio far above its ceiling without failing. Every one of these fixtures has its widest reading on such a row — windows dynasm or ubuntu wasm — so counting them would fit each gate to a reading that cannot fail it, inflating all five.

A ceiling must cover the widest unmarked reading and derive a floor (`ceiling/6`, capped at parity) under the narrowest. That fixes a window:

| fixture | unmarked band | n | window | ceiling |
| --- | --- | --- | --- | --- |
| `exception_loop_warmup` | 2.0x – 4.9x | 55 | 4.9 – 12.0 | 4.1 → **6.5** |
| `for_iter_conditional_store_bridge` | 1.6x – 5.1x | 55 | 5.1 – 9.6 | 4 → **7** |
| `condexpr_heap_const_merge` | 2.2x – 6.6x | 54 | 6.6 – 13.2 | 4.2 → **9** |
| `for_iter_nested_method_inline` | 0.9x – 3.6x | 61 | 3.6 – 5.4 | 3.3 → **4.4** |

### The fifth is retired rather than refitted

`for_iter_method_branch_inline` reads 0.8x to 4.5x over 60 unmarked observations — a factor of 5.6 against a `PERF_GATE_FLOOR_DIVISOR` of 6. That leaves the window 4.5–4.8: six percent wide, with under three percent of margin at either end. A bound that narrow over that many samples reports the runner, not the code.

The spread is the denominator's. pypy executes this loop in 0.30s on macos and 0.10s on ubuntu, and a ratio is scale-invariant, so a longer trip count cannot close it. `synth_perf_gate` documents an absent ceiling as a full exemption, which 252 of the 525 synthetic fixtures already are.

### Not changed

No trip count, no jit-stats baseline, no fixture output. Lengthening was measured and rejected for `exception_loop_warmup`: doubling it takes pypy from 0.05s to 0.10s, the 2x bar rather than past it, and a length that clears it with margin puts the windows dynasm leg over a second. Its counters are identical at both lengths (`loops_compiled=1`, `bridges_compiled=2`, `guard_failures=402`) and match the committed baselines.

`pyre/check.py --check-headers`: 527 headers read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated performance benchmark thresholds to better reflect current execution characteristics.
  - Removed one overly restrictive benchmark ratio guard.
  - Benchmark logic and expected validation behavior remain otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->