### PR TITLE
gc: root the objects ten interpreter paths hold across a collecting call, and close the alias gap that left the gate's tier-1.5 column empty

### DIFF
--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,17 +1,17 @@
 {
   "darwin": {
-    "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
+    "base": "62341f057b3522748535e629561bba2bfe5ac683",
     "brackets_reaching_no_collection": 3,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,
     "frames_across_collecting": 10,
     "frames_across_collecting_fns": 4,
-    "tier15_calls": 0,
-    "tier15_calls_fns": 0,
-    "tier1_calls": 9,
-    "tier1_calls_fns": 7,
-    "unbracketed_calls": 2073,
-    "unbracketed_calls_fns": 830,
+    "tier15_calls": 131,
+    "tier15_calls_fns": 61,
+    "tier1_calls": 0,
+    "tier1_calls_fns": 0,
+    "unbracketed_calls": 2069,
+    "unbracketed_calls_fns": 836,
     "unmatched_seeds": [
       "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
       "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,6 +1,6 @@
 {
   "darwin": {
-    "base": "62341f057b3522748535e629561bba2bfe5ac683",
+    "base": "78501667f5409cec286599d8d25813e879432ed6",
     "brackets_reaching_no_collection": 3,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -398,14 +398,14 @@ fn main() {
             stats.withheld_bracket_short,
             stats.withheld_contents_opaque
         );
-        // `has_nested_scopes` is a whole-body flag, so one pair of overlapping
-        // root scopes anywhere withholds every bracketed call in the function.
-        // Behind an env var because the gate parses this output by regex and
-        // every pattern there must match exactly once.
+        // Overlapping root scopes are read rather than withheld, so this is a
+        // measurement of how much of the unread set happens to be nested, not
+        // of what nesting costs.  Behind an env var because the gate parses
+        // this output by regex and every pattern there must match exactly once.
         if std::env::var("GC_NESTED_CENSUS").is_ok() {
             println!(
                 "           nested-scope census: {} of {} bodies hold two live root \
-                 scopes, withholding {} of the {} unread calls",
+                 scopes, and {} of the {} unread calls come from one",
                 stats.bodies_with_nested_scopes,
                 stats.bodies_scanned,
                 stats.withheld_opaque_from_nested,

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -355,11 +355,23 @@ fn main() {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
-        let movable_callees =
-            liveness::movable_callee_ids(&cg, liveness::MOVABLE_GC_MARKERS, movable_hops);
+        // Asked of the JOINED graph and projected back, the same way `reach` is:
+        // `w_tuple_getitem` and most of the rest of the markers are declared in
+        // this artefact but bodied in a donor, so resolving them against `cg`
+        // alone answers with whatever subset happens to carry a body here.
+        let movable_callees = joined.project(
+            0,
+            &liveness::movable_callee_ids(
+                &joined.graph,
+                liveness::MOVABLE_GC_MARKERS,
+                movable_hops,
+            ),
+        );
         println!(
-            "   movable-addressing callees at {movable_hops} hop(s): {}",
-            movable_callees.len()
+            "   movable-addressing callees at {movable_hops} hop(s): {} \
+             ({} before the join)",
+            movable_callees.len(),
+            liveness::movable_callee_ids(&cg, liveness::MOVABLE_GC_MARKERS, movable_hops).len()
         );
         let gc_tys = liveness::gc_ptr_type_ids(&llbc);
         if gc_tys.is_empty() {
@@ -383,6 +395,13 @@ fn main() {
         println!(
             "       and {} body/bodies with a statement this reader could not parse",
             stats.unparsed_statement_bodies
+        );
+        // What the `movable` columns below had to work with.  A zero says the
+        // ranking never had an input, which is not the same answer as a clean
+        // corpus and must not be read as one.
+        println!(
+            "       movable-argument supply: {} bodies hand {} GC pointer(s) to one",
+            stats.bodies_with_movable_args, stats.movable_arg_locals
         );
         // The withheld figure above says a bracket dominates the call.  It does
         // not say the root the call needed is in that bracket, and nothing has

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -398,6 +398,20 @@ fn main() {
             stats.withheld_bracket_short,
             stats.withheld_contents_opaque
         );
+        // `has_nested_scopes` is a whole-body flag, so one pair of overlapping
+        // root scopes anywhere withholds every bracketed call in the function.
+        // Behind an env var because the gate parses this output by regex and
+        // every pattern there must match exactly once.
+        if std::env::var("GC_NESTED_CENSUS").is_ok() {
+            println!(
+                "           nested-scope census: {} of {} bodies hold two live root \
+                 scopes, withholding {} of the {} unread calls",
+                stats.bodies_with_nested_scopes,
+                stats.bodies_scanned,
+                stats.withheld_opaque_from_nested,
+                stats.withheld_contents_opaque
+            );
+        }
         println!(
             "           of the SHORT, {} miss a root the body produced itself \
              (no caller's bracket can be covering those)",

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -425,6 +425,13 @@ pub const COLLECTING_SEEDS: &[&str] = &[
     "majit_gc::alloc_nursery_collecting_typed",
     "majit_gc::alloc_nursery_collecting_typed_rooted",
     "majit_gc::alloc_fast_nursery_collecting_typed_rooted",
+    // Reported UNMATCHED, and that is the answer rather than a gap: both are
+    // `#[inline]` and reached only from the two wrappers above them
+    // (`majit-gc/src/lib.rs`) and from the dynasm runner's hook, which is not
+    // in the analysed artefacts.  `reaching(standalone_X)` is therefore a
+    // subset of `reaching(X)`, so naming them adds no closure -- they are kept
+    // so a future extraction that does carry them is seeded, and the gate pins
+    // the unmatched set so the pair cannot quietly grow.
     "majit_gc::standalone_alloc_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
     // The generation-carrying entry every backend trampoline dispatches to;

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -43,8 +43,8 @@ pub struct Finding {
     /// Live across the call because the call itself takes them.
     pub live_arg: Vec<String>,
     /// Of the live pointers, those the function later hands to a callee whose
-    /// name says it addresses a `list` or a `dict` — the only two kinds whose
-    /// header a minor collection relocates.  A stale pointer that is only
+    /// name says it addresses a kind whose header a minor collection
+    /// relocates.  A stale pointer that is only
     /// stored or returned is a different (and rarer) problem; this column is
     /// where a stale pointer is actually dereferenced as a movable object.
     pub movable_use: Vec<String>,
@@ -98,7 +98,7 @@ pub struct ScanStats {
     /// produced itself, which no caller's bracket can be covering.
     pub withheld_bracket_short_body_local: usize,
     /// Of [`Self::withheld_bracket_short`], those missing a root this body goes
-    /// on to address as a `list` or `dict`.  A caller's pin does not answer for
+    /// on to address as a movable kind.  A caller's pin does not answer for
     /// these, so they do not depend on the intra-procedural limit.
     pub withheld_bracket_short_movable: usize,
     /// The [`ScanStats::withheld_bracket_short`] calls, named.
@@ -107,10 +107,22 @@ pub struct ScanStats {
     /// slot.  Not a missing root -- a stale word.  See [`StalePinRead`].
     pub pin_arg_read_after: usize,
     /// Of those, the ones reading a local this body later addresses as a
-    /// `list` or `dict`, where the stale word is dereferenced.
+    /// movable kind, where the stale word is dereferenced.
     pub pin_arg_read_after_movable: usize,
     /// The [`Self::pin_arg_read_after`] pins, named.
     pub stale_pin_reads: Vec<StalePinRead>,
+    /// Bodies that hand at least one GC pointer to a movable-addressing callee.
+    ///
+    /// The `movable` columns are all filters over this set, so a zero here says
+    /// the ranking never had anything to rank -- a different fact from "nothing
+    /// ranked".  Worth a counter of its own: the marker list, the id space the
+    /// callees are resolved in, and the operand shape a call argument takes each
+    /// silence the columns the same way, and only this number separates "the
+    /// scan found no such call" from "the scan found them and none was stale".
+    pub bodies_with_movable_args: usize,
+    /// Locals summed over [`Self::bodies_with_movable_args`], so a body that
+    /// contributes one argument is told apart from one that contributes twenty.
+    pub movable_arg_locals: usize,
 }
 
 /// A pin whose argument the body goes on to read.
@@ -134,7 +146,7 @@ pub struct StalePinRead {
     pub pin_name: String,
     /// The locals handed to the pin and still read afterwards.
     pub locals: Vec<String>,
-    /// Of those, the ones this body later addresses as a `list` or `dict`,
+    /// Of those, the ones this body later addresses as a movable kind,
     /// which is where a stale word is dereferenced rather than merely carried.
     pub movable: Vec<String>,
 }
@@ -160,7 +172,7 @@ pub struct ShortBracket {
     /// local it produced, so these are the ones a caller cannot account for.
     pub missing_local: Vec<String>,
     /// Of [`Self::missing`], those this body later hands to a callee whose name
-    /// says it addresses a `list` or a `dict` -- the two kinds whose header a
+    /// says it addresses a movable kind -- one whose header a
     /// minor collection relocates.  A caller's pin cannot rescue one of these:
     /// the collection rewrites the caller's slot, not this body's copy, so the
     /// word in hand is a corpse either way.  The bracket-contents twin of the
@@ -173,9 +185,10 @@ pub struct ShortBracket {
 
 /// Callee names that say the pointer is addressed as a movable object.
 ///
-/// `list` and `dict` are the only two kinds whose header a minor collection
-/// relocates, so a stale `PyObjectRef` handed to one of these is dereferenced
-/// as a corpse rather than merely stored or returned.
+/// A stale `PyObjectRef` handed to one of these is dereferenced as a corpse
+/// rather than merely stored or returned.  The set is not the whole moving
+/// heap: it is the part of it a callee's *name* identifies, and the entries
+/// below record which kind each spelling was checked against.
 pub const MOVABLE_GC_MARKERS: &[&str] = &[
     "w_list_",
     "w_dict_",
@@ -191,11 +204,22 @@ pub const MOVABLE_GC_MARKERS: &[&str] = &[
     // Spelled at the moving constructor rather than at the family prefix: a
     // `w_weakref_lifeline_*` is `allocate_stable` and a `w_str_new` is
     // immortal, so the wider spelling would name a pointer that cannot move.
+    // `w_dict_view_*` needs no entry of its own -- the `w_dict_` prefix already
+    // spells it.
+    //
+    // `str` has no entry at all, and deliberately.  Its mobility is decided per
+    // constructor -- `w_str_from_wtf8_managed_collecting` is the one nursery
+    // spelling, while `w_str_from_wtf8_managed` is `try_gc_alloc_stable` and
+    // `w_str_new` is immortal -- so the accessors every one of them shares
+    // cannot say which kind the pointer reaching them is.  Naming a constructor
+    // here would add nothing either: they take a `Wtf8Buf`, never a
+    // `PyObjectRef`, so no GC-pointer local is ever an argument of one.  The
+    // same reading rules out the items-block and JITFRAME allocators, whose
+    // arguments are a capacity and a type id.
     "w_tuple_",
     "w_method_",
     "w_gc_weakref_box_",
     "w_weakref_new",
-    "w_str_from_wtf8_managed",
 ];
 
 /// The callees that say a pointer reaching them is addressed as a movable
@@ -414,6 +438,24 @@ fn chase_pinned(l: u64, defs: &HashMap<u64, PinSrc>, out: &mut HashSet<u64>, dep
     }
 }
 
+/// Every local an argument to a movable-addressing callee is spelled by.
+///
+/// The alias half of [`chase_pinned`], and needed for the same reason on the
+/// other side of the intersection: a call argument is materialised as its own
+/// temporary (`_t = copy _obj; w_tuple_getitem(move _t, ..)`), so matching the
+/// argument local against the pinned local compares two spellings of one value
+/// and finds nothing.  Aggregates are not followed here -- `pin_roots(&[a, b])`
+/// pins each element, but a callee handed a container is addressing the
+/// container, not the elements.
+fn chase_arg_aliases(l: u64, defs: &HashMap<u64, PinSrc>, out: &mut HashSet<u64>, depth: u32) {
+    if !out.insert(l) || depth > 8 {
+        return;
+    }
+    if let Some(PinSrc::Alias(next)) = defs.get(&l) {
+        chase_arg_aliases(*next, defs, out, depth + 1);
+    }
+}
+
 /// The functions that write a livevar onto the root stack.
 ///
 /// `push_roots` opens the scope and takes no arguments; the set is named
@@ -583,7 +625,8 @@ pub fn scan(
                         // rewound by the *innermost* live guard, because
                         // `RootScope::drop` truncates the shadow stack to the
                         // length it saved, so ownership needs nesting order.
-                        if opens && let Some(scope) = bare_local(&call.dest)
+                        if opens
+                            && let Some(scope) = bare_local(&call.dest)
                             && !normal.contains(&scope)
                         {
                             normal.push(scope);
@@ -913,8 +956,7 @@ pub fn scan(
             })
             .collect();
         for _round in 0..n + 8 {
-            let outs: Vec<HashSet<(u64, u64)>> =
-                (0..n).map(|b| out_of(b, &pinned_in)).collect();
+            let outs: Vec<HashSet<(u64, u64)>> = (0..n).map(|b| out_of(b, &pinned_in)).collect();
             let mut changed = false;
             let mut next: Vec<HashSet<(u64, u64)>> = Vec::with_capacity(n);
             for b in 0..n {
@@ -968,8 +1010,10 @@ pub fn scan(
             }
         }
 
-        // Locals this body hands to a `list`/`dict`-addressing callee.  Built
-        // once: it does not depend on which collecting call is being judged.
+        // Locals this body hands to a callee that addresses a nursery-allocated
+        // kind.  Built once: it does not depend on which collecting call is
+        // being judged, so a local that reaches such a callee anywhere in the
+        // body is in the set for every call the body makes.
         let mut movable_args: HashSet<u64> = HashSet::new();
         for other in &body.body {
             let Ok(TermKind::Call { call: c2, .. }) = other.term() else {
@@ -985,8 +1029,23 @@ pub fn scan(
                 continue;
             }
             for a in &c2.args {
-                use_operand(a, &mut movable_args);
+                let mut seed: HashSet<u64> = HashSet::new();
+                use_operand(a, &mut seed);
+                for l in seed {
+                    chase_arg_aliases(l, &defs, &mut movable_args, 0);
+                }
             }
+        }
+        // Count only the GC pointers: a `Wtf8Buf` or a capacity handed to a
+        // marked callee is an argument the `movable` filters can never select,
+        // so counting it here would report a live ranking that is not one.
+        let movable_gc_args = movable_args
+            .iter()
+            .filter(|l| gc_locals.contains_key(*l))
+            .count();
+        if movable_gc_args > 0 {
+            stats.bodies_with_movable_args += 1;
+            stats.movable_arg_locals += movable_gc_args;
         }
 
         // Every pin whose argument the body goes on to read.  Independent of
@@ -1180,7 +1239,7 @@ pub fn scan(
                 .collect();
             non_arg.sort();
             in_arg.sort();
-            // Does any live pointer reach a list/dict-addressing callee in this
+            // Does any live pointer reach a movable-addressing callee in this
             // body?  Anywhere in the body, not only in the dominated
             // successors — this is a ranking signal, not a proof.
             let mut movable_use: Vec<String> = after

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -120,9 +120,10 @@ pub struct ScanStats {
 /// the caller's copy and the query, leaving the caller's local pointing at a
 /// forwarding stub.  Reading the returned word is the fix; `let _ =` opts out
 /// and thereby asserts the kind never moves, which is what
-/// [`Self::movable`] checks.  `getitem_tuple` states the assertion in prose --
-/// "a tuple never moves, so the root is for liveness alone and the address in
-/// hand stays correct".
+/// [`Self::movable`] checks.  The assertion is worth checking because it has
+/// been written down and been wrong: `getitem_tuple` and `getitem_str` each
+/// stated in prose that their receiver never moves, and both receivers are
+/// nursery-allocated.
 pub struct StalePinRead {
     pub func_name: String,
     pub file: String,

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -59,10 +59,10 @@ pub struct Finding {
 #[derive(Default)]
 pub struct ScanStats {
     pub bodies_scanned: usize,
-    /// Bodies the pin-set read declined solely because two root scopes are
-    /// live at once somewhere in them.  The flag is whole-body, so one nested
-    /// pair anywhere withholds every bracketed call in the function; this
-    /// counts how much of [`Self::withheld_contents_opaque`] that costs.
+    /// Bodies holding two live root scopes at once somewhere in them.  The
+    /// pin set carries an owner, so this on its own no longer withholds a
+    /// body; the count stays because a nested body that is unread is unread
+    /// for one of the other reasons and the distinction is worth measuring.
     pub bodies_with_nested_scopes: usize,
     /// Calls counted in [`Self::withheld_contents_opaque`] that came from a
     /// body in [`Self::bodies_with_nested_scopes`].
@@ -578,11 +578,14 @@ pub fn scan(
                             ),
                             _ => false,
                         };
-                        if opens && let Some(scope) = bare_local(&call.dest) {
-                            match normal.binary_search(&scope) {
-                                Ok(_) => {}
-                                Err(i) => normal.insert(i, scope),
-                            }
+                        // Pushed rather than inserted in id order: a pin is
+                        // rewound by the *innermost* live guard, because
+                        // `RootScope::drop` truncates the shadow stack to the
+                        // length it saved, so ownership needs nesting order.
+                        if opens && let Some(scope) = bare_local(&call.dest)
+                            && !normal.contains(&scope)
+                        {
+                            normal.push(scope);
                         }
                         for (succ, next) in [(*target, normal), (*on_unwind, unwind)] {
                             if (succ as usize) < n && active_at[succ as usize].insert(next) {
@@ -593,10 +596,10 @@ pub fn scan(
                     }
                     TermKind::Drop { place, .. } => {
                         if let Some(scope) = place_local(place) {
-                            if let Ok(i) = normal.binary_search(&scope) {
+                            if let Some(i) = normal.iter().position(|&s| s == scope) {
                                 normal.remove(i);
                             }
-                            if let Ok(i) = unwind.binary_search(&scope) {
+                            if let Some(i) = unwind.iter().position(|&s| s == scope) {
                                 unwind.remove(i);
                             }
                         }
@@ -613,17 +616,52 @@ pub fn scan(
         let unbracketed: HashSet<usize> = (0..n)
             .filter(|&b| active_at[b].iter().any(Vec::is_empty))
             .collect();
+        // The scope that owns a pin made at `b`: the innermost guard live
+        // there.  `None` where the block is reached with two different scope
+        // stacks, because then the owner is path-dependent and no single
+        // answer is right.
+        let owner_at: Vec<Option<u64>> = (0..n)
+            .map(|b| {
+                let mut it = active_at[b].iter();
+                let first = it.next()?;
+                let innermost = *first.last()?;
+                for other in it {
+                    if other.last() != Some(&innermost) {
+                        return None;
+                    }
+                }
+                Some(innermost)
+            })
+            .collect();
+        // The one scope stack live at `b`, innermost last.  `None` where the
+        // block is reached with two different stacks.
+        let stack_at: Vec<Option<Vec<u64>>> = (0..n)
+            .map(|b| {
+                let mut it = active_at[b].iter();
+                let first = it.next()?;
+                if it.next().is_some() {
+                    return None;
+                }
+                Some(first.clone())
+            })
+            .collect();
+        // The scope local a scope-closing Drop names, so the dataflow can
+        // retire that guard's pins and leave an enclosing guard's alone.
+        let closed_scope: Vec<Option<u64>> = (0..n)
+            .map(|b| match &terms[b] {
+                Some(TermKind::Drop { place, .. }) => place_local(place)
+                    .filter(|scope| active_at[b].iter().any(|a| a.contains(scope))),
+                _ => None,
+            })
+            .collect();
         let has_nested_scopes = active_at
             .iter()
             .flat_map(HashSet::iter)
             .any(|scopes| scopes.len() > 1);
         let term_closes_root_scope: Vec<bool> = (0..n)
             .map(|b| match &terms[b] {
-                Some(TermKind::Drop { place, .. }) => place_local(place).is_some_and(|scope| {
-                    active_at[b]
-                        .iter()
-                        .any(|active| active.binary_search(&scope).is_ok())
-                }),
+                Some(TermKind::Drop { place, .. }) => place_local(place)
+                    .is_some_and(|scope| active_at[b].iter().any(|a| a.contains(&scope))),
                 _ => false,
             })
             .collect();
@@ -685,13 +723,16 @@ pub fn scan(
 
         // A body whose pinned set cannot be read is not a body with an empty
         // one: grading it would turn "not understood" into "root missing".
-        // The pin-set analysis below stores only root locals, not which nested
-        // guard owns each one.  Keep nested bodies unread rather than letting
-        // an inner Drop falsely retain its pins as outer-scope coverage.
+        // The pin-set analysis below carries the owning guard alongside each
+        // root local, so an inner Drop retires its own pins and leaves an
+        // enclosing guard's alone; nesting on its own no longer withholds a
+        // body.  This counts how many still hold two live scopes, because a
+        // body that also trips one of the opacity tests below is unread for
+        // that reason and the two populations are easy to confuse.
         if has_nested_scopes {
             stats.bodies_with_nested_scopes += 1;
         }
-        let mut opaque_contents = unparsed_terms || unparsed_stmts || has_nested_scopes;
+        let mut opaque_contents = unparsed_terms || unparsed_stmts;
         let mut saw_pin_call = false;
         let mut term_pins: Vec<HashSet<u64>> = vec![HashSet::new(); n];
         // The locals a pin was *handed*, as distinct from the word it hands
@@ -763,6 +804,16 @@ pub fn scan(
             }
             term_pins[b] = pinned;
         }
+        // A scope-closing Drop this reader cannot name retires an unknown set,
+        // and a pin made where two scope stacks meet has a path-dependent
+        // owner.  Either would let one guard's Drop release another's pins.
+        // Blocks that neither pin nor close a scope need no owner.
+        if (0..n).any(|b| {
+            (term_closes_root_scope[b] && (closed_scope[b].is_none() || stack_at[b].is_none()))
+                || (!term_pins[b].is_empty() && owner_at[b].is_none())
+        }) {
+            opaque_contents = true;
+        }
         if !bracket_blocks.is_empty() && !saw_pin_call {
             // A scope is open and nothing in this body names what went into
             // it: the pins run behind a helper that holds the scope itself,
@@ -806,24 +857,52 @@ pub fn scan(
         // every path reaching it pinned that local and nothing has reassigned
         // it since.  Starts at the universe and intersects down, so a block
         // whose predecessors disagree keeps only what they all hold.
-        let universe: HashSet<u64> = gc_locals.keys().copied().collect();
-        let out_of = |b: usize, pin: &[HashSet<u64>]| -> HashSet<u64> {
-            let mut s: HashSet<u64> = pin[b].difference(&stmt_kills[b]).copied().collect();
+        // Each element carries the guard that owns it, so a Drop retires that
+        // guard's pins and leaves an enclosing guard's in place.  The owner is
+        // the innermost scope live where the pin was made.
+        let all_scopes: HashSet<u64> = active_at
+            .iter()
+            .flat_map(HashSet::iter)
+            .flat_map(|a| a.iter().copied())
+            .collect();
+        let universe: HashSet<(u64, u64)> = gc_locals
+            .keys()
+            .flat_map(|l| all_scopes.iter().map(move |s| (*l, *s)))
+            .collect();
+        let out_of = |b: usize, pin: &[HashSet<(u64, u64)>]| -> HashSet<(u64, u64)> {
+            let mut s: HashSet<(u64, u64)> = pin[b]
+                .iter()
+                .filter(|(l, _)| !stmt_kills[b].contains(l))
+                .copied()
+                .collect();
             if term_closes_root_scope[b] {
-                // Nested scopes were marked opaque above.  In the remaining
-                // bodies this Drop closes the one live scope, so every pin it
-                // owned leaves the root stack here.
-                s.clear();
+                // `RootScope::drop` truncates the shadow stack to the length it
+                // saved, so a guard takes its own pins *and* those of every
+                // guard opened after it -- dropping out of order takes more
+                // than one scope's worth.  An enclosing guard keeps its own.
+                match (closed_scope[b], stack_at[b].as_ref()) {
+                    (Some(scope), Some(stack)) => {
+                        let retired: HashSet<u64> = match stack.iter().position(|&x| x == scope) {
+                            Some(i) => stack[i..].iter().copied().collect(),
+                            None => stack.iter().copied().collect(),
+                        };
+                        s.retain(|(_, owner)| !retired.contains(owner));
+                    }
+                    // A Drop this reader cannot place retires an unknown set.
+                    _ => s.clear(),
+                }
             }
             if let Some(TermKind::Call { call, .. }) = &terms[b] {
                 if let Some(d) = bare_local(&call.dest) {
-                    s.remove(&d);
+                    s.retain(|(l, _)| *l != d);
                 }
             }
-            s.extend(term_pins[b].iter().copied());
+            if let Some(owner) = owner_at[b] {
+                s.extend(term_pins[b].iter().map(|l| (*l, owner)));
+            }
             s
         };
-        let mut pinned_in: Vec<HashSet<u64>> = (0..n)
+        let mut pinned_in: Vec<HashSet<(u64, u64)>> = (0..n)
             .map(|b| {
                 if b == 0 || !reachable.contains(&b) {
                     HashSet::new()
@@ -833,9 +912,10 @@ pub fn scan(
             })
             .collect();
         for _round in 0..n + 8 {
-            let outs: Vec<HashSet<u64>> = (0..n).map(|b| out_of(b, &pinned_in)).collect();
+            let outs: Vec<HashSet<(u64, u64)>> =
+                (0..n).map(|b| out_of(b, &pinned_in)).collect();
             let mut changed = false;
-            let mut next: Vec<HashSet<u64>> = Vec::with_capacity(n);
+            let mut next: Vec<HashSet<(u64, u64)>> = Vec::with_capacity(n);
             for b in 0..n {
                 if b == 0 || !reachable.contains(&b) {
                     next.push(HashSet::new());
@@ -1017,7 +1097,13 @@ pub fn scan(
                     }
                     continue;
                 }
-                let held: HashSet<u64> = pinned_in[b].difference(&stmt_kills[b]).copied().collect();
+                // Drop the owner here: coverage asks only whether the local
+                // is pinned by *some* live guard.
+                let held: HashSet<u64> = pinned_in[b]
+                    .iter()
+                    .map(|(l, _)| *l)
+                    .filter(|l| !stmt_kills[b].contains(l))
+                    .collect();
                 let mut missing: Vec<String> = after
                     .iter()
                     .filter(|l| !held.contains(l))

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -59,6 +59,14 @@ pub struct Finding {
 #[derive(Default)]
 pub struct ScanStats {
     pub bodies_scanned: usize,
+    /// Bodies the pin-set read declined solely because two root scopes are
+    /// live at once somewhere in them.  The flag is whole-body, so one nested
+    /// pair anywhere withholds every bracketed call in the function; this
+    /// counts how much of [`Self::withheld_contents_opaque`] that costs.
+    pub bodies_with_nested_scopes: usize,
+    /// Calls counted in [`Self::withheld_contents_opaque`] that came from a
+    /// body in [`Self::bodies_with_nested_scopes`].
+    pub withheld_opaque_from_nested: usize,
     /// Bodies holding a terminator this reader could not classify.  Their
     /// liveness is incomplete, so they are reported rather than counted clean.
     pub unparsed_terminator_bodies: usize,
@@ -177,6 +185,16 @@ pub const MOVABLE_GC_MARKERS: &[&str] = &[
     "require_dict",
     "dict_method_",
     "list_method_",
+    // The families whose headers the interpreter allocates in the nursery, so
+    // a pointer reaching one of these is addressed as an object that relocates.
+    // Spelled at the moving constructor rather than at the family prefix: a
+    // `w_weakref_lifeline_*` is `allocate_stable` and a `w_str_new` is
+    // immortal, so the wider spelling would name a pointer that cannot move.
+    "w_tuple_",
+    "w_method_",
+    "w_gc_weakref_box_",
+    "w_weakref_new",
+    "w_str_from_wtf8_managed",
 ];
 
 /// The callees that say a pointer reaching them is addressed as a movable
@@ -670,6 +688,9 @@ pub fn scan(
         // The pin-set analysis below stores only root locals, not which nested
         // guard owns each one.  Keep nested bodies unread rather than letting
         // an inner Drop falsely retain its pins as outer-scope coverage.
+        if has_nested_scopes {
+            stats.bodies_with_nested_scopes += 1;
+        }
         let mut opaque_contents = unparsed_terms || unparsed_stmts || has_nested_scopes;
         let mut saw_pin_call = false;
         let mut term_pins: Vec<HashSet<u64>> = vec![HashSet::new(); n];
@@ -991,6 +1012,9 @@ pub fn scan(
                 // reading as coverage.
                 if opaque_contents || !reachable.contains(&b) {
                     stats.withheld_contents_opaque += 1;
+                    if has_nested_scopes {
+                        stats.withheld_opaque_from_nested += 1;
+                    }
                     continue;
                 }
                 let held: HashSet<u64> = pinned_in[b].difference(&stmt_kills[b]).copied().collect();

--- a/pyre/extra_tests/snippets/gc_generic_alias_walk_roots_its_parameters.py
+++ b/pyre/extra_tests/snippets/gc_generic_alias_walk_roots_its_parameters.py
@@ -1,0 +1,90 @@
+# pyre-check: gate=1
+"""`types.GenericAlias` keeps the tuples it walks current across a user `__eq__`.
+
+Building `list[...]` gathers the free type variables of the arguments, and
+every turn of that walk runs Python: the `__typing_subst__` and
+`__parameters__` lookups, and the `__eq__` behind `if item not in parameters`.
+The containers being walked -- the argument tuple, any tuple or list nested in
+it, and each `__parameters__` tuple pulled off an argument -- are all
+nursery-allocated, so a collection during any of those relocates them while the
+walk is still indexing the word it read first.
+
+The parameters gathered so far have the same problem from the other side: they
+were held in a native column that no collector scans, so both operands of the
+uniqueness test had to be published before the comparison and read back after.
+
+Substitution (`alias[...]`) repeats the shape a second time, in the
+`params.index(param)` search that also runs `__eq__`.
+"""
+
+import gc
+
+
+class Collects:
+    """Plays a type variable, and collects from `__eq__`.
+
+    `__typing_subst__` is what marks an argument as a parameter in its own
+    right; without it an object contributes only through `__parameters__`.
+    """
+
+    def __init__(self, i):
+        self.i = i
+
+    def __typing_subst__(self, arg):
+        return arg
+
+    def __eq__(self, other):
+        gc.collect()
+        # Churn so a relocated block is handed straight back out.
+        self.junk = [tuple(range(4)) for _ in range(500)]
+        return isinstance(other, Collects) and other.i == self.i
+
+    def __hash__(self):
+        return 0
+
+    def __repr__(self):
+        return "Collects(%d)" % self.i
+
+
+class Holder:
+    """Exposes a `__parameters__` tuple born just before the walk reads it."""
+
+    def __init__(self, params):
+        self.__parameters__ = params
+
+
+def nested():
+    # The argument tuple, the nested tuple and list, and the `__parameters__`
+    # tuple are each allocated inside the expression, so nothing but the walk's
+    # own roots refers to them once `list[...]` has popped its subscript.
+    return list[
+        Holder(tuple(Collects(i) for i in range(6))),
+        (Collects(6), Collects(7)),
+        [Collects(8)],
+        Collects(9),
+    ]
+
+
+got = [p.i for p in nested().__parameters__]
+assert got == list(range(10)), got
+
+# The same parameter appearing twice takes the `in` test all the way through
+# the gathered column, so every comparison reads a pair back out of the slots.
+shared = Collects(0)
+alias = list[Holder((shared, Collects(1), shared)), shared]
+assert [p.i for p in alias.__parameters__] == [0, 1], alias.__parameters__
+
+
+class Subst(Collects):
+    def __typing_subst__(self, arg):
+        gc.collect()
+        return arg
+
+
+ts = Subst(0)
+generic = dict[ts, Subst(1)]
+assert len(generic.__parameters__) == 2, generic.__parameters__
+substituted = generic[str, int]
+assert substituted == dict[str, int], substituted
+
+print("ok")

--- a/pyre/extra_tests/snippets/gc_mapping_unpack_roots_its_source.py
+++ b/pyre/extra_tests/snippets/gc_mapping_unpack_roots_its_source.py
@@ -1,0 +1,73 @@
+# pyre-check: gate=1
+"""`{**mapping}` keeps the destination dict current across the `keys()` call.
+
+`PyDict_Update`'s generic branch fetches `mapping.keys()` and iterates the
+result before it touches the destination, and all three of those steps run
+Python: the `keys` attribute lookup, the call, and the iteration.  The
+destination is a `W_DictObject`, which a minor collection relocates, so the
+word the caller handed in is the pre-move one by the time the store loop starts
+-- and the loop publishes it as a root, so the whole loop stores into the
+corpse.
+
+The binary operators reach the same shape from the other side: `a + b` and
+`a * b` dispatch a reflected special method with both operands live, and the
+set and dict displays drain a user iterable before storing.
+"""
+
+import gc
+
+CHURN = None
+
+
+def collect():
+    global CHURN
+    gc.collect()
+    # Churn so a relocated block is handed straight back out.
+    CHURN = [tuple(range(4)) for _ in range(400)]
+
+
+class Mapping:
+    """Collects from both halves of the `PyMapping_Keys` protocol."""
+
+    def keys(self):
+        collect()
+        return ["a", "b", "c"]
+
+    def __getitem__(self, key):
+        collect()
+        return key * 2
+
+
+assert {**Mapping(), "z": 1} == {"a": "aa", "b": "bb", "c": "cc", "z": 1}
+
+merged = {"pre": 0}
+merged.update(Mapping())
+assert merged == {"pre": 0, "a": "aa", "b": "bb", "c": "cc"}, merged
+
+
+class RAdd:
+    def __radd__(self, other):
+        collect()
+        return list(other) + ["r"]
+
+
+class RMul:
+    def __rmul__(self, other):
+        collect()
+        return list(other) * 2
+
+
+assert ["p", "q"] + RAdd() == ["p", "q", "r"]
+assert ["m", "n"] * RMul() == ["m", "n", "m", "n"]
+
+
+class Iterable:
+    def __iter__(self):
+        collect()
+        return iter(["s1", "s2"])
+
+
+assert {*Iterable(), "s3"} == {"s1", "s2", "s3"}
+assert [*Iterable(), "s3"] == ["s1", "s2", "s3"]
+
+print("ok")

--- a/pyre/extra_tests/snippets/gc_namespace_paths_root_their_mappings.py
+++ b/pyre/extra_tests/snippets/gc_namespace_paths_root_their_mappings.py
@@ -1,0 +1,157 @@
+# pyre-check: gate=1
+"""Namespace paths re-read their mappings after the Python they dispatch.
+
+`__build_class__`, `exec`, `__import__` and the mapping-pattern match each
+resolve a namespace object up front and consume it several dispatches later.
+Every one of those objects is nursery-allocated -- a dict, a tuple, or a
+freshly built locals snapshot with no other referrer -- so the address held
+across the dispatch is the pre-move one, and the snapshot is sweepable
+besides.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    """Take the freed boxes, so a sweep that frees is not invisible."""
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+def collect():
+    gc.collect()
+    churn()
+
+
+GLOBAL_MARK = "global-mark"
+
+
+class Prepare(type):
+    """`__prepare__` runs Python between the body function's decomposition and
+    the frame that executes the class body."""
+
+    @classmethod
+    def __prepare__(mcls, name, bases, **kwds):
+        collect()
+        return dict(prepared=True)
+
+    def __new__(mcls, name, bases, ns, **kwds):
+        collect()
+        return super().__new__(mcls, name, bases, ns)
+
+
+def build_with_closure():
+    cell_mark = "cell-mark"
+
+    class Built(metaclass=Prepare):
+        # Reads a global and a closure variable, so the frame must have been
+        # given the function's live globals dict and closure tuple.
+        seen_global = GLOBAL_MARK
+        seen_cell = cell_mark
+        prepared_seen = prepared  # noqa: F821 — from the prepared namespace
+
+    return Built
+
+
+Built = build_with_closure()
+assert Built.seen_global == "global-mark", Built.seen_global
+assert Built.seen_cell == "cell-mark", Built.seen_cell
+assert Built.prepared_seen is True, Built.prepared_seen
+
+
+class Entries:
+    """`__mro_entries__` runs on every non-type base, and is handed the same
+    original-bases tuple each round."""
+
+    def __init__(self, *bases):
+        self.bases = bases
+
+    def __mro_entries__(self, orig_bases):
+        collect()
+        assert isinstance(orig_bases, tuple), orig_bases
+        assert self in orig_bases, orig_bases
+        return self.bases
+
+
+class Left:
+    pass
+
+
+class Right:
+    pass
+
+
+class WithEntries(Entries(Left), Entries(Right)):
+    pass
+
+
+assert WithEntries.__bases__ == (Left, Right), WithEntries.__bases__
+assert WithEntries.__orig_bases__[0].bases == (Left,)
+
+
+class CollectingGlobals(dict):
+    """A globals mapping whose `setdefault` runs Python, which is what
+    `exec`/`eval` dispatch through before the frame exists."""
+
+    def setdefault(self, key, default=None):
+        collect()
+        return super().setdefault(key, default)
+
+    def __setitem__(self, key, value):
+        collect()
+        return super().__setitem__(key, value)
+
+
+g = CollectingGlobals(marker="exec-globals")
+exec("from_exec = marker", g)
+assert g["from_exec"] == "exec-globals", g["from_exec"]
+
+separate_locals = CollectingGlobals()
+exec("in_locals = 41 + 1", g, separate_locals)
+assert separate_locals["in_locals"] == 42, separate_locals
+
+
+def exec_into_caller_locals():
+    # `exec(src)` with neither globals nor locals resolves the caller's locals
+    # into a fresh snapshot dict that nothing else holds.  The source reads two
+    # of the caller's locals back out of it; a store into the snapshot itself
+    # is invisible by design, so the result travels through `out`.
+    local_mark = "local-mark"
+    out = {}
+    collect()
+    exec("out['seen'] = local_mark + '/' + GLOBAL_MARK")
+    return out["seen"]
+
+
+assert exec_into_caller_locals() == "local-mark/global-mark"
+
+
+class Level:
+    def __index__(self):
+        collect()
+        return 0
+
+
+imported = __import__("sys", globals(), locals(), ("path",), Level())
+assert imported.path is not None
+
+
+class TupleKey:
+    KEY = (1, 2)
+
+
+class CollectingMapping(dict):
+    def get(self, key, default=None):
+        collect()
+        return super().get(key, default)
+
+
+subject = CollectingMapping({TupleKey.KEY: "tuple-keyed", "plain": "str-keyed"})
+match subject:
+    case {TupleKey.KEY: found, "plain": also}:
+        assert found == "tuple-keyed", found
+        assert also == "str-keyed", also
+    case _:
+        raise AssertionError("mapping pattern did not match")

--- a/pyre/extra_tests/snippets/gc_percent_format_roots_its_operands.py
+++ b/pyre/extra_tests/snippets/gc_percent_format_roots_its_operands.py
@@ -5,8 +5,8 @@ Two separate holes, both reached through the same operand column:
 
 * `BINARY_OP %` pops the format string and the operand off the value stack
   before dispatching, so on `b"%a" % (Collects(),)` nothing refers to the
-  operand tuple while `__repr__` runs.  A tuple never moves, but an
-  unreachable one is still collected.
+  operand tuple while `__repr__` runs, and a tuple is nursery-allocated, so
+  it is both moved and collected out from under an unrooted local.
 * Every conversion runs Python, and the operands are drained into a plain
   native column first.  A list or dict still waiting its turn moves under a
   collection triggered by an earlier conversion, so it would be formatted at

--- a/pyre/extra_tests/snippets/gc_sre_sub_roots_its_subject.py
+++ b/pyre/extra_tests/snippets/gc_sre_sub_roots_its_subject.py
@@ -1,0 +1,72 @@
+# pyre-check: gate=1
+"""`Pattern.sub` keeps the subject and its buffer current across the filter.
+
+`subx` walks the subject once and calls the replacement per match, so every
+turn runs Python.  The subject, the replacement and the subject's buffer object
+are read out of the argument slice once, up front; the match object handed to
+each call is then stamped with the subject and the buffer, and a match object
+is traced.  A stale word here is therefore one the collector follows on its
+next walk, not one that is merely read back wrong -- which is why it surfaces
+as a crash inside the collector rather than as a wrong substitution.
+
+`count` is resolved through `__index__`, so a collection can happen before the
+walk even starts.
+"""
+
+import gc
+import re
+
+CHURN = None
+
+
+def collect():
+    global CHURN
+    gc.collect()
+    CHURN = [tuple(range(4)) for _ in range(400)]
+
+
+pattern = re.compile("b")
+SUBJECT = "a" + ("b" + "z") * 40 + "c"
+EXPECTED = "a" + ("X" + "z") * 40 + "c"
+
+
+class Filter:
+    """A bound method, which is itself nursery-allocated, writing to its own
+    instance dict from inside the walk."""
+
+    def __init__(self):
+        self.n = 0
+
+    def repl(self, match):
+        self.n += 1
+        collect()
+        return "X"
+
+
+f = Filter()
+assert pattern.sub(f.repl, SUBJECT) == EXPECTED
+assert f.n == 40, f.n
+
+# A second walk over a fresh subject, after the first left its roots behind.
+assert len(pattern.split("a" + ("b" + "z") * 40 + "c")) == 41
+
+g = Filter()
+out, n = pattern.subn(g.repl, SUBJECT)
+assert (out, n) == (EXPECTED, 40), (out, n)
+
+
+class Count:
+    def __index__(self):
+        collect()
+        return 3
+
+
+assert pattern.sub("Y", SUBJECT, Count()) == "a" + ("Y" + "z") * 3 + ("b" + "z") * 37 + "c"
+
+# A template replacement takes the other arm, which parses the template after
+# the same `__index__` has run.
+assert pattern.sub(r"[\g<0>]", SUBJECT, Count()) == (
+    "a" + ("[b]" + "z") * 3 + ("b" + "z") * 37 + "c"
+)
+
+print("ok")

--- a/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
+++ b/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
@@ -4,8 +4,9 @@
 `BINARY_SUBSCR` / `STORE_SUBSCR` / `DELETE_SUBSCR` pop every operand before
 the dispatch reaches the by-layout arm, so a container the operand stack was
 the only holder of has nothing rooting it while `__index__` runs Python.  A
-list is nursery-allocated on top of that: a collection there moves it, and the
-address the arm started with is the pre-move one.
+list, a built tuple and a `str()` result are nursery-allocated on top of that:
+a collection there moves them, and the address the arm started with is the
+pre-move one.
 """
 
 import gc
@@ -29,6 +30,11 @@ class Idx:
         return self.n
 
 
+class Named:
+    def __str__(self):
+        return "abcd"
+
+
 # Temporaries: nothing but the operand stack ever held these containers.
 assert [10, 20, 30][Idx(1)] == 20
 assert (10, 20, 30)[Idx(1)] == 20
@@ -38,6 +44,15 @@ assert bytearray(b"abcd")[Idx(1)] == 98
 assert range(10, 20)[Idx(1)] == 11
 assert list(range(8))[Idx(2) :] == [2, 3, 4, 5, 6, 7]
 assert bytearray(b"abcdefgh")[Idx(2) : Idx(6)] == bytearray(b"cdef")
+
+# A tuple or str *literal* is a prebuilt constant and never relocates, so the
+# two lines above exercise liveness and not staleness.  The relocating shapes
+# are the ones a program builds: `tuple()` allocates in the nursery, and
+# `str()` is the one caller of the collecting string constructor.
+assert tuple(range(10, 40, 10))[Idx(1)] == 20
+assert tuple(range(8))[Idx(2) :] == (2, 3, 4, 5, 6, 7)
+assert str(Named())[Idx(1)] == "b"
+assert str(Named())[Idx(1) : Idx(3)] == "bc"
 
 # The assigned value is read after the key's `__index__` has already run.
 target = bytearray(b"abcd")

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -76,51 +76,88 @@ pub fn generic_alias_class_getitem(args: &[PyObjectRef]) -> crate::PyResult {
 /// `GenericAlias.__new__` (`_pypy_generic_alias.py:19`) — wrap a bare item
 /// into a 1-tuple, collect the free parameters, allocate.
 pub fn make_generic_alias(origin: PyObjectRef, item: PyObjectRef) -> crate::PyResult {
-    let args = if unsafe { is_tuple(item) } {
-        item
+    // `collect_parameters` runs Python at every turn of its walk, and the
+    // argument tuple it is handed is nursery-allocated, so the word built here
+    // is the pre-move one by the time the alias is stamped with it.  Stamping a
+    // stale tuple is worse than reading one: the alias is a traced object, so
+    // the collector follows the dead word on the next walk rather than at the
+    // next use.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[origin, item]);
+    let origin = || pyre_object::gc_roots::shadow_stack_get(base);
+    let item = || pyre_object::gc_roots::shadow_stack_get(base + 1);
+    let args = if unsafe { is_tuple(item()) } {
+        item()
     } else {
-        w_tuple_new(vec![item])
+        w_tuple_new(vec![item()])
     };
-    let parameters = collect_parameters(args)?;
-    Ok(w_generic_alias_new(origin, args, parameters))
+    let args_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(args);
+    let args = || pyre_object::gc_roots::shadow_stack_get(args_slot);
+    let parameters = collect_parameters(args())?;
+    Ok(w_generic_alias_new(origin(), args(), parameters))
 }
 
 /// `_collect_parameters(args)` (`_pypy_generic_alias.py:150`) — gather the
 /// free type variables in order of first appearance.
 pub(crate) fn collect_parameters(args: PyObjectRef) -> crate::PyResult {
-    let mut params: Vec<PyObjectRef> = Vec::new();
-    let n = unsafe { w_tuple_len(args) };
+    // Every turn of this walk runs Python — the `__typing_subst__` and
+    // `__parameters__` lookups, and the `__eq__` behind the uniqueness test —
+    // and `args`, the tuples and lists nested inside it, and the parameters
+    // gathered out of them are all nursery-allocated.  One scope owns the whole
+    // walk: the accumulator holds slot indices, and the two helpers pin into
+    // this scope instead of opening their own, because an inner scope's drop
+    // truncates the stack back to its base and would take the accumulated
+    // slots with it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(args);
+    let args = || pyre_object::gc_roots::shadow_stack_get(args_slot);
+    let mut param_slots: Vec<usize> = Vec::new();
+    let n = unsafe { w_tuple_len(args()) };
     for i in 0..n {
-        if let Some(t) = unsafe { w_tuple_getitem(args, i as i64) } {
-            collect_parameters_one(t, &mut params)?;
+        if let Some(t) = unsafe { w_tuple_getitem(args(), i as i64) } {
+            collect_parameters_one(t, &mut param_slots)?;
         }
     }
+    let params: Vec<PyObjectRef> = param_slots
+        .iter()
+        .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+        .collect();
     Ok(w_tuple_new(params))
 }
 
+/// One element of the [`collect_parameters`] walk.  Pins into the caller's
+/// scope: `param_slots` names slots the caller reads once this returns.
 fn collect_parameters_one(
     t: PyObjectRef,
-    params: &mut Vec<PyObjectRef>,
+    param_slots: &mut Vec<usize>,
 ) -> Result<(), crate::PyError> {
+    let t_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(t);
+    let t = || pyre_object::gc_roots::shadow_stack_get(t_slot);
     unsafe {
-        if is_type(t) {
+        if is_type(t()) {
             // A bare class exposes no `__parameters__` descriptor of its own.
             return Ok(());
         }
-        if is_tuple(t) || is_list(t) {
-            let n = if is_tuple(t) {
-                w_tuple_len(t)
+        // A collection cannot change what `t` is, so the container kind is read
+        // once and the recursion below re-reads only the address.
+        let container_is_tuple = is_tuple(t());
+        if container_is_tuple || is_list(t()) {
+            let n = if container_is_tuple {
+                w_tuple_len(t())
             } else {
-                w_list_len(t)
+                w_list_len(t())
             };
             for i in 0..n {
-                let x = if is_tuple(t) {
-                    w_tuple_getitem(t, i as i64)
+                let x = if container_is_tuple {
+                    w_tuple_getitem(t(), i as i64)
                 } else {
-                    w_list_getitem(t, i as i64)
+                    w_list_getitem(t(), i as i64)
                 };
                 if let Some(x) = x {
-                    collect_parameters_one(x, params)?;
+                    collect_parameters_one(x, param_slots)?;
                 }
             }
             return Ok(());
@@ -129,9 +166,9 @@ fn collect_parameters_one(
     // `hasattr(t, '__typing_subst__')` → `t` is itself a parameter.  `hasattr`
     // only swallows `AttributeError`; a misbehaving descriptor that raises
     // anything else propagates.
-    match crate::baseobjspace::getattr_str(t, "__typing_subst__") {
+    match crate::baseobjspace::getattr_str(t(), "__typing_subst__") {
         Ok(_) => {
-            push_unique(params, t)?;
+            push_unique(param_slots, t())?;
             return Ok(());
         }
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {}
@@ -139,13 +176,16 @@ fn collect_parameters_one(
     }
     // Otherwise pull `getattr(t, '__parameters__', ())` — the `()` default
     // applies only on `AttributeError`.
-    match crate::baseobjspace::getattr_str(t, "__parameters__") {
+    match crate::baseobjspace::getattr_str(t(), "__parameters__") {
         Ok(sub) => {
             if unsafe { is_tuple(sub) } {
-                let n = unsafe { w_tuple_len(sub) };
+                let sub_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(sub);
+                let sub = || pyre_object::gc_roots::shadow_stack_get(sub_slot);
+                let n = unsafe { w_tuple_len(sub()) };
                 for i in 0..n {
-                    if let Some(x) = unsafe { w_tuple_getitem(sub, i as i64) } {
-                        push_unique(params, x)?;
+                    if let Some(x) = unsafe { w_tuple_getitem(sub(), i as i64) } {
+                        push_unique(param_slots, x)?;
                     }
                 }
             }
@@ -156,15 +196,21 @@ fn collect_parameters_one(
     Ok(())
 }
 
-fn push_unique(params: &mut Vec<PyObjectRef>, item: PyObjectRef) -> Result<(), crate::PyError> {
-    // `if item not in parameters: parameters.append(item)` — the `in` test is
-    // `tuple.__contains__`, so a raising `__eq__` propagates.
-    for &p in params.iter() {
+/// `if item not in parameters: parameters.append(item)`.  The `in` test is
+/// `tuple.__contains__`, so a raising `__eq__` propagates — and a returning one
+/// may have moved both operands, so each comparison reads its pair back out of
+/// the slots.  Pins into the caller's scope, as [`collect_parameters_one`] does.
+fn push_unique(param_slots: &mut Vec<usize>, item: PyObjectRef) -> Result<(), crate::PyError> {
+    let item_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(item);
+    for index in 0..param_slots.len() {
+        let p = pyre_object::gc_roots::shadow_stack_get(param_slots[index]);
+        let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
         if crate::baseobjspace::eq_w(p, item)? {
             return Ok(());
         }
     }
-    params.push(item);
+    param_slots.push(item_slot);
     Ok(())
 }
 
@@ -350,10 +396,17 @@ fn ga_getitem(args: &[PyObjectRef]) -> crate::PyResult {
 /// `ValueError` raised when the item is absent.  A raising `__eq__`
 /// propagates (`tuple.index` does not swallow comparison errors).
 fn tuple_index(t: PyObjectRef, item: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
-    let n = unsafe { w_tuple_len(t) };
+    // `__eq__` is user code and both operands are nursery-allocated, so the
+    // tuple is re-read for every element rather than indexed from the word
+    // that was live before the first comparison.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[t, item]);
+    let t = || pyre_object::gc_roots::shadow_stack_get(base);
+    let item = || pyre_object::gc_roots::shadow_stack_get(base + 1);
+    let n = unsafe { w_tuple_len(t()) };
     for i in 0..n {
-        if let Some(x) = unsafe { w_tuple_getitem(t, i as i64) }
-            && crate::baseobjspace::eq_w(x, item)?
+        if let Some(x) = unsafe { w_tuple_getitem(t(), i as i64) }
+            && crate::baseobjspace::eq_w(x, item())?
         {
             return Ok(Some(i));
         }
@@ -753,13 +806,18 @@ fn subs_tvars(
             continue;
         };
         // `try: argitems[params.index(param)] except ValueError: param`.
-        let arg = match tuple_index(params(), param)? {
-            Some(idx) => unsafe { w_tuple_getitem(argitems(), idx as i64) }.unwrap_or(param),
-            None => param,
+        // The search runs `__eq__` on every turn, so `param` is published
+        // before it and read back from the slot for each use afterwards.
+        let param_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(param);
+        let param = || pyre_object::gc_roots::shadow_stack_get(param_slot);
+        let arg = match tuple_index(params(), param())? {
+            Some(idx) => unsafe { w_tuple_getitem(argitems(), idx as i64) }.unwrap_or(param()),
+            None => param(),
         };
         // `if isinstance(param, TypeVarTuple): subargs.extend(arg)` — a
         // `TypeVarTuple` captures a sequence, so its bound `arg` is spliced.
-        if is_typevartuple(param) {
+        if is_typevartuple(param()) {
             let members = crate::builtins::collect_iterable(arg)?;
             let member_base = pyre_object::gc_roots::pin_roots(&members);
             for index in 0..members.len() {

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1522,10 +1522,11 @@ impl Arguments {
         // point.  The dictionary moves under one, and the names and values sit
         // in native vectors no root walker updates, so the whole set is
         // published before the first turn and read back on the turn that uses
-        // it.  A tuple is allocated stable, so `w_args` only needs the one pin
-        // that keeps it alive across the same run.
+        // it.  `w_args` is nursery-allocated too, so it is read back at the
+        // return rather than carried across the loop in a local.
         let _roots = pyre_object::gc_roots::push_roots();
-        let w_args = pyre_object::gc_roots::pin_root(w_args);
+        let args_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_args);
         let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
         if let (Some(names), Some(values)) =
@@ -1548,7 +1549,10 @@ impl Arguments {
                 )?;
             }
         }
-        Ok((w_args, pyre_object::gc_roots::shadow_stack_get(kwds_slot)))
+        Ok((
+            pyre_object::gc_roots::shadow_stack_get(args_slot),
+            pyre_object::gc_roots::shadow_stack_get(kwds_slot),
+        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -22,7 +22,7 @@ use crate::function::is_function;
 pub use crate::{PyError, PyErrorKind, PyResult};
 use pyre_object::unicodeobject::is_str;
 use pyre_object::*;
-use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
 
 // ── Re-exports from split-out modules ────────────────────────────────
 pub use crate::objspace::descroperation::*;
@@ -1887,19 +1887,24 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
 
 #[inline(never)]
 unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
+    let mut obj = obj;
     if is_slice(index) {
         // tupleobject.py descr_getslice → slice.indices.
         let len = w_tuple_len(obj) as i64;
         let (rs, rp, st) = {
-            // `slice_unpack` runs each component's `__index__`; the tuple is
-            // rooted for that window and does not move.
+            // `slice_unpack` runs each component's `__index__`, so this runs
+            // Python.  A tuple is nursery-allocated, so read the address back:
+            // a minor collection during the call moves it.  The length is
+            // read before, as `indices4` takes it — a tuple cannot be resized.
             let _roots = pyre_object::gc_roots::push_roots();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            crate::sliceobject::slice_unpack(
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let unpacked = crate::sliceobject::slice_unpack(
                 w_slice_get_start(index),
                 w_slice_get_stop(index),
                 w_slice_get_step(index),
-            )?
+            )?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            unpacked
         };
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
@@ -1923,11 +1928,13 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         let indexed = {
             // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
             // before dispatching here, so nothing else roots it across the
-            // call. A tuple never moves, so the root is for liveness alone
-            // and the address in hand stays correct.
+            // call. A tuple is nursery-allocated, so read the address back —
+            // a minor collection during the call moves it.
             let _roots = pyre_object::gc_roots::push_roots();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            space_index(index)?
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let indexed = space_index(index)?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            indexed
         };
         if is_int(indexed) {
             w_int_get_value(indexed)
@@ -1967,23 +1974,28 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     // at the code point index; a wide or surrogate-bearing one resolves the
     // position through the string's cached `rutf8` index table, so a read is
     // O(1) either way and nothing here has to materialise the code points.
+    let mut obj = obj;
     let len = w_str_len(obj);
-    let at = |i: usize| -> Option<CodePoint> { pyre_object::w_str_codepoint_at(obj, i) };
     if is_slice(index) {
         // `pypy/objspace/std/unicodeobject.py W_UnicodeObject._getitem_slice`
         // → `slice.indices(len)` (`pypy/objspace/std/sliceobject.py`).
         // Use the shared adjusted slice count so very large steps do not
         // overflow the index loop.
         let (rs, rp, st) = {
-            // `slice_unpack` runs each component's `__index__`; the string is
-            // rooted for that window and does not move.
+            // `slice_unpack` runs each component's `__index__`, so this runs
+            // Python.  `space.str` answers a nursery header, so read the
+            // address back: a minor collection during the call moves it.  The
+            // length is read before, as `slice.indices` takes it — a string
+            // cannot be resized.
             let _roots = pyre_object::gc_roots::push_roots();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            crate::sliceobject::slice_unpack(
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let unpacked = crate::sliceobject::slice_unpack(
                 w_slice_get_start(index),
                 w_slice_get_stop(index),
                 w_slice_get_step(index),
-            )?
+            )?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            unpacked
         };
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len as i64);
@@ -2017,11 +2029,13 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         let indexed = {
             // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
             // before dispatching here, so nothing else roots it across the
-            // call. A str never moves, so the root is for liveness alone
-            // and the address in hand stays correct.
+            // call. `space.str` answers a nursery header, so read the address
+            // back — a minor collection during the call moves it.
             let _roots = pyre_object::gc_roots::push_roots();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            space_index(index)?
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let indexed = space_index(index)?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            indexed
         };
         if is_int(indexed) {
             w_int_get_value(indexed)
@@ -2048,7 +2062,7 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     // past `usize::MAX` alike: an `as` cast would truncate `2**32` to `0`
     // and answer `s[0]` where this owes an `IndexError`.
     if let Ok(actual_idx) = usize::try_from(actual_idx)
-        && let Some(cp) = at(actual_idx)
+        && let Some(cp) = pyre_object::w_str_codepoint_at(obj, actual_idx)
     {
         return Ok(pyre_object::unicodeobject::w_str_from_codepoint(
             cp.to_u32(),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6674,8 +6674,8 @@ fn type_descr_new_with_metaclass(
         // with no other referrer, and it has to survive `calculate_metaclass`,
         // the namespace copy, `validate_c3_mro`, `create_all_slots`,
         // `__set_name__` and `__init_subclass__` before anything else refers to
-        // it.  A tuple never moves, so the plain uses below stay valid
-        // addresses; the pin is what keeps a major cycle from sweeping it.
+        // it.  A tuple is nursery-allocated and every one of those collects,
+        // so each use below reads the slot back instead of carrying the word.
         let _effective_bases_roots = pyre_object::gc_roots::push_roots();
         let w_effective_bases =
             if bases.is_null() || !unsafe { is_tuple(bases) } || unsafe { w_tuple_len(bases) } == 0
@@ -6689,7 +6689,8 @@ fn type_descr_new_with_metaclass(
             } else {
                 bases
             };
-        let w_effective_bases = pyre_object::gc_roots::pin_root(w_effective_bases);
+        let effective_bases_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_effective_bases);
         // calculate_metaclass — delegate to winner if different
         let default_meta = if w_metaclass.is_null() {
             crate::typedef::w_type()
@@ -6745,7 +6746,12 @@ fn type_descr_new_with_metaclass(
 
         // This is type.__new__'s own construction path. A different winning
         // metaclass above received the original bases without a C3 pre-check.
-        unsafe { crate::baseobjspace::validate_c3_mro(w_effective_bases, false)? };
+        unsafe {
+            crate::baseobjspace::validate_c3_mro(
+                pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
+                false,
+            )?
+        };
 
         let _dict_root = pyre_object::gc_roots::push_roots();
         let dict_root = pyre_object::gc_roots::shadow_stack_len();
@@ -6757,7 +6763,11 @@ fn type_descr_new_with_metaclass(
         // raised, since the store cannot propagate one).
         let dict_obj = unsafe { pyre_object::w_dict_copy(class_ns) };
         let dict_obj = pyre_object::gc_roots::pin_root(dict_obj);
-        let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
+        let w_type = pyre_object::w_type_new(
+            name,
+            pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
+            dict_obj as *mut u8,
+        );
         // Nothing refers to a class this young — the classcell is optional and
         // `weak_subclasses` is weak — while the passes below allocate, so a
         // major cycle sweeps it out from under `create_all_slots` and the
@@ -6770,7 +6780,12 @@ fn type_descr_new_with_metaclass(
         // pass receives the forwarded address rather than the word above.
         type_new_take_qualname(w_type, pyre_object::gc_roots::shadow_stack_get(dict_root))?;
         // typeobject.py create_all_slots parity.
-        unsafe { crate::call::create_all_slots(w_type, w_effective_bases)? };
+        unsafe {
+            crate::call::create_all_slots(
+                w_type,
+                pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
+            )?
+        };
         // `type_ready_fill_dict` defaults the doc entry once the slot and
         // instance descriptors own their names.
         type_dict_set_doc(w_type);
@@ -6869,7 +6884,11 @@ fn type_descr_new_with_metaclass(
             },
             None => Vec::new(),
         };
-        crate::call::call_init_subclass_on_bases(w_type, w_effective_bases, &init_subclass_kwargs)?;
+        crate::call::call_init_subclass_on_bases(
+            w_type,
+            pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
+            &init_subclass_kwargs,
+        )?;
 
         return Ok(w_type);
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -16088,6 +16088,19 @@ pub(crate) fn exec_or_eval(
             (crate::box_code_object(code), false)
         }
     };
+    // A compiled source has just been boxed, and this local is its only
+    // referrer: the wrapper is `try_gc_alloc_stable`, so it does not move, but
+    // it is swept like any other unreferenced object.  Everything below runs
+    // Python -- the `__getitem__` probes on the namespace arguments, and then
+    // `ensure_*_builtins` through the globals mapping's `setdefault` (exec) or
+    // `__setitem__` (eval) -- and the frame is built from this word at the very
+    // end, so a collection in between leaves `createframe_obj` handing a reused
+    // block to `w_code_frame_stores_global`'s write barrier.  `code_ptr` below
+    // is a host allocation the destructor leaves standing, so only the wrapper
+    // needs the root.
+    let _code_roots = pyre_object::gc_roots::push_roots();
+    let code_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(code_obj_ref);
     let raw_code = unsafe {
         crate::w_code_get_ptr(code_obj_ref as pyre_object::PyObjectRef) as *const crate::CodeObject
     };
@@ -16300,6 +16313,20 @@ pub(crate) fn exec_or_eval(
     } else {
         pyre_object::w_dict_new()
     };
+    // The namespace mappings this function hands to the new frame are dicts,
+    // which the nursery relocates, and the `exec(src)` snapshot below has no
+    // referrer at all until `setdictscope` stores it.  `ensure_*_builtins`, the
+    // frame construction and `pick_builtin_obj_checked` each dispatch through a
+    // dict subclass and can collect, so all three are published here and read
+    // back at the site that consumes them.  Every pin is taken before
+    // `_closure_root` opens: a slot claimed after that scope would be truncated
+    // away by its drop.
+    let ns_roots = pyre_object::gc_roots::push_roots();
+    let w_globals_slot = (!w_globals.is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(w_globals);
+        slot
+    });
     // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
     // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
@@ -16342,6 +16369,11 @@ pub(crate) fn exec_or_eval(
         // function from adding `y` to that function's locals.
         implicit_caller_locals = unsafe { (*caller_frame).frame_locals_snapshot()? };
     }
+    let implicit_locals_slot = (!implicit_caller_locals.is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(implicit_caller_locals);
+        slot
+    });
     let mut locals_object_arg: pyre_object::PyObjectRef = std::ptr::null_mut();
     if !is_none_or_null(locals_arg) {
         let same_as_globals =
@@ -16360,6 +16392,11 @@ pub(crate) fn exec_or_eval(
             locals_object_arg = locals_arg;
         }
     }
+    let locals_object_slot = (!locals_object_arg.is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(locals_object_arg);
+        slot
+    });
     // function.py Function.__init__ — build the closure carrier for
     // `exec(code, ..., closure=...)`.  A `Function` whose `__closure__` is the
     // validated cell tuple; createframe reads it back through
@@ -16373,7 +16410,7 @@ pub(crate) fn exec_or_eval(
     let outer_func = if inject_closure {
         let name = unsafe { (&*raw_code).obj_name.clone() };
         let f = crate::function::function_new_with_closure(
-            code_obj_ref as *const (),
+            pyre_object::gc_roots::shadow_stack_get(code_slot) as *const (),
             name,
             pyre_object::PY_NULL,
             closure,
@@ -16388,14 +16425,18 @@ pub(crate) fn exec_or_eval(
     // None so createframe surfaces pyframe.py:242-246's TypeError "directly
     // executed code object may not contain free variables" — exec()'s
     // closure-mismatch TypeError was already raised above.
-    let mut frame =
-        match crate::createframe_obj(code_obj_ref as *const (), w_globals, exec_ctx, outer_func) {
-            Ok(frame) => frame,
-            Err(err) => {
-                let _ = raw_code;
-                return Err(err);
-            }
-        };
+    let mut frame = match crate::createframe_obj(
+        pyre_object::gc_roots::shadow_stack_get(code_slot) as *const (),
+        w_globals_slot.map_or(w_globals, pyre_object::gc_roots::shadow_stack_get),
+        exec_ctx,
+        outer_func,
+    ) {
+        Ok(frame) => frame,
+        Err(err) => {
+            let _ = raw_code;
+            return Err(err);
+        }
+    };
     // Python 3.14 always selects the builtin namespace supplied through an
     // explicit exec/eval globals dict.  PyPy expresses the same selection as
     // `space.builtin.pick_builtin(w_globals)` when
@@ -16428,14 +16469,15 @@ pub(crate) fn exec_or_eval(
     // were separately supplied.  Without this call, initialize_frame_scopes'
     // module-code arm has already bound w_locals = w_globals, matching
     // PyPy's `exec(src, g)` (and `exec(src, g, l)` where `l is g`).
-    if !locals_object_arg.is_null() {
-        frame.setdictscope(locals_object_arg)?;
-    } else if !implicit_caller_locals.is_null() {
+    if let Some(slot) = locals_object_slot {
+        frame.setdictscope(pyre_object::gc_roots::shadow_stack_get(slot))?;
+    } else if let Some(implicit_locals_slot) = implicit_locals_slot {
         // pyopcode.py:2015 — `exec(src)` with no globals/locals uses
         // the caller's `getdictscope()` as locals.  Skip when the
         // resolved object is the caller's globals (module-level exec
         // collapses to locals=globals — same-dict shape kept by the
         // module-frame's initialize_frame_scopes binding).
+        let implicit_caller_locals = pyre_object::gc_roots::shadow_stack_get(implicit_locals_slot);
         let caller_globals_obj = unsafe { (*caller_anchor.live()).get_w_globals() };
         let same_as_globals = !caller_globals_obj.is_null()
             && std::ptr::eq(implicit_caller_locals, caller_globals_obj);
@@ -22786,9 +22828,24 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let _name_roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(name_obj);
-    let globals = scope[1];
-    let locals = scope[2];
-    let fromlist = scope[3];
+    // The other three bound arguments outlive `level.__index__` too, and each
+    // is a kind the nursery relocates: two dicts and the `fromlist` tuple.
+    // Publish them beside the name and read every one back below.
+    let globals_slot = (!scope[1].is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(scope[1]);
+        slot
+    });
+    let locals_slot = (!scope[2].is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(scope[2]);
+        slot
+    });
+    let fromlist_slot = (!scope[3].is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(scope[3]);
+        slot
+    });
     let level_obj = scope[4];
     // `@unwrap_spec(level=int)` — an omitted level defaults to 0; a supplied
     // non-integer raises through the index protocol rather than defaulting.
@@ -22808,6 +22865,13 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     // such spelling goes straight to the app-level bootstrap.  Re-read the
     // name through its root: `space_index_w` above may have moved it.
     let name_obj = pyre_object::gc_roots::shadow_stack_get(name_slot);
+    let read = |slot: Option<usize>| {
+        slot.map_or(
+            pyre_object::PY_NULL,
+            pyre_object::gc_roots::shadow_stack_get,
+        )
+    };
+    let (globals, locals, fromlist) = (read(globals_slot), read(locals_slot), read(fromlist_slot));
     let Some(name) = (unsafe { pyre_object::w_str_get_value_opt(name_obj) }) else {
         return crate::importing::dunder_import_name_obj(
             name_obj, globals, locals, fromlist, level,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4899,11 +4899,10 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // Neither tuple has a referrer besides this frame's Rust locals until
     // `w_type_new` stores the resolved one into `W_TypeObject.bases`, and
     // `__mro_entries__`, `__prepare__`, the class body and the metaclass call
-    // all run in between.  A tuple is allocated stable, so it never moves and
-    // the raw copies stay valid addresses — but an unmarked stable block is
-    // still swept, and a class body long enough to span a whole major cycle
-    // frees it under the local.  Both slots therefore stay pinned until
-    // `build_class_inner`, the one consumer, returns.
+    // all run in between.  A tuple is nursery-allocated, so a raw copy goes
+    // stale as soon as one of those collects, and an unreferenced one is
+    // swept besides; every use below therefore reads its slot back, and both
+    // slots stay pinned until `build_class_inner`, the one consumer, returns.
     let bases_roots = pyre_object::gc_roots::push_roots();
     let orig_bases_slot = bases_roots.base();
     let _ = bases_roots.pin_root(pyre_object::w_tuple_new(base_args.to_vec()));

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4756,7 +4756,14 @@ fn update_bases(
     // `__mro_entries__` call both run Python.  Pinning each returned tuple
     // keeps its entries traced for the rest of the walk; the caller's
     // `w_tuple_new` re-pins them before it allocates.
+    //
+    // `w_orig_bases` is the tuple every `__mro_entries__` in the walk is handed,
+    // and it is nursery-allocated: the caller's pin keeps it alive and forwards
+    // its slot, but this parameter copy is the pre-move word from the first
+    // `getattr_str` onwards.  Re-publish it here and read the slot at each call.
     let _entry_roots = pyre_object::gc_roots::push_roots();
+    let orig_bases_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_orig_bases);
     let mut new_bases: Option<Vec<PyObjectRef>> = None;
     for (i, &w_base) in base_args.iter().enumerate() {
         if unsafe { pyre_object::is_type(w_base) } {
@@ -4773,7 +4780,10 @@ fn update_bases(
             }
             Err(e) => return Err(e),
             Ok(w_meth) => {
-                let w_new_base = crate::call_function(w_meth, &[w_orig_bases]);
+                let w_new_base = crate::call_function(
+                    w_meth,
+                    &[pyre_object::gc_roots::shadow_stack_get(orig_bases_slot)],
+                );
                 if w_new_base.is_null() {
                     if let Some(err) = take_call_error() {
                         return Err(err);
@@ -5013,9 +5023,9 @@ pub fn build_class_body_namespace_is_module_dict(args: &[PyObjectRef]) -> bool {
 
 /// `bases` and `w_orig_bases` are borrowed, not owned: the only caller,
 /// `real_build_class`, keeps both pinned for the whole of this call.  They are
-/// tuples, so they never move and the raw copies below stay valid addresses;
-/// what the caller's scope buys is that the blocks are still allocated when
-/// the class body returns.  A second caller would have to pin them the same
+/// nursery-allocated tuples, so the parameter copies go stale as soon as
+/// `__prepare__` or the class body collects; both are re-published below and
+/// read back at each use.  A second caller would have to pin them the same
 /// way before calling.
 fn build_class_inner(
     body_fn: PyObjectRef,
@@ -5040,11 +5050,11 @@ fn build_class_inner(
     let current_kwds = || kwds_roots.as_ref().map(|(scope, slot)| scope.get(*slot));
 
     // `bases` and `w_orig_bases` are raw copies taken before `__prepare__` and
-    // before the class body runs, and both execute Python.  A tuple does not
-    // move, but one with no heap edge is sweepable rather than merely immobile,
-    // so a copy held across those calls can name freed memory by the time
-    // `is_tuple` / `w_tuple_len` read it.  Publish both and read them back at
-    // each site that consumes them.
+    // before the class body runs, and both execute Python.  A tuple is
+    // nursery-allocated, so a copy held across those calls names the pre-move
+    // address by the time `is_tuple` / `w_tuple_len` read it, and one with no
+    // heap edge is swept besides.  Publish both and read them back at each site
+    // that consumes them.
     let bases_scope = pyre_object::gc_roots::push_roots();
     let bases_slot = bases_scope.base();
     let _ = bases_scope.pin_root(bases);
@@ -5053,14 +5063,16 @@ fn build_class_inner(
         let _ = pyre_object::gc_roots::pin_root(w_orig_bases);
         slot
     });
+    // The class body's frame is built from the function's code, globals and
+    // closure at the bottom of this function, after `__prepare__`, the
+    // namespace allocations and the namespace replay have all run.  The globals
+    // are a dict and the closure a tuple, both nursery-allocated, so the three
+    // are read off `body_fn` there rather than cached here.  A `Function` is
+    // `try_gc_alloc_stable`, so its own address survives; what the pin buys is
+    // that the block is still allocated when that late read happens.
+    let body_fn_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(body_fn);
     let bases = || bases_scope.get(bases_slot);
-
-    let w_code = unsafe { crate::getcode(body_fn) };
-    let w_globals = unsafe { function_get_globals_obj(body_fn) };
-    let closure = unsafe { function_get_closure(body_fn) };
-    let func_code = unsafe {
-        crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
-    };
 
     // Call metaclass.__prepare__(name, bases, **kwds) if it exists.
     // PyPy: build_class → metaclass.__prepare__(name, bases, **kwds)
@@ -5223,6 +5235,16 @@ fn build_class_inner(
     // Create frame with class_locals set AND closure from enclosing scope.
     // PyPy: executes class body with w_locals = fresh dict, w_globals = module globals,
     // and the closure tuple is passed through for LOAD_DEREF access.
+    //
+    // Read the three off the pinned function here: everything above ran Python
+    // or allocated, and the globals dict and the closure tuple both relocate.
+    let body_fn = pyre_object::gc_roots::shadow_stack_get(body_fn_slot);
+    let w_code = unsafe { crate::getcode(body_fn) };
+    let w_globals = unsafe { function_get_globals_obj(body_fn) };
+    let closure = unsafe { function_get_closure(body_fn) };
+    let func_code = unsafe {
+        crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
+    };
     // Debug: dump code object for __class__ cell investigation. Reads the real
     // process env + writes real stderr, so keep it out of the sandbox build.
     #[cfg(not(feature = "sandbox"))]

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -4014,9 +4014,9 @@ impl Converter<'_> {
                     .iter()
                     .map(|v| self.constant_value(v))
                     .collect::<Result<Vec<_>, _>>()?;
-                // A tuple header never moves, but it is untraced until it is
-                // pinned, so its members are read only once there is nothing
-                // left to allocate before the store.
+                // A tuple header is untraced until it is pinned, so its members
+                // are read only once there is nothing left to allocate before
+                // the store, and the pin's returned word is what is kept.
                 self.pin(pyre_object::w_tuple_new(
                     values.into_iter().map(Rooted::get).collect(),
                 ))

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -362,8 +362,8 @@ pub(crate) fn compat_map(
     // through `getitem`, which can run Python and drive a collection. Pin the
     // freshly built key so a collection there cannot sweep it mid-lookup — the
     // Rust counterpart of the RPython GC transform auto-rooting `w_key` across
-    // `space.finditem`. The key is a born-old-stable (non-moving) tuple over
-    // immortal element strings, so keeping it alive is sufficient (no re-read).
+    // `space.finditem`. The tuple is nursery-allocated, so the local below is
+    // the word the pin handed back rather than the one it was handed.
     // The cached real-dict tables take the native `w_dict_lookup_checked` path
     // and never collect, so this only guards a user-replaced mapping.
     let _key_root = pyre_object::gc_roots::push_roots();

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -1400,32 +1400,45 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
         return Err(crate::PyError::type_error("sub requires self, repl, string"));
     }
     let pat = args[0];
-    let w_repl = args[1];
-    let string = args[2];
+    // `pat` is `malloc_typed` and held in the process-wide pattern table, so it
+    // is immortal and needs no root of its own.  The replacement and the
+    // subject are ordinary objects, and everything below runs Python -- an
+    // `__index__` on `count`, the template parse, and the filter once per
+    // match.  A match object stamps the subject and its buffer into traced
+    // fields, so a stale word here is one the collector follows on its next
+    // walk rather than one that is merely read back wrong.
+    let base = pyre_object::gc_roots::pin_roots(&[args[1], args[2]]);
+    let w_repl = || pyre_object::gc_roots::shadow_stack_get(base);
+    let string = || pyre_object::gc_roots::shadow_stack_get(base + 1);
     let code = get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
-    let subj = make_subject(pat, string)?;
-    let w_buffer = unsafe { readbuf_obj(string) };
+    // The subject borrows the string's value box, which is `try_gc_alloc_stable`
+    // and so keeps its address; the pin above is what keeps that box allocated
+    // for the length of the walk.
+    let subj = make_subject(pat, string())?;
+    let buffer_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(unsafe { readbuf_obj(string()) });
+    let w_buffer = || pyre_object::gc_roots::shadow_stack_get(buffer_slot);
     let count = arg_int_kw(args, 3, kwargs, "count", 0)?;
 
     // interp_sre.py:437-472 — a callable filter is applied per match; a
     // literal (no backslash) is inserted verbatim; otherwise the template
     // is compiled into a literal/group reference list.  The replacement's
     // type must match the subject's (str↔str, bytes↔bytes).
-    let filter_is_callable = crate::baseobjspace::callable_w(w_repl);
+    let filter_is_callable = crate::baseobjspace::callable_w(w_repl());
     let template = if filter_is_callable {
         None
     } else {
         let (repl_bytes, is_bytes) = match subj {
             Subject::AsciiStr(_) | Subject::Str(_) => {
-                if !unsafe { is_str(w_repl) } {
+                if !unsafe { is_str(w_repl()) } {
                     return Err(crate::PyError::type_error(
                         "sub: replacement must be str or callable",
                     ));
                 }
-                (unsafe { w_str_get_wtf8(w_repl) }.as_bytes(), false)
+                (unsafe { w_str_get_wtf8(w_repl()) }.as_bytes(), false)
             }
             Subject::Bytes(_) => {
-                let Some(w_bytes) = crate::typedef::buffer_as_bytes_like(w_repl)? else {
+                let Some(w_bytes) = crate::typedef::buffer_as_bytes_like(w_repl())? else {
                     return Err(crate::PyError::type_error(
                         "sub: replacement must be bytes-like or callable",
                     ));
@@ -1437,7 +1450,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
                 )
             }
         };
-        Some(parse_replacement_template(w_repl, repl_bytes, pat, is_bytes)?)
+        Some(parse_replacement_template(w_repl(), repl_bytes, pat, is_bytes)?)
     };
 
     let endpos = subj.len();
@@ -1454,13 +1467,13 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
         }
         last = mend;
         if let Some(items) = &template {
-            let m = make_match_from_snapshot(pat, string, w_buffer, snap, 0, endpos as i64);
+            let m = make_match_from_snapshot(pat, string(), w_buffer(), snap, 0, endpos as i64);
             expand_into(&mut out, items, m as *const W_SRE_Match, subj);
         } else {
             // interp_sre.py:505-513 — callable filter; None means "no
             // piece" (treated as empty), otherwise the returned string.
-            let m = make_match_from_snapshot(pat, string, w_buffer, snap, 0, endpos as i64);
-            let w_piece = crate::call::call_function_impl_result(w_repl, &[m])?;
+            let m = make_match_from_snapshot(pat, string(), w_buffer(), snap, 0, endpos as i64);
+            let w_piece = crate::call::call_function_impl_result(w_repl(), &[m])?;
             if !unsafe { is_none(w_piece) } {
                 match subj {
                     Subject::AsciiStr(_) | Subject::Str(_) => {
@@ -1501,8 +1514,8 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
     // (`str`/`bytes` subclass or buffer input) is normalized to a base-type
     // slice of the whole subject.
     if n == 0 {
-        let w_result = if is_exact_str_or_bytes(string) {
-            string
+        let w_result = if is_exact_str_or_bytes(string()) {
+            string()
         } else {
             slice_subject(subj, (0, endpos as i64), empty_subject(subj))
         };

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -560,8 +560,9 @@ impl<'a> MiniXmlParser<'a> {
         // The content model is a fresh `tuple` that nothing but this local
         // refers to while the position update writes three parser slots and the
         // handler runs Python; a collection completing there would reclaim it.
-        // One liveness pin at the mint — a tuple does not move, so the local
-        // stays current.
+        // One pin at the mint, and the local is the word the pin handed back:
+        // a tuple is nursery-allocated, so the address it was handed in on is
+        // the one a collection would leave behind.
         let roots = pyre_object::gc_roots::push_roots();
         let model = w_tuple_new(vec![
             w_int_new(2),

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -328,8 +328,9 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     // reach a collection while the fresh set and sentinel still have no heap
     // edge.  Hold all of them on the shadow stack and read each back at its
     // use; the results accumulate in slots rather than in a native `Vec`,
-    // which would keep pre-move addresses.  The keys themselves are hashable,
-    // so no kind that moves reaches `key_items`.
+    // which would keep pre-move addresses.  The keys go the same way: being
+    // hashable does not make one immobile, and a value pattern that names a
+    // tuple (`case {Cls.KEY: v}`) puts a nursery-allocated key in `key_items`.
     let _roots = pyre_object::gc_roots::push_roots();
     let subject_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(subject);
@@ -347,12 +348,18 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(
         crate::typedef::gettypeobject(&pyre_object::pyobject::INSTANCE_TYPE),
     ));
+    let keys_base = pyre_object::gc_roots::shadow_stack_len();
+    for &key in &key_items {
+        let _ = pyre_object::gc_roots::pin_root(key);
+    }
     let values_base = pyre_object::gc_roots::shadow_stack_len();
     let mut value_count = 0usize;
     let mut all_match = true;
-    for key in key_items {
+    for key_index in 0..key_items.len() {
+        let key = pyre_object::gc_roots::shadow_stack_get(keys_base + key_index);
         let w_seen = pyre_object::gc_roots::shadow_stack_get(seen_slot);
         if crate::baseobjspace::contains(w_seen, key)? {
+            let key = pyre_object::gc_roots::shadow_stack_get(keys_base + key_index);
             let key_repr = unsafe { crate::display::py_repr_wtf8(key)? };
             return Err(PyError::value_error(crate::display::wtf8_format!(
                 "mapping pattern checks duplicate key (",
@@ -360,12 +367,20 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
                 ")"
             )));
         }
-        unsafe { pyre_object::w_set_add(pyre_object::gc_roots::shadow_stack_get(seen_slot), key) };
+        unsafe {
+            pyre_object::w_set_add(
+                pyre_object::gc_roots::shadow_stack_get(seen_slot),
+                pyre_object::gc_roots::shadow_stack_get(keys_base + key_index),
+            )
+        };
         let w_sentinel = pyre_object::gc_roots::shadow_stack_get(sentinel_slot);
         let w_value = crate::baseobjspace::call_method(
             pyre_object::gc_roots::shadow_stack_get(subject_slot),
             "get",
-            &[key, w_sentinel],
+            &[
+                pyre_object::gc_roots::shadow_stack_get(keys_base + key_index),
+                w_sentinel,
+            ],
         );
         if w_value.is_null() {
             return Err(crate::call::take_call_error()
@@ -774,7 +789,16 @@ pub fn dict_update(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError
             return Ok(());
         }
     }
-    let keys_method = crate::baseobjspace::getattr_str(source, "keys")?;
+    // The scope opens ahead of the key fetch, not after it: `getattr_str`, the
+    // `keys()` call and the iteration of whatever it answers are all Python,
+    // and `dict` is a `W_DictObject`, which relocates.  Pinning the pair below
+    // the fetch published the words that were live before it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(source);
+    let source_now = || pyre_object::gc_roots::shadow_stack_get(sp + 1);
+    let keys_method = crate::baseobjspace::getattr_str(source_now(), "keys")?;
     let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
     let keys = crate::builtins::collect_iterable(keys_obj)?;
     unsafe {
@@ -786,19 +810,14 @@ pub fn dict_update(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError
         // duration: `getitem` (arbitrary `__getitem__`) and
         // `try_hash_value` (arbitrary `__hash__`) both may allocate and
         // move them.
-        let _roots = pyre_object::gc_roots::push_roots();
-        let sp = pyre_object::gc_roots::shadow_stack_len();
-        let dict = pyre_object::gc_roots::pin_root(dict);
-        let source = pyre_object::gc_roots::pin_root(source);
-        let key_base = sp + 2;
+        let key_base = pyre_object::gc_roots::shadow_stack_len();
         for index in 0..keys.len() {
             let _ = pyre_object::gc_roots::pin_root(keys[index]);
         }
         let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
         for i in 0..key_len {
-            let source = pyre_object::gc_roots::shadow_stack_get(sp + 1);
             let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
-            let val = crate::baseobjspace::getitem(source, key)?;
+            let val = crate::baseobjspace::getitem(source_now(), key)?;
             let _val_root = pyre_object::gc_roots::push_roots();
             let val_slot = pyre_object::gc_roots::shadow_stack_len();
             let _ = pyre_object::gc_roots::pin_root(val);

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -97,8 +97,8 @@ pub fn w_method_new(
         // Remember the shell before publishing nursery members: running the
         // barrier after the stores would leave a movable `w_self` (notably a
         // list) named by a slot no collection traces until it does. This is
-        // the same pre-store shape as tupleobject's stable shell plus young
-        // items block. A nursery shell answers the barrier in its `is_in_nursery`
+        // the same pre-store shape as tupleobject's shell plus its young items
+        // block. A nursery shell answers the barrier in its `is_in_nursery`
         // arm, so the call stands for the spill case alone.
         crate::gc_hook::try_gc_write_barrier_managed(raw);
         // The four slots are not one contiguous run — `shell_slot` was read

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -109,9 +109,9 @@ pub static SPECIALISED_TUPLE_OO_TYPE: PyType = new_pytype("tuple");
 /// init. The variant carries no GC-pointer fields
 /// (`gc_ptr_offsets = []`, `eval.rs`), so mark-sweep traversal
 /// has nothing to follow and routing through the GC stays
-/// correctness-safe. Unrelated to W_TupleObject canonical allocations
-/// (those depend on ItemsBlock migration before they can
-/// move).
+/// correctness-safe. The canonical `W_TupleObject` is on the other side of
+/// this split: `w_tuple_new` allocates in the nursery, so two objects that
+/// answer `tuple` to `type()` differ in whether a minor collection moves them.
 pub fn w_specialised_tuple_ii_new(value0: i64, value1: i64) -> PyObjectRef {
     let header = PyObject {
         ob_type: &SPECIALISED_TUPLE_II_TYPE as *const PyType,

--- a/scripts/check-gc-root-brackets.py
+++ b/scripts/check-gc-root-brackets.py
@@ -80,17 +80,31 @@ PATTERNS = [
      r"tier 1 \(callee IS a dispatch seed\): (?P<v>\d+) call\(s\) in (?P<w>\d+) fn"),
 ]
 
-# Held at zero rather than ratcheted.  `tier 1.5` is a live pointer later
-# addressed as a list or dict -- the two kinds a minor collection relocates, so
-# a stale one is dereferenced as a corpse rather than merely stored.  A frame
-# carried across a collecting call whose callee is a dispatch seed is the same
-# hazard for the frame itself.
-INVARIANT_ZERO = ("tier15_calls", "frame_tier1_calls")
+# Held at zero rather than ratcheted.  A frame carried across a collecting call
+# whose callee is a dispatch seed is a stale frame, not a backlog entry.
+INVARIANT_ZERO = ("frame_tier1_calls",)
 
 # Ratcheted: may fall, may not rise.
+#
+# `tier15_calls` was held at zero here until the column that feeds it was
+# measured and found dead: the pinned locals and the movable-callee arguments
+# were two spellings of one value -- MIR materialises a call argument as its own
+# temporary -- so the intersection was empty whatever the corpus contained, and
+# the zero said nothing.  With the alias closure in place the same corpus scores
+# in the hundreds, and the first site the column named reproduced a crash at
+# production defaults, so the entries are real rather than noise.  A ratchet is
+# what a real backlog gets; restoring the zero would mean either the dead column
+# or a corpus nobody has paid down yet.
+#
+# The label the report prints still reads `list/dict`, and the regex above
+# matches it: it is the report's wording, not this gate's claim, and the two
+# are kept in step rather than corrected apart.  Read this count with the
+# `movable-argument supply` line beside it -- the column ranks only what that
+# supply feeds it, so a fall here is progress only while that supply holds.
 RATCHET = (
     "unbracketed_calls",
     "tier1_calls",
+    "tier15_calls",
     "frames_across_collecting",
     "brackets_reaching_no_collection",
 )


### PR DESCRIPTION
The gate's `tier15_calls` invariant read zero because the column feeding it was
empty for structural reasons, not because the corpus was clean. `liveness.rs`
chased the pinned set through its alias chain but read the movable-callee
argument set literally, and MIR materialises a call argument as its own
temporary (`_t = copy _obj; w_tuple_getitem(move _t, ..)`), so the two sets
named different spellings of one value and their intersection was empty for
every body. `chase_arg_aliases` walks the alias half of `chase_pinned`;
aggregates are not followed, since a callee handed a container addresses the
container rather than its elements. Over `pyre-interpreter.ullbc` joined with
the three donors, the column goes from 0 to 131 calls in 61 functions.

The first entry the restored column named reproduced a crash at production
defaults, and ten paths are fixed here:

* `build_class_inner` reads the class body's code, globals and closure off
  `body_fn` after `__prepare__` and the namespace replay rather than before.
* `update_bases` re-reads `w_orig_bases` at each `__mro_entries__`.
* `exec_or_eval` roots the globals, the implicit locals and the locals object
  across `ensure_*_builtins`, and the boxed code object across the namespace
  probes and the builtins install.
* `builtin_dunder_import` reads `globals`, `locals` and `fromlist` back from
  slots; `match_keys_value` pins the mapping pattern's keys.
* `collect_parameters` / `collect_parameters_one` carry the walk in one scope
  with a slot-index accumulator, `push_unique` reads both operands of the
  uniqueness test back, `tuple_index` re-reads the tuple per element, and
  `make_generic_alias` roots `origin` and the argument tuple across
  `collect_parameters` before stamping them into the alias.
* `dict_update` opens its scope ahead of the `keys()` fetch instead of after it.
* `subx` roots the subject, the replacement and the subject's buffer across the
  `count` conversion, the template parse and the filter.

Four earlier sites (`getitem_tuple`, `getitem_str`, `Arguments::topacked`,
`type_new`) pinned a value and then went on using the word they pinned rather
than the one the pin handed back; `w_tuple_new` is `try_gc_alloc_nursery_raw`
and `space.str` answers a nursery header, so both a built tuple and a `str()`
result are relocated by a minor collection. The comments that said a tuple or a
str does not move are corrected in the same places, and `getitem_bytes_like` is
left alone because bytes and bytearray are `try_gc_alloc_stable_raw`.

`gctransform`'s pin-set dataflow now carries the owning root scope, so a
scope-closing `Drop` retires the closed scope and every scope opened after it
rather than clearing the whole set, and bodies holding two live root scopes are
no longer withheld as a class (unread calls 1052 -> 780, covered 1753 -> 1972).

Four snippets cover the new paths. Three of them fail on the prior build only
under `PYPY_GC_NURSERY=512 MAJIT_GC_NURSERY_POISON=1`: `pin_root` follows a
forwarding stub, so a path that pins a stale word self-heals while the stub
survives, and plain-mode passing is not evidence that the path is sound.

`tier15_calls` moves from the zero invariant to the ratchet with the measured
count. Restoring the zero would mean either keeping the dead column or paying
down 131 sites; the ratchet still blocks new ones. The darwin baseline is
re-measured on this base over freshly extracted artefacts and every count is
unchanged, so only its `base` field is rewritten. The linux entry still names
an older base, so a rise there reports as the unattributed-backlog warning
until it is refit from a linux run.

Not addressed: `builtin_bytearray` crashes deterministically under
`PYPY_GC_NURSERY=512` alone, in the collector rather than the mutator, on a
tuple's items block. It reproduces identically on this base with no file this
branch touches (majit-gc, object_array, tupleobject, listobject, gc_hook and
gc_roots are all unmodified here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection safety across generic aliases, indexing, class creation, imports, execution, mapping operations, and regular-expression replacements.
  - Prevented object relocation during collection from causing stale references or incorrect results.
  - Expanded handling for movable nursery-allocated object types and nested scopes.

- **Tests**
  - Added regression coverage for generic aliases, mapping unpacking, namespace operations, regular expressions, and relocating subscript containers.
  - Updated GC-root tracking baselines and validation thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->