### PR TITLE
blackhole: portal driver identity, the abort-boundary contract, and the production builder's coverage

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -58,12 +58,33 @@ cover the condition they diagnose.
 - What it does: **UNRECORDED** — no doc comment at the read site.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
+### `MAJIT_BH_ENTRY_EXC`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `bh_entry_stale_exc_report()`, called from both single- and multi-frame drivers
+- What it does: `MAJIT_BH_ENTRY_EXC`: report a `BH_LAST_EXC_VALUE` that survived into a blackhole drive the caller did not describe as raising.  The clear-before / check-after protocol brackets every call-shaped opcode inside a drive, so the channel cannot go stale within one; what no bracket covers is the window between phases, where a residual raise's leftover value is still in TLS when the next drive starts and a drive entered with `raising_exception == false` seeds `exception_last_value` from its own argument instead.  Clearing the channel on entry is not the fix — `call_jit.rs` deliberately keeps a pending value across its decline path — so this reports the disagreement rather than repairing it.
+- Retirement condition: Remove once the inter-phase window is either measured to be unobservable, or closed by a bracket that spans it, so the disagreement has no producer left.
+
 ### `MAJIT_BH_NULL_ARG`
 
 - Read sites: 1 — `majit/majit-metainterp/src/blackhole.rs`
 - Accessor: `bh_null_arg_report()`
 - What it does: `MAJIT_BH_NULL_ARG`: report a null ref argument about to be handed to a residual call, with the jitcode coordinate, before the callee can dereference it.  Some ABIs pass a legitimate null sentinel (e.g. the CallFn `null_or_self` slot), so this reports rather than aborts.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_BH_PORTAL_SUBST`
+
+- Read sites: 1 — `majit/majit-metainterp/src/blackhole.rs`
+- Accessor: `portal_substitution_report()`, called from `portal_dispatch_for()`
+- What it does: `MAJIT_BH_PORTAL_SUBST`: name each recursive portal level that re-enters through a runner its own driver did not register.  `pyre_portal_runner` reads `all_r[1]` as a `PyFrame*`, so a substituted runner reached with another driver's reds is a type confusion that would surface as a bug in the substituted driver.  It is not reported as a fault because pyre registers one runner for many drivers by construction, so this makes the substitutions countable — separating the set that actually re-enters a portal from the set that merely resolves a hook it never calls.
+- Retirement condition: Remove when every portal driver index registers its own runner, so a substitution becomes a fault the dispatch path can refuse outright rather than a counted norm.
+
+### `MAJIT_BH_VABLE_INTBASE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/blackhole.rs`
+- Accessor: `bh_vable_intbase_report()`, called from the `getfield_vable_i` / `setfield_vable_i` / `setfield_vable_r` intbase handlers
+- What it does: `MAJIT_BH_VABLE_INTBASE`: report a vable base read out of the int bank that disagrees with the rooted `virtualizable_ptr`.  The `*_vable_*_intbase` handlers take their struct operand from `registers_i`, and no walker forwards the int banks — only `registers_r`, the packed resume roots, and `virtualizable_ptr` are — so a collection between the write of that int register and the handler leaves the address pointing where the object used to be.  `virtualizable_ptr` names the same object and is forwarded, so the two disagreeing is the observable form of that staleness.  Reported rather than repaired: the vable bytecodes are operand-addressed by design, and substituting the rooted address would change which object a multi-virtualizable chain writes to.
+- Retirement condition: Remove when the int banks are forwarded by the walkers, or the vable handlers take their base from a rooted operand, so a stale intbase cannot be produced.
 
 ### `MAJIT_BRIDGE_BAIL`
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1176,6 +1176,12 @@ impl BlackholeInterpreter {
             // propagates instead of being absorbed: `Ok(0)` would have popped
             // to the caller and resumed it right after the call whose callee
             // bailed, with the result register never written.
+            //
+            // One variant covers both aborts because only one of them is
+            // resumable, and which one it is travels beside the exception in
+            // `abort_permanent_bail` — on the frame here, and on the register
+            // image the drivers hand out.  Every consumer checks that flag
+            // before it treats the bailed frame as a resume point.
             return Err(JitException::BailToInterpreter);
         }
 
@@ -2996,6 +3002,12 @@ pub struct BlackholeTerminalImage {
     pub registers_f: Vec<i64>,
     pub position: usize,
     pub last_opcode_position: usize,
+    /// [`BlackholeInterpreter::abort_permanent_bail`] of the frame this image
+    /// was taken from, so a consumer of `BailToInterpreter` can tell the abort
+    /// that stamped a resume coordinate from the one that did not.  Without it
+    /// the exception says only *that* the chain bailed, and every consumer has
+    /// to assume the boundary it cannot check.
+    pub abort_permanent_bail: bool,
 }
 
 /// Result that escaped a recursive portal runner.
@@ -3037,6 +3049,7 @@ impl BlackholeTerminalImage {
             registers_f: std::mem::take(&mut bh.registers_f),
             position: bh.position,
             last_opcode_position: bh.last_opcode_position,
+            abort_permanent_bail: bh.abort_permanent_bail,
         }
     }
 }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -11519,6 +11519,7 @@ fn handler_getfield_vable_i_intbase(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let struct_ptr = bh.registers_i[code[p] as usize];
+    bh_vable_intbase_report(bh, struct_ptr, "getfield_vable_i");
     if !bh.virtualizable_info.is_null() {
         let vinfo = unsafe { &*bh.virtualizable_info };
         unsafe { crate::virtualizable::bh_clear_vable_token(vinfo, struct_ptr as *mut u8) };
@@ -11575,12 +11576,43 @@ fn handler_setfield_vable_i(
     cpu.bh_setfield_gc_i(struct_ptr, value, &descr);
     Ok(p)
 }
+/// `MAJIT_BH_VABLE_INTBASE`: report a vable base read out of the int bank that
+/// disagrees with the frame's forwarded virtualizable address.
+///
+/// The `*_vable_*_intbase` handlers take their struct operand from
+/// `registers_i`, and no walker forwards the int banks — only `registers_r`,
+/// the packed resume roots, and `virtualizable_ptr` are.  So a collection
+/// between the write of that int register and the handler leaves the address
+/// pointing where the object used to be, and the store lands in memory the
+/// collector has already reused.
+///
+/// `virtualizable_ptr` names the same object and IS forwarded (the drivers root
+/// it beside the Ref bank, precisely because a `-live-` clear can drop it from
+/// the bank), so the two disagreeing is the observable form of that staleness.
+/// Reported rather than repaired: the vable bytecodes are operand-addressed by
+/// design and substituting the rooted address would change which object a
+/// multi-virtualizable chain writes to.  Off unless armed.
+fn bh_vable_intbase_report(bh: &BlackholeInterpreter, struct_ptr: i64, opname: &str) {
+    static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if !*ARMED.get_or_init(|| std::env::var_os("MAJIT_BH_VABLE_INTBASE").is_some()) {
+        return;
+    }
+    if bh.virtualizable_ptr != 0 && struct_ptr != bh.virtualizable_ptr {
+        eprintln!(
+            "[bh-vable-intbase] {opname}: int-bank base {struct_ptr:#x} != \
+             forwarded virtualizable {:#x} (jitcode {:?} pos {} last {})",
+            bh.virtualizable_ptr, bh.jitcode.name, bh.position, bh.last_opcode_position,
+        );
+    }
+}
+
 fn handler_setfield_vable_i_intbase(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
 ) -> Result<usize, DispatchError> {
     let struct_ptr = bh.registers_i[code[p] as usize];
+    bh_vable_intbase_report(bh, struct_ptr, "setfield_vable_i");
     let value = bh.registers_i[code[p + 1] as usize];
     if !bh.virtualizable_info.is_null() {
         let vinfo = unsafe { &*bh.virtualizable_info };
@@ -11613,6 +11645,7 @@ fn handler_setfield_vable_r_intbase(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let struct_ptr = bh.registers_i[code[p] as usize];
+    bh_vable_intbase_report(bh, struct_ptr, "setfield_vable_r");
     let value = bh.registers_r[code[p + 1] as usize];
     if !bh.virtualizable_info.is_null() {
         let vinfo = unsafe { &*bh.virtualizable_info };

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3135,17 +3135,16 @@ fn handle_jitexception(
     //
     // `bh` is upstream's `self` — the portal frame that raised — so its own
     // driver owns the runner, and `_run_forever`'s walk stopped here precisely
-    // because this frame carries a driver stamp.  `portal_runner_for` answers
-    // `None` only when no runner is registered at all, and then the runner this
-    // call was handed stands in; a driver registered without its own runner
-    // fails there rather than borrowing another driver's.
-    let own_runner = portal_runner_for(&bh);
+    // because this frame carries a driver stamp.  `portal_dispatch_for` hands
+    // back that driver's runner and kind together, or — when it registered no
+    // runner of its own — someone else's runner and no kind at all, so the two
+    // never describe different drivers.
+    let (own_runner, result_kind) = portal_dispatch_for(&bh);
     let own_runner = own_runner.as_ref().map(|hook| {
         hook as &dyn Fn(
             &crate::jitexc::JitException,
         ) -> Result<(BhReturnType, i64), PortalRunnerFailure>
     });
-    let result_kind = portal_result_kind_for(&bh);
     let caller = bh.nextblackholeinterp.as_mut().unwrap();
     let portal_outcome =
         handle_jitexception_in_portal(caller, exc, own_runner.or(portal_runner), result_kind);
@@ -3390,9 +3389,9 @@ pub fn convert_and_run_from_pyjitpl(
     // This is only the fallback for the entry frame, which has not passed
     // `_run_forever`'s walk and so need not carry a driver stamp: the recursive
     // level resolves its own runner from the raising portal frame
-    // (`portal_runner_for`), because the driver that owns that jitcode is the
+    // (`portal_dispatch_for`), because the driver that owns that jitcode is the
     // one whose portal has to be re-entered.
-    let hook = portal_runner_for(&first_bh);
+    let (hook, _) = portal_dispatch_for(&first_bh);
     let portal_runner = hook.as_ref().map(|hook| {
         hook as &dyn Fn(
             &crate::jitexc::JitException,
@@ -7235,8 +7234,8 @@ pub type PortalRunnerHook =
 /// `_handle_jitexception_in_portal` can pick the one whose `mainjitcode is
 /// self.jitcode`.  Keeping the table beside `BhJitDriverSd` rather than in it
 /// only avoids an initialisation order between the driver table (built once,
-/// lazily) and the consumer's registration; [`portal_runner_for`] joins the two
-/// at the point of use, through the same relation upstream tests.
+/// lazily) and the consumer's registration; [`portal_dispatch_for`] joins the
+/// two at the point of use, through the same relation upstream tests.
 static PORTAL_RUNNER_HOOKS: std::sync::RwLock<Vec<Option<PortalRunnerHook>>> =
     std::sync::RwLock::new(Vec::new());
 
@@ -7285,55 +7284,76 @@ fn portal_jd_for(bh: &BlackholeInterpreter) -> Option<usize> {
     bh.jitcode.jitdriver_sd()
 }
 
-/// The `jd.handle_jitexc_from_bh` of the driver [`portal_jd_for`] picked.
+/// The `jd.handle_jitexc_from_bh` and the `result_kind` a recursive portal
+/// level uses, resolved together so they cannot come from different drivers.
 ///
-/// `None` asks the caller to keep the runner it was handed.  Upstream needs no
-/// such answer: `jd.handle_jitexc_from_bh` exists per driver by construction,
-/// so a found driver always has one.  pyre registers the hooks from the
-/// consumer crate instead, which splits that into two states this must not
-/// conflate — a table nothing has registered into yet, and a table other
-/// drivers registered into while this frame's driver did not.
-fn portal_runner_for(bh: &BlackholeInterpreter) -> Option<PortalRunnerHook> {
+/// Upstream needs no such pairing: `blackhole.py` picks one `jd` and reads both
+/// off it. pyre splits them because the hooks are registered from the consumer
+/// crate, and the split is what let a substituted runner be validated against
+/// the owning driver's declared kind.
+///
+/// ★ The substitution is the common case, not a fault. `codewriter.rs` stamps a
+/// driver index on every portal jitcode (`jitdriver_sd_from_portal_graph`
+/// matches `jd.portal_graph == code`, and `setup_jitdriver` appends one entry
+/// per portal graph), while `eval.rs` registers exactly one
+/// `handle_jitexc_from_bh` — index 0's. So most portal frames name a driver
+/// that has no runner of its own, and refusing to substitute would withdraw
+/// portal re-entry from paths that have it today.
+///
+/// What is withheld instead is the *kind*: a substituted runner's outcome is
+/// not validated against the owning driver's `result_type`, because that pair
+/// describes two different drivers. `None` leaves
+/// [`handle_jitexception_dispatch`] deciding on the variant alone, which is
+/// what it did before any driver was consulted.
+fn portal_dispatch_for(
+    bh: &BlackholeInterpreter,
+) -> (Option<PortalRunnerHook>, Option<BhReturnType>) {
     let hooks = PORTAL_RUNNER_HOOKS
         .read()
         .expect("portal runner table poisoned");
+    let any_registered = || hooks.iter().find_map(|slot| *slot);
     let Some(jd_index) = portal_jd_for(bh) else {
-        // No driver claims this jitcode, so there is no owner to be wrong
-        // about, and this must still hand back what it did before the search
-        // existed.  Returning `None` here would not report a missing driver,
-        // it would silently withdraw the portal re-entry from a path that had
-        // it.
-        return hooks.iter().find_map(|slot| *slot);
+        // No driver claims this jitcode, so there is no owner whose kind could
+        // apply, and this must still hand back the runner it did before the
+        // search existed: returning `None` would not report a missing driver,
+        // it would silently withdraw the portal re-entry.
+        return (any_registered(), None);
     };
-    if let Some(hook) = hooks.get(jd_index).copied().flatten() {
-        return Some(hook);
+    match hooks.get(jd_index).copied().flatten() {
+        // The owning driver answers both.
+        Some(hook) => (
+            Some(hook),
+            bh.jitdrivers_sd.get(jd_index).map(|jd| jd.result_type),
+        ),
+        // Someone else's runner, and therefore nobody's declared kind.
+        None => {
+            portal_substitution_report(bh, jd_index, hooks.len());
+            (any_registered(), None)
+        }
     }
-    // The driver that owns this portal registered no runner while other
-    // drivers did.  Substituting one of theirs re-enters *their* portal
-    // carrying this frame's greens and reds — `pyre_portal_runner` reads
-    // `all_r[1]` as a `PyFrame*` — so the type confusion would surface as a
-    // bug in the substituted driver rather than here.  Upstream cannot reach
-    // this state, so failing is what keeps the two tables agreeing.
-    assert!(
-        hooks.is_empty(),
-        "jitdrivers_sd[{jd_index}] owns portal jitcode `{}` but registered no \
-         handle_jitexc_from_bh while {} other driver(s) did",
-        bh.jitcode.name,
-        hooks.iter().filter(|slot| slot.is_some()).count(),
-    );
-    // Nothing is registered at all: the caller's own runner stands in.
-    None
 }
 
-/// The `result_kind` `warmspot.py:984-996` tests each `DoneWithThisFrame*`
-/// against, taken from the same driver [`portal_jd_for`] picked, so the runner
-/// and the kind can never come from different drivers.
+/// `MAJIT_BH_PORTAL_SUBST`: name each recursive portal level that re-enters
+/// through a runner its own driver did not register.
 ///
-/// `None` when no driver claims the jitcode, and when the driver table was
-/// never installed: a builder that assembles a blackhole without one keeps the
-/// variant-alone behaviour [`handle_jitexception_dispatch`] describes.
-fn portal_result_kind_for(bh: &BlackholeInterpreter) -> Option<BhReturnType> {
-    Some(bh.jitdrivers_sd.get(portal_jd_for(bh)?)?.result_type)
+/// `pyre_portal_runner` reads `all_r[1]` as a `PyFrame*`, so a substituted
+/// runner reached with another driver's reds is a type confusion that would
+/// surface as a bug in the substituted driver. It is not reported as a fault
+/// because pyre registers one runner for many drivers by construction (see
+/// [`portal_dispatch_for`]); this makes the substitutions countable so the
+/// set that actually re-enters a portal can be separated from the set that
+/// merely resolves a hook it never calls.
+fn portal_substitution_report(bh: &BlackholeInterpreter, jd_index: usize, registered: usize) {
+    static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if !*ARMED.get_or_init(|| std::env::var_os("MAJIT_BH_PORTAL_SUBST").is_some()) {
+        return;
+    }
+    eprintln!(
+        "[bh-portal-subst] jitdrivers_sd[{jd_index}] owns portal jitcode `{}` \
+         and registered no handle_jitexc_from_bh; {registered} slot(s) in the \
+         table",
+        bh.jitcode.name,
+    );
 }
 
 /// Called at every `-live-` marker, i.e. once per source-level instruction the

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5016,6 +5016,9 @@ mod tests {
                         registers_f: vec![333],
                         position: TERMINAL_POSITION,
                         last_opcode_position: 17,
+                        // The resumable bail: a consumer that checks the flag
+                        // before adopting this image accepts it.
+                        abort_permanent_bail: true,
                     },
                 ))
             };

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -157,7 +157,9 @@ pub struct BhJitDriverSd {
     /// `blackhole.py` `_handle_jitexception_in_portal` picks the driver whose
     /// `mainjitcode is self.jitcode`, so a recursive `ContinueRunningNormally`
     /// re-enters the portal that raised it and not some other driver's.
-    /// [`portal_runner_for`] runs that same search.
+    /// [`portal_jd_for`] asks for that same relation through the back-reference
+    /// `call.py:148` writes (`jd.mainjitcode.jitdriver_sd = jd`), which survives
+    /// a resume path materializing a fresh `Arc`.
     pub mainjitcode: Option<std::sync::Arc<JitCode>>,
 }
 
@@ -2850,10 +2852,11 @@ fn handle_jitexception_dispatch(
     // kinds carry the value in different banks — `DoneWithThisFrameInt` at a
     // ref portal would install an integer through `setup_return_value_i` and
     // the caller would read it as a pointer — so the wrong arm is a wrong
-    // answer, not a mislabelled one.  `None` is a jitcode no driver claims
-    // (the unit-test builders build `BhJitDriverSd` without `mainjitcode`);
-    // there is no `result_kind` to test against, so the variant alone decides
-    // as it did before the driver was consulted.
+    // answer, not a mislabelled one.  `None` is a jitcode no driver claims, or
+    // a blackhole assembled without a driver table at all (the unit-test
+    // builders leave `jitdrivers_sd` empty); there is no `result_kind` to test
+    // against, so the variant alone decides as it did before the driver was
+    // consulted.
     let kind_matches = |kind: BhReturnType| result_kind.is_none_or(|want| want == kind);
     let done_arm = |kind: BhReturnType, value: i64| {
         assert!(
@@ -3116,8 +3119,11 @@ fn handle_jitexception(
     // In Rust we can do this directly since JitException carries the result.
     //
     // `bh` is upstream's `self` — the portal frame that raised — so its own
-    // driver owns the runner.  Only a frame no driver claims falls back to the
-    // runner this call was handed.
+    // driver owns the runner, and `_run_forever`'s walk stopped here precisely
+    // because this frame carries a driver stamp.  `portal_runner_for` answers
+    // `None` only when no runner is registered at all, and then the runner this
+    // call was handed stands in; a driver registered without its own runner
+    // fails there rather than borrowing another driver's.
     let own_runner = portal_runner_for(&bh);
     let own_runner = own_runner.as_ref().map(|hook| {
         hook as &dyn Fn(
@@ -3366,7 +3372,8 @@ pub fn convert_and_run_from_pyjitpl(
     // `handle_jitexception_dispatch` has nothing to call and
     // `ContinueRunningNormally` reaches its `expect`.
     //
-    // This is only the fallback for a frame no driver claims: the recursive
+    // This is only the fallback for the entry frame, which has not passed
+    // `_run_forever`'s walk and so need not carry a driver stamp: the recursive
     // level resolves its own runner from the raising portal frame
     // (`portal_runner_for`), because the driver that owns that jitcode is the
     // one whose portal has to be re-entered.
@@ -7211,7 +7218,7 @@ pub type PortalRunnerHook =
 /// self.jitcode`.  Keeping the table beside `BhJitDriverSd` rather than in it
 /// only avoids an initialisation order between the driver table (built once,
 /// lazily) and the consumer's registration; [`portal_runner_for`] joins the two
-/// at the point of use, by the same identity test upstream uses.
+/// at the point of use, through the same relation upstream tests.
 static PORTAL_RUNNER_HOOKS: std::sync::RwLock<Vec<Option<PortalRunnerHook>>> =
     std::sync::RwLock::new(Vec::new());
 
@@ -7240,41 +7247,75 @@ pub fn register_portal_runner_hook(jd_index: usize, hook: PortalRunnerHook) {
 /// jd.handle_jitexc_from_bh(self.nextblackholeinterp, e)
 /// ```
 ///
-/// `bh` is the portal frame that raised, i.e. upstream's `self`.  Upstream
-/// asserts when no driver owns that jitcode; here a miss returns `None` and
-/// each caller keeps the behaviour it had before the driver was consulted,
-/// because a `BhJitDriverSd` table assembled without `mainjitcode` (the
-/// unit-test builders) would otherwise abort paths that used to work.
+/// `bh` is the portal frame that raised, i.e. upstream's `self`.
+///
+/// The relation that loop walks is established from the other end by
+/// `call.py:148` `jd.mainjitcode.jitdriver_sd = jd`, so `jd.mainjitcode is
+/// self.jitcode` and `self.jitcode.jitdriver_sd is jd` answer the same
+/// question.  Reading the stamp is also the form `_run_forever`'s walk already
+/// uses to decide where to stop (`jitcode.jitdriver_sd().is_none()`), so asking
+/// it here leaves one mechanism where two could disagree: `resolve_jitcode`
+/// materializes a fresh `Arc` per resolution on the novable path, and an
+/// `Arc::ptr_eq` against `mainjitcode` misses such a frame even after the walk
+/// accepted it as a portal.
+///
+/// A miss returns `None`.  Upstream's `assert 0, "portal jitcode not found??"`
+/// is unreachable for the walk's own caller, which stops only on a stamped
+/// frame; the entry frame [`run_forever_with_portal`] is handed has not passed
+/// that walk, and neither has the guard-failure loop in `call_jit.rs`.
 fn portal_jd_for(bh: &BlackholeInterpreter) -> Option<usize> {
-    bh.jitdrivers_sd.iter().position(|jd| {
-        jd.mainjitcode
-            .as_ref()
-            .is_some_and(|code| std::sync::Arc::ptr_eq(code, &bh.jitcode))
-    })
+    bh.jitcode.jitdriver_sd()
 }
 
 /// The `jd.handle_jitexc_from_bh` of the driver [`portal_jd_for`] picked.
+///
+/// `None` asks the caller to keep the runner it was handed.  Upstream needs no
+/// such answer: `jd.handle_jitexc_from_bh` exists per driver by construction,
+/// so a found driver always has one.  pyre registers the hooks from the
+/// consumer crate instead, which splits that into two states this must not
+/// conflate — a table nothing has registered into yet, and a table other
+/// drivers registered into while this frame's driver did not.
 fn portal_runner_for(bh: &BlackholeInterpreter) -> Option<PortalRunnerHook> {
     let hooks = PORTAL_RUNNER_HOOKS
         .read()
         .expect("portal runner table poisoned");
-    let own = portal_jd_for(bh).and_then(|jd_index| *hooks.get(jd_index)?);
-    // The search may find nothing, and then this must still hand back the
-    // runner it would have handed back before the search existed.  Upstream can
-    // assert instead (`blackhole.py:1704` "portal jitcode not found??") because
-    // every level it reaches came through `_run_forever`, so the frame that
-    // stopped the walk really is a portal frame.  pyre's production guard-failure
-    // loop in `call_jit.rs` does not go through `_run_forever`, so the chain can
-    // stop at a frame whose jitcode is not any driver's `mainjitcode`; returning
-    // `None` there does not report a missing driver, it silently withdraws the
-    // portal re-entry from a path that had it.
-    own.or_else(|| hooks.iter().find_map(|slot| *slot))
+    let Some(jd_index) = portal_jd_for(bh) else {
+        // No driver claims this jitcode, so there is no owner to be wrong
+        // about, and this must still hand back what it did before the search
+        // existed.  Returning `None` here would not report a missing driver,
+        // it would silently withdraw the portal re-entry from a path that had
+        // it.
+        return hooks.iter().find_map(|slot| *slot);
+    };
+    if let Some(hook) = hooks.get(jd_index).copied().flatten() {
+        return Some(hook);
+    }
+    // The driver that owns this portal registered no runner while other
+    // drivers did.  Substituting one of theirs re-enters *their* portal
+    // carrying this frame's greens and reds — `pyre_portal_runner` reads
+    // `all_r[1]` as a `PyFrame*` — so the type confusion would surface as a
+    // bug in the substituted driver rather than here.  Upstream cannot reach
+    // this state, so failing is what keeps the two tables agreeing.
+    assert!(
+        hooks.is_empty(),
+        "jitdrivers_sd[{jd_index}] owns portal jitcode `{}` but registered no \
+         handle_jitexc_from_bh while {} other driver(s) did",
+        bh.jitcode.name,
+        hooks.iter().filter(|slot| slot.is_some()).count(),
+    );
+    // Nothing is registered at all: the caller's own runner stands in.
+    None
 }
 
 /// The `result_kind` `warmspot.py:984-996` tests each `DoneWithThisFrame*`
-/// against, taken from the same driver [`portal_jd_for`] picked.
+/// against, taken from the same driver [`portal_jd_for`] picked, so the runner
+/// and the kind can never come from different drivers.
+///
+/// `None` when no driver claims the jitcode, and when the driver table was
+/// never installed: a builder that assembles a blackhole without one keeps the
+/// variant-alone behaviour [`handle_jitexception_dispatch`] describes.
 fn portal_result_kind_for(bh: &BlackholeInterpreter) -> Option<BhReturnType> {
-    Some(bh.jitdrivers_sd[portal_jd_for(bh)?].result_type)
+    Some(bh.jitdrivers_sd.get(portal_jd_for(bh)?)?.result_type)
 }
 
 /// Called at every `-live-` marker, i.e. once per source-level instruction the

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -999,9 +999,11 @@ impl BlackholeInterpreter {
     /// blackhole.py `get_current_position_info`.
     ///
     /// RPython returns an offset into `metainterp_sd.liveness_info`
-    /// (via `jitcode.get_live_vars_info(self.position, self.builder.op_live)`).
-    /// Pyre uses a temporary per-interpreter sidecar until its codewriter
-    /// emits `-live-` opcodes directly into JitCode.code.
+    /// (via `jitcode.get_live_vars_info(self.position, self.builder.op_live)`),
+    /// and so does this: `get_live_vars_info` reads the `-live-` marker out of
+    /// `JitCode.code` at `position` and decodes the offset that follows it.
+    /// There is no side table to disagree with the code stream, so the marker
+    /// hook's register clear and a resume's register seeding read one source.
     pub fn get_current_position_info(&self) -> usize {
         self.jitcode.get_live_vars_info(self.position, self.op_live)
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -180,16 +180,6 @@ fn seed_deopt_vinfo_ptr(
     }
 }
 
-/// Run one tracing MIFrame forward in the already-ported blackhole.
-///
-/// This is the single-frame counterpart of the structured back-edge template
-/// at the call site below.  `copy_data_from_miframe` deliberately copies only
-/// the typed register values and pc, so all interpreter-global / frame-global
-/// state is supplied explicitly here.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "The parameter order mirrors the corresponding RPython metainterpreter routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and frame ownership"
-)]
 /// `MAJIT_BH_ENTRY_EXC`: report a `BH_LAST_EXC_VALUE` that survived into a
 /// blackhole drive the caller did not describe as raising.
 ///
@@ -220,6 +210,16 @@ fn bh_entry_stale_exc_report(last_exc_value: i64, raising_exception: bool, arm: 
     }
 }
 
+/// Run one tracing MIFrame forward in the already-ported blackhole.
+///
+/// This is the single-frame counterpart of the structured back-edge template
+/// at the call site below.  `copy_data_from_miframe` deliberately copies only
+/// the typed register values and pc, so all interpreter-global / frame-global
+/// state is supplied explicitly here.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The parameter order mirrors the corresponding RPython metainterpreter routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and frame ownership"
+)]
 pub fn drive_single_frame_blackhole(
     miframe: &mut crate::pyjitpl::MIFrame,
     cpu: &dyn majit_backend::Backend,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -80,6 +80,12 @@ pub struct SingleFrameBlackholeResult {
     /// marker clears each Ref the live set omits, so the frame red reads 0
     /// whenever the run stopped past that register's last use.
     pub virtualizable_ptr: i64,
+    /// [`crate::blackhole::BlackholeInterpreter::abort_permanent_bail`] of the
+    /// frame the run stopped in, carried for the same reason
+    /// [`crate::blackhole::BlackholeTerminalImage`] carries it: `outcome`
+    /// alone cannot tell a bail that stamped a resume coordinate from one that
+    /// stopped mid-instruction.
+    pub abort_permanent_bail: bool,
 }
 
 /// The blackhole's view of `metainterp_sd.jitdrivers_sd`, cast once and shared.
@@ -296,6 +302,7 @@ pub fn drive_single_frame_blackhole(
         position: bh.position,
         last_opcode_position: bh.last_opcode_position,
         virtualizable_ptr,
+        abort_permanent_bail: bh.abort_permanent_bail,
     };
     builder.release_interp(bh);
     result

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -190,6 +190,36 @@ fn seed_deopt_vinfo_ptr(
     clippy::too_many_arguments,
     reason = "The parameter order mirrors the corresponding RPython metainterpreter routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and frame ownership"
 )]
+/// `MAJIT_BH_ENTRY_EXC`: report a `BH_LAST_EXC_VALUE` that survived into a
+/// blackhole drive the caller did not describe as raising.
+///
+/// The clear-before / check-after protocol brackets every call-shaped opcode
+/// inside a drive, so within one drive the channel cannot go stale.  What no
+/// bracket covers is the window between phases: the value a residual raise left
+/// behind is still in TLS when the next drive starts, and a drive entered with
+/// `raising_exception == false` seeds `exception_last_value` from its own
+/// `last_exc_value` argument instead.  The two can disagree.
+///
+/// Clearing the channel unconditionally on entry is NOT the fix — `call_jit.rs`
+/// deliberately keeps a pending value across its decline path so the blackhole
+/// can deliver it — so this reports the disagreement rather than repairing it,
+/// and stays off unless armed.  What it is for: deciding whether the window is
+/// ever actually observed, which no reading of the code settles.
+fn bh_entry_stale_exc_report(last_exc_value: i64, raising_exception: bool, arm: &str) {
+    static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if !*ARMED.get_or_init(|| std::env::var_os("MAJIT_BH_ENTRY_EXC").is_some()) {
+        return;
+    }
+    let live = crate::blackhole::BH_LAST_EXC_VALUE.with(|cell| cell.get());
+    if live != 0 && live != last_exc_value {
+        eprintln!(
+            "[bh-entry-exc] {arm}: BH_LAST_EXC_VALUE={live:#x} survives into a \
+             drive carrying last_exc_value={last_exc_value:#x} \
+             (raising_exception={raising_exception})"
+        );
+    }
+}
+
 pub fn drive_single_frame_blackhole(
     miframe: &mut crate::pyjitpl::MIFrame,
     cpu: &dyn majit_backend::Backend,
@@ -201,6 +231,7 @@ pub fn drive_single_frame_blackhole(
     mut last_exc_value: i64,
     raising_exception: bool,
 ) -> SingleFrameBlackholeResult {
+    bh_entry_stale_exc_report(last_exc_value, raising_exception, "single-frame");
     // The MIFrame is handed here from a force-time TLS latch.  Publish its Ref
     // values before leasing/building the interpreter because first use of the
     // pooled builder may allocate.  Option<i64> is not a contiguous root area,
@@ -382,6 +413,7 @@ pub fn drive_multi_frame_blackhole(
     on_enter_level: Option<&dyn Fn(i64)>,
     on_leave_level: Option<&dyn Fn(i64)>,
 ) -> MultiFrameBlackholeResult {
+    bh_entry_stale_exc_report(last_exc_value, raising_exception, "multi-frame");
     let mut ref_locations = Vec::new();
     let mut packed_ref_roots = Vec::new();
     for (frame_index, frame) in framestack.frames.iter().enumerate() {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -150,7 +150,7 @@ fn build_bh_jitdrivers_sd(
                 result_type,
                 portal_runner_ptr,
                 mainjitcode_calldescr,
-                // warmspot.py:921 `jd.mainjitcode`; `portal_runner_for` matches
+                // warmspot.py:921 `jd.mainjitcode`; `portal_jd_for` matches
                 // it against the raising portal frame's own jitcode.
                 mainjitcode: jd.mainjitcode.clone(),
             }

--- a/majit/majit-metainterp/src/quasiimmut.rs
+++ b/majit/majit-metainterp/src/quasiimmut.rs
@@ -56,9 +56,18 @@ pub fn do_force_quasi_immutable(
         return;
     }
     let hook = FORCE_QUASI_IMMUTABLE.load(Ordering::Acquire);
-    if hook == 0 {
-        return;
-    }
+    // Reaching here means the codewriter emitted `jit_force_quasi_immutable`
+    // and the blackhole executed it, so the frontend is one that needs the
+    // hook.  Returning quietly would skip the invalidation upstream always
+    // performs, leaving every loop that folded a read of this field compiled
+    // against a value the store just changed — a wrong answer with nothing to
+    // trace it back to.
+    assert!(
+        hook != 0,
+        "jit_force_quasi_immutable executed with no host invalidation routine: \
+         call `set_force_quasi_immutable_hook` before running a jitcode that \
+         emits it",
+    );
     let field_addr = struct_ptr.wrapping_add(mutatefielddescr.as_offset() as i64);
     // Safety: the only stored values come from a `ForceQuasiImmutable`
     // function pointer in `set_force_quasi_immutable_hook`.

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -573,8 +573,8 @@ pub const BC_ABORT_RESULT_R: u8 = 195;
 // because Python dispatch goes through `cpu.bh_call_*` resolved at
 // runtime; pyre's Rust port hits this only when a `dyn Trait` method
 // pointer must be reified into the bytecode stream (backend-epic
-// adaptation, see `blackhole.rs`'s
-// `handler_vtable_method_ptr_unimplemented`).
+// adaptation, see `blackhole.rs`'s `handler_vtable_method_ptr_bail`, which
+// aborts the frame rather than manufacturing a pointer).
 pub const BC_VTABLE_METHOD_PTR: u8 = 196;
 
 // `record_quasiimmut_field/rdd` — RPython `blackhole.py:1538-1545`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7730,10 +7730,24 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     // the collector, so forward every populated color until the walk-end
     // handler takes the latch. The adopters bridge the pre-drive publication
     // window and the blackhole drivers then install their own packed roots.
+    //
+    // A `MIFrame` stores each Ref register twice — the `OpRef` box and the
+    // `ref_values` concrete mirror — and the two are kept fresh by two
+    // different walkers.  `MetaInterp::walk_active_trace_refs` forwards the
+    // boxes while a trace is being recorded; once the frames are latched here
+    // that walker no longer reaches them, so both halves are forwarded below.
+    // Forwarding only the mirror leaves whichever half a future reader picks
+    // deciding whether it sees a moved object, which is not a property a
+    // reader can check.
     let single_frame_blackhole = unsafe { &mut *(*area.single_frame_blackhole).as_ptr() };
     if let Some(latched) = single_frame_blackhole.as_mut() {
         for value in latched.miframe.ref_values.iter_mut().flatten() {
             visitor(unsafe { &mut *(value as *mut i64).cast() });
+        }
+        for slot in latched.miframe.ref_regs.iter_mut() {
+            if let Some(majit_ir::OpRef::ConstPtr(gcref)) = slot.as_mut() {
+                visitor(unsafe { &mut *(&mut gcref.0 as *mut usize).cast() });
+            }
         }
         if latched.last_exc_value != 0 {
             visitor(unsafe { &mut *(&mut latched.last_exc_value as *mut i64).cast() });
@@ -7755,6 +7769,12 @@ pub unsafe fn fbw_store_journal_root_walker_area(
         for frame in latched.framestack.frames.iter_mut() {
             for value in frame.ref_values.iter_mut().flatten() {
                 visitor(unsafe { &mut *(value as *mut i64).cast() });
+            }
+            // Both halves, for the reason the single-frame arm gives.
+            for slot in frame.ref_regs.iter_mut() {
+                if let Some(majit_ir::OpRef::ConstPtr(gcref)) = slot.as_mut() {
+                    visitor(unsafe { &mut *(&mut gcref.0 as *mut usize).cast() });
+                }
             }
         }
         if latched.last_exc_value != 0 {

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2078,8 +2078,8 @@ pub fn build_pyre_production_bh_builder() -> majit_metainterp::blackhole::Blackh
 ///    rejects two keys claiming one byte within this builder and nothing
 ///    checks the byte against the generated table, so (2) is silent.
 ///
-/// Both were pinned by tests alone (`production_bh_builder_covers_every_\
-/// build_emitted_opname`, `production_bh_builder_bytes_match_canonical_table`),
+/// Both were pinned by tests alone — `production_bh_builder_covers_every_build_emitted_opname`
+/// and `production_bh_builder_bytes_match_canonical_table` —
 /// which read the generated tables of whatever tree ran them; the failure they
 /// describe belongs to the binary that dispatches, so it is raised where that
 /// binary assembles its builder.  Both production call sites build once per

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2055,7 +2055,88 @@ pub fn build_default_bh_builder_with_unwired_report() -> (
 /// `_pyre/P` adapter handlers (registered by `insns.rs`'s
 /// `wellknown_bh_insns`, payload decoder at `pyre_p_payload_len` below).
 pub fn build_pyre_production_bh_builder() -> majit_metainterp::blackhole::BlackholeInterpBuilder {
-    majit_metainterp::blackhole::build_inline_call_only_bh_builder()
+    let builder = majit_metainterp::blackhole::build_inline_call_only_bh_builder();
+    assert_production_builder_spans_the_emitted_universe(&builder);
+    builder
+}
+
+/// The two coverage properties `blackhole.py setup_insns` holds by
+/// construction, checked here because pyre's production builder cannot get
+/// them that way.
+///
+/// Upstream calls `setup_insns(asm.insns)`, so its dispatch table spans exactly
+/// the opnames the assembler emitted, each resolved through `_get_method`.
+/// `build_inline_call_only_bh_builder` instead hand-curates its registered set
+/// family by family and spells each byte as a `BC_*` constant, which admits two
+/// drifts upstream cannot have:
+///
+/// 1. an emitted opname it never registered — reached only when a forward
+///    resume happens to land on that byte, as `dispatch_step`'s unwired-opcode
+///    panic;
+/// 2. a key bound to a byte the canonical table gives to a *different* opname,
+///    which decodes every occurrence as the wrong instruction.  `setup_insns`
+///    rejects two keys claiming one byte within this builder and nothing
+///    checks the byte against the generated table, so (2) is silent.
+///
+/// Both were pinned by tests alone (`production_bh_builder_covers_every_\
+/// build_emitted_opname`, `production_bh_builder_bytes_match_canonical_table`),
+/// which read the generated tables of whatever tree ran them; the failure they
+/// describe belongs to the binary that dispatches, so it is raised where that
+/// binary assembles its builder.  Both production call sites build once per
+/// thread behind a `thread_local!`, so this walks a few hundred keys per
+/// thread, not per resume.
+///
+/// The universe is `build_emitted_insns()` — pyre's `asm.insns`, the serialised
+/// build-time `pipeline.insns` before the canonical overlay — and deliberately
+/// not `insns_opname_to_byte()`, which also carries `wellknown_bh_insns` /
+/// `extension_insns` keys this build never emitted.  Their bytes cannot appear
+/// in any jitcode here, so leaving them unregistered is the state upstream is
+/// in too.
+fn assert_production_builder_spans_the_emitted_universe(
+    builder: &majit_metainterp::blackhole::BlackholeInterpBuilder,
+) {
+    let mut unregistered: Vec<&str> = build_emitted_insns()
+        .iter()
+        .filter(|(_key, byte)| {
+            builder
+                ._insns
+                .get(**byte as usize)
+                .is_none_or(|name| name.is_empty())
+        })
+        .map(|(key, _)| key.as_str())
+        .collect();
+    unregistered.sort_unstable();
+    assert!(
+        unregistered.is_empty(),
+        "the production blackhole cannot dispatch {} opname(s) this build's \
+         jitcodes can carry: {unregistered:?} — register them in \
+         `build_inline_call_only_bh_builder`, confirming the emit-side operand \
+         shape matches the wired handler's decoder",
+        unregistered.len(),
+    );
+
+    let mut mismatched: Vec<String> = Vec::new();
+    for (byte, key) in builder._insns.iter().enumerate() {
+        if key.is_empty() {
+            continue;
+        }
+        match insns_opname_to_byte().get(key) {
+            Some(&canonical) if canonical as usize == byte => {}
+            Some(&canonical) => mismatched.push(format!(
+                "{key:?} registered at byte {byte}, canonical byte is {canonical}"
+            )),
+            None => mismatched.push(format!(
+                "{key:?} registered at byte {byte} but is not a canonical opname"
+            )),
+        }
+    }
+    mismatched.sort();
+    assert!(
+        mismatched.is_empty(),
+        "the production blackhole's hand-spelled bytes disagree with the \
+         canonical opname table, so each listed byte decodes as the wrong \
+         instruction: {mismatched:?}",
+    );
 }
 
 /// Strict-coverage variant of [`build_default_bh_builder_with_unwired_report`]

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3226,14 +3226,28 @@ fn try_adopt_single_frame_blackhole(
         // routing this through the void arm made the aborted statement's
         // result a Python-visible `None`.
         //
-        // Every abort that can reach a running blackhole stops on a Python
-        // opcode boundary with the frame's own resume coordinate already
-        // stamped (`call_jit.rs` states the same invariant for the
-        // guard-failure resume path), so the frame is resumable as it stands
-        // and the handoff is the CRN one with the coordinate read back out of
-        // the frame instead of out of the green list.  Declining is not
-        // available after the drive — see this path's note on post-drive
-        // declines.
+        // An abort that reaches a running blackhole is resumable only if it
+        // stopped on a Python opcode boundary with the frame's own resume
+        // coordinate already stamped; then the handoff is the CRN one with the
+        // coordinate read back out of the frame instead of out of the green
+        // list.  Declining is not available after the drive — see this path's
+        // note on post-drive declines — so the condition is asserted instead.
+        //
+        // `abort_permanent` is the abort that stamps such a coordinate, and
+        // `abort` itself never reaches dispatch (`PyJitCode::has_abort_opcode`
+        // gates the jitcode out at resolution).  `reject_unresolved_call` is
+        // the third producer and it stops wherever the declined call sat,
+        // which is a jitcode position inside an instruction, not at its
+        // boundary: whatever this run applied between the last stamped
+        // boundary and the reject — an earlier residual in the same span, or
+        // residuals inside an inlined callee subtree — is applied a second
+        // time when the interpreter re-runs from the stamped pc.  That is the
+        // cost #326 removed the rollback snapshot to stop paying.
+        //
+        // `call_jit.rs` already refuses this state on the guard-failure resume
+        // path.  Asserting it here puts both consumers of `aborted` on one
+        // contract; before this, the consumer that absorbed the abort cited
+        // the consumer that panics on it as its authority.
         majit_metainterp::jitexc::JitException::BailToInterpreter => {
             // Reported on the way through, alongside the multi-frame arm's
             // report of the same handoff: a census that speaks only when the
@@ -3243,6 +3257,14 @@ fn try_adopt_single_frame_blackhole(
             if majit_metainterp::majit_log_enabled() {
                 eprintln!("[blackhole-resume] single-frame bail");
             }
+            assert!(
+                terminal.abort_permanent_bail,
+                "single-frame blackhole bailed without an abort_permanent \
+                 marker at position {} (last opcode {}); the stamped resume \
+                 coordinate names an earlier boundary, so adopting it replays \
+                 whatever this run already applied past it",
+                terminal.position, terminal.last_opcode_position,
+            );
             let resume_py_pc = frame_resume_py_pc(forwarded_root_addr);
             adopt_blackhole_crn(cf_addr, forwarded_root_addr, resume_py_pc);
             sfdbg!("adopted bail with resume_py_pc={resume_py_pc}");
@@ -3856,14 +3878,28 @@ fn try_adopt_multi_frame_blackhole(
         // routing this through the void arm made the aborted statement's
         // result a Python-visible `None`.
         //
-        // Every abort that can reach a running blackhole stops on a Python
-        // opcode boundary with the frame's own resume coordinate already
-        // stamped (`call_jit.rs` states the same invariant for the
-        // guard-failure resume path), so the frame is resumable as it stands
-        // and the handoff is the CRN one with the coordinate read back out of
-        // the frame instead of out of the green list.  Declining is not
-        // available after the drive — see this path's note on post-drive
-        // declines.
+        // An abort that reaches a running blackhole is resumable only if it
+        // stopped on a Python opcode boundary with the frame's own resume
+        // coordinate already stamped; then the handoff is the CRN one with the
+        // coordinate read back out of the frame instead of out of the green
+        // list.  Declining is not available after the drive — see this path's
+        // note on post-drive declines — so the condition is asserted instead.
+        //
+        // `abort_permanent` is the abort that stamps such a coordinate, and
+        // `abort` itself never reaches dispatch (`PyJitCode::has_abort_opcode`
+        // gates the jitcode out at resolution).  `reject_unresolved_call` is
+        // the third producer and it stops wherever the declined call sat,
+        // which is a jitcode position inside an instruction, not at its
+        // boundary: whatever this run applied between the last stamped
+        // boundary and the reject — an earlier residual in the same span, or
+        // residuals inside an inlined callee subtree — is applied a second
+        // time when the interpreter re-runs from the stamped pc.  That is the
+        // cost #326 removed the rollback snapshot to stop paying.
+        //
+        // `call_jit.rs` already refuses this state on the guard-failure resume
+        // path.  Asserting it here puts both consumers of `aborted` on one
+        // contract; before this, the consumer that absorbed the abort cited
+        // the consumer that panics on it as its authority.
         //
         // The coordinate is the ROOT's.  Unlike the raise arm below, a bail
         // does not walk the chain to the portal before taking its terminal
@@ -3880,6 +3916,17 @@ fn try_adopt_multi_frame_blackhole(
             // never mismatches still says whether it ever got here.
             if majit_metainterp::majit_log_enabled() {
                 eprintln!("[blackhole-resume] multi-frame bail");
+            }
+            // An absent image is the chain reporting no terminal at all, which
+            // the arm below already treats as "nothing to check against the
+            // root"; there is no flag to read and nothing this assert can say.
+            if let Some(image) = mf_terminal.as_ref() {
+                assert!(
+                    image.abort_permanent_bail,
+                    "multi-frame blackhole bailed without an abort_permanent \
+                     marker: terminal jitcode={} position={} (last opcode {})",
+                    image.jitcode_index, image.position, image.last_opcode_position,
+                );
             }
             if majit_metainterp::majit_log_enabled()
                 && let Some(image) = mf_terminal.as_ref()


### PR DESCRIPTION
Follow-ups from the blackhole parity audit that #1663 landed without. Each was
adjudicated against the RPython source before being written; three are latent
wrong answers, three are hardening, two are env-gated probes, and two are
comment corrections.

### Portal re-entry validated one driver's outcome against another's contract

`portal_jd_for` searched `jitdrivers_sd` for a `mainjitcode` matching
`bh.jitcode` under `Arc::ptr_eq`. Nothing in pyre populates `mainjitcode` on a
`BhJitDriverSd` — the only writer is `register_dispatch_jitcode`, whose callers
are the `#[jit_interp]` macro codegen and tests — so that search returned `None`
on every production call and `portal_runner_for` reached its global fallback
each time.

`call.py:148` establishes the same relation from the other end
(`jd.mainjitcode.jitdriver_sd = jd`), pyre already stamps it
(`codewriter.rs` `set_jitdriver_sd`), and `_run_forever`'s walk already asks for
it (`jitcode.jitdriver_sd().is_none()`). Reading the stamp answers the same
question and leaves one mechanism where two could disagree — an `Arc::ptr_eq`
misses a resume-reconstructed frame the walk accepted as a portal, because
`resolve_jitcode` allocates a fresh `Arc` per resolution.

**What the search finding actually is.** I first narrowed the fallback so that a
driver found with no registered runner failed instead of borrowing another's.
`check.py` rejected that on all three backends across 14 synth fixtures, naming
`jitdrivers_sd[1]` for jitcodes `peek`, `inner`, `leaf`, `rec`, `callee_d1` and
`jitdrivers_sd[2]` for `leaf_b`. The premise was wrong: `codewriter.rs` stamps a
driver index on *every* portal jitcode (`jitdriver_sd_from_portal_graph` matches
`jd.portal_graph == code`, `setup_jitdriver` appends one entry per portal graph)
while `eval.rs` registers exactly one `handle_jitexc_from_bh`. A portal frame
naming a runner-less driver is the norm here, and upstream's `assert 0` does not
transfer, because there `jd.handle_jitexc_from_bh` exists per driver by
construction.

So the substitution stays. What is removed is the *mixing*:
`portal_runner_for` and `portal_result_kind_for` become one
`portal_dispatch_for` returning both. The owning driver answers both when it has
a runner; otherwise the runner is substituted as before and the kind is
withheld, so a substituted runner's outcome is no longer checked against the
owning driver's declared `result_type`. `MAJIT_BH_PORTAL_SUBST` counts the
substitutions, which is the measurement needed to tell the frames that merely
*resolve* a hook from the frames that actually re-enter a portal through it.

### The two consumers of `aborted` disagreed

`call_jit.rs`'s guard-failure loop panics on a bail that is not
`abort_permanent_bail`. The two CRN-adopt arms in `trace.rs` absorbed any bail
— and justified it by citing that same loop as stating the invariant.

`JitException::BailToInterpreter` does not distinguish the two aborts, so the
flag now travels on both result images (`BlackholeTerminalImage`,
`SingleFrameBlackholeResult`) and the adopters require it.
`reject_unresolved_call` stops at a jitcode position inside an instruction, not
at its boundary, so adopting the stamped coordinate re-applies whatever the run
already performed past it — the cost #326 removed the rollback snapshot to stop
paying.

### The production blackhole builder's coverage was pinned only by tests

`blackhole.py setup_insns(asm.insns)` spans the emitted opname universe by
construction. `build_inline_call_only_bh_builder` hand-curates its set and
spells each byte as a `BC_*` constant, which admits an emitted opname it never
registered (a `dispatch_step: unwired opcode` panic once a resume lands there)
and a key bound to a byte the canonical table gives to another opname (every
occurrence decodes as the wrong instruction, silently). Both are now checked
where the dispatching binary assembles its builder, not only in a test reading
whatever tree ran it.

### Rooting

The TLS extra-root walker forwarded each latched `MIFrame`'s `ref_values`
mirror and left `ref_regs` untouched. `walk_active_trace_refs` forwards the
boxes but no longer reaches these frames once latched, so a reader of an
`OpRef::ConstPtr` payload on a latched frame would read a pre-collection
address. Both halves are forwarded now, so which half a reader picks stops
deciding whether it sees a moved object.

### Quasi-immutable invalidation

`do_force_quasi_immutable` returned quietly with no host hook installed,
skipping the invalidation `quasiimmut.py` always performs and leaving every loop
that folded a read of the field compiled against a value the store just
changed. Its only caller is the opcode handler, so reaching it means the
frontend owes the hook.

### Probes (off by default)

- `MAJIT_BH_ENTRY_EXC` — a `BH_LAST_EXC_VALUE` that survives into a drive
  carrying a different `last_exc_value`. The clear-before/check-after protocol
  brackets every call-shaped opcode *within* a drive; the window between drives
  has none, and `call_jit.rs` keeps a pending value across its decline path on
  purpose, so this reports rather than clears.
- `MAJIT_BH_VABLE_INTBASE` — a `*_vable_*_intbase` struct operand that disagrees
  with `virtualizable_ptr`. Those handlers read the base from `registers_i`,
  which no walker forwards, while `virtualizable_ptr` names the same object and
  is rooted by the drivers.

### Testing

`cargo test -p majit-metainterp`: 1774 passed, 0 failed. `pyre/check.py` is the
gate that caught the first attempt above; the re-run against this branch is
reported in a comment below.

The new `portal_dispatch_for` tripwire path has no unit test: `PORTAL_RUNNER_HOOKS`
is a process-global with no unregister, so registering into it from a test would
change the table every other blackhole test reads. Splitting the tier decision
into a pure function over `(jd, &[Option<hook>])` would make it testable and is
worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved blackhole bailout handling to prevent invalid or ambiguous resume states.
  - Fixed garbage-collection reference forwarding during blackhole execution, improving runtime stability.
  - Improved recursive portal dispatch and virtualizable object handling.
  - Added validation to ensure production instruction mappings are complete and consistent.
  - Quasi-immutable invalidation now detects missing host hooks instead of silently continuing.

- **Diagnostics**
  - Added optional diagnostics for stale exception state, recursive portal substitutions, and virtualizable integer-base mismatches.

- **Documentation**
  - Updated interpreter and instruction documentation to accurately describe bailout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->