### PR TITLE
bench/synth: restore for_iter_method_branch_inline's ceiling, fitted against the readings

### DIFF
--- a/pyre/bench/synth/for_iter_method_branch_inline.py
+++ b/pyre/bench/synth/for_iter_method_branch_inline.py
@@ -1,3 +1,4 @@
+# pyre-check: max-pypy-ratio=4.8
 # A FOR_ITER caller should inline a method-form callee whose body branches on a
 # field.  The callee body carries a `truth` residual before trace-time folding;
 # the replay-safety scan must defer it so the walker can erase it instead of


### PR DESCRIPTION
#1666 removed this fixture's `max-pypy-ratio` on the grounds that its 0.8x–4.5x band left no value satisfying both bounds. That was wrong, and the error was in the method: the conclusion came from applying a 1.3x ceiling margin and a 1.2x floor margin, not from testing candidates against the readings. Against the 60 unmarked observations themselves —

| ceiling | derived floor | readings under the floor | readings over the ceiling |
| --- | --- | --- | --- |
| 4.4 | 0.733 | 0 | 1 |
| **4.8** | **0.800** | **0** | **0** |
| 5.0 | 0.833 | 1 | 0 |

4.8 fails none of them. The floor comparison adds `compare_buffer` to the measured side — `exec_measured * (limit / minimum) + compare_buffer < exec_baseline * limit` — so the single 0.8x reading that lands on the derived floor carries real slack rather than sitting exactly on the boundary.

### The band is the denominator's

Execution-only medians over the same 12 runs, at 94,560,000 iterations:

| host | backend | pyre | pypy |
| --- | --- | --- | --- |
| ubuntu | cranelift | 0.380s | 0.110s |
| ubuntu | dynasm | 0.300s | 0.100s |
| ubuntu | wasm | 0.335s | 0.100s |
| windows | dynasm | 0.340s | 0.110s |
| macos | cranelift | 0.275s | 0.260s |
| macos | dynasm | 0.320s | 0.260s |

pyre reads 0.275s–0.380s on **every** host and backend. pypy reads 0.10s–0.11s on x86-64 and 0.26s on arm64. The 5.6x span is pypy's own 2.4x x86-64-vs-arm64 difference on this loop; nothing on the pyre side moves.

That does not make the 3x gap on x86-64 acceptable — pypy runs this loop at ~1.1 ns/iteration there against our ~3.2–4.0 ns — and closing it is tracked separately. This PR only restores the gate.