### PR TITLE
interp: pass the format spec and the __format__ result through as objects

### DIFF
--- a/extra_tests/test_format_protocol.py
+++ b/extra_tests/test_format_protocol.py
@@ -1,0 +1,83 @@
+"""`__format__` dispatch passes objects through, it does not rebuild them.
+
+`format` (descroperation.py) resolves `__format__` on the type and calls it
+with the spec the caller supplied, then returns what it got back:
+
+    w_res = space.get_and_call_function(w_descr, w_obj, w_format_spec)
+    if not space.isinstance_w(w_res, space.w_unicode): raise ...
+    return w_res
+
+Neither end is read out and rebuilt, so all three of the assertions below hold.
+Reading the spec into a buffer and building a fresh `str` from it — at either
+end — passes every equality test and fails all three of these.
+"""
+
+
+class SpecEcho:
+    def __format__(self, spec):
+        return "same" if spec is SPEC else "copy"
+
+
+class Fixed:
+    def __format__(self, spec):
+        return RESULT
+
+
+class MyStr(str):
+    pass
+
+
+class SubclassResult:
+    def __format__(self, spec):
+        return MyStr("x")
+
+
+SPEC = ">4"
+RESULT = "res"
+
+
+def test_spec_reaches_dunder_as_the_same_object():
+    assert format(SpecEcho(), SPEC) == "same"
+
+
+def test_spec_survives_an_fstring_replacement_field():
+    # A spec that is a single replacement field formats the operand with an
+    # empty spec first; `format(s, "")` on an exact `str` hands back `s`, so
+    # the object reaching `__format__` is still the one that was bound.
+    assert f"{SpecEcho():{SPEC}}" == "same"
+
+
+def test_result_is_the_object_the_dunder_returned():
+    assert format(Fixed(), "") is RESULT
+    assert f"{Fixed()}" is RESULT
+
+
+def test_str_subclass_result_keeps_its_type():
+    assert type(format(SubclassResult(), "")) is MyStr
+
+
+def test_empty_spec_arrives_as_a_string():
+    # FORMAT_SIMPLE carries no spec operand; the dunder's parameter is still a
+    # `str`, so concatenating it is not a TypeError.
+    class Concat:
+        def __format__(self, spec):
+            return "<" + spec + ">"
+
+    assert f"{Concat()}" == "<>"
+    assert f"{Concat():x}" == "<x>"
+
+
+def test_non_str_spec_is_a_type_error():
+    # The one place the two upstreams disagree: `format()` validates that
+    # format_spec is a str, while pypy hands whatever it was given straight to
+    # `__format__` and this raises nothing there.  The spec follows CPython, so
+    # the TypeError is the behaviour to keep -- this asserts the check is still
+    # applied, and that the dispatch below it did not start seeing the spec as
+    # empty instead.
+    assert format(SpecEcho(), "") == "copy"
+    try:
+        format(SpecEcho(), 34)
+    except TypeError as exc:
+        assert "must be str" in str(exc)
+    else:
+        raise AssertionError("format() accepted a non-str spec")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -22757,11 +22757,11 @@ fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // subclass's) or, for a plain builtin, the shared spec parser; the same
     // path f-string `{v:spec}` and `"{:spec}".format(v)` use.
     let spec = if args.len() > 1 {
-        crate::type_methods::read_format_spec(args[1], "format() argument 2")?
+        crate::type_methods::check_format_spec(args[1], "format() argument 2")?
     } else {
-        rustpython_wtf8::Wtf8Buf::new()
+        pyre_object::PY_NULL
     };
-    crate::type_methods::format_value_dispatch_w(value, &spec)
+    crate::type_methods::format_w(value, spec)
 }
 
 /// `__import__(name, globals=None, locals=None, fromlist=(), level=0)`

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -444,11 +444,11 @@ pub unsafe extern "C" fn PyObject_Format(
     };
     let spec = unsafe { pyobject::from_ref(spec) };
     let spec = if spec.is_null() {
-        Ok(rustpython_wtf8::Wtf8Buf::new())
+        Ok(pyre_object::PY_NULL)
     } else {
-        crate::type_methods::read_format_spec(spec, "PyObject_Format() argument 2")
+        crate::type_methods::check_format_spec(spec, "PyObject_Format() argument 2")
     };
-    result(spec.and_then(|spec| crate::type_methods::format_value_dispatch_w(object, &spec)))
+    result(spec.and_then(|spec| crate::type_methods::format_w(object, spec)))
 }
 
 /// `PyObject_Dir(object)` — `dir(object)`, and the caller's own scope for a

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -710,17 +710,11 @@ pub fn convert_value(value: PyObjectRef, conv: i64) -> Result<PyObjectRef, crate
 /// fallible); a `PY_NULL` or non-`str` `spec` reads as the empty spec
 /// (`str(value)`), matching `format_simple`.
 pub fn format_value(value: PyObjectRef, spec: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-    // The spec is read as WTF-8: its fill may be any code point, so
-    // `f"{x:\ud800>4}"` pads with the lone surrogate it was given instead of
-    // dropping a spec that has no `&str` view.
-    let spec_str = unsafe {
-        if !spec.is_null() && pyre_object::is_str(spec) {
-            pyre_object::w_str_get_wtf8(spec).to_wtf8_buf()
-        } else {
-            rustpython_wtf8::Wtf8Buf::new()
-        }
-    };
-    crate::type_methods::format_value_dispatch_w(value, &spec_str)
+    // The spec crosses to `__format__` as the object the opcode pushed, the
+    // way `FORMAT_VALUE` hands `w_spec` to `space.format` (pyopcode.py:1712).
+    // Its fill may be any code point, and nothing here reads it, so
+    // `f"{x:\ud800>4}"` keeps the lone surrogate it was given.
+    crate::type_methods::format_w(value, spec)
 }
 
 /// STORE_SLICE evaluation (`obj[start:stop] = value`): builds a `slice`

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3031,11 +3031,11 @@ pub fn format_with_spec_public(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf,
 /// and binds a `@staticmethod` / `@classmethod` / other descriptor override
 /// through the descriptor protocol.  The spec is passed through untouched so
 /// the type's own `__format__` runs its validation.
-pub(crate) fn call_format_dispatch(
+pub(crate) fn call_format_dispatch_w(
     val: PyObjectRef,
     meth: PyObjectRef,
     spec_obj: PyObjectRef,
-) -> Result<Wtf8Buf, crate::PyError> {
+) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         let w_type = crate::typedef::r#type(val).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         let result = crate::baseobjspace::get_and_call_function(meth, val, w_type, &[spec_obj])?;
@@ -3045,8 +3045,21 @@ pub(crate) fn call_format_dispatch(
                 arg_type_name(result)
             )));
         }
-        Ok(pyre_object::w_str_get_wtf8(result).to_wtf8_buf())
+        // Returned as it came back: `format` (descroperation.py:399) checks
+        // `isinstance_w(w_res, w_unicode)` and hands `w_res` itself on, so a
+        // `str` subclass keeps its type and the result keeps its identity.
+        Ok(result)
     }
+}
+
+/// [`call_format_dispatch_w`] for the callers that want the formatted bytes.
+pub(crate) fn call_format_dispatch(
+    val: PyObjectRef,
+    meth: PyObjectRef,
+    spec_obj: PyObjectRef,
+) -> Result<Wtf8Buf, crate::PyError> {
+    let result = call_format_dispatch_w(val, meth, spec_obj)?;
+    Ok(unsafe { pyre_object::w_str_get_wtf8(result) }.to_wtf8_buf())
 }
 
 /// Whether the type-level `__format__` in `meth` is the shared builtin body
@@ -3162,6 +3175,66 @@ pub fn format_value_dispatch_w(
     )?))
 }
 
+/// `space.format(w_obj, w_format_spec)` (descroperation.py:399) — the
+/// object-to-object form of [`format_value_dispatch_w`], for the callers that
+/// already hold the spec as an object.
+///
+/// Upstream threads the spec from the caller to `__format__` and returns
+/// `w_res` unchanged, so nothing is rebuilt at either end.  Going through a
+/// `Wtf8Buf` instead costs a copy and a fresh `str` on the way in and again on
+/// the way out, and the substitution is observable three ways: `spec is` the
+/// argument that was passed, `format(x, s) is` what `__format__` returned, and
+/// a `str` subclass result keeps its type.  Only a builtin `__format__` and
+/// the fast paths below read the bytes.
+///
+/// A `PY_NULL` or non-`str` spec reads as the empty spec, matching
+/// `format_simple`.  A user `__format__` reached that way is handed a real
+/// empty `str`, since its second parameter is a string.
+pub fn format_w(val: PyObjectRef, w_spec: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let spec_is_str = !w_spec.is_null() && unsafe { is_str(w_spec) };
+    let spec_is_empty = !spec_is_str || unsafe { pyre_object::w_str_get_wtf8(w_spec) }.is_empty();
+
+    // The empty-spec fast paths of `format_value_dispatch`: an exact `str` or
+    // `int` cannot carry a `__format__` override, so resolve and call nothing.
+    if spec_is_empty {
+        if unsafe { pyre_object::is_exact_type(val, &pyre_object::STR_TYPE) } {
+            return Ok(val);
+        }
+        if unsafe {
+            pyre_object::is_exact_type(val, &pyre_object::INT_TYPE)
+                || pyre_object::is_exact_type(val, &pyre_object::LONG_TYPE)
+        } {
+            return Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+                crate::py_str_wtf8(val)?
+            }));
+        }
+    }
+
+    if let Some(meth) = unsafe { crate::baseobjspace::lookup(val, "__format__") }
+        && (unsafe { is_instance(val) } || !unsafe { is_shared_builtin_format(val, meth) })
+    {
+        let spec_obj = if spec_is_str {
+            w_spec
+        } else {
+            pyre_object::w_str_new("")
+        };
+        return call_format_dispatch_w(val, meth, spec_obj);
+    }
+
+    if spec_is_empty {
+        return Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+            crate::py_str_wtf8(val)?
+        }));
+    }
+    // The shared spec parser wants the bytes.  Copied out rather than
+    // borrowed: `format_with_spec_public` can run Python, and a borrow into
+    // `w_spec`'s storage would not survive the heap moving under it.
+    let spec = unsafe { pyre_object::w_str_get_wtf8(w_spec) }.to_wtf8_buf();
+    Ok(pyre_object::w_str_from_wtf8_managed(
+        format_with_spec_public(val, &spec)?,
+    ))
+}
+
 /// The type name of `obj` for a TypeError message — the `w_class` name
 /// for instances, else the storage type name.
 /// `_PyArg_BadArgument`'s rendering of a rejected argument: `None` names
@@ -3194,11 +3267,21 @@ pub(crate) fn read_format_spec(
     spec_obj: PyObjectRef,
     arg_desc: &str,
 ) -> Result<Wtf8Buf, crate::PyError> {
+    let spec_obj = check_format_spec(spec_obj, arg_desc)?;
+    // Read through the raw buffer: the fill character may be any code
+    // point, so `format(x, '\ud800<6')` pads with the lone surrogate it
+    // was given rather than demanding a `&str` view of the buffer.
+    Ok(unsafe { pyre_object::w_str_get_wtf8(spec_obj) }.to_wtf8_buf())
+}
+
+/// [`read_format_spec`]'s check alone, returning the spec object itself for
+/// the callers that pass it onward rather than reading its bytes.
+pub(crate) fn check_format_spec(
+    spec_obj: PyObjectRef,
+    arg_desc: &str,
+) -> Result<PyObjectRef, crate::PyError> {
     if !spec_obj.is_null() && unsafe { is_str(spec_obj) } {
-        // Read through the raw buffer: the fill character may be any code
-        // point, so `format(x, '\ud800<6')` pads with the lone surrogate it
-        // was given rather than demanding a `&str` view of the buffer.
-        return Ok(unsafe { pyre_object::w_str_get_wtf8(spec_obj) }.to_wtf8_buf());
+        return Ok(spec_obj);
     }
     Err(crate::PyError::type_error(format!(
         "{arg_desc} must be str, not {}",


### PR DESCRIPTION
`foriter_format_with_spec_user_dunder` reads 62-90x pypy. Chasing where that
goes, the dispatch itself turned out to rebuild both of its operands.

## What upstream does

```python
# pyopcode.py:1712
w_spec = self.popvalue()
w_res = space.format(w_value, w_spec)

# descroperation.py:399
def format(space, w_obj, w_format_spec):
    w_descr = space.lookup(w_obj, '__format__')
    w_res = space.get_and_call_function(w_descr, w_obj, w_format_spec)
    if not space.isinstance_w(w_res, space.w_unicode): raise ...
    return w_res
```

The spec goes from the stack to `__format__` untouched, and `w_res` is returned
as it came back.

## What pyre did

| step | cost |
|---|---|
| `runtime_ops::format_value` read the spec `str` into a `Wtf8Buf` | copy |
| `format_value_dispatch` built a fresh `str` from it for the call | copy + alloc |
| `call_format_dispatch` copied the returned `str`'s bytes out | copy |
| `format_value_dispatch_w` built another `str` from those | copy + alloc |

Four buffer copies and two allocations per call, to pass a string in and get a
string out.

## It is observable, three ways

Both upstreams agree on all three; pyre disagreed on all three.

```python
S = ">4"
class SpecEcho:
    def __format__(self, spec): return "same" if spec is S else "copy"
format(SpecEcho(), S)          # "same" upstream

R = "res"
class Fixed:
    def __format__(self, spec): return R
format(Fixed(), "") is R       # True upstream

class MyStr(str): pass
class Sub:
    def __format__(self, spec): return MyStr("x")
type(format(Sub(), ""))        # MyStr upstream -- the byte round trip flattened it
```

## The change

`format_w` is the object-to-object form: the spec's bytes are read only for the
empty-spec fast paths and for a builtin `__format__`, while a user
`__format__` receives `w_spec` itself and has its result returned unchanged.
`call_format_dispatch_w` is the call half and `call_format_dispatch` becomes
its byte-returning wrapper, kept for `str.format` and the import machinery;
`check_format_spec` is `read_format_spec`'s validation alone.

`runtime_ops::format_value` (FORMAT_SIMPLE, FORMAT_WITH_SPEC and both JIT
residuals), the `format()` builtin and `PyObject_Format` already hold the spec
as an object and take the new path. A `PY_NULL` or non-`str` spec still reads
as the empty spec, and a user `__format__` reached that way is handed a real
empty `str` — `foriter_format_with_spec_user_dunder`'s `"<" + spec + ">"` is
the assertion for that and is unchanged.

## Verification, and what is not verified

* `extra_tests/test_format_protocol.py` covers the three identities, the empty
  spec, and the non-`str` spec TypeError. Every case passes on CPython. On
  pypy all pass except the TypeError, which is a real upstream disagreement —
  `format()` validates the spec type, pypy hands it straight to `__format__` —
  and the spec follows CPython there, which is what pyre already did.
* `cargo check` clean.
* **Not measured.** This worktree could not complete a build-and-measure cycle:
  it was rebased three times during the session, a release build takes the LLBC
  artefacts down with it each time, and the ratio a loaded box prints for this
  fixture is junk in any case (its pypy denominator sits at the clamp floor, so
  the printed ratio tracks machine load — locally it read `?12.5x` against a
  recorded 60-68x band with identical code). CI is the instrument here.

I do not expect this alone to move 62-90x much: the dominant cost is that the
`__format__` body runs behind a residual, not the copies. This removes a
constant-factor tax that is on every `__format__` call in the interpreter, and
it is a correctness fix independent of the timing.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting behavior for `format()`, f-strings, and `str.format()`.
  - Preserved the original format-specification object when passed to `__format__`.
  - Preserved custom result types returned by `__format__`, including `str` subclasses.
  - Improved handling of empty and surrogate-containing format specifications.
  - Added clear errors when a non-string format specification is provided.

- **Tests**
  - Added coverage for format-specification identity, result preservation, empty specifications, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->