### PR TITLE
interp, jit-trace: move the recursion accounting onto the ExecutionContext

### DIFF
--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -3519,7 +3519,7 @@ fn classify_unported_reason(reason: &str) -> &'static str {
             || reason.contains("TL_")
             || reason.contains("TYPEOBJECT_CACHE")
             || reason.contains("W_TYPE_TYPEOBJECT")
-            || reason.contains("PY_RECURSION_DEPTH")
+            || reason.contains("RECURSION_STATE")
             || reason.contains("PENDING_EXCEPTION")
         {
             "FRONTEND-THREADLOCAL/ONCELOCK (threadlocalref_get)"

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -3519,7 +3519,7 @@ fn classify_unported_reason(reason: &str) -> &'static str {
             || reason.contains("TL_")
             || reason.contains("TYPEOBJECT_CACHE")
             || reason.contains("W_TYPE_TYPEOBJECT")
-            || reason.contains("RECURSION_STATE")
+            || reason.contains("DETACHED_RECURSION")
             || reason.contains("PENDING_EXCEPTION")
         {
             "FRONTEND-THREADLOCAL/ONCELOCK (threadlocalref_get)"

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -252,13 +252,14 @@ type DepthBumpFn = fn() -> Option<Box<dyn std::any::Any>>;
 static DEPTH_BUMP_OVERRIDE: OnceLock<DepthBumpFn> = OnceLock::new();
 
 thread_local! {
-    /// This thread's activation accounting — see [`RecursionState`].
-    static RECURSION_STATE: RecursionState = const {
-        RecursionState {
-            depth: Cell::new(0),
-            accounted: Cell::new(0),
-        }
-    };
+    /// Activation accounting for a thread that has no `ExecutionContext`
+    /// installed yet.  The counters live on the context (`py_recursion_depth`
+    /// and `accounted_activation`) so a compiled trace can charge them with
+    /// the field ops it already emits there; this pair is the same state for
+    /// the window before process boot seeds `LAST_EXEC_CTX`, and every
+    /// activation records which of the two it used so the two can never be
+    /// read against each other.
+    static DETACHED_RECURSION: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
 
     /// Monotonic count of Python frame eval-loop entries — bumped once per
     /// `eval_loop` / `eval_loop_jit` entry (every user-level bytecode frame
@@ -275,32 +276,40 @@ thread_local! {
     static FRAME_ENTRY_COUNT: Cell<u64> = const { Cell::new(0) };
 }
 
-/// The pair every activation entry and exit touches together.
+/// The context this activation charged its unit to, or a null pointer when
+/// the thread had none and [`DETACHED_RECURSION`] stood in for it.
 ///
-/// One thread-local rather than two because both are read and written by the
-/// same handful of operations, and a `thread_local!` access is not free on
-/// every platform: darwin resolves each key through a `_tlv_get_addr` call
-/// into the dynamic loader, so the cost is per KEY per access, not per byte.
-/// Sharing one key lets `enter_recursive_frame` and the activation seam pay
-/// for a single lookup and then touch both fields through it.
-struct RecursionState {
-    /// Number of user Python frames currently executing bytecode on this
-    /// thread.  Bumped once at every `eval_loop` / `eval_loop_jit` entry and
-    /// dropped when that activation returns, so the module-level frame, an
-    /// `exec`ed body and a resumed generator each cost one unit exactly like a
-    /// called function does.  `stack_check()` compares it against
-    /// `sys.getrecursionlimit()`.
-    depth: Cell<u32>,
-    /// The innermost frame whose activation has already spent its [`depth`]
-    /// unit.  A frame is executed through nested entry points — the JIT
-    /// wrapper may run it as compiled code, hand it to the JIT eval loop, or
-    /// decline and re-enter the plain evaluator for the very same frame — and
-    /// only the outermost of those pays.  Any frame reached from here is a
-    /// different, simultaneously-live frame, so its address cannot collide
-    /// with the one recorded.
-    ///
-    /// [`depth`]: RecursionState::depth
-    accounted: Cell<usize>,
+/// Carried on the guard rather than looked up again at exit: the context a
+/// frame entered under is the one its release must reach, and reading the
+/// slot twice would let a context installed mid-activation take back a unit
+/// it never received.
+type RecursionHome = *mut crate::PyExecutionContext;
+
+/// Read `(py_recursion_depth, accounted_activation)` from `home`.
+#[inline]
+fn recursion_state_get(home: RecursionHome) -> (usize, usize) {
+    match unsafe { home.as_ref() } {
+        Some(ec) => (ec.py_recursion_depth, ec.accounted_activation),
+        None => DETACHED_RECURSION.with(|c| c.get()),
+    }
+}
+
+/// Write `(py_recursion_depth, accounted_activation)` back to `home`.
+#[inline]
+fn recursion_state_set(home: RecursionHome, depth: usize, accounted: usize) {
+    match unsafe { home.as_mut() } {
+        Some(ec) => {
+            ec.py_recursion_depth = depth;
+            ec.accounted_activation = accounted;
+        }
+        None => DETACHED_RECURSION.with(|c| c.set((depth, accounted))),
+    }
+}
+
+/// The context the next activation will charge.
+#[inline]
+fn recursion_home() -> RecursionHome {
+    getexecutioncontext() as RecursionHome
 }
 
 /// Number of user Python frames currently executing bytecode on this thread.
@@ -312,7 +321,7 @@ struct RecursionState {
 /// annotator.
 #[majit_macros::dont_look_inside]
 pub fn py_recursion_depth() -> u32 {
-    RECURSION_STATE.with(|s| s.depth.get())
+    recursion_state_get(recursion_home()).0 as u32
 }
 
 /// Snapshot of the monotonic Python frame eval-loop entry odometer
@@ -345,23 +354,22 @@ pub fn bump_frame_entry_count() {
 /// puts the matching stack check at the same seam.
 #[inline]
 pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
+    let home = recursion_home();
     let key = frame as usize;
-    RECURSION_STATE.with(|s| {
-        let saved_depth = s.depth.get();
-        if s.accounted.get() == key {
-            return RecursionDepthGuard {
-                prev: key,
-                spent: false,
-                saved_depth,
-            };
-        }
-        s.depth.set(saved_depth + 1);
-        RecursionDepthGuard {
-            prev: s.accounted.replace(key),
-            spent: true,
+    let (saved_depth, accounted) = recursion_state_get(home);
+    if accounted == key {
+        return RecursionDepthGuard {
+            home,
+            prev: key,
             saved_depth,
-        }
-    })
+        };
+    }
+    recursion_state_set(home, saved_depth + 1, key);
+    RecursionDepthGuard {
+        home,
+        prev: accounted,
+        saved_depth,
+    }
 }
 
 /// Spend one unit of the recursion budget on a dispatch level that pushes no
@@ -370,93 +378,46 @@ pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
 /// The self-referential `A.__call__ = A()` chain recurses through
 /// `user_call_slot` natively and never reaches a frame activation, so there is
 /// no activation to key on: the unit is spent unconditionally and
-/// [`RecursionState::accounted`] is carried through unchanged, leaving the
-/// next real activation to account for itself.
+/// `accounted_activation` is carried through unchanged, leaving the next real
+/// activation to account for itself.
 #[inline]
 pub fn enter_native_dispatch() -> RecursionDepthGuard {
-    RECURSION_STATE.with(|s| {
-        let saved_depth = s.depth.get();
-        s.depth.set(saved_depth + 1);
-        RecursionDepthGuard {
-            prev: s.accounted.get(),
-            spent: true,
-            saved_depth,
-        }
-    })
+    let home = recursion_home();
+    let (saved_depth, accounted) = recursion_state_get(home);
+    recursion_state_set(home, saved_depth + 1, accounted);
+    RecursionDepthGuard {
+        home,
+        prev: accounted,
+        saved_depth,
+    }
 }
 
-/// RAII guard that releases the [`RecursionState::depth`] unit on drop.
+/// RAII guard that gives back the activation unit `enter_recursive_frame`
+/// spent, and restores the claim it displaced.
 ///
 /// It restores the depth this activation was entered with rather than
-/// subtracting its own unit.  Compiled code charges and releases the units of
-/// the activations it mints itself ([`jit_charge_recursion_unit`]), and an exit
-/// that leaves compiled code between one of those pairs — a guard failure, a
-/// raise — skips the release the same way it skips the `ec.topframeref`
-/// restore.  Restoring the entry value closes both halves at the activation
-/// boundary, which is where `pyre-jit`'s `TopFrameRefGuard` already balances
-/// the frame chain for the same exits.
+/// subtracting its own unit, and it restores the claim unconditionally --
+/// including for a re-entry that spent nothing.  Compiled code charges and
+/// releases the same two slots inline at its activation seam, and an exit
+/// that leaves compiled code between one of those pairs -- a guard failure, a
+/// raise -- skips the release the same way it skips the `ec.topframeref`
+/// restore.  Writing both slots back at the activation boundary is what
+/// absorbs that skipped release: a conditional claim restore would leave the
+/// slot naming a callee that has already finished, and the next frame minted
+/// at that address would read itself as already accounted and never pay.
+/// This is the boundary where `pyre-jit`'s `TopFrameRefGuard` already
+/// balances the frame chain for the same exits.
 pub struct RecursionDepthGuard {
+    home: RecursionHome,
     prev: usize,
-    spent: bool,
-    saved_depth: u32,
+    saved_depth: usize,
 }
 
 impl Drop for RecursionDepthGuard {
     #[inline]
     fn drop(&mut self) {
-        RECURSION_STATE.with(|s| {
-            s.depth.set(self.saved_depth);
-            if self.spent {
-                s.accounted.set(self.prev);
-            }
-        });
+        recursion_state_set(self.home, self.saved_depth, self.prev);
     }
-}
-
-/// Spend one recursion unit on the activation `frame` names, without a guard
-/// to give it back.
-///
-/// This is [`enter_recursive_frame`]'s body for a caller that cannot hold an
-/// RAII value: a compiled trace, which records the charge as an operation and
-/// records the matching [`jit_release_recursion_unit`] where it records
-/// `executioncontext.leave`.  Claiming [`RecursionState::accounted`] here is
-/// what keeps a frame that later reaches a portal door — a guard failure
-/// resuming this same activation — from paying a second time.
-///
-/// `units` is more than one where the trace mints more than one activation
-/// before it reaches this call: a fragment inlines a run of callee levels and
-/// only then hands the rest to `CALL_ASSEMBLER`, so the seam that survives to
-/// run time pays for the whole run at once.  Charging per inlined level
-/// instead would be exact at the moment of the call and wrong afterwards —
-/// a guard leaving the callee skips the recorded release the same way it skips
-/// the `ec.topframeref` restore, and unlike that slot the depth is read by
-/// every call, so the drift is a spurious `RecursionError` rather than a stale
-/// frame link.
-///
-/// Returns the claim it displaced — the value its release takes back — and the
-/// depth the charge produced, so the caller's limit test costs no second
-/// lookup of the thread-local this already holds open.
-/// The trace threads that word from the one to the other, so the pair is held
-/// together by a dataflow edge rather than by two separate spellings of the
-/// caller, and no reader has to recover a frame from `f_backref`, which holds
-/// the caller's *vref* and not the caller.
-#[majit_macros::dont_look_inside]
-pub fn jit_charge_recursion_unit(frame: *const PyFrame, units: u32) -> (usize, u32) {
-    RECURSION_STATE.with(|s| {
-        let depth = s.depth.get() + units;
-        s.depth.set(depth);
-        (s.accounted.replace(frame as usize), depth)
-    })
-}
-
-/// Give back the units [`jit_charge_recursion_unit`] spent, restoring the claim
-/// it returned.
-#[majit_macros::dont_look_inside]
-pub fn jit_release_recursion_unit(displaced_activation: usize, units: u32) {
-    RECURSION_STATE.with(|s| {
-        s.depth.set(s.depth.get().saturating_sub(units));
-        s.accounted.set(displaced_activation);
-    });
 }
 
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -252,26 +252,17 @@ type DepthBumpFn = fn() -> Option<Box<dyn std::any::Any>>;
 static DEPTH_BUMP_OVERRIDE: OnceLock<DepthBumpFn> = OnceLock::new();
 
 thread_local! {
-    /// Python recursion depth — the number of user Python frames currently
-    /// executing bytecode on this thread.  Bumped once at every `eval_loop` /
-    /// `eval_loop_jit` entry and dropped when that activation returns, so the
-    /// module-level frame, an `exec`ed body and a resumed generator each cost
-    /// one unit exactly like a called function does.  `stack_check()` compares
-    /// it against `sys.getrecursionlimit()`.
-    static PY_RECURSION_DEPTH: Cell<u32> = const { Cell::new(0) };
-
-    /// The innermost frame whose activation has already spent its
-    /// [`PY_RECURSION_DEPTH`] unit.  A frame is executed through nested entry
-    /// points — the JIT wrapper may run it as compiled code, hand it to the
-    /// JIT eval loop, or decline and re-enter the plain evaluator for the very
-    /// same frame — and only the outermost of those pays.  Any frame reached
-    /// from here is a different, simultaneously-live frame, so its address
-    /// cannot collide with the one recorded.
-    static ACCOUNTED_ACTIVATION: Cell<usize> = const { Cell::new(0) };
+    /// This thread's activation accounting — see [`RecursionState`].
+    static RECURSION_STATE: RecursionState = const {
+        RecursionState {
+            depth: Cell::new(0),
+            accounted: Cell::new(0),
+        }
+    };
 
     /// Monotonic count of Python frame eval-loop entries — bumped once per
     /// `eval_loop` / `eval_loop_jit` entry (every user-level bytecode frame
-    /// that begins running), NEVER decremented.  Unlike [`PY_RECURSION_DEPTH`] (net
+    /// that begins running), NEVER decremented.  Unlike the depth (net
     /// zero after a balanced call returns), this is a cumulative odometer, so
     /// a snapshot taken before a residual call and re-read after it reveals
     /// whether ANY user Python frame ran during the call regardless of how
@@ -284,6 +275,34 @@ thread_local! {
     static FRAME_ENTRY_COUNT: Cell<u64> = const { Cell::new(0) };
 }
 
+/// The pair every activation entry and exit touches together.
+///
+/// One thread-local rather than two because both are read and written by the
+/// same handful of operations, and a `thread_local!` access is not free on
+/// every platform: darwin resolves each key through a `_tlv_get_addr` call
+/// into the dynamic loader, so the cost is per KEY per access, not per byte.
+/// Sharing one key lets `enter_recursive_frame` and the activation seam pay
+/// for a single lookup and then touch both fields through it.
+struct RecursionState {
+    /// Number of user Python frames currently executing bytecode on this
+    /// thread.  Bumped once at every `eval_loop` / `eval_loop_jit` entry and
+    /// dropped when that activation returns, so the module-level frame, an
+    /// `exec`ed body and a resumed generator each cost one unit exactly like a
+    /// called function does.  `stack_check()` compares it against
+    /// `sys.getrecursionlimit()`.
+    depth: Cell<u32>,
+    /// The innermost frame whose activation has already spent its [`depth`]
+    /// unit.  A frame is executed through nested entry points — the JIT
+    /// wrapper may run it as compiled code, hand it to the JIT eval loop, or
+    /// decline and re-enter the plain evaluator for the very same frame — and
+    /// only the outermost of those pays.  Any frame reached from here is a
+    /// different, simultaneously-live frame, so its address cannot collide
+    /// with the one recorded.
+    ///
+    /// [`depth`]: RecursionState::depth
+    accounted: Cell<usize>,
+}
+
 /// Number of user Python frames currently executing bytecode on this thread.
 /// Used by pyre-jit for JIT_CALL_DEPTH parity.
 ///
@@ -293,7 +312,7 @@ thread_local! {
 /// annotator.
 #[majit_macros::dont_look_inside]
 pub fn py_recursion_depth() -> u32 {
-    PY_RECURSION_DEPTH.with(|d| d.get())
+    RECURSION_STATE.with(|s| s.depth.get())
 }
 
 /// Snapshot of the monotonic Python frame eval-loop entry odometer
@@ -327,20 +346,22 @@ pub fn bump_frame_entry_count() {
 #[inline]
 pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
     let key = frame as usize;
-    let saved_depth = PY_RECURSION_DEPTH.with(|d| d.get());
-    if ACCOUNTED_ACTIVATION.with(|c| c.get()) == key {
-        return RecursionDepthGuard {
-            prev: key,
-            spent: false,
+    RECURSION_STATE.with(|s| {
+        let saved_depth = s.depth.get();
+        if s.accounted.get() == key {
+            return RecursionDepthGuard {
+                prev: key,
+                spent: false,
+                saved_depth,
+            };
+        }
+        s.depth.set(saved_depth + 1);
+        RecursionDepthGuard {
+            prev: s.accounted.replace(key),
+            spent: true,
             saved_depth,
-        };
-    }
-    PY_RECURSION_DEPTH.with(|d| d.set(saved_depth + 1));
-    RecursionDepthGuard {
-        prev: ACCOUNTED_ACTIVATION.with(|c| c.replace(key)),
-        spent: true,
-        saved_depth,
-    }
+        }
+    })
 }
 
 /// Spend one unit of the recursion budget on a dispatch level that pushes no
@@ -349,20 +370,22 @@ pub fn enter_recursive_frame(frame: *const PyFrame) -> RecursionDepthGuard {
 /// The self-referential `A.__call__ = A()` chain recurses through
 /// `user_call_slot` natively and never reaches a frame activation, so there is
 /// no activation to key on: the unit is spent unconditionally and
-/// `ACCOUNTED_ACTIVATION` is carried through unchanged, leaving the next real
-/// activation to account for itself.
+/// [`RecursionState::accounted`] is carried through unchanged, leaving the
+/// next real activation to account for itself.
 #[inline]
 pub fn enter_native_dispatch() -> RecursionDepthGuard {
-    let saved_depth = PY_RECURSION_DEPTH.with(|d| d.get());
-    PY_RECURSION_DEPTH.with(|d| d.set(saved_depth + 1));
-    RecursionDepthGuard {
-        prev: ACCOUNTED_ACTIVATION.with(|c| c.get()),
-        spent: true,
-        saved_depth,
-    }
+    RECURSION_STATE.with(|s| {
+        let saved_depth = s.depth.get();
+        s.depth.set(saved_depth + 1);
+        RecursionDepthGuard {
+            prev: s.accounted.get(),
+            spent: true,
+            saved_depth,
+        }
+    })
 }
 
-/// RAII guard that releases the [`PY_RECURSION_DEPTH`] unit on drop.
+/// RAII guard that releases the [`RecursionState::depth`] unit on drop.
 ///
 /// It restores the depth this activation was entered with rather than
 /// subtracting its own unit.  Compiled code charges and releases the units of
@@ -381,10 +404,12 @@ pub struct RecursionDepthGuard {
 impl Drop for RecursionDepthGuard {
     #[inline]
     fn drop(&mut self) {
-        PY_RECURSION_DEPTH.with(|d| d.set(self.saved_depth));
-        if self.spent {
-            ACCOUNTED_ACTIVATION.with(|c| c.set(self.prev));
-        }
+        RECURSION_STATE.with(|s| {
+            s.depth.set(self.saved_depth);
+            if self.spent {
+                s.accounted.set(self.prev);
+            }
+        });
     }
 }
 
@@ -394,9 +419,9 @@ impl Drop for RecursionDepthGuard {
 /// This is [`enter_recursive_frame`]'s body for a caller that cannot hold an
 /// RAII value: a compiled trace, which records the charge as an operation and
 /// records the matching [`jit_release_recursion_unit`] where it records
-/// `executioncontext.leave`.  Claiming `ACCOUNTED_ACTIVATION` here is what
-/// keeps a frame that later reaches a portal door — a guard failure resuming
-/// this same activation — from paying a second time.
+/// `executioncontext.leave`.  Claiming [`RecursionState::accounted`] here is
+/// what keeps a frame that later reaches a portal door — a guard failure
+/// resuming this same activation — from paying a second time.
 ///
 /// `units` is more than one where the trace mints more than one activation
 /// before it reaches this call: a fragment inlines a run of callee levels and
@@ -408,23 +433,30 @@ impl Drop for RecursionDepthGuard {
 /// every call, so the drift is a spurious `RecursionError` rather than a stale
 /// frame link.
 ///
-/// Returns the claim it displaced, which is the value its release takes back.
+/// Returns the claim it displaced — the value its release takes back — and the
+/// depth the charge produced, so the caller's limit test costs no second
+/// lookup of the thread-local this already holds open.
 /// The trace threads that word from the one to the other, so the pair is held
 /// together by a dataflow edge rather than by two separate spellings of the
 /// caller, and no reader has to recover a frame from `f_backref`, which holds
 /// the caller's *vref* and not the caller.
 #[majit_macros::dont_look_inside]
-pub fn jit_charge_recursion_unit(frame: *const PyFrame, units: u32) -> usize {
-    PY_RECURSION_DEPTH.with(|d| d.set(d.get() + units));
-    ACCOUNTED_ACTIVATION.with(|c| c.replace(frame as usize))
+pub fn jit_charge_recursion_unit(frame: *const PyFrame, units: u32) -> (usize, u32) {
+    RECURSION_STATE.with(|s| {
+        let depth = s.depth.get() + units;
+        s.depth.set(depth);
+        (s.accounted.replace(frame as usize), depth)
+    })
 }
 
 /// Give back the units [`jit_charge_recursion_unit`] spent, restoring the claim
 /// it returned.
 #[majit_macros::dont_look_inside]
 pub fn jit_release_recursion_unit(displaced_activation: usize, units: u32) {
-    PY_RECURSION_DEPTH.with(|d| d.set(d.get().saturating_sub(units)));
-    ACCOUNTED_ACTIVATION.with(|c| c.set(displaced_activation));
+    RECURSION_STATE.with(|s| {
+        s.depth.set(s.depth.get().saturating_sub(units));
+        s.accounted.set(displaced_activation);
+    });
 }
 
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -551,6 +551,33 @@ pub struct ExecutionContext {
     /// Recursive `__repr__` (e.g. `OrderedDict`) consults it to emit `...`
     /// instead of recursing.  Execution-context-owned like `contextvar_context`.
     pub py_repr: PyObjectRef,
+    /// Number of user Python frames currently executing bytecode on this
+    /// context.  Bumped once at every `eval_loop` / `eval_loop_jit` entry and
+    /// dropped when that activation returns, so the module-level frame, an
+    /// `exec`ed body and a resumed generator each cost one unit exactly like a
+    /// called function does.  `stack_check()` compares it against
+    /// `sys.getrecursionlimit()`.
+    ///
+    /// Context-owned rather than a Rust TLS side table because a compiled
+    /// trace already holds this context as a value -- it reads and writes
+    /// `topframeref` at every inlined call -- so the activation seam charges
+    /// the unit with the same GETFIELD_GC/SETFIELD_GC pair it already emits
+    /// there instead of residualizing a call to reach a thread-local.
+    pub py_recursion_depth: usize,
+    /// The innermost frame whose activation has already spent its
+    /// [`py_recursion_depth`](Self::py_recursion_depth) unit, as a bare
+    /// address.  A frame is executed through nested entry points -- the JIT
+    /// wrapper may run it as compiled code, hand it to the JIT eval loop, or
+    /// decline and re-enter the plain evaluator for the very same frame -- and
+    /// only the outermost of those pays.  Any frame reached from here is a
+    /// different, simultaneously-live frame, so its address cannot collide
+    /// with the one recorded.
+    ///
+    /// Never dereferenced and never a GC root: `eval.rs`'s `visit_ec_slots`
+    /// forwards the context's reference slots one named field at a time, and
+    /// this one is an identity token that may name a frame already freed, so
+    /// forwarding it would be wrong rather than merely unnecessary.
+    pub accounted_activation: usize,
 }
 
 pub type PyExecutionContext = ExecutionContext;
@@ -581,6 +608,19 @@ pub const EC_TOPFRAMEREF_OFFSET: usize = std::mem::offset_of!(ExecutionContext, 
 /// that with a guard, so installing a global trace function leaves compiled
 /// code instead of running on past the events it now owes.
 pub const EC_W_TRACEFUNC_OFFSET: usize = std::mem::offset_of!(ExecutionContext, w_tracefunc);
+
+/// Byte offset of `py_recursion_depth` within `ExecutionContext`, for the
+/// JIT's GETFIELD_GC_I/SETFIELD_GC lowering of the activation seam that
+/// `pyframe.py` (`execute_frame.insert_stack_check_here`) puts at the same
+/// place in the plain evaluator.
+pub const EC_PY_RECURSION_DEPTH_OFFSET: usize =
+    std::mem::offset_of!(ExecutionContext, py_recursion_depth);
+
+/// Byte offset of `accounted_activation` within `ExecutionContext`, read and
+/// restored by the same seam so a frame that reaches a portal door after the
+/// charge does not pay a second unit.
+pub const EC_ACCOUNTED_ACTIVATION_OFFSET: usize =
+    std::mem::offset_of!(ExecutionContext, accounted_activation);
 
 /// Size of `ExecutionContext`, for the JIT's StructPtrInfo SizeDescr
 /// describing the (non-GC) EC struct.  The EC is never JIT-allocated;
@@ -624,6 +664,8 @@ impl ExecutionContext {
             w_asyncgen_finalizer_fn: pyre_object::PY_NULL,
             contextvar_context: pyre_object::PY_NULL,
             py_repr: pyre_object::PY_NULL,
+            py_recursion_depth: 0,
+            accounted_activation: 0,
         }
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3674,21 +3674,6 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         "pyre_interpreter::stack_check::drain_jit_pending_exception",
         crate::stack_check::drain_jit_pending_exception_jit_abi,
     );
-    // The two halves of `execute_frame`'s activation seam, for the fold that
-    // mints a callee activation inside compiled code and records
-    // `executioncontext.enter` / `leave` for it.  Both touch the recursion
-    // counter thread-local, so they are residual Calls like the rest of this
-    // block rather than anything the optimizer may fold.
-    cp2(
-        &mut entries,
-        "pyre_interpreter::stack_check::jit_activation_enter",
-        crate::stack_check::jit_activation_enter_abi,
-    );
-    cp2(
-        &mut entries,
-        "pyre_interpreter::stack_check::jit_activation_leave",
-        crate::stack_check::jit_activation_leave_abi,
-    );
 
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`

--- a/pyre/pyre-interpreter/src/module/sys/state.rs
+++ b/pyre/pyre-interpreter/src/module/sys/state.rs
@@ -8,7 +8,7 @@
 //! the `sys` module (not to the stack-check subsystem) so the data
 //! structure lives in the same namespace as its upstream owner.
 
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
 
 /// Default recursion limit, matching CPython / PyPy. `Module.__init__`
 /// sets `self.recursionlimit = 1000` in the PyPy tree
@@ -24,7 +24,18 @@ pub const MAX_RECURSION_LIMIT: i32 = 1_000_000;
 /// subsystem (`crate::stack_check`) consults this value when the user
 /// raises/lowers the budget, but otherwise keeps its own derived
 /// byte-budget (`PYRE_STACKTOOBIG.length`) hot in L1.
-static RECURSION_LIMIT: AtomicI32 = AtomicI32::new(DEFAULT_RECURSION_LIMIT);
+///
+/// Stored a word wide rather than as an `i32` so a compiled trace can read it
+/// with the word-sized raw load it uses for the eval-breaker word, instead of
+/// residualizing a call to reach it.  `set_recursion_limit` clamps its
+/// argument at zero, so the stored value is always a non-negative `i32`.
+static RECURSION_LIMIT: AtomicUsize = AtomicUsize::new(DEFAULT_RECURSION_LIMIT as usize);
+
+/// Width of that word, in bytes.  The activation seam's load descriptor must
+/// use exactly this size: a narrower load truncates the limit and a wider one
+/// reads past it into the adjacent static, and either way the compiled
+/// recursion answers to a bound the interpreter never set.
+pub const RECURSION_LIMIT_WORD_SIZE: usize = std::mem::size_of::<AtomicUsize>();
 
 /// PyPy `pypy/module/sys/system.py:15-18`.
 pub const DEFAULT_MAX_STR_DIGITS: i32 = 4300;
@@ -42,14 +53,21 @@ static INT_MAX_STR_DIGITS: AtomicI32 = AtomicI32::new(DEFAULT_MAX_STR_DIGITS);
 /// rather than bake the build process's atomic value into a JitCode.
 #[majit_macros::dont_look_inside]
 pub fn recursion_limit() -> i32 {
-    RECURSION_LIMIT.load(Ordering::Relaxed)
+    RECURSION_LIMIT.load(Ordering::Relaxed) as i32
+}
+
+/// Address of the word [`recursion_limit`] reads, for the activation seam's
+/// raw load.  Traces do not outlive the process, so the address a recording
+/// observes is the one its compiled form runs against.
+pub fn recursion_limit_addr() -> usize {
+    std::ptr::addr_of!(RECURSION_LIMIT) as usize
 }
 
 /// `space.sys.recursionlimit = new_limit` parity
 /// (`pypy/module/sys/vm.py:96`).
 #[inline]
 pub fn set_recursion_limit(new_limit: i32) {
-    RECURSION_LIMIT.store(new_limit, Ordering::Relaxed);
+    RECURSION_LIMIT.store(new_limit.max(0) as usize, Ordering::Relaxed);
 }
 
 #[inline]
@@ -74,5 +92,5 @@ pub fn set_int_max_str_digits(maxdigits: i32) -> Result<(), crate::PyError> {
 /// recursion-limit state between runs.
 #[cfg(test)]
 pub fn reset_recursion_limit_for_tests() {
-    RECURSION_LIMIT.store(DEFAULT_RECURSION_LIMIT, Ordering::Relaxed);
+    RECURSION_LIMIT.store(DEFAULT_RECURSION_LIMIT as usize, Ordering::Relaxed);
 }

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -763,7 +763,7 @@ pub fn stack_check() -> Result<(), PyError> {
     // CPython 3.14 checks `py_recursion_remaining`, i.e. Python interpreter
     // depth, independently of native stack protection.  pyre's matching
     // counter is bumped around every user-function call.
-    recursion_depth_check()?;
+    recursion_depth_check(crate::call::py_recursion_depth())?;
     let current = current_sp();
     let end = PYRE_STACKTOOBIG.stack_end.load(Ordering::Relaxed);
     let length = PYRE_STACKTOOBIG.stack_length.load(Ordering::Relaxed);
@@ -797,8 +797,8 @@ pub extern "C" fn stack_check_jit_abi() -> i64 {
 /// boundary would only pay for it twice.  The logical half has no such home,
 /// so it is the half a synthesized activation has to carry.
 #[inline]
-fn recursion_depth_check() -> Result<(), PyError> {
-    if crate::call::py_recursion_depth() >= get_recursion_limit() as u32 {
+fn recursion_depth_check(depth: u32) -> Result<(), PyError> {
+    if depth >= get_recursion_limit() as u32 {
         return Err(PyError::recursion_error("maximum recursion depth exceeded"));
     }
     Ok(())
@@ -829,9 +829,10 @@ fn recursion_depth_check() -> Result<(), PyError> {
 ///
 /// `units` counts the activations the fragment reaching this call has minted,
 /// so the check runs against the depth they all add up to rather than against
-/// the one this call names.  The charge goes first for that reason, and is
-/// given back when the check refuses: an activation that never begins owes no
-/// unit.
+/// the one this call names.  The charge goes first for that reason — it also
+/// hands back the depth it produced, which is what keeps this whole call to a
+/// single thread-local lookup — and is given back when the check refuses: an
+/// activation that never begins owes no unit.
 ///
 /// Returns the word [`jit_activation_leave_abi`] takes back, which the trace
 /// threads from the one call to the other.  The error travels on the published
@@ -839,9 +840,9 @@ fn recursion_depth_check() -> Result<(), PyError> {
 /// result is free to carry the pairing.
 pub extern "C" fn jit_activation_enter_abi(callee_frame: i64, units: i64) -> i64 {
     let units = units as u32;
-    let displaced =
+    let (displaced, depth) =
         crate::call::jit_charge_recursion_unit(callee_frame as *const crate::PyFrame, units);
-    if let Err(error) = recursion_depth_check() {
+    if let Err(error) = recursion_depth_check(depth) {
         crate::call::jit_release_recursion_unit(displaced, units);
         return crate::runtime_ops::jit_publish_residual_error(error);
     }

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -804,58 +804,6 @@ fn recursion_depth_check(depth: u32) -> Result<(), PyError> {
     Ok(())
 }
 
-/// `pyframe.py execute_frame`'s activation entry, in the form a trace can
-/// record.
-///
-/// `insert_ll_stackcheck` (`rpython/translator/transform.py`) puts
-/// `stack_check()` at operation 0 of the start block of every graph carrying
-/// `insert_stack_check_here`, and `pyframe.py` puts that marker on
-/// `execute_frame` — so the check runs ahead of that function's own
-/// `executioncontext.enter(self)`.
-///
-/// Traces upstream never carry it: `driver.py`'s `pyjitpl_lltype` task depends
-/// on `rtype` alone while `stackcheckinsertion_lltype` runs after
-/// `backendopt`, so the jitcodes are built before the operation exists.  What
-/// covers compiled code there is the native SP probe the backend emits once
-/// per fragment entry (`_call_header_with_stack_check`), and that is the whole
-/// of `rstack.stack_check`, which tests nothing but the stack.
-///
-/// [`stack_check`] here tests logical depth against `sys.getrecursionlimit()`
-/// as well, and `execute_frame`'s entry is that half's only home.  A fold that
-/// mints a callee activation inside compiled code has to run it there or the
-/// limit binds nothing for as long as the recursion stays compiled — the
-/// shape `insert_ll_stackcheck` names when it sets `inhibit_tail_call`, a
-/// recursion that consumes no stack and so answers no stack probe.
-///
-/// `units` counts the activations the fragment reaching this call has minted,
-/// so the check runs against the depth they all add up to rather than against
-/// the one this call names.  The charge goes first for that reason — it also
-/// hands back the depth it produced, which is what keeps this whole call to a
-/// single thread-local lookup — and is given back when the check refuses: an
-/// activation that never begins owes no unit.
-///
-/// Returns the word [`jit_activation_leave_abi`] takes back, which the trace
-/// threads from the one call to the other.  The error travels on the published
-/// -exception channel the following guard reads, not in this result, so the
-/// result is free to carry the pairing.
-pub extern "C" fn jit_activation_enter_abi(callee_frame: i64, units: i64) -> i64 {
-    let units = units as u32;
-    let (displaced, depth) =
-        crate::call::jit_charge_recursion_unit(callee_frame as *const crate::PyFrame, units);
-    if let Err(error) = recursion_depth_check(depth) {
-        crate::call::jit_release_recursion_unit(displaced, units);
-        return crate::runtime_ops::jit_publish_residual_error(error);
-    }
-    displaced as i64
-}
-
-/// The `finally` half of the same seam — `executioncontext.leave`'s position
-/// in `execute_frame` — giving back what [`jit_activation_enter_abi`] spent.
-pub extern "C" fn jit_activation_leave_abi(displaced_activation: i64, units: i64) -> i64 {
-    crate::call::jit_release_recursion_unit(displaced_activation as usize, units as u32);
-    0
-}
-
 /// rpython/rlib/rstack.py `stack_almost_full` parity.
 ///
 /// ```python

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -5754,14 +5754,35 @@ fn ec_field_descr(offset: usize) -> DescrRef {
     majit_ir::descr::field_descr_from_parent_by_offset(&parent, offset)
 }
 
+/// Field descr for `ExecutionContext::py_recursion_depth`, the slot the
+/// activation seam charges and gives back around a minted callee activation.
+/// `pyframe.py` (`execute_frame.insert_stack_check_here`) puts the matching
+/// test at the same place in the plain evaluator.
+pub fn ec_py_recursion_depth_descr() -> DescrRef {
+    ec_field_descr(pyre_interpreter::EC_PY_RECURSION_DEPTH_OFFSET)
+}
+
+/// Field descr for `ExecutionContext::accounted_activation`, read and restored
+/// by the same seam so a frame that reaches a portal door after the charge
+/// does not pay a second unit.
+pub fn ec_accounted_activation_descr() -> DescrRef {
+    ec_field_descr(pyre_interpreter::EC_ACCOUNTED_ACTIVATION_OFFSET)
+}
+
 /// The `ExecutionContext` field group.  `type_id 0 + vtable 0` →
 /// `SimpleSizeDescr::is_object() == false`, so the optimizer builds a
-/// StructPtrInfo for the (non-GC) EC pointer.  Every field is Ref-typed
+/// StructPtrInfo for the (non-GC) EC pointer.  The object slots are Ref-typed
 /// (ref value tracking) but Unsigned-flagged (`is_pointer_field()` is false →
-/// no write barrier), which is correct because each slot is forwarded
-/// directly as a GC root every collection (`eval::walk_pyframe_roots` for the
-/// running context, `module::thread`'s per-context walk for the rest), so the
+/// no write barrier), which is correct because each is forwarded directly as
+/// a GC root every collection (`eval::walk_pyframe_roots` for the running
+/// context, `module::thread`'s per-context walk for the rest), so the
 /// generational remembered-set barrier is unnecessary.
+///
+/// The two activation-accounting slots are Int-typed instead.  That walk
+/// visits the context's object slots by name and never reaches them, which is
+/// what makes an integer sound here: `accounted_activation` is a bare
+/// identity token that may name an already-freed frame, so forwarding it as a
+/// root would be wrong rather than merely unnecessary.
 ///
 /// The group is minted with `is_gc_managed = false`: `ExecutionContext` is a
 /// plain Rust struct reached through a raw pointer (`EC_SIZE` is
@@ -5793,6 +5814,23 @@ static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::n
         // Stamped below, once the specs are in offset order.
         index_in_parent: 0,
     };
+    // The activation counters.  `field_size` is derived from the field's own
+    // type rather than spelled, so the 32-bit target reads the same four bytes
+    // the struct actually stores there.
+    let int_field = |index: u32, field_key: &str, offset: usize| SimpleFieldDescrSpec {
+        index,
+        field_key: field_key.to_string(),
+        name: format!("ExecutionContext.{field_key}"),
+        offset,
+        field_size: std::mem::size_of::<usize>(),
+        field_type: Type::Int,
+        is_immutable: false,
+        is_quasi_immutable: false,
+        flag: ArrayFlag::Unsigned,
+        virtualizable: false,
+        is_class_word: Some(false),
+        index_in_parent: 0,
+    };
     let mut specs = vec![
         field(
             0,
@@ -5801,6 +5839,16 @@ static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::n
         ),
         field(1, "topframeref", pyre_interpreter::EC_TOPFRAMEREF_OFFSET),
         field(2, "w_tracefunc", pyre_interpreter::EC_W_TRACEFUNC_OFFSET),
+        int_field(
+            3,
+            "py_recursion_depth",
+            pyre_interpreter::EC_PY_RECURSION_DEPTH_OFFSET,
+        ),
+        int_field(
+            4,
+            "accounted_activation",
+            pyre_interpreter::EC_ACCOUNTED_ACTIVATION_OFFSET,
+        ),
     ];
     // `index_in_parent` is the field's rank by byte offset
     // (`jitcode/assembler.rs`'s `field_specs_from_layout`), and once a parent

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1988,30 +1988,18 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // over: without it the activation the CALL_ASSEMBLER runs never reaches
     // `topframeref`, so `sys._getframe().f_back` walks straight from the
     // callee's callee to this caller and every level in between is missing.
-    // Ahead of it stands `execute_frame`'s operation 0, which
-    // `insert_ll_stackcheck` (`rpython/translator/transform.py`) puts in front
-    // of the `enter` the next line records.  Upstream keeps it out of jitcodes
-    // and lets the backend's per-fragment SP probe stand for it; that probe
-    // answers the native half only, and `jit_activation_enter_abi` documents
-    // why the logical half has to be recorded here instead.
-    //
-    // It pays for the inlined levels above it as well.  This fold re-enters
-    // the fragment that inlined them, so charging one unit here would count
-    // one activation per fragment and divide the recursion's depth by the
-    // inline width; `open_inline_activations` is that width, and it is
-    // charged here because this is the seam a guard cannot leave unbalanced.
+    // `record_activation_charge` records the stack check that stands in front
+    // of that `enter`, and documents why.  It pays for the inlined levels
+    // above it as well: this fold re-enters the fragment that inlined them, so
+    // charging one unit here would count one activation per fragment and
+    // divide the recursion's depth by the inline width.
+    // `open_inline_activations` is that width, and it is charged here because
+    // this is the seam a guard cannot leave unbalanced.
     let units = ctx
         .trace_ctx
         .const_int(i64::from(open_inline_activations() + 1));
-    let displaced_activation = ctx.trace_ctx.call_typed_with_effect(
-        OpCode::CallI,
-        pyre_interpreter::stack_check::jit_activation_enter_abi as *const (),
-        &[callee_frame, units],
-        &[Type::Ref, Type::Int],
-        Type::Int,
-        majit_metainterp::can_raise_effect_info(),
-    );
-    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
+    let (saved_depth, displaced_activation) =
+        record_activation_charge(ctx, op.pc, ec, callee_frame, units)?;
     record_ec_enter_frame_chain(ctx.trace_ctx, callee_frame, ec);
 
     // do_residual_call step 1 (`pyjitpl.py`): FORCE_TOKEN +
@@ -2201,14 +2189,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // `execute_frame`'s `finally` half of the same seam: the unit the enter
     // spent, given back where the frame chain is given back.  It takes the
     // enter's own result, so the two are one dataflow edge apart.
-    ctx.trace_ctx.call_typed_with_effect(
-        OpCode::CallI,
-        pyre_interpreter::stack_check::jit_activation_leave_abi as *const (),
-        &[displaced_activation, units],
-        &[Type::Int, Type::Int],
-        Type::Int,
-        majit_metainterp::cannot_raise_effect_info(),
-    );
+    record_activation_release(ctx.trace_ctx, ec, saved_depth, displaced_activation);
     // pyjitpl.py `handle_possible_exception`.
     if exec_raised {
         // Raising branch (pyjitpl.py): `GUARD_EXCEPTION` with
@@ -3245,6 +3226,135 @@ fn open_inline_activations() -> u32 {
 
 thread_local! {
     static OPEN_INLINE_ACTIVATIONS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Descriptor for the activation seam's load of the recursion-limit word.
+///
+/// The twin of `eval_breaker_word_descr`: the load is exactly as wide as the
+/// word it reads, taking the width from the word itself rather than restating
+/// it.  Non-pure like that one, and for the same reason -- a pure load is a
+/// candidate for CSE against the value the recording observed, which would
+/// bake the limit in force at trace time into the fragment and leave
+/// `sys.setrecursionlimit` unable to reach it.
+fn recursion_limit_word_descr() -> DescrRef {
+    static DESCR: std::sync::OnceLock<DescrRef> = std::sync::OnceLock::new();
+    DESCR
+        .get_or_init(|| {
+            majit_ir::descr::make_array_descr_signed(
+                0,
+                pyre_interpreter::module::sys::state::RECURSION_LIMIT_WORD_SIZE,
+                Type::Int,
+                true,
+            )
+        })
+        .clone()
+}
+
+/// `pyframe.py execute_frame`'s activation entry, in the form a trace carries.
+///
+/// Ahead of `ec.enter` stands `execute_frame`'s operation 0, which
+/// `insert_ll_stackcheck` (`rpython/translator/transform.py`) puts there.
+/// Upstream keeps it out of jitcodes -- `driver.py`'s `pyjitpl_lltype` task
+/// depends on `rtype` alone while `stackcheckinsertion_lltype` runs after
+/// `backendopt` -- and lets the backend's per-fragment SP probe stand for it.
+/// That probe answers the native half only.  The logical half, the test
+/// against `sys.getrecursionlimit()`, has `execute_frame`'s entry as its only
+/// home, so a fold that mints a callee activation inside compiled code has to
+/// run it here or the limit binds nothing for as long as the recursion stays
+/// compiled -- the shape `insert_ll_stackcheck` names when it sets
+/// `inhibit_tail_call`, a recursion that consumes no stack and so answers no
+/// stack probe.
+///
+/// The counters live on the `ExecutionContext`, which this seam already holds
+/// and already reads a field of one line further down, so the charge is the
+/// same GETFIELD_GC/SETFIELD_GC pair rather than a residual call into a
+/// thread-local.  The limit is read the way the back-edge poll reads the
+/// eval-breaker word, a raw load of a published word, so lowering the limit
+/// reaches compiled code without invalidating it.
+///
+/// Claim and charge both land before the guard, and neither is given back on
+/// it.  That is the state a deopt wants: the guard exit resumes the very frame
+/// the claim names, so the interpreter's own entry finds it already accounted,
+/// spends nothing, and raises off the depth this charge produced.
+///
+/// Returns the depth to restore and the claim to put back -- the two words the
+/// release takes, threaded to it as dataflow rather than respelled there.
+fn record_activation_charge<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    ec: OpRef,
+    callee_frame: OpRef,
+    units: OpRef,
+) -> Result<(OpRef, OpRef), DispatchError> {
+    let saved_depth = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcI,
+        &[ec],
+        crate::descr::ec_py_recursion_depth_descr(),
+    );
+    let charged = ctx
+        .trace_ctx
+        .record_op(OpCode::IntAdd, &[saved_depth, units]);
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[ec, charged],
+        crate::descr::ec_py_recursion_depth_descr(),
+    );
+
+    let displaced_activation = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcI,
+        &[ec],
+        crate::descr::ec_accounted_activation_descr(),
+    );
+    // The claim is an identity token, never dereferenced, so it is banked as
+    // an integer rather than as the reference the frame arrives in.
+    let claim = ctx
+        .trace_ctx
+        .record_op(OpCode::CastPtrToInt, &[callee_frame]);
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[ec, claim],
+        crate::descr::ec_accounted_activation_descr(),
+    );
+
+    let limit_addr = ctx
+        .trace_ctx
+        .const_int(pyre_interpreter::module::sys::state::recursion_limit_addr() as i64);
+    let zero = ctx.trace_ctx.const_int(0);
+    let limit = ctx.trace_ctx.record_op_with_descr(
+        OpCode::RawLoadI,
+        &[limit_addr, zero],
+        recursion_limit_word_descr(),
+    );
+    let over_limit = ctx.trace_ctx.record_op(OpCode::UintGe, &[charged, limit]);
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[over_limit])?;
+
+    Ok((saved_depth, displaced_activation))
+}
+
+/// The `finally` half of the same seam, where the frame chain is given back.
+///
+/// It restores the depth the activation was entered with rather than
+/// subtracting the units it spent, matching `RecursionDepthGuard`: an exit
+/// that leaves compiled code between the charge and here -- a guard failure, a
+/// raise -- skips this store the same way it skips the `ec.topframeref`
+/// restore, and an absolute restore at the next activation boundary is what
+/// absorbs the drift.
+fn record_activation_release(
+    ctx: &mut TraceCtx,
+    ec: OpRef,
+    saved_depth: OpRef,
+    displaced_activation: OpRef,
+) {
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[ec, saved_depth],
+        crate::descr::ec_py_recursion_depth_descr(),
+    );
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[ec, displaced_activation],
+        crate::descr::ec_accounted_activation_descr(),
+    );
 }
 
 /// Holds one inlined level open for as long as the walk is inside its body.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -411,7 +411,7 @@ extern "C" fn jit_call_user_function_from_frame(
     let frame = unsafe { &*(frame_ptr as *const PyFrame) };
     let args =
         unsafe { std::slice::from_raw_parts(args_ptr as *const PyObjectRef, nargs as usize) };
-    // Depth tracked by pyre_interpreter::call::RECURSION_STATE (eval-loop entry).
+    // Depth tracked by ExecutionContext::py_recursion_depth (eval-loop entry).
     match pyre_interpreter::call::call_user_function(frame, callable as PyObjectRef, args) {
         Ok(result) => result as i64,
         Err(mut err) => {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -411,7 +411,7 @@ extern "C" fn jit_call_user_function_from_frame(
     let frame = unsafe { &*(frame_ptr as *const PyFrame) };
     let args =
         unsafe { std::slice::from_raw_parts(args_ptr as *const PyObjectRef, nargs as usize) };
-    // Depth tracked by pyre_interpreter::call::PY_RECURSION_DEPTH (eval-loop entry).
+    // Depth tracked by pyre_interpreter::call::RECURSION_STATE (eval-loop entry).
     match pyre_interpreter::call::call_user_function(frame, callable as PyObjectRef, args) {
         Ok(result) => result as i64,
         Err(mut err) => {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7006,8 +7006,10 @@ fn init_callbacks() {
 }
 
 /// Read the Python recursion depth from pyre-interpreter's
-/// `RECURSION_STATE` TLS — the single source of truth for both crates.
-// dont_look_inside: reads a TLS; no registry-resolvable accessor.
+/// `ExecutionContext::py_recursion_depth` — the single source of truth for
+/// both crates.
+// dont_look_inside: reaches the context through the `LAST_EXEC_CTX` TLS; no
+// registry-resolvable accessor.
 #[majit_macros::dont_look_inside]
 pub(crate) fn call_depth() -> u32 {
     pyre_interpreter::call::py_recursion_depth()
@@ -7031,7 +7033,7 @@ pub fn make_green_key(code_ptr: *const (), pc: usize, is_being_profiled: bool) -
     pyre_jit_trace::driver::make_green_key(code_ptr, pc, is_being_profiled)
 }
 
-// JIT_CALL_DEPTH removed — pyre-interpreter::call::RECURSION_STATE is the
+// JIT_CALL_DEPTH removed — ExecutionContext::py_recursion_depth is the
 // single source of truth. call_depth() reads it.
 
 /// RPython compile.py (record_loop_or_bridge) parity:

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7006,7 +7006,7 @@ fn init_callbacks() {
 }
 
 /// Read the Python recursion depth from pyre-interpreter's
-/// PY_RECURSION_DEPTH TLS — the single source of truth for both crates.
+/// `RECURSION_STATE` TLS — the single source of truth for both crates.
 // dont_look_inside: reads a TLS; no registry-resolvable accessor.
 #[majit_macros::dont_look_inside]
 pub(crate) fn call_depth() -> u32 {
@@ -7031,7 +7031,7 @@ pub fn make_green_key(code_ptr: *const (), pc: usize, is_being_profiled: bool) -
     pyre_jit_trace::driver::make_green_key(code_ptr, pc, is_being_profiled)
 }
 
-// JIT_CALL_DEPTH removed — pyre-interpreter::call::PY_RECURSION_DEPTH is the
+// JIT_CALL_DEPTH removed — pyre-interpreter::call::RECURSION_STATE is the
 // single source of truth. call_depth() reads it.
 
 /// RPython compile.py (record_loop_or_bridge) parity:


### PR DESCRIPTION
The `CALL_ASSEMBLER` activation seam charged its recursion unit with two
residual calls into a thread-local. This moves the two counters onto the
`ExecutionContext` — the seam already holds it as a value and reads and
writes `topframeref` one line further down — so the charge becomes the same
`GETFIELD_GC`/`SETFIELD_GC` pair instead.

`ThreadlocalrefGet` was not a route: it is declared in `majit-ir` but is
unimplemented in dynasm, and cranelift lowers it through `emit_host_call`,
so it stays a residual call on both backends.

### What the seam records

Before:

```
CallI(jit_activation_enter_abi, callee_frame, units)
GuardNoException()
  ... CallAssemblerR ...
CallI(jit_activation_leave_abi, displaced, units)
```

After:

```
saved     = GetfieldGcI(ec, ExecutionContext.py_recursion_depth)
charged   = IntAdd(saved, units) ; SetfieldGc(ec, charged)
displaced = GetfieldGcI(ec, ExecutionContext.accounted_activation)
SetfieldGc(ec, CastPtrToInt(callee_frame))
limit     = RawLoadI(<RECURSION_LIMIT addr>, 0)
GuardFalse(UintGe(charged, limit))
  ... CallAssemblerR ...
SetfieldGc(ec, saved) ; SetfieldGc(ec, displaced)
```

`MAJIT_LOG_OPT` on `bench/fib_recursive.py` now shows **zero `CallI`** in the
compiled corpus (all 34 were this seam) and zero `GuardNoException`.

### Notes on the shape

- The limit is read the way the back-edge poll reads the eval-breaker word —
  a raw load of a published word — so lowering `sys.setrecursionlimit`
  reaches compiled code without invalidating it. `RECURSION_LIMIT` widens
  from `AtomicI32` to `AtomicUsize` and publishes its address and its width.
  The load carries a **non-pure** array descr for the reason the eval-breaker
  one does: a pure load is a CSE candidate against the value the recording
  observed, which would bake the trace-time limit into the fragment.
- The claim is banked as an `Int` via `CastPtrToInt`. It is an identity token
  that is never dereferenced, and `eval.rs`'s `visit_ec_slots` forwards the
  context's reference slots one named field at a time, so it never reaches
  these two — which is what makes an integer sound here, and what would make
  forwarding the claim as a root wrong rather than merely unnecessary.
- Charge and claim both land **before** the guard and neither is given back on
  it. That is the state a deopt wants: the exit resumes the very frame the
  claim names, so the interpreter's own entry finds it already accounted,
  spends nothing, and raises off the charged depth. The compiled compare
  `UintGe(charged, limit)` is the interpreter's `depth >= limit`, in the same
  charge-then-test order.
- `RecursionDepthGuard` drops its `spent` field and restores the claim
  unconditionally. A conditional restore leaves the slot naming a callee that
  has already finished, and the next frame minted at that address reads itself
  as already accounted and never pays.

### Gates

Run on this tree, with the LLBC artefacts re-extracted for it and
`extract-llbc.py --check` green before and after:

| gate | result |
|---|---|
| `check.py` | **ALL PASSED** — dynasm 539/539, cranelift 539/539, wasm 532/532 |
| `cargo test --all` (dynasm,cpyext) | 9080 passed / 0 failed |
| parity suite | all parity tests pass |
| CPython suite (dynasm) | 227 PASS / 0 FAIL, no regressions |
| CPython suite (cranelift) | 227 PASS / 0 FAIL, no regressions |

jit-stats baselines did not move — the two benches reported are within band
and not gated, so nothing needed re-recording.

### Two things a reviewer should know

- The first commit merges the two thread-locals into one `RecursionState`;
  the second removes that struct outright. The first is superseded by the
  second and is kept only so the two steps stay legible.
- The branch is based on e75174702af (#1666); `main` has since advanced by
  five commits. It is a descendant, not a divergence, but it is not rebased
  onto current `main`.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recursion-depth tracking across interpreter and JIT execution paths.
  - Improved handling of recursive calls when execution context is unavailable.
  - Recursion limits are now applied more consistently, including for compiled traces.
  - Corrected failure categorization for detached-recursion conditions.

- **Documentation**
  - Updated internal documentation to reflect the current source of recursion-depth information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->