### PR TITLE
rgil, thread: register RPyGilAllocate's pthread_atfork child arm, and repair the collector's world before the child reaches Python objects

### DIFF
--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -116,7 +116,7 @@ fn quiesce() -> &'static Mutex<QuiesceState> {
     unsafe { &*GC_SYNC.quiesce.0.get() }
 }
 
-/// `thread_gil.c:92-98 rpy_init_mutexes`, for the quiescence mutex.
+/// `rpy_init_mutexes`, for the quiescence mutex.
 ///
 /// `mutex1_init` is a `pthread_mutex_init` call, which resets an already-locked
 /// mutex and abandons whatever state it held; replacing the whole `Mutex` is
@@ -1434,9 +1434,9 @@ mod tests {
         assert_eq!(registered_threads(), 0);
     }
 
-    /// `thread_gil.c:105-107` hands `rpy_init_mutexes` to `pthread_atfork` as
-    /// the CHILD handler precisely because a mutex can be copied LOCKED by a
-    /// thread that does not exist in the child.  `quiesce` needs the same
+    /// `RPyGilAllocate` hands `rpy_init_mutexes` to `pthread_atfork` as the
+    /// CHILD handler precisely because a mutex can be copied LOCKED by a thread
+    /// that does not exist in the child.  `quiesce` needs the same
     /// treatment: `quiesce_mutators` releases it before `collect_fn` runs —
     /// which is where `os.fork()` sits — and eight lockers take it outside the
     /// GIL, so the STW bracket does not exclude them.

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -74,7 +74,11 @@ pub struct GcSync {
     /// RUNNING registered-mutator count. A thread waiting for the GIL removes
     /// itself for the wait, so a collector — which holds the GIL — can drain
     /// every other mutator while remaining counted itself.
-    quiesce: Mutex<QuiesceState>,
+    ///
+    /// Behind a cell for the same reason `rgil`'s `GilMutexCell` is: the child
+    /// of a `fork()` has to be able to REPLACE this mutex.  See
+    /// [`init_quiesce_mutex`].
+    quiesce: QuiesceCell,
     /// Signalled whenever RUNNING decreases toward the collector-inclusive
     /// drain target (one when the collector is counted, otherwise zero).
     quiesced: Condvar,
@@ -89,14 +93,53 @@ struct QuiesceState {
     running: usize,
 }
 
+struct QuiesceCell(UnsafeCell<Mutex<QuiesceState>>);
+
+// SAFETY: the contents are `Sync`; the cell exists only so that
+// `init_quiesce_mutex` can replace them in a forked child, where the calling
+// thread is the only one alive.
+unsafe impl Sync for QuiesceCell {}
+
 static GC_SYNC: GcSync = GcSync {
     install_mutex: Mutex::new(()),
     stw_requested: AtomicBool::new(false),
-    quiesce: Mutex::new(QuiesceState { running: 0 }),
+    quiesce: QuiesceCell(UnsafeCell::new(Mutex::new(QuiesceState { running: 0 }))),
     quiesced: Condvar::new(),
     resumed: Condvar::new(),
     stw_generation: AtomicUsize::new(0),
 };
+
+#[inline]
+fn quiesce() -> &'static Mutex<QuiesceState> {
+    // SAFETY: only `init_quiesce_mutex` ever writes, and only in a forked
+    // child before any other thread exists.
+    unsafe { &*GC_SYNC.quiesce.0.get() }
+}
+
+/// `thread_gil.c:92-98 rpy_init_mutexes`, for the quiescence mutex.
+///
+/// `mutex1_init` is a `pthread_mutex_init` call, which resets an already-locked
+/// mutex and abandons whatever state it held; replacing the whole `Mutex` is
+/// the same act.  Nothing is lost: [`after_fork_child`] overwrites `running`
+/// from the surviving thread's own census bits anyway.
+///
+/// This is needed because a `fork()` can copy the mutex LOCKED.  The forking
+/// thread does not hold it — `quiesce_mutators` drops its guard before
+/// `collect_fn` runs — but eight lockers take it OUTSIDE the GIL, so the STW
+/// bracket does not exclude them: `register_thread` locks before
+/// `rgil::acquire_maybe_in_new_thread`, `unregister_thread` releases the GIL
+/// first, and the park/unpark pair around every external call is the GIL
+/// release itself.
+fn init_quiesce_mutex() {
+    // SAFETY: reached only from the surviving thread of a `fork()`, which is
+    // the child's only thread, so no reference into the old value is live.
+    unsafe {
+        std::ptr::write(
+            GC_SYNC.quiesce.0.get(),
+            Mutex::new(QuiesceState { running: 0 }),
+        )
+    };
+}
 
 // ──────────────────────────────────────────────────────────────
 // Singleton management
@@ -260,7 +303,7 @@ pub fn register_thread() {
         FOREIGN_MUTATOR_SEEN.store(true, Ordering::Release);
     }
 
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     state = GC_SYNC
         .resumed
         .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -310,7 +353,7 @@ pub fn unregister_thread() {
     if crate::rgil::am_i_holding_the_gil() {
         crate::rgil::release();
     }
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     // A thread that came in through `register_thread_parked` sits outside the
     // census between callbacks, so there is nothing to subtract for it.
     if GC_THREAD.with(|t| t.running.replace(false)) {
@@ -370,7 +413,7 @@ impl Drop for BlockingGuard {
         if !self.left_census {
             return;
         }
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        let mut state = quiesce().lock().unwrap();
         state = GC_SYNC
             .resumed
             .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -400,7 +443,7 @@ pub fn before_external_block() -> BlockingGuard {
     // leave, and nothing to rejoin when it ends.
     let left_census = GC_THREAD.with(|t| t.registered.get() && t.running.get());
     if left_census {
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        let mut state = quiesce().lock().unwrap();
         GC_THREAD.with(|t| t.running.set(false));
         state.running = state
             .running
@@ -418,7 +461,7 @@ pub fn before_external_block() -> BlockingGuard {
 impl Drop for CallbackGuard {
     fn drop(&mut self) {
         if self.rejoined {
-            let mut state = GC_SYNC.quiesce.lock().unwrap();
+            let mut state = quiesce().lock().unwrap();
             assert!(
                 GC_THREAD.with(|t| t.running.replace(false)),
                 "GC mutator left an external callback twice"
@@ -445,7 +488,7 @@ pub fn enter_external_callback() -> CallbackGuard {
     let running = GC_THREAD.with(|t| t.running.get());
     let mut rejoined = false;
     if registered && !running {
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        let mut state = quiesce().lock().unwrap();
         state = GC_SYNC
             .resumed
             .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -471,7 +514,7 @@ pub(crate) fn leave_running_for_gil() -> GilCensus {
     if !GC_THREAD.with(|t| t.registered.get() && t.running.get()) {
         return GilCensus { rejoin: false };
     }
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     GC_THREAD.with(|t| t.running.set(false));
     state.running = state
         .running
@@ -488,7 +531,7 @@ pub(crate) fn rejoin_running_after_gil(census: GilCensus) {
     if !census.rejoin {
         return;
     }
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     debug_assert!(
         !GC_SYNC.stw_requested.load(Ordering::Acquire),
         "the GIL was acquired while a collector was draining mutators"
@@ -529,6 +572,10 @@ pub fn after_fork_child() {
     // `fork()` runs inside `request_stw`, so this thread held the GIL across
     // it and still does; only the queue behind it has to be rebuilt.
     crate::rgil::after_fork_child();
+    // The other half of what `thread_gil.c` hands `pthread_atfork`'s child
+    // handler.  Both mutexes are replaced before anything locks them, because
+    // the thread whose claim the child inherited does not exist here.
+    init_quiesce_mutex();
     STW_OWNER.store(0, Ordering::SeqCst);
     STW_DEPTH.store(0, Ordering::SeqCst);
     GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -537,7 +584,7 @@ pub fn after_fork_child() {
     // that did not survive the fork has no dispatch loop left to raise it in
     // the child.
     majit_ir::eval_breaker_word::memory_error_after_fork_child();
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     state.running = usize::from(registered && running);
     GC_SYNC.stw_generation.fetch_add(1, Ordering::SeqCst);
     GC_SYNC.resumed.notify_all();
@@ -650,7 +697,7 @@ pub fn quiesce_mutators() -> StwGuard {
         };
     }
 
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     GC_SYNC.stw_requested.store(true, Ordering::Release);
     majit_ir::eval_breaker_word::set_stw();
 
@@ -691,7 +738,7 @@ impl Drop for StwGuard {
         assert_eq!(remaining, 0, "outer STW guard dropped before nested guard");
         STW_OWNER.store(0, Ordering::Release);
 
-        let _state = GC_SYNC.quiesce.lock().unwrap();
+        let _state = quiesce().lock().unwrap();
         GC_SYNC.stw_requested.store(false, Ordering::Release);
         majit_ir::eval_breaker_word::clear_stw();
         GC_SYNC.stw_generation.fetch_add(1, Ordering::Release);
@@ -798,7 +845,7 @@ fn park_until_stw_done() {
         return;
     }
 
-    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    let mut state = quiesce().lock().unwrap();
     if !GC_SYNC.stw_requested.load(Ordering::Acquire) {
         return;
     }
@@ -1384,5 +1431,84 @@ mod tests {
         blocking(|| worker.join()).unwrap();
         unregister_test_mutator();
         assert_eq!(registered_threads(), 0);
+    }
+
+    /// `thread_gil.c:105-107` hands `rpy_init_mutexes` to `pthread_atfork` as
+    /// the CHILD handler precisely because a mutex can be copied LOCKED by a
+    /// thread that does not exist in the child.  `quiesce` needs the same
+    /// treatment: `quiesce_mutators` drops its own guard before `collect_fn`
+    /// runs — which is where `os.fork()` sits — and eight lockers take it
+    /// outside the GIL, so the STW bracket does not exclude them.
+    ///
+    /// Without [`init_quiesce_mutex`], `after_fork_child`'s own
+    /// `quiesce().lock()` never returns in the child and every `os.fork()`
+    /// taken from a worker thread can wedge the child process.
+    #[test]
+    #[cfg(unix)]
+    #[ignore = "requires exclusive process — forks, and registers a process-global mutator"]
+    fn a_quiesce_mutex_inherited_locked_does_not_wedge_the_forked_child() {
+        use std::sync::atomic::AtomicBool;
+
+        static HELD: AtomicBool = AtomicBool::new(false);
+        static RELEASE: AtomicBool = AtomicBool::new(false);
+
+        // The forking thread holds the GIL across `fork()` in production, and
+        // `rgil::after_fork_child` asserts exactly that.
+        register_test_mutator();
+
+        let holder = std::thread::spawn(|| {
+            let _guard = quiesce().lock().unwrap();
+            HELD.store(true, Ordering::Release);
+            while !RELEASE.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        });
+        while !HELD.load(Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+
+        // SAFETY: the child runs only the after-fork reinit and `_exit`.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork() failed");
+        if pid == 0 {
+            after_fork_child();
+            // Reached only if the mutex was rebuilt; a `lock()` on the
+            // inherited claim never returns.
+            unsafe { libc::_exit(0) };
+        }
+
+        RELEASE.store(true, Ordering::Release);
+        holder.join().unwrap();
+
+        let mut status: libc::c_int = 0;
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let mut reaped = false;
+        while std::time::Instant::now() < deadline {
+            // SAFETY: `pid` is this process's own child.
+            let seen = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if seen == pid {
+                reaped = true;
+                break;
+            }
+            assert!(seen == 0, "waitpid failed for child {pid}");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        if !reaped {
+            // SAFETY: `pid` is this process's own child, still alive.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+                libc::waitpid(pid, &mut status, 0);
+            }
+        }
+        unregister_test_mutator();
+        assert!(
+            reaped,
+            "the child never returned from after_fork_child(): it inherited `quiesce` locked \
+             by a thread that does not exist here"
+        );
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "child exited abnormally: status {status}"
+        );
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -900,6 +900,23 @@ mod tests {
     // must provide the same exclusive serialization as it does for the GC.
     unsafe impl Sync for GcOpCounter {}
 
+    /// Install a GC only if this process has none.
+    ///
+    /// The `--ignored` tests share one process (`--test-threads=1`) and one GC
+    /// singleton, so **whichever runs first installs the GC everything else
+    /// then inherits**, and libtest orders them by name.  Three of them —
+    /// `entry_only_safepoint_preserves_fresh_gc_op_return`,
+    /// `multithreaded_collections_preserve_each_mutators_roots` and
+    /// `oldgen_nonmoving_preserves_other_mutators_roots` — allocate
+    /// `alloc_nursery_typed(0, 16)`, so they install a GC that has type 0
+    /// registered and guard it with the same `is_initialized` test.  The one
+    /// which sorts first is the one that actually installs.
+    ///
+    /// The GC built here registers no types.  A test whose name sorts ahead of
+    /// all three and reaches this therefore hands them a singleton whose type 0
+    /// does not exist — the typed allocations then run against an unregistered
+    /// type and the run wedges rather than fails.  Keep new names out of that
+    /// window, or install a typed GC as those three do.
     fn ensure_gc() {
         if !is_initialized() {
             let gc = Box::new(MiniMarkGC::new());
@@ -1446,10 +1463,14 @@ mod tests {
     /// `StwGuard::drop`, which locks `quiesce` on the way out of that same
     /// window.  A test that forks with no live guard passes without the
     /// `pthread_atfork` registration and proves nothing.
+    ///
+    /// The name must not sort ahead of [`entry_only_safepoint_preserves_fresh_gc_op_return`]:
+    /// see [`ensure_gc`] for the ordering contract this whole `--ignored` set
+    /// runs under.
     #[test]
     #[cfg(unix)]
     #[ignore = "requires exclusive process — forks, and registers process-global mutators"]
-    fn a_quiesce_mutex_taken_during_stw_does_not_wedge_the_forked_child() {
+    fn quiesce_mutex_taken_during_stw_does_not_wedge_the_forked_child() {
         use std::sync::atomic::AtomicBool;
 
         static PARKED: AtomicBool = AtomicBool::new(false);

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -74,11 +74,7 @@ pub struct GcSync {
     /// RUNNING registered-mutator count. A thread waiting for the GIL removes
     /// itself for the wait, so a collector — which holds the GIL — can drain
     /// every other mutator while remaining counted itself.
-    ///
-    /// Behind a cell for the same reason `rgil`'s `GilMutexCell` is: the child
-    /// of a `fork()` has to be able to REPLACE this mutex.  See
-    /// [`init_quiesce_mutex`].
-    quiesce: QuiesceCell,
+    quiesce: Mutex<QuiesceState>,
     /// Signalled whenever RUNNING decreases toward the collector-inclusive
     /// drain target (one when the collector is counted, otherwise zero).
     quiesced: Condvar,
@@ -93,53 +89,14 @@ struct QuiesceState {
     running: usize,
 }
 
-struct QuiesceCell(UnsafeCell<Mutex<QuiesceState>>);
-
-// SAFETY: the contents are `Sync`; the cell exists only so that
-// `init_quiesce_mutex` can replace them in a forked child, where the calling
-// thread is the only one alive.
-unsafe impl Sync for QuiesceCell {}
-
 static GC_SYNC: GcSync = GcSync {
     install_mutex: Mutex::new(()),
     stw_requested: AtomicBool::new(false),
-    quiesce: QuiesceCell(UnsafeCell::new(Mutex::new(QuiesceState { running: 0 }))),
+    quiesce: Mutex::new(QuiesceState { running: 0 }),
     quiesced: Condvar::new(),
     resumed: Condvar::new(),
     stw_generation: AtomicUsize::new(0),
 };
-
-#[inline]
-fn quiesce() -> &'static Mutex<QuiesceState> {
-    // SAFETY: only `init_quiesce_mutex` ever writes, and only in a forked
-    // child before any other thread exists.
-    unsafe { &*GC_SYNC.quiesce.0.get() }
-}
-
-/// `rpy_init_mutexes`, for the quiescence mutex.
-///
-/// `mutex1_init` is a `pthread_mutex_init` call, which resets an already-locked
-/// mutex and abandons whatever state it held; replacing the whole `Mutex` is
-/// the same act.  Nothing is lost: [`after_fork_child`] overwrites `running`
-/// from the surviving thread's own census bits anyway.
-///
-/// This is needed because a `fork()` can copy the mutex LOCKED.  The forking
-/// thread does not hold it — `quiesce_mutators` drops its guard before
-/// `collect_fn` runs — but eight lockers take it OUTSIDE the GIL, so the STW
-/// bracket does not exclude them: `register_thread` locks before
-/// `rgil::acquire_maybe_in_new_thread`, `unregister_thread` releases the GIL
-/// first, and the park/unpark pair around every external call is the GIL
-/// release itself.
-pub(crate) fn init_quiesce_mutex() {
-    // SAFETY: reached only from the surviving thread of a `fork()`, which is
-    // the child's only thread, so no reference into the old value is live.
-    unsafe {
-        std::ptr::write(
-            GC_SYNC.quiesce.0.get(),
-            Mutex::new(QuiesceState { running: 0 }),
-        )
-    };
-}
 
 // ──────────────────────────────────────────────────────────────
 // Singleton management
@@ -303,7 +260,7 @@ pub fn register_thread() {
         FOREIGN_MUTATOR_SEEN.store(true, Ordering::Release);
     }
 
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     state = GC_SYNC
         .resumed
         .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -353,7 +310,7 @@ pub fn unregister_thread() {
     if crate::rgil::am_i_holding_the_gil() {
         crate::rgil::release();
     }
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     // A thread that came in through `register_thread_parked` sits outside the
     // census between callbacks, so there is nothing to subtract for it.
     if GC_THREAD.with(|t| t.running.replace(false)) {
@@ -413,7 +370,7 @@ impl Drop for BlockingGuard {
         if !self.left_census {
             return;
         }
-        let mut state = quiesce().lock().unwrap();
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
         state = GC_SYNC
             .resumed
             .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -443,7 +400,7 @@ pub fn before_external_block() -> BlockingGuard {
     // leave, and nothing to rejoin when it ends.
     let left_census = GC_THREAD.with(|t| t.registered.get() && t.running.get());
     if left_census {
-        let mut state = quiesce().lock().unwrap();
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
         GC_THREAD.with(|t| t.running.set(false));
         state.running = state
             .running
@@ -461,7 +418,7 @@ pub fn before_external_block() -> BlockingGuard {
 impl Drop for CallbackGuard {
     fn drop(&mut self) {
         if self.rejoined {
-            let mut state = quiesce().lock().unwrap();
+            let mut state = GC_SYNC.quiesce.lock().unwrap();
             assert!(
                 GC_THREAD.with(|t| t.running.replace(false)),
                 "GC mutator left an external callback twice"
@@ -488,7 +445,7 @@ pub fn enter_external_callback() -> CallbackGuard {
     let running = GC_THREAD.with(|t| t.running.get());
     let mut rejoined = false;
     if registered && !running {
-        let mut state = quiesce().lock().unwrap();
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
         state = GC_SYNC
             .resumed
             .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
@@ -514,7 +471,7 @@ pub(crate) fn leave_running_for_gil() -> GilCensus {
     if !GC_THREAD.with(|t| t.registered.get() && t.running.get()) {
         return GilCensus { rejoin: false };
     }
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     GC_THREAD.with(|t| t.running.set(false));
     state.running = state
         .running
@@ -531,7 +488,7 @@ pub(crate) fn rejoin_running_after_gil(census: GilCensus) {
     if !census.rejoin {
         return;
     }
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     debug_assert!(
         !GC_SYNC.stw_requested.load(Ordering::Acquire),
         "the GIL was acquired while a collector was draining mutators"
@@ -572,11 +529,6 @@ pub fn after_fork_child() {
     // `fork()` runs inside `request_stw`, so this thread held the GIL across
     // it and still does; only the queue behind it has to be rebuilt.
     crate::rgil::after_fork_child();
-    // `rgil`'s `pthread_atfork` child arm has already done both of these on
-    // the way out of `fork()`.  Repeat them for the process that never reached
-    // `rgil::allocate` and so registered no handler; the child is still its own
-    // only thread, and `running` is set from this thread's census bits below.
-    init_quiesce_mutex();
     STW_OWNER.store(0, Ordering::SeqCst);
     STW_DEPTH.store(0, Ordering::SeqCst);
     GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -585,7 +537,7 @@ pub fn after_fork_child() {
     // that did not survive the fork has no dispatch loop left to raise it in
     // the child.
     majit_ir::eval_breaker_word::memory_error_after_fork_child();
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     state.running = usize::from(registered && running);
     GC_SYNC.stw_generation.fetch_add(1, Ordering::SeqCst);
     GC_SYNC.resumed.notify_all();
@@ -698,7 +650,7 @@ pub fn quiesce_mutators() -> StwGuard {
         };
     }
 
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     GC_SYNC.stw_requested.store(true, Ordering::Release);
     majit_ir::eval_breaker_word::set_stw();
 
@@ -739,7 +691,7 @@ impl Drop for StwGuard {
         assert_eq!(remaining, 0, "outer STW guard dropped before nested guard");
         STW_OWNER.store(0, Ordering::Release);
 
-        let _state = quiesce().lock().unwrap();
+        let _state = GC_SYNC.quiesce.lock().unwrap();
         GC_SYNC.stw_requested.store(false, Ordering::Release);
         majit_ir::eval_breaker_word::clear_stw();
         GC_SYNC.stw_generation.fetch_add(1, Ordering::Release);
@@ -846,7 +798,7 @@ fn park_until_stw_done() {
         return;
     }
 
-    let mut state = quiesce().lock().unwrap();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
     if !GC_SYNC.stw_requested.load(Ordering::Acquire) {
         return;
     }
@@ -1449,139 +1401,5 @@ mod tests {
         blocking(|| worker.join()).unwrap();
         unregister_test_mutator();
         assert_eq!(registered_threads(), 0);
-    }
-
-    /// `RPyGilAllocate` hands `rpy_init_mutexes` to `pthread_atfork` as the
-    /// CHILD handler precisely because a mutex can be copied LOCKED by a thread
-    /// that does not exist in the child.  `quiesce` needs the same
-    /// treatment: `quiesce_mutators` releases it before `collect_fn` runs —
-    /// which is where `os.fork()` sits — and eight lockers take it outside the
-    /// GIL, so the STW bracket does not exclude them.
-    ///
-    /// The fork is taken INSIDE `request_stw`, as production does, because the
-    /// first thing the child touches is not an after-fork hook: it is
-    /// `StwGuard::drop`, which locks `quiesce` on the way out of that same
-    /// window.  A test that forks with no live guard passes without the
-    /// `pthread_atfork` registration and proves nothing.
-    ///
-    /// The name must not sort ahead of [`entry_only_safepoint_preserves_fresh_gc_op_return`]:
-    /// see [`ensure_gc`] for the ordering contract this whole `--ignored` set
-    /// runs under.
-    #[test]
-    #[cfg(unix)]
-    #[ignore = "requires exclusive process — forks, and registers process-global mutators"]
-    fn quiesce_mutex_taken_during_stw_does_not_wedge_the_forked_child() {
-        use std::sync::atomic::AtomicBool;
-
-        static PARKED: AtomicBool = AtomicBool::new(false);
-        static PARK_DONE: AtomicBool = AtomicBool::new(false);
-        static TAKE: AtomicBool = AtomicBool::new(false);
-        static HELD: AtomicBool = AtomicBool::new(false);
-        static RELEASE: AtomicBool = AtomicBool::new(false);
-        static RELEASED: AtomicBool = AtomicBool::new(false);
-
-        ensure_gc();
-        // `RPyGilAllocate` is what registers the child handler.
-        crate::rgil::allocate();
-        register_test_mutator();
-
-        // A second registered mutator, parked.  Without it `stw_required()` is
-        // false, `quiesce_mutators` hands back an inactive guard, and
-        // `StwGuard::drop` locks nothing — the ordering under test disappears.
-        let parked = std::thread::spawn(|| {
-            register_test_mutator();
-            let blocked = before_external_block();
-            PARKED.store(true, Ordering::Release);
-            while !PARK_DONE.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-            drop(blocked);
-            unregister_test_mutator();
-        });
-        // Releasing the GIL is not optional: `register_thread` takes it, and
-        // this thread has held it since its own `register_test_mutator`.
-        blocking(|| {
-            while !PARKED.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-        });
-
-        // Unregistered, and that is the point: it stands for any thread that
-        // locks `quiesce` outside the GIL while the collector owns STW.
-        let holder = std::thread::spawn(|| {
-            while !TAKE.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-            let guard = quiesce().lock().unwrap();
-            HELD.store(true, Ordering::Release);
-            while !RELEASE.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-            drop(guard);
-            RELEASED.store(true, Ordering::Release);
-        });
-
-        let mut child_pid = -1;
-        let mut in_child = false;
-        request_stw(|_| {
-            TAKE.store(true, Ordering::Release);
-            while !HELD.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-            // SAFETY: the child only returns from this closure and `_exit`s.
-            let pid = unsafe { libc::fork() };
-            assert!(pid >= 0, "fork() failed");
-            if pid == 0 {
-                in_child = true;
-                return;
-            }
-            child_pid = pid;
-            RELEASE.store(true, Ordering::Release);
-            while !RELEASED.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-        });
-
-        // Reaching here in the child means `StwGuard::drop` got `quiesce` back.
-        if in_child {
-            after_fork_child();
-            // SAFETY: the child must not run the harness's own teardown.
-            unsafe { libc::_exit(0) };
-        }
-
-        PARK_DONE.store(true, Ordering::Release);
-        holder.join().unwrap();
-        blocking(|| parked.join()).unwrap();
-
-        let mut status: libc::c_int = 0;
-        let deadline = std::time::Instant::now() + Duration::from_secs(20);
-        let mut reaped = false;
-        while std::time::Instant::now() < deadline {
-            // SAFETY: `child_pid` is this process's own child.
-            let seen = unsafe { libc::waitpid(child_pid, &mut status, libc::WNOHANG) };
-            if seen == child_pid {
-                reaped = true;
-                break;
-            }
-            assert!(seen == 0, "waitpid failed for child {child_pid}");
-            blocking(|| std::thread::sleep(Duration::from_millis(10)));
-        }
-        if !reaped {
-            // SAFETY: `child_pid` is this process's own child, still alive.
-            unsafe {
-                libc::kill(child_pid, libc::SIGKILL);
-                libc::waitpid(child_pid, &mut status, 0);
-            }
-        }
-        unregister_test_mutator();
-        assert!(
-            reaped,
-            "the forked child never came back out of the STW window: it inherited \
-             `quiesce` locked by a thread that does not exist there"
-        );
-        assert!(
-            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
-            "child exited abnormally: status {status}"
-        );
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -130,7 +130,7 @@ fn quiesce() -> &'static Mutex<QuiesceState> {
 /// `rgil::acquire_maybe_in_new_thread`, `unregister_thread` releases the GIL
 /// first, and the park/unpark pair around every external call is the GIL
 /// release itself.
-fn init_quiesce_mutex() {
+pub(crate) fn init_quiesce_mutex() {
     // SAFETY: reached only from the surviving thread of a `fork()`, which is
     // the child's only thread, so no reference into the old value is live.
     unsafe {
@@ -572,9 +572,10 @@ pub fn after_fork_child() {
     // `fork()` runs inside `request_stw`, so this thread held the GIL across
     // it and still does; only the queue behind it has to be rebuilt.
     crate::rgil::after_fork_child();
-    // The other half of what `thread_gil.c` hands `pthread_atfork`'s child
-    // handler.  Both mutexes are replaced before anything locks them, because
-    // the thread whose claim the child inherited does not exist here.
+    // `rgil`'s `pthread_atfork` child arm has already done both of these on
+    // the way out of `fork()`.  Repeat them for the process that never reached
+    // `rgil::allocate` and so registered no handler; the child is still its own
+    // only thread, and `running` is set from this thread's census bits below.
     init_quiesce_mutex();
     STW_OWNER.store(0, Ordering::SeqCst);
     STW_DEPTH.store(0, Ordering::SeqCst);
@@ -1436,75 +1437,126 @@ mod tests {
     /// `thread_gil.c:105-107` hands `rpy_init_mutexes` to `pthread_atfork` as
     /// the CHILD handler precisely because a mutex can be copied LOCKED by a
     /// thread that does not exist in the child.  `quiesce` needs the same
-    /// treatment: `quiesce_mutators` drops its own guard before `collect_fn`
-    /// runs — which is where `os.fork()` sits — and eight lockers take it
-    /// outside the GIL, so the STW bracket does not exclude them.
+    /// treatment: `quiesce_mutators` releases it before `collect_fn` runs —
+    /// which is where `os.fork()` sits — and eight lockers take it outside the
+    /// GIL, so the STW bracket does not exclude them.
     ///
-    /// Without [`init_quiesce_mutex`], `after_fork_child`'s own
-    /// `quiesce().lock()` never returns in the child and every `os.fork()`
-    /// taken from a worker thread can wedge the child process.
+    /// The fork is taken INSIDE `request_stw`, as production does, because the
+    /// first thing the child touches is not an after-fork hook: it is
+    /// `StwGuard::drop`, which locks `quiesce` on the way out of that same
+    /// window.  A test that forks with no live guard passes without the
+    /// `pthread_atfork` registration and proves nothing.
     #[test]
     #[cfg(unix)]
-    #[ignore = "requires exclusive process — forks, and registers a process-global mutator"]
-    fn a_quiesce_mutex_inherited_locked_does_not_wedge_the_forked_child() {
+    #[ignore = "requires exclusive process — forks, and registers process-global mutators"]
+    fn a_quiesce_mutex_taken_during_stw_does_not_wedge_the_forked_child() {
         use std::sync::atomic::AtomicBool;
 
+        static PARKED: AtomicBool = AtomicBool::new(false);
+        static PARK_DONE: AtomicBool = AtomicBool::new(false);
+        static TAKE: AtomicBool = AtomicBool::new(false);
         static HELD: AtomicBool = AtomicBool::new(false);
         static RELEASE: AtomicBool = AtomicBool::new(false);
+        static RELEASED: AtomicBool = AtomicBool::new(false);
 
-        // The forking thread holds the GIL across `fork()` in production, and
-        // `rgil::after_fork_child` asserts exactly that.
+        ensure_gc();
+        // `RPyGilAllocate` is what registers the child handler.
+        crate::rgil::allocate();
         register_test_mutator();
 
+        // A second registered mutator, parked.  Without it `stw_required()` is
+        // false, `quiesce_mutators` hands back an inactive guard, and
+        // `StwGuard::drop` locks nothing — the ordering under test disappears.
+        let parked = std::thread::spawn(|| {
+            register_test_mutator();
+            let blocked = before_external_block();
+            PARKED.store(true, Ordering::Release);
+            while !PARK_DONE.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            drop(blocked);
+            unregister_test_mutator();
+        });
+        // Releasing the GIL is not optional: `register_thread` takes it, and
+        // this thread has held it since its own `register_test_mutator`.
+        blocking(|| {
+            while !PARKED.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        });
+
+        // Unregistered, and that is the point: it stands for any thread that
+        // locks `quiesce` outside the GIL while the collector owns STW.
         let holder = std::thread::spawn(|| {
-            let _guard = quiesce().lock().unwrap();
+            while !TAKE.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            let guard = quiesce().lock().unwrap();
             HELD.store(true, Ordering::Release);
             while !RELEASE.load(Ordering::Acquire) {
                 std::thread::yield_now();
             }
+            drop(guard);
+            RELEASED.store(true, Ordering::Release);
         });
-        while !HELD.load(Ordering::Acquire) {
-            std::thread::yield_now();
-        }
 
-        // SAFETY: the child runs only the after-fork reinit and `_exit`.
-        let pid = unsafe { libc::fork() };
-        assert!(pid >= 0, "fork() failed");
-        if pid == 0 {
+        let mut child_pid = -1;
+        let mut in_child = false;
+        request_stw(|_| {
+            TAKE.store(true, Ordering::Release);
+            while !HELD.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            // SAFETY: the child only returns from this closure and `_exit`s.
+            let pid = unsafe { libc::fork() };
+            assert!(pid >= 0, "fork() failed");
+            if pid == 0 {
+                in_child = true;
+                return;
+            }
+            child_pid = pid;
+            RELEASE.store(true, Ordering::Release);
+            while !RELEASED.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        });
+
+        // Reaching here in the child means `StwGuard::drop` got `quiesce` back.
+        if in_child {
             after_fork_child();
-            // Reached only if the mutex was rebuilt; a `lock()` on the
-            // inherited claim never returns.
+            // SAFETY: the child must not run the harness's own teardown.
             unsafe { libc::_exit(0) };
         }
 
-        RELEASE.store(true, Ordering::Release);
+        PARK_DONE.store(true, Ordering::Release);
         holder.join().unwrap();
+        blocking(|| parked.join()).unwrap();
 
         let mut status: libc::c_int = 0;
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         let mut reaped = false;
         while std::time::Instant::now() < deadline {
-            // SAFETY: `pid` is this process's own child.
-            let seen = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
-            if seen == pid {
+            // SAFETY: `child_pid` is this process's own child.
+            let seen = unsafe { libc::waitpid(child_pid, &mut status, libc::WNOHANG) };
+            if seen == child_pid {
                 reaped = true;
                 break;
             }
-            assert!(seen == 0, "waitpid failed for child {pid}");
-            std::thread::sleep(Duration::from_millis(10));
+            assert!(seen == 0, "waitpid failed for child {child_pid}");
+            blocking(|| std::thread::sleep(Duration::from_millis(10)));
         }
         if !reaped {
-            // SAFETY: `pid` is this process's own child, still alive.
+            // SAFETY: `child_pid` is this process's own child, still alive.
             unsafe {
-                libc::kill(pid, libc::SIGKILL);
-                libc::waitpid(pid, &mut status, 0);
+                libc::kill(child_pid, libc::SIGKILL);
+                libc::waitpid(child_pid, &mut status, 0);
             }
         }
         unregister_test_mutator();
         assert!(
             reaped,
-            "the child never returned from after_fork_child(): it inherited `quiesce` locked \
-             by a thread that does not exist here"
+            "the forked child never came back out of the STW window: it inherited \
+             `quiesce` locked by a thread that does not exist there"
         );
         assert!(
             libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -184,13 +184,52 @@ fn init_mutexes() {
 /// publishing that the GIL may now be waited on. Until then
 /// [`acquire_slow_path`] is a fatal error, exactly as upstream: a program which
 /// never set threads up can only ever take the compare-and-swap.
+///
+/// The other half of `RPyGilAllocate` is the `pthread_atfork` registration —
+/// see [`register_atfork_child_handler`].
 pub fn allocate() {
-    let _ = RPY_WAITING_THREADS.compare_exchange(
-        GIL_NOT_INITIALIZED,
-        0,
-        Ordering::SeqCst,
-        Ordering::Relaxed,
-    );
+    if RPY_WAITING_THREADS
+        .compare_exchange(GIL_NOT_INITIALIZED, 0, Ordering::SeqCst, Ordering::Relaxed)
+        .is_ok()
+    {
+        register_atfork_child_handler();
+    }
+}
+
+/// thread_gil.c:105-107 `pthread_atfork(NULL, NULL, rpy_init_mutexes)`, guarded
+/// upstream by `HAVE_PTHREAD_ATFORK`.
+///
+/// This is what makes a `fork()` taken while another thread held one of these
+/// mutexes survivable at all: the child arm runs on the surviving thread before
+/// any other code in the child, so nothing can block on a claim whose owner did
+/// not survive.  Registering only once is upstream's shape too — the
+/// `rpy_waiting_threads < 0` test guards both statements.
+#[cfg(unix)]
+fn register_atfork_child_handler() {
+    // SAFETY: `pthread_atfork` only records the handler.
+    unsafe { libc::pthread_atfork(None, None, Some(atfork_child_reinit_mutexes)) };
+}
+
+#[cfg(not(unix))]
+fn register_atfork_child_handler() {}
+
+/// thread_gil.c:93-98 `rpy_init_mutexes`, reached as the `pthread_atfork` child
+/// arm.
+///
+/// Runs before any pyre code in the child — including `StwGuard::drop`, which
+/// locks `gc_sync`'s quiescence mutex on the way out of the very STW window the
+/// `os.fork()` was taken inside, and so would block there long before any
+/// after-fork hook could repair anything.  Writes only: an atfork handler must
+/// take no lock and allocate nothing.
+#[cfg(unix)]
+unsafe extern "C" fn atfork_child_reinit_mutexes() {
+    init_mutexes();
+    RPY_WAITING_THREADS.store(0, Ordering::SeqCst);
+    // pyre-only, and here for upstream's reason rather than by analogy:
+    // `gc_sync`'s quiescence mutex is taken outside the GIL by `register_thread`,
+    // by `unregister_thread`, and by the park/unpark pair around every external
+    // call, so a fork can copy it locked exactly as it can these two.
+    crate::gc_sync::init_quiesce_mutex();
 }
 
 /// Whether [`allocate`] has run, i.e. whether this process has a GIL at all.

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -215,20 +215,19 @@ fn register_atfork_child_handler() {}
 
 /// `rpy_init_mutexes`, reached as the `pthread_atfork` child arm.
 ///
-/// Runs before any pyre code in the child — including `StwGuard::drop`, which
-/// locks `gc_sync`'s quiescence mutex on the way out of the very STW window the
-/// `os.fork()` was taken inside, and so would block there long before any
-/// after-fork hook could repair anything.  Writes only: an atfork handler must
-/// take no lock and allocate nothing.
+/// Runs before any pyre code in the child, which is what [`after_fork_child`]
+/// cannot do: that one is reached from `reinit_threads`, and a fork taken
+/// anywhere else — `_posixsubprocess.fork_exec`, or a library that forks on its
+/// own — never reaches it at all.  Writes only: an atfork handler must take no
+/// lock and allocate nothing.
+///
+/// Scope is upstream's: the two GIL mutexes.  `gc_sync`'s quiescence mutex is
+/// not in it, because `fork_under_stw` already holds that one across the fork,
+/// so the child inherits it owned by the one thread that survived.
 #[cfg(unix)]
 unsafe extern "C" fn atfork_child_reinit_mutexes() {
     init_mutexes();
     RPY_WAITING_THREADS.store(0, Ordering::SeqCst);
-    // pyre-only, and here for upstream's reason rather than by analogy:
-    // `gc_sync`'s quiescence mutex is taken outside the GIL by `register_thread`,
-    // by `unregister_thread`, and by the park/unpark pair around every external
-    // call, so a fork can copy it locked exactly as it can these two.
-    crate::gc_sync::init_quiesce_mutex();
 }
 
 /// Whether [`allocate`] has run, i.e. whether this process has a GIL at all.

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -196,7 +196,7 @@ pub fn allocate() {
     }
 }
 
-/// thread_gil.c:105-107 `pthread_atfork(NULL, NULL, rpy_init_mutexes)`, guarded
+/// `RPyGilAllocate`'s `pthread_atfork(NULL, NULL, rpy_init_mutexes)`, guarded
 /// upstream by `HAVE_PTHREAD_ATFORK`.
 ///
 /// This is what makes a `fork()` taken while another thread held one of these
@@ -213,8 +213,7 @@ fn register_atfork_child_handler() {
 #[cfg(not(unix))]
 fn register_atfork_child_handler() {}
 
-/// thread_gil.c:93-98 `rpy_init_mutexes`, reached as the `pthread_atfork` child
-/// arm.
+/// `rpy_init_mutexes`, reached as the `pthread_atfork` child arm.
 ///
 /// Runs before any pyre code in the child — including `StwGuard::drop`, which
 /// locks `gc_sync`'s quiescence mutex on the way out of the very STW window the

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -638,7 +638,7 @@ pub(crate) fn after_fork_child() {
     let ident = current_ident();
     // Before anything below, which reaches Python objects and can therefore
     // collect.  The mutex rebuild is already done — `rgil::allocate` hands it
-    // to `pthread_atfork`'s child arm, as `thread_gil.c:105-107` does — but the
+    // to `pthread_atfork`'s child arm, as `RPyGilAllocate` does — but the
     // collector's *census* is not something upstream has to repair, so nothing
     // in `reinit_threads` covers it: until these two run, `REGISTERED_THREADS`
     // and the RUNNING count still describe threads that did not survive, so a

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -636,6 +636,16 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn after_fork_child() {
     let ident = current_ident();
+    // Before anything below, which reaches Python objects and can therefore
+    // collect.  `thread_gil.c` hands the mutex rebuild to `pthread_atfork`'s
+    // child handler, so upstream has it done before `reinit_threads` runs at
+    // all; pyre registers no `pthread_atfork`, and until these two run the
+    // collector's world still describes the parent — `REGISTERED_THREADS` and
+    // the RUNNING census count threads that did not survive, so a collection
+    // taken here would wait in `quiesce_mutators` for them to park, and an STW
+    // root walk would read their vanished root areas.
+    majit_gc::shadow_stack::after_fork_child();
+    majit_gc::gc_sync::after_fork_child();
     {
         let mut contexts = EXECUTION_CONTEXTS.lock();
         // threadlocals.py `reinit_threads`: a fork can leave a worker
@@ -685,8 +695,6 @@ pub(crate) fn after_fork_child() {
         any(target_os = "macos", target_os = "linux")
     ))]
     crate::cpyext::after_fork_child();
-    majit_gc::shadow_stack::after_fork_child();
-    majit_gc::gc_sync::after_fork_child();
 }
 
 // os_lock.py `RPY_LOCK_FAILURE, RPY_LOCK_ACQUIRED, RPY_LOCK_INTR`.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -637,13 +637,13 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
 pub(crate) fn after_fork_child() {
     let ident = current_ident();
     // Before anything below, which reaches Python objects and can therefore
-    // collect.  `thread_gil.c` hands the mutex rebuild to `pthread_atfork`'s
-    // child handler, so upstream has it done before `reinit_threads` runs at
-    // all; pyre registers no `pthread_atfork`, and until these two run the
-    // collector's world still describes the parent — `REGISTERED_THREADS` and
-    // the RUNNING census count threads that did not survive, so a collection
-    // taken here would wait in `quiesce_mutators` for them to park, and an STW
-    // root walk would read their vanished root areas.
+    // collect.  The mutex rebuild is already done — `rgil::allocate` hands it
+    // to `pthread_atfork`'s child arm, as `thread_gil.c:105-107` does — but the
+    // collector's *census* is not something upstream has to repair, so nothing
+    // in `reinit_threads` covers it: until these two run, `REGISTERED_THREADS`
+    // and the RUNNING count still describe threads that did not survive, so a
+    // collection taken here would wait in `quiesce_mutators` for them to park,
+    // and an STW root walk would read their vanished root areas.
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();
     {


### PR DESCRIPTION
`os.fork()`'s child path was missing two things.

## `RPyGilAllocate`'s second statement

`RPyGilAllocate` is two statements: `rpy_init_mutexes()` and
`pthread_atfork(NULL, NULL, rpy_init_mutexes)`. pyre had the first and not the
second, so the only thing rebuilding the GIL mutexes in a child was
`rgil::after_fork_child`, reached from `reinit_threads` — a hook that a fork
taken anywhere else (`_posixsubprocess.fork_exec`, or a library forking on its
own) never reaches.

`rgil::allocate` now registers the child arm, once, behind the same
`rpy_waiting_threads < 0` test that guards the rest of it.

## The collector's census, before the child reaches Python objects

`thread::after_fork_child` ran `shadow_stack::after_fork_child` and
`gc_sync::after_fork_child` last — after code that reaches Python objects and
can therefore collect. Until those two run, `REGISTERED_THREADS` and the RUNNING
count still describe threads that did not survive the fork: a collection taken in
that window waits in `quiesce_mutators` for them to park, and an STW root walk
reads their vanished root areas. They now run first.

## Withdrawn from the first revision

The first revision also replaced `GcSync::quiesce` from the atfork child arm.
#1677 has since landed `fork_under_stw`, which takes that mutex before the fork
and drops it after, so the child inherits it owned by the thread that survived;
replacing it would leave that guard pointing at a mutex it never locked. The
last commit takes it back out, and
`fork_under_stw_holds_the_quiesce_mutex_across_the_fork` covers that fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when creating processes with `fork()`, preventing child processes from becoming stuck during concurrent garbage collection.
  - Ensured garbage collection, runtime synchronization, and interpreter state are reinitialized safely in forked child processes before application objects are accessed.
  - Improved handling of forks occurring while another thread holds a runtime lock.
- **Documentation**
  - Documented ordering requirements for ignored garbage-collection tests to preserve reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->