### PR TITLE
metainterp, backend: stop retaining per-bridge frontend records; pack compiled code into an RWX arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ name = "majit-backend"
 version = "0.0.2"
 dependencies = [
  "indexmap",
+ "libc",
  "majit-gc",
  "majit-ir",
  "majit-translate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ version = "0.0.2"
 dependencies = [
  "indexmap",
  "parking_lot",
+ "rustc-hash",
  "serde",
  "smallvec",
  "vecmap-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "majit-ir",
  "majit-macros",
  "majit-metainterp",
+ "mimalloc",
 ]
 
 [[package]]

--- a/majit/examples/regex/Cargo.toml
+++ b/majit/examples/regex/Cargo.toml
@@ -11,6 +11,12 @@ dynasm = ["majit-metainterp/dynasm"]
 # on a busy machine. Off by default: it is process-wide, so its four relaxed
 # atomics per allocation would sit inside the timed rows otherwise.
 alloc-census = []
+# Swap the allocator under the census without changing what the census counts:
+# `pyrex` ships mimalloc as its default global allocator and this example did
+# not, so a per-bridge cost measured here was charged the platform allocator's
+# price rather than the one pyre runs on. The counters are identical across the
+# pair, which makes it a control for allocation *cost* alone.
+fast-alloc = ["dep:mimalloc"]
 
 [dependencies]
 majit-backend = { workspace = true }
@@ -18,3 +24,4 @@ majit-gc = { workspace = true }
 majit-ir = { workspace = true }
 majit-metainterp = { workspace = true }
 majit-macros = { workspace = true }
+mimalloc = { version = "0.1", optional = true }

--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -404,6 +404,36 @@ the machine at all, reproduces to the digit: 11.4 allocations and 1,360.4
 bytes per input character. That is why the census is the instrument this gap
 is graded with.
 
+#### Re-measured 2026-09-03: 2.3-2.5x, after the per-bridge retention fixes
+
+With bridges on, majit's heap grew with the input -- 1,138 MiB peak RSS at
+1,048,576 characters against 15 MiB with `MAJIT_NO_BRIDGE=1` -- and the
+`and`/`or` row followed it: 10.5x slower per character at 1M than at 4K.
+Three causes, each a majit-only retention with no upstream counterpart: a
+`CompiledTrace` kept per bridge in the frontend (`send_bridge_to_backend`
+keeps nothing), a page per compiled block where `asmmemmgr.py` packs blocks
+into 1 MiB RWX mappings, and cranelift's per-descr bridge cells plus a
+recovery layout rebuilt per deopt. With those gone the peak is 124 MiB at 1M
+and the row no longer moves with length (448K / 473K / 416K chars/s at 4K /
+64K / 1M in one sitting).
+
+Three same-round pairs at 1,048,576 characters, `n = 20`, 1-minute load 4.1
+to 4.7, the two binaries back to back and each row the median of five timed
+runs:
+
+| round | RPython `--opt=jit` | majit | ratio |
+|---|---:|---:|---:|
+| 1 | 1,075,379 | 459,039 | 2.34x |
+| 2 | 1,092,345 | 463,868 | 2.35x |
+| 3 | 1,127,526 | 460,087 | 2.45x |
+
+The 3.0-4.1x above becomes 2.3-2.5x, at the same length and against a binary
+translated the same afternoon. What is left is length-independent: with
+bridges off majit reads 750K in the same sitting, so the compiled bridges
+still cost 1.5x over running none, and the deopt that every character takes
+on both sides runs 124 blackhole operations here against RPython's 82 (the
+table below). The heap is no longer in the ratio; the deopt is.
+
 ### Where majit's share of that gap goes
 
 Three theories about that gap were measured and two of them were wrong, so the

--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -406,6 +406,16 @@ is graded with.
 
 #### Re-measured 2026-09-03: 2.3-2.5x, after the per-bridge retention fixes
 
+The RSS runs in this subsection used the macOS system allocator, a release
+`dynasm` build with `alloc-census` and `fast-alloc` both off, and
+`/usr/bin/time -l`'s `maximum resident set size`.  The measured arm was run as
+`PYRE_REGEX_LENGTHS=1048576 PYRE_REGEX_ROWS=2 target/release/regex`; bridges
+were on unless the control explicitly set `MAJIT_NO_BRIDGE=1`.  The 139 MiB
+quoted in the PR summary was the intermediate reading immediately after the
+RWX-arena change.  The 124 MiB below is the later reading after the remaining
+descriptor/cell retention fixes, so it is the final same-configuration number
+rather than a conflicting measurement.
+
 With bridges on, majit's heap grew with the input -- 1,138 MiB peak RSS at
 1,048,576 characters against 15 MiB with `MAJIT_NO_BRIDGE=1` -- and the
 `and`/`or` row followed it: 10.5x slower per character at 1M than at 4K.

--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -428,11 +428,11 @@ runs:
 | 3 | 1,127,526 | 460,087 | 2.45x |
 
 The 3.0-4.1x above becomes 2.3-2.5x, at the same length and against a binary
-translated the same afternoon. What is left is length-independent: with
-bridges off majit reads 750K in the same sitting, so the compiled bridges
-still cost 1.5x over running none, and the deopt that every character takes
-on both sides runs 124 blackhole operations here against RPython's 82 (the
-table below). The heap is no longer in the ratio; the deopt is.
+translated the same afternoon. At that revision, with bridges off majit read
+750K in the same sitting, so the compiled bridges cost 1.5x over running none,
+and the deopt that every character takes ran 124 blackhole operations here
+against RPython's 82. The 2026-09-04 follow-up below closes that operation-count
+gap; bridge construction remains the structural difference.
 
 ### Where majit's share of that gap goes
 
@@ -444,7 +444,8 @@ and never converges, but so does RPython — see "The bridges are RPython's too"
 above. Refuted.
 
 **Not the blackhole byte-interpreting callees.** That was recorded as majit's
-big deviation, at 2142 blackhole ops per character against 39. Re-measured with
+big deviation, at 2142 blackhole ops per character against 39. Re-measured at
+that revision with
 `MAJIT_BH_DEBUG=1 MAJIT_GUARDLOG=1` at 1024 characters, and with RPython's own
 dump counted the same way (`bh: (\w+)` lines over `runner.py 20 1024`), both
 halves of that were wrong:
@@ -468,6 +469,56 @@ On this exact `shift` JitCode the working-register footprint falls from **36
 int / 26 ref** to **4 int / 3 ref**; the blackhole therefore has fewer slots to
 initialize and fewer renamings to execute. The native-entry test pins those
 counts so monotonic allocation cannot return unnoticed.
+
+#### 2026-09-04: the missing coalescing half
+
+The footprint result did not mean the register allocator was complete. RPython
+`tool/algo/regalloc.py::RegAllocator.coalesce_variables` runs between building
+the interference graph and coloring it, then
+`flatten.py::GraphFlattener.insert_renamings` omits a link copy when source and
+target received the same color. The proc-macro adapter skipped both operations;
+it also reserved the whole ABI-input prefix from temporaries instead of doing
+`GraphFlattener.enforce_input_args`' post-color swaps. In the flattened adapter,
+branch-join `Move{I,R,F}` operations are the link source/target pairs. They are
+now coalesced in reverse control-flow order, input colors are swapped into the
+ABI prefix afterwards, and identity moves are omitted.
+
+The same 1,024-character logs, normalized by actual deopts, now read:
+
+| per deopt | RPython | majit before coalescing | majit after |
+|---|---:|---:|---:|
+| all blackhole ops | 82.20 | 80.73 | **65.39** |
+| register copies | 3.09 `int_copy` | 17.55 | **2.21** |
+
+The earlier 124.3 total included the pre-coloring implementation; after the
+first coloring pass it had already fallen to 80.73, but that fact had not been
+re-measured. Coalescing removes another 15.34 `move_i` operations per deopt.
+The total is now lower than RPython rather than higher, so blackhole opcode
+count is no longer an explanation for the remaining speed gap.
+
+Retired-instruction slope over 262,144 → 1,048,576 characters, five timed runs
+per point, moved from the branch baseline's 28,274 to **27,464 instructions per
+character**. That is a real but much smaller 2.9% change: most remaining
+instructions are still spent constructing and optimizing bridges, not running
+the copies. Against the freshly translated RPython's 11,354 the current ratio
+is **2.42x**.
+
+Repeated non-null ConstPtr operands now share the trace's upstream-shaped ref
+cache; null uses the reserved inline ref-zero representation. Its same-tree A/B
+at 65,536 characters was 19.0 / 2,650 → 9.9 allocations / 1,747 bytes per
+character. Two ownership copies in bridge preparation were then removed: a
+tentative trace retains its existing `Rc<Op>` handles across `cut` instead of
+deep-cloning every operation, and snapshot maps read the live snapshot slice
+instead of cloning every frame/box vector first. Those bring the same census to
+**9.7 allocations / 1,649 bytes per character**. The peeled trace remains
+exactly `0 / 24 / 93 / 2`.
+
+The remaining boundary is literal rather than diagnostic: the live recorder is
+still `recorder::Trace` (`Vec<Rc<Op>>` plus structured snapshots), while the
+already-ported `opencoder::TraceRecordBuffer` flat operation and snapshot
+buffers are not yet the `TraceCtx` owner. Completing that field swap, then
+letting its `TraceIterator` be the sole operation materializer, is the remaining
+RPython-shaped route to remove the per-bridge allocator traffic.
 
 **It is bridge compilation, and allocation traffic inside it.** `/usr/bin/sample`
 over a 262,144-character run, counting only the `shortcircuit::mainloop`

--- a/majit/examples/regex/src/alloc_census.rs
+++ b/majit/examples/regex/src/alloc_census.rs
@@ -25,7 +25,13 @@
 //!     --features dynasm,alloc-census
 //! ```
 
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::alloc::{GlobalAlloc, Layout};
+
+/// The allocator the counters sit in front of. See the `fast-alloc` feature.
+#[cfg(feature = "fast-alloc")]
+const INNER: mimalloc::MiMalloc = mimalloc::MiMalloc;
+#[cfg(not(feature = "fast-alloc"))]
+const INNER: std::alloc::System = std::alloc::System;
 use std::cell::Cell;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
@@ -159,30 +165,30 @@ pub struct Counting;
 unsafe impl GlobalAlloc for Counting {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         if IN_TRACE.try_with(Cell::get).unwrap_or(false) {
-            return unsafe { System.alloc(layout) };
+            return unsafe { INNER.alloc(layout) };
         }
         observe(layout.size(), false);
         trace_size(layout.size());
-        unsafe { System.alloc(layout) }
+        unsafe { INNER.alloc(layout) }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         if IN_TRACE.try_with(Cell::get).unwrap_or(false) {
-            return unsafe { System.alloc_zeroed(layout) };
+            return unsafe { INNER.alloc_zeroed(layout) };
         }
         observe(layout.size(), true);
         trace_size(layout.size());
-        unsafe { System.alloc_zeroed(layout) }
+        unsafe { INNER.alloc_zeroed(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         FREES.fetch_add(1, Relaxed);
-        unsafe { System.dealloc(ptr, layout) }
+        unsafe { INNER.dealloc(ptr, layout) }
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         if IN_TRACE.try_with(Cell::get).unwrap_or(false) {
-            return unsafe { System.realloc(ptr, layout, new_size) };
+            return unsafe { INNER.realloc(ptr, layout, new_size) };
         }
         // Counted as one allocation of the growth, not of the whole block: a
         // `Vec` doubling from 1 MiB to 2 MiB moves 1 MiB of new bytes, and
@@ -190,7 +196,7 @@ unsafe impl GlobalAlloc for Counting {
         let growth = new_size.saturating_sub(layout.size());
         observe(growth, false);
         trace_size(growth);
-        unsafe { System.realloc(ptr, layout, new_size) }
+        unsafe { INNER.realloc(ptr, layout, new_size) }
     }
 }
 

--- a/majit/examples/regex/src/main.rs
+++ b/majit/examples/regex/src/main.rs
@@ -93,8 +93,9 @@ fn row_selected(index: usize) -> bool {
                 .map(str::trim)
                 .filter(|part| !part.is_empty())
                 .map(|part| {
-                    part.parse::<usize>()
-                        .unwrap_or_else(|_| panic!("PYRE_REGEX_ROWS contains a non-usize: {part:?}"))
+                    part.parse::<usize>().unwrap_or_else(|_| {
+                        panic!("PYRE_REGEX_ROWS contains a non-usize: {part:?}")
+                    })
                 })
                 .collect(),
         )

--- a/majit/examples/regex/src/main.rs
+++ b/majit/examples/regex/src/main.rs
@@ -78,6 +78,31 @@ fn lengths() -> Vec<usize> {
     parsed
 }
 
+/// `PYRE_REGEX_ROWS=<comma-separated row indexes>` runs only those rows of
+/// [`NAMES`]; a deselected row reports `NaN`. A process-wide counter such as
+/// `/usr/bin/time -l`'s `instructions retired` then charges one row alone,
+/// which is the reading that survives a loaded machine.
+fn row_selected(index: usize) -> bool {
+    static ROWS: std::sync::OnceLock<Option<Vec<usize>>> = std::sync::OnceLock::new();
+    ROWS.get_or_init(|| {
+        let value = std::env::var_os("PYRE_REGEX_ROWS")?;
+        let value = value.to_string_lossy();
+        Some(
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(|part| {
+                    part.parse::<usize>()
+                        .unwrap_or_else(|_| panic!("PYRE_REGEX_ROWS contains a non-usize: {part:?}"))
+                })
+                .collect(),
+        )
+    })
+    .as_ref()
+    .is_none_or(|rows| rows.contains(&index))
+}
+
 /// The `{N}` of the post's benchmark regex `(a|b)*a(a|b){20}a(a|b)*`.
 const N: usize = 20;
 
@@ -214,6 +239,21 @@ fn bench(
     counter: Option<&AtomicUsize>,
     mut run: impl FnMut(*mut NodeRec, &[u8]) -> bool,
 ) -> Row {
+    let index = NAMES
+        .iter()
+        .position(|candidate| *candidate == name)
+        .expect("every row is named in NAMES");
+    if !row_selected(index) {
+        return Row {
+            name,
+            rates: vec![f64::NAN],
+            compiles: 0,
+            #[cfg(feature = "alloc-census")]
+            alloc: alloc_census::read().since(alloc_census::read()),
+            #[cfg(feature = "alloc-census")]
+            alloc_sizes: Vec::new(),
+        };
+    }
     assert!(
         !run(root, s),
         "{name}: the benchmark input is supposed NOT to match"

--- a/majit/examples/regex/src/main.rs
+++ b/majit/examples/regex/src/main.rs
@@ -544,6 +544,21 @@ fn main() {
         started.elapsed().as_secs_f64()
     );
 
+    // The bridge row, on stderr so it never enters the tables above. `BRIDGES`
+    // is what the guards earned; `BRIDGE_OPS` is how much trace each carried,
+    // and the quotient is the unit a per-bridge cost divides by.
+    {
+        use std::sync::atomic::Ordering::Relaxed;
+        let bridges = shortcircuit::BRIDGES.load(Relaxed);
+        if bridges != 0 {
+            eprintln!(
+                "bridges {bridges}, ops {}, {:.1} ops/bridge",
+                shortcircuit::BRIDGE_OPS.load(Relaxed),
+                shortcircuit::BRIDGE_OPS.load(Relaxed) as f64 / bridges as f64,
+            );
+        }
+    }
+
     if bad != 0 {
         std::process::exit(1);
     }

--- a/majit/examples/regex/src/main.rs
+++ b/majit/examples/regex/src/main.rs
@@ -79,9 +79,10 @@ fn lengths() -> Vec<usize> {
 }
 
 /// `PYRE_REGEX_ROWS=<comma-separated row indexes>` runs only those rows of
-/// [`NAMES`]; a deselected row reports `NaN`. A process-wide counter such as
-/// `/usr/bin/time -l`'s `instructions retired` then charges one row alone,
-/// which is the reading that survives a loaded machine.
+/// [`NAMES`]. A process-wide counter such as `/usr/bin/time -l`'s
+/// `instructions retired` then charges one row alone, which is the reading
+/// that survives a loaded machine. Deselected rows are absent, not synthetic
+/// NaNs, so they cannot enter the summary's spreads or ratios.
 fn row_selected(index: usize) -> bool {
     static ROWS: std::sync::OnceLock<Option<Vec<usize>>> = std::sync::OnceLock::new();
     ROWS.get_or_init(|| {
@@ -239,21 +240,13 @@ fn bench(
     s: &[u8],
     counter: Option<&AtomicUsize>,
     mut run: impl FnMut(*mut NodeRec, &[u8]) -> bool,
-) -> Row {
+) -> Option<Row> {
     let index = NAMES
         .iter()
         .position(|candidate| *candidate == name)
         .expect("every row is named in NAMES");
     if !row_selected(index) {
-        return Row {
-            name,
-            rates: vec![f64::NAN],
-            compiles: 0,
-            #[cfg(feature = "alloc-census")]
-            alloc: alloc_census::read().since(alloc_census::read()),
-            #[cfg(feature = "alloc-census")]
-            alloc_sizes: Vec::new(),
-        };
+        return None;
     }
     assert!(
         !run(root, s),
@@ -287,7 +280,7 @@ fn bench(
     };
     let compiles = counter.map_or(0, |c| c.load(Ordering::Relaxed) - before);
     rates.sort_by(f64::total_cmp);
-    Row {
+    Some(Row {
         name,
         rates,
         compiles,
@@ -295,7 +288,7 @@ fn bench(
         alloc,
         #[cfg(feature = "alloc-census")]
         alloc_sizes,
-    }
+    })
 }
 
 /// The peeled loop body of a recorded trace: everything from the last `Label`
@@ -382,7 +375,7 @@ fn main() {
     println!("the input is nonmatching(len, {N}, {SEED}) — it matches nothing, so the matcher");
     println!("must read every character and no early exit can hide the per-character cost.");
 
-    let mut sweep: Vec<(usize, [Row; 3])> = Vec::new();
+    let mut sweep: Vec<(usize, [Option<Row>; 3])> = Vec::new();
     for len in lengths() {
         let s = nonmatching(len, N, SEED);
         assert!(
@@ -409,7 +402,11 @@ fn main() {
 
         println!();
         println!("  {} chars, no match as intended:", commas(len as f64));
-        for row in &rows {
+        for (name, row) in NAMES.iter().zip(&rows) {
+            let Some(row) = row else {
+                println!("    {name:<32}: not selected");
+                continue;
+            };
             let compiled = if row.compiles > 0 {
                 format!(
                     "   {:.1} loops compiled per run",
@@ -449,35 +446,45 @@ fn main() {
 
     // Per row: the spread across the lengths, and which length was fastest —
     // the direction is what separates the two explanations below.
-    let mut shape: Vec<(f64, usize)> = Vec::new();
+    let mut shape: Vec<Option<(f64, usize)>> = Vec::new();
     for (i, name) in NAMES.iter().enumerate() {
         print!("  {name:<32}");
         let (mut lo, mut hi, mut best) = (f64::MAX, 0.0f64, 0usize);
         for (j, (_, rows)) in sweep.iter().enumerate() {
-            let m = rows[i].median();
-            lo = lo.min(m);
-            if m > hi {
-                hi = m;
-                best = j;
+            if let Some(row) = &rows[i] {
+                let m = row.median();
+                lo = lo.min(m);
+                if m > hi {
+                    hi = m;
+                    best = j;
+                }
+                print!("{:>14}", commas(m));
+            } else {
+                print!("{:>14}", "-");
             }
-            print!("{:>14}", commas(m));
         }
-        println!("{:>8.2}x", hi / lo);
-        shape.push((hi / lo, best));
+        if hi == 0.0 {
+            println!("{:>9}", "n/a");
+            shape.push(None);
+        } else {
+            println!("{:>8.2}x", hi / lo);
+            shape.push(Some((hi / lo, best)));
+        }
     }
 
     let not_flat: Vec<usize> = (0..NAMES.len())
-        .filter(|i| shape[*i].0 > FLAT_ENOUGH)
+        .filter(|i| shape[*i].is_some_and(|shape| shape.0 > FLAT_ENOUGH))
         .collect();
     if !not_flat.is_empty() {
         println!();
         println!("  FINDING: not every row reports a per-character rate.");
         for i in &not_flat {
+            let (spread, best) = shape[*i].expect("not_flat contains measured rows");
             println!(
                 "    {:<32} spread {:>6.2}x, fastest at {:>9} chars",
                 NAMES[*i],
-                shape[*i].0,
-                commas(sweep[shape[*i].1].0 as f64),
+                spread,
+                commas(sweep[best].0 as f64),
             );
         }
         println!("    A row fastest at the LONGEST input is amortizing a cost that is fixed per");
@@ -516,8 +523,9 @@ fn main() {
     let (len, rows) = sweep.last().expect("lengths() is not empty");
     let slowest = rows
         .iter()
+        .flatten()
         .min_by(|a, b| a.median().total_cmp(&b.median()))
-        .expect("three rows");
+        .expect("PYRE_REGEX_ROWS selected no benchmark rows");
     println!();
     println!(
         "SUMMARY — (a|b)*a(a|b){{{N}}}a(a|b)* over {} chars, median of {REPEATS} runs.",
@@ -531,7 +539,11 @@ fn main() {
         "  {:<32}{:>14}{:>12}",
         "implementation", "chars/s", "speedup"
     );
-    for row in rows {
+    for (name, row) in NAMES.iter().zip(rows) {
+        let Some(row) = row else {
+            println!("  {name:<32}{:>26}", "not selected");
+            continue;
+        };
         println!(
             "  {:<32}{:>14}{:>11.1}x",
             row.name,
@@ -542,14 +554,16 @@ fn main() {
     println!("  {:<32}{:>26}", "CPython `re`", "not ported here");
 
     // ── the two ratios the post makes its claims from ──────────────────────
-    let jit = rows[R_JIT].median();
-    let aot = rows[R_INTERP].median();
     println!();
     println!("the two ratios the post's headline claims are made of:");
-    println!(
-        "  majit JIT / the same matcher compiled ahead of time : {:>5.1}x",
-        jit / aot
-    );
+    if let (Some(jit), Some(aot)) = (&rows[R_JIT], &rows[R_INTERP]) {
+        println!(
+            "  majit JIT / the same matcher compiled ahead of time : {:>5.1}x",
+            jit.median() / aot.median()
+        );
+    } else {
+        println!("  majit JIT / the same matcher compiled ahead of time :   n/a");
+    }
     println!("      the comparable quantity in the post is its own 16,500,000 / 720,000 = 22.9x,");
     println!("      on its 2010 machine. Both sides divide a JIT that specialized on the regex");
     println!("      by the same algorithm compiled ahead of time — here `rustc -O`, there");

--- a/majit/examples/regex/src/shortcircuit.rs
+++ b/majit/examples/regex/src/shortcircuit.rs
@@ -524,6 +524,10 @@ pub static COMPILES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicU
 /// the loop counter cannot see them, because a guard that declines to bridge
 /// still deopts through the blackhole and leaves the loop count at 1.
 pub static BRIDGES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+/// Operations in every bridge this run compiled, summed. `BRIDGES` counts how
+/// many the guards earned; this counts how much trace each one carried, so a
+/// per-bridge cost can be divided by the work the bridge actually holds.
+pub static BRIDGE_OPS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 /// Traces abandoned. `COMPILES > 0` does not rule this out: a bridge can abort
 /// while the loop stands.
 pub static ABORTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -651,8 +655,9 @@ impl Matcher {
             COMPILES.fetch_add(1, Relaxed);
             *LAST_BODY.lock().unwrap() = opcodes.to_vec();
         });
-        driver.set_on_compile_bridge(|_gk, _fail_index, _num_ops| {
+        driver.set_on_compile_bridge(|_gk, _fail_index, num_ops| {
             BRIDGES.fetch_add(1, Relaxed);
+            BRIDGE_OPS.fetch_add(num_ops, Relaxed);
         });
         driver.set_on_trace_abort(|_gk, _permanent| {
             ABORTS.fetch_add(1, Relaxed);

--- a/majit/majit-backend-cranelift/src/asm_memory.rs
+++ b/majit/majit-backend-cranelift/src/asm_memory.rs
@@ -61,18 +61,12 @@ impl JITMemoryProvider for CraneliftArenaMemoryProvider {
     fn allocate(&mut self, size: usize, align: u64, kind: JITMemoryKind) -> io::Result<*mut u8> {
         let align = usize::try_from(align)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "JIT alignment overflow"))?;
-        if !align.is_power_of_two() || align > region::page::size() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "JIT alignment must be a power of two no larger than a page",
-            ));
-        }
         let used = if matches!(kind, JITMemoryKind::Executable) {
             size
         } else {
             0
         };
-        let block = self.shared.arena.allocate(size, used)?;
+        let block = self.shared.arena.allocate_aligned(size, used, align)?;
         let ptr = block.ptr() as *mut u8;
         self.shared.allocations.lock().push(Allocation {
             block,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -9428,7 +9428,7 @@ impl CraneliftBackend {
             asm_memory_handle,
             module,
             func_ctx,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             callinfocollection: None,
             func_counter: 0,
             trace_counter: 1,
@@ -18249,6 +18249,12 @@ impl majit_backend::Backend for CraneliftBackend {
         )
         .and_then(|descr| fail_descr_bridge_ref(as_fd(&descr)))
         .is_some()
+    }
+
+    /// The guard's dispatch cell holds the `BridgeData` once a bridge is
+    /// attached; `patch_jump_for_descr` installs it.
+    fn bridge_attached(&self, descr: &dyn majit_ir::FailDescr) -> Option<bool> {
+        Some(fail_descr_bridge_ref(descr).is_some())
     }
 
     fn migrate_bridges(&self, old_token: &JitCellToken, new_token: &JitCellToken) {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -2163,46 +2163,6 @@ pub fn register_resumedata_deopt(f: ResumeDataDeoptFn) {
     let _ = RESUMEDATA_DEOPT_FN.set(f);
 }
 
-/// On-demand layout reconstruction callback.  Returns
-/// an `ExitRecoveryLayout` for the descr at `descr_addr`, optionally
-/// prefixed by `caller_prefix`.  Implementation looks up the
-/// metainterp's `StoredExitLayout` cache (keyed by trace_id /
-/// fail_index_per_trace) and converts the cached `resume_layout` via
-/// `ResumeLayout::to_exit_recovery_layout_with_caller_prefix`.
-///
-/// Sibling of [`RESUMEDATA_DEOPT_FN`] but returns layout structure
-/// instead of replaying deopt — used by `recovery_layout_ref()` to
-/// produce `ExitRecoveryLayout` without depending on the meta-side
-/// `ResumeGuardDescr.recovery_layout` cache.
-///
-/// Returns `None` for descrs without a `ResumeGuardDescr` meta_descr
-/// (synthetic FINISH / external-JUMP) or when the StoredExitLayout
-/// lookup fails (descr not in metainterp cache, e.g. overlay
-/// synthetics).  Callers must handle `None`.
-type RecoveryLayoutFn = fn(usize, Option<&ExitRecoveryLayout>) -> Option<ExitRecoveryLayout>;
-static RECOVERY_LAYOUT_FN: OnceLock<RecoveryLayoutFn> = OnceLock::new();
-
-/// Register the on-demand layout reconstruction callback for the
-/// Path 1 epic.  pyre-jit calls this during JIT boot alongside
-/// `register_resumedata_deopt`.
-pub fn register_recovery_layout(f: RecoveryLayoutFn) {
-    let _ = RECOVERY_LAYOUT_FN.set(f);
-}
-
-/// Dispatch helper consulted by `fail_descr_recovery_layout`.
-/// Returns `None` if the callback hasn't been registered yet
-/// (cranelift in pure-backend tests without pyre-jit boot); production
-/// callers fall through to the metainterp's
-/// `trace_layout_ref.recovery_layout` fallback at
-/// `pyjitpl.rs`, matching dynasm parity.
-pub(crate) fn recovery_layout_via_callback(
-    descr_addr: usize,
-    caller_prefix: Option<&ExitRecoveryLayout>,
-) -> Option<ExitRecoveryLayout> {
-    let cb = RECOVERY_LAYOUT_FN.get().copied()?;
-    cb(descr_addr, caller_prefix)
-}
-
 /// Dispatch entry used by the four runtime-deopt callers
 /// (compiler.rs) — drives the on-demand
 /// `ResumeDataDirectReader` callback
@@ -8137,30 +8097,6 @@ impl CompiledLoop {
     }
 }
 
-/// Resolve the `ExitRecoveryLayout` for a fail descr via the on-demand
-/// callback.  The cranelift backend no longer caches a
-/// recovery layout — pyre-jit's
-/// `cranelift_recovery_layout_for_descr` reconstructs it from the
-/// metainterp's `StoredExitLayout.resume_layout` cache, matching
-/// dynasm's contract where `describe_deadframe` returns
-/// `recovery_layout: None` and consumers fall back to the metainterp's
-/// `trace_layout_ref.recovery_layout`.  Returns `None` when no
-/// callback is registered (test scaffolds without pyre-jit) or when
-/// the descr is synthetic (no `rd_loop_token_clt`).
-fn fail_descr_recovery_layout(descr: &DescrRef) -> Option<ExitRecoveryLayout> {
-    // The callback (`cranelift_recovery_layout_for_descr`) resolves the
-    // descr via `Backend::fail_descr_arc_from_addr` →
-    // `recover_fail_descr_cell`, which requires a `FailDescrCell` thin
-    // pointer.  Wrap in a fresh cell and bake its address; the local
-    // cell stays alive through the callback and the recovery bumps the
-    // refcount inside.
-    let cell = majit_ir::FailDescrCell::wrap(descr.clone());
-    let addr = Arc::as_ptr(&cell) as *const () as usize;
-    let result = recovery_layout_via_callback(addr, None);
-    drop(cell);
-    result
-}
-
 /// Read the per-trace `CompiledTraceInfo` from the meta-side
 /// per-emission slot.  Routes through the
 /// `FailDescr::trace_info_any` trait method so copied descrs return
@@ -8186,8 +8122,6 @@ fn fail_descr_layout(
         .as_fail_descr()
         .expect("fail_descr_layout requires a Descr that exposes the FailDescr trait");
     let fail_arg_types = fd.fail_arg_types();
-    let recovery = fail_descr_recovery_layout(descr);
-    let frame_stack = recovery.as_ref().map(|r| r.frames.clone());
     majit_backend::FailDescrLayout {
         fail_index,
         source_op_index: fd.source_op_index(),
@@ -8196,8 +8130,8 @@ fn fail_descr_layout(
         fail_arg_types: fail_arg_types.to_vec(),
         is_finish: fd.is_finish(),
         is_exception_exit: fd.is_exit_frame_with_exception(),
-        recovery_layout: recovery,
-        frame_stack,
+        recovery_layout: None,
+        frame_stack: None,
         descr: Some(descr.clone()),
     }
 }
@@ -17594,10 +17528,6 @@ fn collect_guards(
             if descr.is_resume_guard() || descr.is_resume_guard_copied() {
                 as_fd(&descr).set_source_op_index(op_idx);
             }
-            // Backend no longer caches an `ExitRecoveryLayout` per descr;
-            // `fail_descr_recovery_layout` reads on demand via
-            // `recovery_layout_via_callback` (metainterp's
-            // `compute_recovery_layout_for_descr`).
             let _ = recovery_layout;
             if let Some(target) = external_jump_target {
                 fail_descr_set_external_jump_target(&descr, target);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8198,10 +8198,7 @@ fn fail_descr_layout(
         is_exception_exit: fd.is_exit_frame_with_exception(),
         recovery_layout: recovery,
         frame_stack,
-        rd_numb: fd.rd_numb().map(|s| s.to_vec()),
-        rd_consts: fd.rd_consts().map(|s| s.to_vec()),
-        rd_virtuals: fd.rd_virtuals().map(|s| s.to_vec()),
-        rd_pendingfields: fd.rd_pendingfields().map(|s| s.to_vec()),
+        descr: Some(descr.clone()),
     }
 }
 
@@ -17870,6 +17867,7 @@ impl majit_backend::Backend for CraneliftBackend {
         ops: &[OpRc],
         token: &JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         // `x86/assembler.py:514` parity — bump
         // `cpu.tracker.total_compiled_loops` and open the
         // `jit-mem-looptoken-alloc` debug section at the same point
@@ -18013,6 +18011,7 @@ impl majit_backend::Backend for CraneliftBackend {
         previous_tokens: &[std::sync::Arc<JitCellToken>],
         caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         // `x86/runner.py:100-101` parity — bump this backend's
         // tracker and the per-loop bridges_count before assembling.
         if let Some(clt) = original_token.compiled_loop_token() {
@@ -18299,74 +18298,27 @@ impl majit_backend::Backend for CraneliftBackend {
         CraneliftBackend::set_callinfocollection(self, cic);
     }
 
-    fn store_guard_hashes(&self, token: &JitCellToken, hashes: &[u64]) {
-        let compiled = token
-            .compiled
-            .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>())
-            .map(CompiledLoop::current);
-        if let Some(compiled) = compiled {
-            for (i, &hash) in hashes.iter().enumerate() {
-                if let Some(descr) = compiled.fail_descrs.get(i) {
-                    // `compile.py` `store_hash` only fires for non-
-                    // final `AbstractResumeGuardDescr` whose status is
-                    // still 0.  Route through the FailDescr trait so the
-                    // metainterp class hierarchy answers `final_descr`
-                    // (Done*/Exit*/Propagate, compile.py:624 / 658-662 /
-                    // 1092) instead of the backend-local mirror.
-                    // `compile.py` `store_hash` only fires on
-                    // `AbstractResumeGuardDescr`.  `is_finish()` excludes
-                    // `Done*` finishes but still permits other final
-                    // non-guard descrs (`ExitFrameWithExceptionDescrRef`,
-                    // `PropagateExceptionDescr`) since they answer
-                    // `is_finish() == false`.  Gate on the canonical
-                    // `ResumeDescr` family instead.
-                    let fd = as_fd(descr);
-                    if (fd.is_resume_guard() || fd.is_resume_guard_copied()) && fd.get_status() == 0
-                    {
-                        fd.store_hash(hash);
-                    }
-                }
-            }
-        }
-    }
-
-    fn store_bridge_guard_hashes(
+    fn bridge_was_compiled(
         &self,
-        token: &JitCellToken,
+        original_token: &JitCellToken,
         source_trace_id: u64,
         source_fail_index: u32,
-        hashes: &[u64],
-    ) {
-        let compiled = token
+    ) -> bool {
+        let Some(original_compiled) = original_token
             .compiled
             .get()
-            .and_then(|c| c.downcast_ref::<CompiledLoop>())
-            .map(CompiledLoop::current);
-        if let Some(compiled) = compiled {
-            // Use recursive search matching compiled_bridge_fail_descr_layouts.
-            let source_descr = find_fail_descr_in_fail_descrs(
-                &compiled.fail_descrs,
-                source_trace_id,
-                source_fail_index,
-            );
-            if let Some(descr) = source_descr
-                && let Some(bridge) = fail_descr_bridge_ref(as_fd(&descr))
-            {
-                for (i, &hash) in hashes.iter().enumerate() {
-                    if let Some(bd) = bridge.fail_descrs.get(i) {
-                        // Same `ResumeDescr`-family gate as in
-                        // `store_guard_hashes` above (compile.py:826-829).
-                        let fd = as_fd(bd);
-                        if (fd.is_resume_guard() || fd.is_resume_guard_copied())
-                            && fd.get_status() == 0
-                        {
-                            fd.store_hash(hash);
-                        }
-                    }
-                }
-            }
-        }
+            .and_then(|compiled| compiled.downcast_ref::<CompiledLoop>())
+            .map(CompiledLoop::current)
+        else {
+            return false;
+        };
+        find_fail_descr_in_fail_descrs(
+            &original_compiled.fail_descrs,
+            source_trace_id,
+            source_fail_index,
+        )
+        .and_then(|descr| fail_descr_bridge_ref(as_fd(&descr)))
+        .is_some()
     }
 
     fn migrate_bridges(&self, old_token: &JitCellToken, new_token: &JitCellToken) {
@@ -18986,6 +18938,7 @@ impl majit_backend::Backend for CraneliftBackend {
         old: &JitCellToken,
         new: &JitCellToken,
     ) -> Result<(), BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         let new_addr = new.ll_function_addr();
         if new_addr != 0 {
             old.set_ll_function_addr(new_addr);

--- a/majit/majit-backend-cranelift/src/lib.rs
+++ b/majit/majit-backend-cranelift/src/lib.rs
@@ -27,7 +27,7 @@ pub use compiler::{
     jit_exc_value_peek, jit_exc_value_raw, register_call_assembler_blackhole,
     register_call_assembler_bridge, register_call_assembler_force,
     register_call_assembler_unbox_int, register_jitframe_layout, register_materialize_str_call,
-    register_materialize_str_plain, register_prologue_probe_addr, register_recovery_layout,
-    register_resumedata_deopt, register_stack_check_addresses, set_gil_hooks,
-    set_savedata_ref_on_deadframe, take_pending_frame_restore,
+    register_materialize_str_plain, register_prologue_probe_addr, register_resumedata_deopt,
+    register_stack_check_addresses, set_gil_hooks, set_savedata_ref_on_deadframe,
+    take_pending_frame_restore,
 };

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -797,7 +797,11 @@ impl<'a> AssemblerARM64<'a> {
     /// (`patch_gcref_table`; `GcTable::in_code`). Must run before any
     /// instruction is emitted.
     pub(crate) fn reserve_gcref_table(&mut self, n: usize) {
-        assert_eq!(self.mc.offset().0, 0, "the gcref table opens the code block");
+        assert_eq!(
+            self.mc.offset().0,
+            0,
+            "the gcref table opens the code block"
+        );
         for _ in 0..n {
             let slot = self.mc.new_dynamic_label();
             dynasm!(self.mc ; =>slot ; .u64 0);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -14,7 +14,10 @@ use indexmap::IndexMap;
 use std::sync::Arc;
 
 // aarch64/assembler.py parity: aarch64-only backend.
-use dynasmrt::aarch64::Assembler;
+/// `codebuf.py MachineCodeBlockWrapper`: code is assembled into a plain byte
+/// vector (every relocation is PC-relative) and copied into the arena block
+/// at `materialize`; no per-trace executable mapping.
+pub(crate) type Assembler = dynasmrt::VecAssembler<dynasmrt::aarch64::Aarch64Relocation>;
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
 use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
@@ -209,7 +212,7 @@ pub(crate) fn build_propagate_exception_path(
     cpu_handle: &crate::guard::CpuDescrHandle,
     arena: &Arc<AsmMemoryManager>,
 ) -> (codebuf::ArenaExecutableBuffer, usize) {
-    let mut mc = Assembler::new().expect("propagate_exception_path: new Assembler");
+    let mut mc = Assembler::new(0);
     let propagate_descr = cpu_handle.read().descr_ptrs().propagate_exception_descr as i64;
     let exc_value_addr = crate::jit_exc_value_addr() as i64;
     let exc_type_addr = crate::jit_exc_type_addr() as i64;
@@ -256,7 +259,7 @@ pub(crate) fn build_malloc_slowpath_fixed(
     propagate_path: usize,
     arena: &Arc<AsmMemoryManager>,
 ) -> (codebuf::ArenaExecutableBuffer, usize) {
-    let mut mc = Assembler::new().expect("malloc_slowpath: new Assembler");
+    let mut mc = Assembler::new(0);
     let base_ofs = FIRST_ITEM_OFFSET as u32;
 
     // `_push_all_regs_to_jitframe(mc, [x0, x1], True)`.
@@ -609,12 +612,11 @@ pub struct AssemblerARM64<'a> {
     /// `self.cpu` attribute-access after whole-program translation,
     /// where the `cpu` object's identity is guaranteed by Python.
     cpu_handle: crate::guard::CpuDescrHandle,
-    /// `assembler.py` `genop_load_from_gc_table`: base address of
-    /// this loop's per-loop `GcTable` slot array. Baked as a 64-bit
-    /// immediate by the `LoadFromGcTable` genop; 0 when the trace
-    /// references no reference constants. Set before `assemble_loop` /
-    /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
-    gc_table_base: usize,
+    /// `assembler.py reserve_gcref_table`: one label per slot of the
+    /// reference-constant table reserved at the start of this code block,
+    /// which the `LoadFromGcTable` genop reads PC-relative. Empty when the
+    /// trace references no reference constants.
+    gcref_table: Vec<dynasmrt::DynamicLabel>,
     /// Address of the owning `JitCellToken.invalidated` `AtomicBool`
     /// (`history.py:443`). `GUARD_NOT_INVALIDATED` bakes it as a 64-bit
     /// immediate and loads the byte at runtime, branching to its recovery
@@ -689,6 +691,14 @@ pub struct CompiledCode {
     pub source_guard: Option<(u64, u32)>,
 }
 
+impl CompiledCode {
+    /// `looptoken._ll_function_addr = rawstart + functionpos`: the first
+    /// instruction, past the reserved gcref table.
+    pub fn entry_ptr(&self) -> *const u8 {
+        self.buffer.ptr(self.entry_offset)
+    }
+}
+
 /// The `genop_*` methods here are line-by-line ports of the RPython emitters
 /// (`aarch64/assembler.py` / `x86/assembler.py` `genop_*`).  Emission runs
 /// through `regalloc_perform`, which works from regalloc `arglocs`, so the
@@ -731,7 +741,7 @@ impl<'a> AssemblerARM64<'a> {
         let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
         AssemblerARM64 {
-            mc: Assembler::new().unwrap(),
+            mc: Assembler::new(0),
             asm_memory_manager,
             pending_guard_tokens: Vec::new(),
             pending_malloc_nursery_gcmap: None,
@@ -774,18 +784,28 @@ impl<'a> AssemblerARM64<'a> {
             pending_force_cell: None,
             attached_descrs,
             cpu_handle,
-            gc_table_base: 0,
+            gcref_table: Vec::new(),
             invalidated_flag_addr: 0,
             malloc_slowpath_fixed,
         }
     }
 
-    /// `assembler.py:793-824` parity: hand the per-loop `GcTable`'s base
-    /// address to the assembler before emission, so `LoadFromGcTable`
-    /// genops bake it as the slot-array base immediate. 0 leaves the
-    /// trace with no reference constants (no `LoadFromGcTable` emitted).
-    pub(crate) fn set_gc_table_base(&mut self, base: usize) {
-        self.gc_table_base = base;
+    /// `assembler.py reserve_gcref_table`: reserve `n` zeroed words,
+    /// padded to a multiple of 16 bytes, at the start of the machine code,
+    /// so the `LoadFromGcTable` genop can address them PC-relative. The
+    /// runner writes the gcrefs into them once the block is materialized
+    /// (`patch_gcref_table`; `GcTable::in_code`). Must run before any
+    /// instruction is emitted.
+    pub(crate) fn reserve_gcref_table(&mut self, n: usize) {
+        assert_eq!(self.mc.offset().0, 0, "the gcref table opens the code block");
+        for _ in 0..n {
+            let slot = self.mc.new_dynamic_label();
+            dynasm!(self.mc ; =>slot ; .u64 0);
+            self.gcref_table.push(slot);
+        }
+        if n % 2 == 1 {
+            dynasm!(self.mc ; .u64 0);
+        }
     }
 
     /// `compile.py:665` parity: heap-pinned address of `self.cpu`'s
@@ -2657,14 +2677,11 @@ impl<'a> AssemblerARM64<'a> {
                     self.regalloc_mov(src, dst);
                 }
             }
-            // `assembler.py:1545` `genop_load_from_gc_table`: load the
-            // reference constant at `gc_table_base + index*WORD`. The
-            // index arrives as an immediate (the `ConstInt(index)` arg
-            // produced by `remove_constptr`); the table base is baked
-            // absolute (x86-32 `MOV_rj` model, `assembler.py:1551-1552`)
-            // because dynasm has no code-buffer-start reservation seam.
-            // The slot value is GC-forwarded in place by the gc_table
-            // root walker, so each load observes the relocated object.
+            // `assembler.py genop_load_from_gc_table`: load the reference
+            // constant from slot `index` of the table reserved at the start
+            // of this code block (`reserve_gcref_table`), PC-relative. The
+            // gc_table root walker forwards the slot in place, so each load
+            // observes the relocated object.
             OpCode::LoadFromGcTable => {
                 let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
                 else {
@@ -2673,13 +2690,11 @@ impl<'a> AssemblerARM64<'a> {
                          got arglocs={arglocs:?} result={result_loc:?}"
                     );
                 };
-                debug_assert_ne!(
-                    self.gc_table_base, 0,
-                    "LoadFromGcTable emitted without a GcTable base"
-                );
-                let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
-                self.emit_mov_imm64(dst.value as u32, slot_addr as i64);
-                dynasm!(self.mc ; .arch aarch64 ; ldr X(dst.value), [X(dst.value)]);
+                let slot = *self
+                    .gcref_table
+                    .get(idx.value as usize)
+                    .expect("LoadFromGcTable index inside the reserved gcref table");
+                dynasm!(self.mc ; .arch aarch64 ; ldr X(dst.value), =>slot);
             }
             // `opassembler.py:269-270 emit_op_cast_ptr_to_int =
             // _genop_same_as` / `emit_op_cast_int_to_ptr = _genop_same_as`.

--- a/majit/majit-backend-dynasm/src/aarch64/codebuilder.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/codebuilder.rs
@@ -4,7 +4,7 @@
 /// the trace/op lowering in `assembler.py`.  The dynasm backend still stores
 /// the dynasm assembler inside `AssemblerARM64`, but the codebuilder-shaped
 /// helpers live here so PyPy backend patches have the same file boundary.
-use dynasmrt::aarch64::Assembler;
+use super::assembler::Assembler;
 use dynasmrt::{DynasmApi, dynasm};
 
 use super::assembler::AssemblerARM64;
@@ -107,7 +107,7 @@ impl<'a> AssemblerARM64<'a> {
 
 #[cfg(test)]
 mod tests {
-    use dynasmrt::aarch64::Assembler;
+    use super::super::assembler::Assembler;
     use dynasmrt::{DynasmApi, dynasm};
 
     use super::*;
@@ -133,7 +133,7 @@ mod tests {
             (17, 0x0001_0000_0001_0000),
         ];
         for &(rd, val) in cases {
-            let mut mc = Assembler::new().unwrap();
+            let mut mc = Assembler::new(0);
             let r = rd as u8;
             let v = val as u64;
             dynasm!(mc ; .arch aarch64

--- a/majit/majit-backend-dynasm/src/codebuf.rs
+++ b/majit/majit-backend-dynasm/src/codebuf.rs
@@ -79,7 +79,13 @@ pub fn finalize_writable<R: Relocation>(
     let mut block = arena
         .allocate(len, len)
         .map_err(|error| BackendError::CompilationFailed(error.to_string()))?;
-    block.as_mut_slice()[..len].copy_from_slice(&source[..len]);
+    {
+        // `copy_to_raw_memory` runs inside the caller's bracket when there is
+        // one (`assemble_loop` / `assemble_bridge`); the slow-path stubs built
+        // at `setup_once` have none, so open one here too.
+        let _writing = majit_backend::AssemblerWriting::enter();
+        block.as_mut_slice()[..len].copy_from_slice(&source[..len]);
+    }
     Ok(ArenaExecutableBuffer { block })
 }
 
@@ -92,145 +98,16 @@ pub fn finalize_executable<R: Relocation>(
     Ok(buffer)
 }
 
-/// Make a memory region writable for in-place patching, execute the
-/// closure, then restore execute permission. Arena blocks are page-isolated,
-/// so this does not change a neighboring live block's protection.
+/// Patch finished code in place: `rmmap.enter_assembler_writing()` around the
+/// write (`aarch64/runner.py` `invalidate_loop`), then `clear_cache` over the
+/// patched bytes (`aarch64/codebuilder.py` `copy_to_raw_memory`). The mapping
+/// is RWX throughout, so no neighbouring block changes protection.
 pub fn with_writable<F: FnOnce()>(addr: *mut u8, len: usize, f: F) {
-    #[cfg(unix)]
     {
-        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
-        let page_start = (addr as usize) & !(page_size - 1);
-        let page_end = ((addr as usize + len) + page_size - 1) & !(page_size - 1);
-        let mprotect_len = page_end - page_start;
-        let page_ptr = page_start as *mut libc::c_void;
-
-        let rc1 =
-            unsafe { libc::mprotect(page_ptr, mprotect_len, libc::PROT_READ | libc::PROT_WRITE) };
-        assert!(
-            rc1 == 0,
-            "[dynasm] mprotect RW failed: addr={:?} len={} errno={}",
-            page_ptr,
-            mprotect_len,
-            std::io::Error::last_os_error()
-        );
-
-        struct RestoreRx {
-            ptr: *mut libc::c_void,
-            len: usize,
-        }
-        impl Drop for RestoreRx {
-            fn drop(&mut self) {
-                let rc = unsafe {
-                    libc::mprotect(self.ptr, self.len, libc::PROT_READ | libc::PROT_EXEC)
-                };
-                assert!(
-                    rc == 0,
-                    "[dynasm] mprotect RX failed: addr={:?} len={} errno={}",
-                    self.ptr,
-                    self.len,
-                    std::io::Error::last_os_error()
-                );
-                #[cfg(target_arch = "aarch64")]
-                {
-                    flush_icache_range(self.ptr as *const u8, self.len);
-                }
-            }
-        }
-        let _guard = RestoreRx {
-            ptr: page_ptr,
-            len: mprotect_len,
-        };
+        let _writing = majit_backend::AssemblerWriting::enter();
         f();
     }
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::raw::HANDLE;
-
-        // Win64 SYSTEM_INFO is 48 bytes; we only read dwPageSize at offset 4.
-        #[repr(C)]
-        struct SystemInfo {
-            _arch: u32,
-            dw_page_size: u32,
-            _rest: [u8; 40],
-        }
-
-        let page_size = {
-            let mut si = std::mem::MaybeUninit::<SystemInfo>::zeroed();
-            unsafe { GetSystemInfo(si.as_mut_ptr()) };
-            unsafe { si.assume_init().dw_page_size as usize }
-        };
-        let page_start = (addr as usize) & !(page_size - 1);
-        let page_end = ((addr as usize + len) + page_size - 1) & !(page_size - 1);
-        let region_len = page_end - page_start;
-        let page_ptr = page_start as *mut u8;
-
-        const PAGE_READWRITE: u32 = 0x04;
-        const PAGE_EXECUTE_READ: u32 = 0x20;
-
-        unsafe extern "system" {
-            fn VirtualProtect(addr: *mut u8, size: usize, new: u32, old: *mut u32) -> i32;
-            fn GetSystemInfo(info: *mut SystemInfo);
-        }
-
-        let mut old_protect: u32 = 0;
-        let rc1 = unsafe { VirtualProtect(page_ptr, region_len, PAGE_READWRITE, &mut old_protect) };
-        assert!(
-            rc1 != 0,
-            "[dynasm] VirtualProtect RW failed: addr={:?} len={} err={}",
-            page_ptr,
-            region_len,
-            std::io::Error::last_os_error()
-        );
-
-        struct RestoreRx {
-            ptr: *mut u8,
-            len: usize,
-        }
-        impl Drop for RestoreRx {
-            fn drop(&mut self) {
-                const PAGE_EXECUTE_READ: u32 = 0x20;
-                unsafe extern "system" {
-                    fn VirtualProtect(addr: *mut u8, size: usize, new: u32, old: *mut u32) -> i32;
-                    fn FlushInstructionCache(process: isize, addr: *const u8, size: usize) -> i32;
-                    fn GetCurrentProcess() -> isize;
-                }
-                let mut old: u32 = 0;
-                let rc = unsafe { VirtualProtect(self.ptr, self.len, PAGE_EXECUTE_READ, &mut old) };
-                assert!(
-                    rc != 0,
-                    "[dynasm] VirtualProtect RX failed: addr={:?} len={} err={}",
-                    self.ptr,
-                    self.len,
-                    std::io::Error::last_os_error()
-                );
-                unsafe { FlushInstructionCache(GetCurrentProcess(), self.ptr, self.len) };
-            }
-        }
-        let _guard = RestoreRx {
-            ptr: page_ptr,
-            len: region_len,
-        };
-        f();
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn flush_icache_range(addr: *const u8, len: usize) {
-    #[cfg(target_os = "macos")]
-    {
-        unsafe extern "C" {
-            fn sys_icache_invalidate(start: *mut u8, size: usize);
-        }
-        unsafe { sys_icache_invalidate(addr as *mut u8, len) };
-    }
-    #[cfg(target_os = "linux")]
-    {
-        unsafe extern "C" {
-            fn __clear_cache(start: *mut u8, end: *mut u8);
-        }
-        unsafe { __clear_cache(addr as *mut u8, (addr as *mut u8).add(len)) };
-    }
+    majit_backend::flush_instruction_cache(addr as *const u8, len);
 }
 
 /// Get the raw pointer to an arena buffer's code.

--- a/majit/majit-backend-dynasm/src/codebuf.rs
+++ b/majit/majit-backend-dynasm/src/codebuf.rs
@@ -1,8 +1,9 @@
 //! codebuf.py: Code buffer management.
 //!
 //! In RPython, MachineCodeBlockWrapper wraps rx86 code builders with block
-//! management. Here dynasm emits into a temporary mapping, which is copied
-//! into the CPU's `AsmMemoryManager` to return the final arena-owned buffer.
+//! management. Here dynasm emits into a byte vector (`VecAssembler`), which is
+//! copied into the CPU's `AsmMemoryManager` to return the final arena-owned
+//! buffer (`copy_to_raw_memory`).
 
 /// codebuf.py MachineCodeBlockWrapper
 /// The arena/free-list ownership below is the `MachineCodeBlockWrapper` role.
@@ -57,25 +58,22 @@ impl std::ops::Deref for ArenaExecutableBuffer {
 /// Copy the assembled code into an arena-owned RW block. The caller may patch
 /// backend placeholders before switching the block to RX.
 ///
-/// Relocating finalized code to a different address is only sound while no
-/// relocation encodes an address. dynasm keeps those (`RelToAbs`, `AbsToRel`)
-/// in a private `managed` list and re-applies them when it moves its own
-/// buffer; nothing outside that crate can re-apply them here. This backend
+/// Placing finalized code at an address other than the one it was assembled
+/// for (`VecAssembler::new(0)`) is only sound while no relocation encodes an
+/// address: dynasm resolves those (`RelToAbs`, `AbsToRel`) against the base
+/// address it was given, and nothing here re-applies them. This backend
 /// emits neither kind: aarch64 encodes every jump target PC-relative, and the
 /// x86 emitter uses no `extern` targets and no 8-byte label operands — the two
 /// forms that produce one. `tests/relocation_guard.rs` holds that in place.
 pub fn finalize_writable<R: Relocation>(
-    mut assembler: dynasmrt::Assembler<R>,
+    assembler: dynasmrt::VecAssembler<R>,
     arena: &Arc<AsmMemoryManager>,
 ) -> Result<ArenaExecutableBuffer, BackendError> {
     let len = assembler.offset().0;
-    // Surface relocation errors as an `Err`; `finalize` panics on them.
-    assembler
-        .commit()
+    // Surface relocation errors as an `Err`.
+    let source = assembler
+        .finalize()
         .map_err(|error| BackendError::CompilationFailed(error.to_string()))?;
-    let source = assembler.finalize().map_err(|_| {
-        BackendError::CompilationFailed("assembler is still borrowed by an Executor".to_string())
-    })?;
     let mut block = arena
         .allocate(len, len)
         .map_err(|error| BackendError::CompilationFailed(error.to_string()))?;
@@ -90,7 +88,7 @@ pub fn finalize_writable<R: Relocation>(
 }
 
 pub fn finalize_executable<R: Relocation>(
-    assembler: dynasmrt::Assembler<R>,
+    assembler: dynasmrt::VecAssembler<R>,
     arena: &Arc<AsmMemoryManager>,
 ) -> Result<ArenaExecutableBuffer, BackendError> {
     let mut buffer = finalize_writable(assembler, arena)?;

--- a/majit/majit-backend-dynasm/src/guard.rs
+++ b/majit/majit-backend-dynasm/src/guard.rs
@@ -2,7 +2,6 @@
 /// jump offset (`history.py _attrs_` `adr_jump_offset`) lives on the
 /// metainterp `ResumeGuardDescr` (`majit-metainterp/src/compile.rs`) and
 /// is accessed here via `meta_resume_fd()` forwarding.
-use majit_ir::FailDescr;
 
 // Descr-by-address recovery is now a pure `Arc::from_raw` against the
 // `FailDescrCell` wrapper baked at codegen time —
@@ -70,13 +69,13 @@ pub use majit_backend::llmodel::decode_rd_loc_slot;
 /// answer the trait-default `0` for both methods; the layout pipeline
 /// must read position from the Vec, not from the descr.
 pub fn layout_for_fail_descr(
-    fd: &dyn FailDescr,
+    descr: &majit_ir::DescrRef,
     fail_index: u32,
     trace_id: u64,
 ) -> majit_backend::FailDescrLayout {
-    // resume.py:450-488 propagate rd_* so `compiled_exit_layout_from_backend`
-    // can reach them after the frontend trace cache evicts the owning
-    // `CompiledTrace` entry (pyjitpl.rs).
+    let fd = descr
+        .as_fail_descr()
+        .expect("layout_for_fail_descr requires a Descr that exposes the FailDescr trait");
     let fail_arg_types = fd.fail_arg_types();
     majit_backend::FailDescrLayout {
         fail_index,
@@ -92,10 +91,7 @@ pub fn layout_for_fail_descr(
         // `StoredExitLayout.recovery_layout`).
         recovery_layout: None,
         trace_info: None,
-        rd_numb: fd.rd_numb().map(|s| s.to_vec()),
-        rd_consts: fd.rd_consts().map(|s| s.to_vec()),
-        rd_virtuals: fd.rd_virtuals().map(|s| s.to_vec()),
-        rd_pendingfields: fd.rd_pendingfields().map(|s| s.to_vec()),
+        descr: Some(descr.clone()),
     }
 }
 

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -221,13 +221,13 @@ impl fmt::Display for TracePlanSummary<'_> {
 fn lower_op(op: &Op) -> LirOp {
     match op.opcode {
         OpCode::Label => LirOp::Label {
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
         },
         OpCode::Jump => LirOp::Jump {
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
         },
         OpCode::Finish => LirOp::Finish {
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
         },
         OpCode::IntAdd
         | OpCode::IntAddOvf
@@ -289,7 +289,7 @@ fn lower_op(op: &Op) -> LirOp {
             offset: Some(op.arg(1).to_opref()),
             index: None,
             scale: None,
-            size: op.getarglist().get(2).map(|a| a.to_opref()),
+            size: op.with_arglist(|args| args.get(2).map(|a| a.to_opref())),
         },
         OpCode::GcLoadIndexedI | OpCode::GcLoadIndexedR | OpCode::GcLoadIndexedF
             if op.num_args() >= 5 =>
@@ -342,7 +342,7 @@ fn lower_op(op: &Op) -> LirOp {
         },
         opcode if opcode.is_guard() => LirOp::Guard {
             kind: guard_kind(opcode),
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
             fail_args: op
                 .getfailargs()
                 .map(|fa| fa.iter().map(|a| a.to_opref()).collect())
@@ -351,12 +351,12 @@ fn lower_op(op: &Op) -> LirOp {
         opcode if opcode.is_call() => LirOp::Call {
             opcode,
             dst: result_ref(op),
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
         },
         opcode => LirOp::Opcode {
             opcode,
             dst: result_ref(op),
-            args: op.getarglist().iter().map(|a| a.to_opref()).collect(),
+            args: op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
             fail_args: op
                 .getfailargs()
                 .map(|fa| fa.iter().map(|a| a.to_opref()).collect())

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1908,8 +1908,12 @@ impl<'a> RegAlloc<'a> {
             return;
         }
         let descr_id = op.getdescr().as_ref().map(descr_identity);
-        self.final_jump_args =
-            descr_id.map(|id| (id, op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect())));
+        self.final_jump_args = descr_id.map(|id| {
+            (
+                id,
+                op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
+            )
+        });
         self.final_jump_op_position = (operations.len() - 1) as i32;
         let Some(descr) = op.getdescr() else {
             return;
@@ -3404,7 +3408,8 @@ impl<'a> RegAlloc<'a> {
             }
             // aarch64/regalloc.py prepare_op_cond_call_gc_wb
             OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
-                let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
+                let args: Vec<OpRef> =
+                    op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
                 let mut arglocs = Vec::new();
                 for (idx, arg) in op.getarglist().iter().enumerate() {
                     let arg = arg.to_opref();
@@ -3571,7 +3576,8 @@ impl<'a> RegAlloc<'a> {
             } else {
                 self.make_sure_var_in_reg(y, Type::Int, &[], Some(ECX), false)
             };
-            let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
+            let args: Vec<OpRef> =
+                op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
             let loc1 = self.rm.force_result_in_reg(
                 op.pos.get(),
                 op.arg(0).to_opref(),
@@ -5733,8 +5739,12 @@ impl<'a> RegAlloc<'a> {
     fn consider_jump(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
         // x86/regalloc.py:1306-1309: descr = op.getdescr(); self.jump_target_descr = descr
         let descr_id = op.getdescr().as_ref().map(descr_identity);
-        self.final_jump_args =
-            descr_id.map(|id| (id, op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect())));
+        self.final_jump_args = descr_id.map(|id| {
+            (
+                id,
+                op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect()),
+            )
+        });
         self.jump_target_descr = descr_id;
         let mut locs = Vec::new();
         for arg in op.getarglist().iter() {

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1909,7 +1909,7 @@ impl<'a> RegAlloc<'a> {
         }
         let descr_id = op.getdescr().as_ref().map(descr_identity);
         self.final_jump_args =
-            descr_id.map(|id| (id, op.getarglist().iter().map(|a| a.to_opref()).collect()));
+            descr_id.map(|id| (id, op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect())));
         self.final_jump_op_position = (operations.len() - 1) as i32;
         let Some(descr) = op.getdescr() else {
             return;
@@ -3404,7 +3404,7 @@ impl<'a> RegAlloc<'a> {
             }
             // aarch64/regalloc.py prepare_op_cond_call_gc_wb
             OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
-                let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+                let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
                 let mut arglocs = Vec::new();
                 for (idx, arg) in op.getarglist().iter().enumerate() {
                     let arg = arg.to_opref();
@@ -3493,7 +3493,7 @@ impl<'a> RegAlloc<'a> {
         }
 
         let tp = self.tp(x);
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc = self.rm.force_result_in_reg(
             op.pos.get(),
             x,
@@ -3571,7 +3571,7 @@ impl<'a> RegAlloc<'a> {
             } else {
                 self.make_sure_var_in_reg(y, Type::Int, &[], Some(ECX), false)
             };
-            let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+            let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
             let loc1 = self.rm.force_result_in_reg(
                 op.pos.get(),
                 op.arg(0).to_opref(),
@@ -3588,7 +3588,7 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py int_neg / int_invert / int_is_true / int_is_zero / int_signext
     fn consider_unary_int(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc = self.rm.force_result_in_reg(
             op.pos.get(),
             op.arg(0).to_opref(),
@@ -3949,7 +3949,7 @@ impl<'a> RegAlloc<'a> {
         let tmp = self.fresh_temp_var();
         self.longevity
             .set(tmp, Lifetime::new(self.rm.position, self.rm.position));
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc1 = Loc::Reg(self.rm.force_allocate_reg(
             tmp,
             &args,
@@ -3980,7 +3980,7 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py consider_restore_exception
     fn consider_restore_exception(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc0 = self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
         let loc1 = self.make_sure_var_in_reg(op.arg(1).to_opref(), Type::Ref, &args, None, false);
         self.perform_discard(i, vec![loc0, loc1], output);
@@ -4060,7 +4060,7 @@ impl<'a> RegAlloc<'a> {
     fn consider_same_as(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
         let tp = op.opcode.result_type();
         let arg = op.arg(0).to_opref();
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // aarch64/regalloc.py:880-884
         let argloc = if arg.is_constant() {
             self.rm.convert_to_imm(arg, &self.constants)
@@ -4110,7 +4110,7 @@ impl<'a> RegAlloc<'a> {
             &mut self.fm,
             &self.constants,
         );
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc0 = self.xrm.force_result_in_reg(
             op.pos.get(),
             op.arg(0).to_opref(),
@@ -4156,7 +4156,7 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py float_neg / float_abs
     fn consider_float_unary(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let loc = self.xrm.force_result_in_reg(
             op.pos.get(),
             op.arg(0).to_opref(),
@@ -4291,7 +4291,7 @@ impl<'a> RegAlloc<'a> {
 
     /// Memory load: getarrayitem pattern (2 args → result)
     fn consider_getarrayitem(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
         let index_loc =
@@ -4320,7 +4320,7 @@ impl<'a> RegAlloc<'a> {
 
     /// Memory load: getinteriorfield (3 args → result)
     fn consider_getinteriorfield(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
         let index_loc =
@@ -4526,7 +4526,7 @@ impl<'a> RegAlloc<'a> {
     /// Returns [res_loc, base_loc, index_loc, imm(nsize), imm(ofs)].
     #[cfg(target_arch = "aarch64")]
     fn consider_gc_load_indexed(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // aarch64/regalloc.py:564
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
@@ -4576,7 +4576,7 @@ impl<'a> RegAlloc<'a> {
     /// + result_loc.
     #[cfg(target_arch = "x86_64")]
     fn consider_gc_load_indexed(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // x86/regalloc.py:1175
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
@@ -4622,7 +4622,7 @@ impl<'a> RegAlloc<'a> {
 
     /// Memory store: setfield pattern (2 args: base, value)
     fn consider_setfield(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
         let tp_val = self.tp(op.arg(1).to_opref());
@@ -4646,7 +4646,7 @@ impl<'a> RegAlloc<'a> {
 
     /// Memory store: setarrayitem pattern (3 args: base, index, value)
     fn consider_setarrayitem(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
         let index_loc =
@@ -4785,7 +4785,7 @@ impl<'a> RegAlloc<'a> {
     /// aarch64/regalloc.py prepare_op_gc_store parity.
     /// Returns [value_loc, base_loc, ofs_loc, imm(size)].
     fn consider_gc_store(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // aarch64/regalloc.py:522
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
@@ -4826,7 +4826,7 @@ impl<'a> RegAlloc<'a> {
     /// Returns [value_loc, base_loc, index_loc, imm(size), imm(ofs)].
     #[cfg(target_arch = "aarch64")]
     fn consider_gc_store_indexed(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // aarch64/regalloc.py:554
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
@@ -4873,7 +4873,7 @@ impl<'a> RegAlloc<'a> {
     /// Returns [base_loc, ofs_loc, value_loc, imm(factor), imm(offset), imm(size)].
     #[cfg(target_arch = "x86_64")]
     fn consider_gc_store_indexed(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         // x86/regalloc.py:1129
         let base_loc =
             self.make_sure_var_in_reg(op.arg(0).to_opref(), Type::Ref, &args, None, false);
@@ -5734,7 +5734,7 @@ impl<'a> RegAlloc<'a> {
         // x86/regalloc.py:1306-1309: descr = op.getdescr(); self.jump_target_descr = descr
         let descr_id = op.getdescr().as_ref().map(descr_identity);
         self.final_jump_args =
-            descr_id.map(|id| (id, op.getarglist().iter().map(|a| a.to_opref()).collect()));
+            descr_id.map(|id| (id, op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect())));
         self.jump_target_descr = descr_id;
         let mut locs = Vec::new();
         for arg in op.getarglist().iter() {
@@ -5963,7 +5963,7 @@ impl<'a> RegAlloc<'a> {
 
     /// Discard op with 3 args (zero_array, strsetitem, etc.)
     fn consider_discard_3args(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let mut locs = Vec::new();
         for &arg in &args {
             let tp = self.tp(arg);
@@ -6060,7 +6060,7 @@ impl<'a> RegAlloc<'a> {
     }
 
     fn consider_zero_array(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
-        let args: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
+        let args: Vec<OpRef> = op.with_arglist(|args| args.iter().map(|a| a.to_opref()).collect());
         let mut locs = Vec::with_capacity(args.len());
         for &arg in &args {
             locs.push(self.make_sure_var_in_reg(arg, self.tp(arg), &args, None, false));

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1681,7 +1681,7 @@ impl DynasmBackend {
             asm_memory_manager: Arc::clone(&asm_memory_manager),
             next_trace_id: 1,
             next_header_pc: 0,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             vtable_offset: None,
             descr_attachments: Arc::new(crate::guard::CpuDescrCell::default()),
             arch_cpu_ext: ArchCpuExt::new(asm_memory_manager),
@@ -1710,7 +1710,7 @@ impl DynasmBackend {
             if let Some(bridge) = block.downcast_ref::<CompiledCode>()
                 && bridge.source_guard == Some((source_trace_id, source_fail_index))
             {
-                return codebuf::buffer_ptr(&bridge.buffer) as usize;
+                return bridge.entry_ptr() as usize;
             }
         }
         0
@@ -2502,19 +2502,20 @@ impl Backend for DynasmBackend {
             inputargs,
             &prepared_ops,
         );
-        // assembler.py:793-824 parity: build the per-loop gc_table from
-        // the rewrite's reference-constant list and bake its base before
-        // emission, so `LoadFromGcTable` genops resolve their slot
-        // addresses. Empty list ⇒ no table, base stays 0.
-        let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
-        if let Some(table) = gc_table.as_ref() {
-            asm.set_gc_table_base(table.base_addr());
-        }
+        // `assembler.py assemble_loop`: `reserve_gcref_table(allgcrefs)`
+        // opens the code block with one word per reference constant, and
+        // `patch_gcref_table` fills them in once the block is materialized.
+        asm.reserve_gcref_table(gcrefs.len());
         asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&token.invalidated) as usize);
         let compiled = asm.assemble_loop()?;
 
-        let code_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
+        let rawstart = codebuf::buffer_ptr(&compiled.buffer) as usize;
+        let code_addr = compiled.entry_ptr() as usize;
         let code_size = compiled.buffer.len();
+        // SAFETY: `reserve_gcref_table` reserved `gcrefs.len()` words at
+        // `rawstart`, in the arena block the token's CLT keeps alive.
+        let gc_table =
+            (!gcrefs.is_empty()).then(|| unsafe { majit_gc::GcTable::in_code(rawstart, &gcrefs) });
         let frame_depth = compiled.frame_depth.load(Ordering::Acquire) as i64;
         Self::register_call_assembler_target(token, code_addr);
         self.register_fail_descrs(token, &compiled.fail_descrs);
@@ -2748,13 +2749,9 @@ impl Backend for DynasmBackend {
             inputargs,
             &prepared_ops,
         );
-        // assembler.py:793-824 parity: build the per-loop gc_table from
-        // the rewrite's reference-constant list and bake its base before
-        // emission (same as compile_loop). A bridge gets its own table.
-        let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
-        if let Some(table) = gc_table.as_ref() {
-            asm.set_gc_table_base(table.base_addr());
-        }
+        // `assembler.py assemble_bridge`: `reserve_gcref_table(allgcrefs)`
+        // opens the bridge's own code block (same as compile_loop).
+        asm.reserve_gcref_table(gcrefs.len());
         let bridge_flag = original_token.mint_bridge_invalidation_flag();
         asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&bridge_flag) as usize);
 
@@ -2777,8 +2774,12 @@ impl Backend for DynasmBackend {
         let arglocs = Asm::rebuild_faillocs_from_descr(fail_descr, inputargs);
         let compiled = asm.assemble_bridge(fail_descr, &arglocs)?;
 
-        let bridge_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
+        let rawstart = codebuf::buffer_ptr(&compiled.buffer) as usize;
+        let bridge_addr = compiled.entry_ptr() as usize;
         let code_size = compiled.buffer.len();
+        // SAFETY: as in `compile_loop`.
+        let gc_table =
+            (!gcrefs.is_empty()).then(|| unsafe { majit_gc::GcTable::in_code(rawstart, &gcrefs) });
         if crate::dynasm_exec_diag_enabled() {
             eprintln!(
                 "[dynasm-bridge] trace={trace_id} source={}:{} addr={bridge_addr:#x} len={code_size}",
@@ -2887,7 +2888,7 @@ impl Backend for DynasmBackend {
         // call only guarded top-level entry and missed compiled-to-
         // compiled CALL_ASSEMBLER recursion.
         let compiled = Self::get_compiled(token);
-        let entry = codebuf::buffer_ptr(&compiled.buffer);
+        let entry = compiled.entry_ptr();
 
         // jitframe.py — every JITFRAME carries a non-null JITFRAMEINFO
         // so the bridge-entry `_check_frame_depth` realloc slowpath
@@ -3079,7 +3080,7 @@ impl Backend for DynasmBackend {
         // stack-overflow detection site, so no runner-level probe is
         // needed here.
         let compiled = Self::get_compiled(token);
-        let entry = codebuf::buffer_ptr(&compiled.buffer);
+        let entry = compiled.entry_ptr();
 
         // Same non-null JITFRAMEINFO + `jfi_frame_depth` sizing as
         // `execute_token` (jitframe.py) — the bridge realloc slowpath
@@ -3375,8 +3376,8 @@ impl Backend for DynasmBackend {
                 .frame_depth
                 .fetch_max(new_depth, Ordering::Release);
         }
-        let old_addr = codebuf::buffer_ptr(&old_compiled.buffer);
-        let new_addr = codebuf::buffer_ptr(&new_compiled.buffer);
+        let old_addr = old_compiled.entry_ptr();
+        let new_addr = new_compiled.entry_ptr();
         Asm::redirect_call_assembler(old_addr, new_addr);
         Self::redirect_call_assembler_target(old.number, new_addr as usize);
         Ok(())
@@ -3391,6 +3392,16 @@ impl Backend for DynasmBackend {
         source_fail_index: u32,
     ) -> bool {
         self.lookup_bridge_addr(token, source_trace_id, source_fail_index) != 0
+    }
+
+    /// `patch_pending_failure_recoveries` stamps every assembled guard's
+    /// recovery stub address into `adr_jump_offset`, and `patch_jump_for_descr`
+    /// zeroes it once the guard's jump has been redirected into a bridge. A
+    /// non-zero offset therefore still names the guard's own stub: no bridge.
+    /// Zero is left to the block scan, since a guard that never received a
+    /// stub reads the same way as a patched one.
+    fn bridge_attached(&self, descr: &dyn majit_ir::FailDescr) -> Option<bool> {
+        (descr.adr_jump_offset() != 0).then_some(false)
     }
 
     fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
@@ -3983,7 +3994,7 @@ impl Backend for DynasmBackend {
         let blocks = blocks_clt.asmmemmgr_blocks.lock();
         for block in blocks.iter() {
             if let Some(bridge) = block.downcast_ref::<CompiledCode>() {
-                let addr = codebuf::buffer_ptr(&bridge.buffer) as usize;
+                let addr = bridge.entry_ptr() as usize;
                 if addr == bridge_addr {
                     let bridge_trace_id = bridge.trace_id;
                     return Some(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1696,9 +1696,8 @@ impl DynasmBackend {
     /// `asmmemmgr_blocks` is append-only, so retracing the same guard
     /// leaves multiple matching bridges in place.  Walk in reverse to
     /// return the most recently compiled bridge — that is the one
-    /// `store_bridge_guard_hashes` / `compiled_bridge_fail_descr_layouts`
-    /// just wrote against and the one subsequent guard failures should
-    /// dispatch into.
+    /// `bridge_was_compiled` / `compiled_bridge_fail_descr_layouts` ask
+    /// about and the one subsequent guard failures should dispatch into.
     pub fn lookup_bridge_addr(
         &self,
         token: &JitCellToken,
@@ -2346,81 +2345,6 @@ impl DynasmBackend {
         cell.descr.clone()
     }
 
-    /// Find a descr by (trace_id, fail_index) across root loop + all
-    /// bridges. Used by compile_bridge to locate the exact guard descr
-    /// that failed — RPython passes the faildescr object directly.
-    ///
-    /// Panics if not found — in RPython, the faildescr is the exact
-    /// object, so there is no lookup-miss path. Use `try_find_descr` for
-    /// query-style callers (e.g. `bridge_was_compiled` /
-    /// `compiled_bridge_fail_descr_layouts`) that legitimately probe
-    /// "is this guard already compiled?" and must treat the miss as
-    /// `None` (matching cranelift's `?`-on-miss semantics in
-    /// `compiler.rs`).
-    fn find_descr(token: &JitCellToken, trace_id: u64, fail_index: u32) -> majit_ir::DescrRef {
-        Self::try_find_descr(token, trace_id, fail_index).unwrap_or_else(|| {
-            panic!(
-                "find_descr: (trace_id={}, fail_index={}) not found in \
-                 root loop or any bridge — RPython uses exact faildescr \
-                 object identity, so this lookup must succeed",
-                trace_id, fail_index
-            )
-        })
-    }
-
-    fn try_find_descr(
-        token: &JitCellToken,
-        trace_id: u64,
-        fail_index: u32,
-    ) -> Option<majit_ir::DescrRef> {
-        // Query-style miss tolerance: when `token.compiled` is absent
-        // (e.g. a freshly issued JitCellToken whose backend code has
-        // not been attached, or one rotated into `previous_tokens`),
-        // probing callers like `compiled_bridge_fail_descr_layouts`
-        // must observe `None` instead of a panic.  Cranelift's
-        // counterpart at `compiler.rs`
-        // (`token.compiled.as_ref().and_then(|c|
-        // c.downcast_ref::<CompiledLoop>())?`) follows the same
-        // contract.
-        let compiled = token
-            .compiled
-            .get()?
-            .downcast_ref::<CompiledCode>()
-            .expect("compiled data is not CompiledCode");
-        // RPython looks up the faildescr by object identity (the resume
-        // descr stored on the guard op IS what `cpu.get_latest_descr()`
-        // returns).  Pyre's lookup is `(trace_id, fail_index)`-keyed; the
-        // `trace_id` is always a real allocated id (alloc_trace_id starts
-        // at 1).  No `0 → root_trace_id` sentinel — that path was a
-        // pyre-only deviation removed alongside `normalize_trace_id`.
-        //
-        // `fail_descrs[i].fail_index_per_trace() == i` is enforced at
-        // codegen end (`x86/assembler.rs` and
-        // `aarch64/assembler.rs`); the per-Compiled trace
-        // identity is the `CompiledCode::trace_id` field rather than a
-        // per-descr `trace_id()` read.  Look up by position so the
-        // descr's internal per-emission state is not required —
-        // singleton FINISH descrs share an Arc across emissions and
-        // would otherwise answer `fail_index_per_trace()` / `trace_id()`
-        // with the trait default `0`.
-        if compiled.trace_id == trace_id
-            && let Some(found) = compiled.fail_descrs.get(fail_index as usize)
-        {
-            return Some(found.descr.clone());
-        }
-        let blocks_clt = token.compiled_loop_token_expect();
-        let blocks = blocks_clt.asmmemmgr_blocks.lock();
-        for block in blocks.iter() {
-            if let Some(bridge) = block.downcast_ref::<CompiledCode>()
-                && bridge.trace_id == trace_id
-                && let Some(found) = bridge.fail_descrs.get(fail_index as usize)
-            {
-                return Some(found.descr.clone());
-            }
-        }
-        None
-    }
-
     /// `rpython/jit/backend/x86/assembler.py:599` parity: store
     /// `_ll_function_addr` after the loop is fully assembled and retain the
     /// compiled-loop metadata for GC rewrite callbacks.
@@ -2497,6 +2421,7 @@ impl Backend for DynasmBackend {
         ops: &[OpRc],
         token: &JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         // `x86/assembler.py:514` parity: PyPy creates the
         // `CompiledLoopToken` inside `assemble_loop`, and that's where
         // the `cpu.tracker.total_compiled_loops` bump and the
@@ -2746,6 +2671,7 @@ impl Backend for DynasmBackend {
         _previous_tokens: &[std::sync::Arc<JitCellToken>],
         _caller_recovery_layout: Option<&majit_backend::ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         // `x86/runner.py:100-101` parity:
         //   clt = original_loop_token.compiled_loop_token
         //   clt.compiling_a_bridge()
@@ -2834,23 +2760,16 @@ impl Backend for DynasmBackend {
 
         let _orig_compiled = Self::get_compiled(original_token);
 
-        let guard_descr = Self::find_descr(
-            original_token,
-            fail_descr.trace_id(),
-            fail_descr.fail_index_per_trace(),
-        );
         // `assembler.py assemble_bridge` reads the locations off the
         // `faildescr` it was handed — the descr the guard actually failed on —
-        // and `compile.py ResumeGuardDescr.compile_and_attach` is what hands it
-        // over. `guard_descr` below is a `(trace_id, fail_index)` lookup that
-        // exists for `patch_jump_for_descr`'s `adr_jump_offset`, and it can
-        // answer with a different object than the one that failed.
+        // and patches that same descr's jump below; `compile.py
+        // ResumeGuardDescr.compile_and_attach` is what hands it over.
         //
-        // These two must be the same descr: `jitdriver.rs`
-        // `start_bridge_tracing` takes the bridge's inputarg count from
-        // `fail_descr.fail_arg_types().len()`, while `_update_bindings` zips
-        // that inputarg vector against this location vector. Reading the
-        // locations off the other object let the two lengths disagree —
+        // `jitdriver.rs` `start_bridge_tracing` takes the bridge's inputarg
+        // count from `fail_descr.fail_arg_types().len()`, while
+        // `_update_bindings` zips that inputarg vector against this location
+        // vector, so both must come off the one descr. Reading the locations
+        // off a `(trace_id, fail_index)` lookup let the two lengths disagree —
         // measured on `pyre/bench/fannkuch.py`, 17 inputargs against 15
         // locations — and every inputarg past the shorter list then bound
         // nothing at all (`RegisterManager.loc: box InputArgInt(1844) not
@@ -2894,10 +2813,7 @@ impl Backend for DynasmBackend {
             .fetch_max(bridge_frame_depth as usize, Ordering::Release);
 
         // assembler.py:987 patch_jump_for_descr — redirect guard to bridge.
-        // Use the exact guard descr found above, not a fail_index search.
-        let guard_fd = guard_descr
-            .as_fail_descr()
-            .expect("guard_descr is FailDescr");
+        let guard_fd = fail_descr;
         let ajo = guard_fd.adr_jump_offset();
         if crate::majit_log_enabled() {
             eprintln!(
@@ -3237,7 +3153,7 @@ impl Backend for DynasmBackend {
             });
         }
         let exit_layout = Some(crate::guard::layout_for_fail_descr(
-            descr_fd,
+            &descr,
             descr_fd.fail_index_per_trace(),
             descr_fd.trace_id(),
         ));
@@ -3409,6 +3325,7 @@ impl Backend for DynasmBackend {
     }
 
     fn invalidate_loop(&self, token: &JitCellToken) {
+        let _writing = majit_backend::AssemblerWriting::enter();
         // `model.py:145` activates the guards in the loop AND in its attached
         // bridges. Each bridge's GUARD_NOT_INVALIDATED reads its own
         // generation flag, so storing to the root flag alone would leave every
@@ -3422,6 +3339,7 @@ impl Backend for DynasmBackend {
         old: &JitCellToken,
         new: &JitCellToken,
     ) -> Result<(), BackendError> {
+        let _writing = majit_backend::AssemblerWriting::enter();
         let old_compiled = Self::get_compiled(old);
         let new_compiled = Self::get_compiled(new);
         // x86/assembler.py:1146-1151 update_frame_info parity: propagate
@@ -3466,55 +3384,13 @@ impl Backend for DynasmBackend {
 
     // No migrate_bridges — we patch in place.
 
-    fn store_guard_hashes(&self, token: &JitCellToken, hashes: &[u64]) {
-        let compiled = Self::get_compiled(token);
-        for (i, &hash) in hashes.iter().enumerate() {
-            if let Some(descr) = compiled.fail_descrs.get(i) {
-                // `compile.py` `store_hash` only fires for non-final
-                // `AbstractResumeGuardDescr` whose status is still 0 (no
-                // counter yet stamped).  Route the predicate through the
-                // FailDescr trait so the metainterp class hierarchy
-                // (`final_descr=True` on Done*/Exit*/Propagate) answers.
-                if let Some(fd) = descr.as_fail_descr()
-                    && !fd.is_finish()
-                    && fd.get_status() == 0
-                {
-                    fd.store_hash(hash);
-                }
-            }
-        }
-    }
-
-    fn store_bridge_guard_hashes(
+    fn bridge_was_compiled(
         &self,
         token: &JitCellToken,
         source_trace_id: u64,
         source_fail_index: u32,
-        hashes: &[u64],
-    ) {
-        let bridge_addr = self.lookup_bridge_addr(token, source_trace_id, source_fail_index);
-        if bridge_addr == 0 {
-            return;
-        }
-        let blocks_clt = token.compiled_loop_token_expect();
-        let blocks = blocks_clt.asmmemmgr_blocks.lock();
-        for block in blocks.iter() {
-            if let Some(bridge) = block.downcast_ref::<CompiledCode>() {
-                let addr = codebuf::buffer_ptr(&bridge.buffer) as usize;
-                if addr == bridge_addr {
-                    for (i, &hash) in hashes.iter().enumerate() {
-                        if let Some(descr) = bridge.fail_descrs.get(i)
-                            && let Some(fd) = descr.as_fail_descr()
-                            && !fd.is_finish()
-                            && fd.get_status() == 0
-                        {
-                            fd.store_hash(hash);
-                        }
-                    }
-                    return;
-                }
-            }
-        }
+    ) -> bool {
+        self.lookup_bridge_addr(token, source_trace_id, source_fail_index) != 0
     }
 
     fn bh_new(&self, sizedescr: &majit_translate::jitcode::BhDescr) -> i64 {
@@ -4042,13 +3918,7 @@ impl Backend for DynasmBackend {
                 .fail_descrs
                 .iter()
                 .enumerate()
-                .map(|(idx, d)| {
-                    crate::guard::layout_for_fail_descr(
-                        d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                        idx as u32,
-                        trace_id,
-                    )
-                })
+                .map(|(idx, d)| crate::guard::layout_for_fail_descr(&d.descr, idx as u32, trace_id))
                 .collect(),
         )
     }
@@ -4066,11 +3936,7 @@ impl Backend for DynasmBackend {
                     .iter()
                     .enumerate()
                     .map(|(idx, d)| {
-                        crate::guard::layout_for_fail_descr(
-                            d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                            idx as u32,
-                            trace_id,
-                        )
+                        crate::guard::layout_for_fail_descr(&d.descr, idx as u32, trace_id)
                     })
                     .collect(),
             );
@@ -4088,11 +3954,7 @@ impl Backend for DynasmBackend {
                         .iter()
                         .enumerate()
                         .map(|(idx, d)| {
-                            crate::guard::layout_for_fail_descr(
-                                d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
-                                idx as u32,
-                                trace_id,
-                            )
+                            crate::guard::layout_for_fail_descr(&d.descr, idx as u32, trace_id)
                         })
                         .collect(),
                 );
@@ -4131,7 +3993,7 @@ impl Backend for DynasmBackend {
                             .enumerate()
                             .map(|(idx, d)| {
                                 crate::guard::layout_for_fail_descr(
-                                    d.as_fail_descr().expect("fail_descrs entry is FailDescr"),
+                                    &d.descr,
                                     idx as u32,
                                     bridge_trace_id,
                                 )
@@ -4797,7 +4659,7 @@ mod tests {
         let failed = backend.execute_token(&token, &[Value::Ref(payload)]);
         let guard_fail_index = backend.get_latest_descr(&failed).fail_index();
         let guard_trace_id = backend.get_latest_descr(&failed).trace_id();
-        let guard_descr = DynasmBackend::find_descr(&token, guard_trace_id, guard_fail_index);
+        let guard_descr = backend.get_latest_descr_arc(&failed);
 
         let mut bridge_constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
         bridge_constants.insert(200, return_ref_passthrough as *const () as usize as i64);
@@ -4894,7 +4756,7 @@ mod tests {
         );
         let guard_fail_index = backend.get_latest_descr(&failed).fail_index();
         let guard_trace_id = backend.get_latest_descr(&failed).trace_id();
-        let guard_descr = DynasmBackend::find_descr(&token, guard_trace_id, guard_fail_index);
+        let guard_descr = backend.get_latest_descr_arc(&failed);
 
         backend.set_constants(indexmap::IndexMap::new());
         let field_descr: DescrRef =

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2969,8 +2969,14 @@ impl Backend for DynasmBackend {
             // regardless of whether MAJIT_LOG is set, so emit via plain
             // eprintln (debug_print would silently no-op without
             // MAJIT_LOG and lose the dump).
-            let code = unsafe { std::slice::from_raw_parts(entry, compiled.buffer.len()) };
-            eprintln!("[dynasm] CODE DUMP ({} bytes at {:?}):", code.len(), entry);
+            let rawstart = codebuf::buffer_ptr(&compiled.buffer);
+            let code = unsafe { std::slice::from_raw_parts(rawstart, compiled.buffer.len()) };
+            eprintln!(
+                "[dynasm] CODE DUMP ({} bytes at {:?}, entry {:?}):",
+                code.len(),
+                rawstart,
+                entry
+            );
             for (i, chunk) in code.chunks(4).enumerate() {
                 let word = u32::from_le_bytes([
                     chunk.first().copied().unwrap_or(0),

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -14,7 +14,10 @@ use indexmap::IndexMap;
 use std::sync::Arc;
 
 // x86/assembler.py parity: x86_64-only backend.
-use dynasmrt::x64::Assembler;
+/// `codebuf.py MachineCodeBlockWrapper`: code is assembled into a plain byte
+/// vector (every relocation is PC-relative) and copied into the arena block
+/// at `materialize`; no per-trace executable mapping.
+pub(crate) type Assembler = dynasmrt::VecAssembler<dynasmrt::x64::X64Relocation>;
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
 use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
@@ -370,7 +373,7 @@ pub(crate) fn build_propagate_exception_path(
     cpu_handle: &crate::guard::CpuDescrHandle,
     arena: &Arc<AsmMemoryManager>,
 ) -> (codebuf::ArenaExecutableBuffer, usize) {
-    let mut asm = Assembler::new().expect("propagate_exception_path: new Assembler");
+    let mut asm = Assembler::new(0);
     let propagate_descr = cpu_handle.read().descr_ptrs().propagate_exception_descr as i64;
     assert!(
         propagate_descr != 0,
@@ -453,7 +456,7 @@ pub(crate) fn build_malloc_slowpath_fixed(
     // attrs).  The propagate descr itself is now baked once into the
     // standalone propagate trampoline, not re-baked here.
     let _ = cpu_handle;
-    let mut asm = Assembler::new().expect("malloc_slowpath: new Assembler");
+    let mut asm = Assembler::new(0);
 
     // assembler.py:264 `SUB_rr(edx, ecx)` — recover total_size at
     // runtime.  Both `malloc_cond` and `malloc_cond_varsize_frame`
@@ -477,7 +480,7 @@ pub(crate) fn build_malloc_slowpath_headerless(
     arena: &Arc<AsmMemoryManager>,
 ) -> (codebuf::ArenaExecutableBuffer, usize) {
     let _ = cpu_handle;
-    let mut asm = Assembler::new().expect("malloc_slowpath_headerless: new Assembler");
+    let mut asm = Assembler::new(0);
 
     dynasm!(asm ; .arch x64 ; sub rdx, rcx);
 
@@ -943,12 +946,11 @@ pub struct Assembler386<'a> {
     malloc_slowpath_fixed: usize,
     /// Headerless fixed-size nursery malloc slowpath trampoline.
     malloc_slowpath_headerless: usize,
-    /// `assembler.py` `genop_load_from_gc_table`: base address of
-    /// this loop's per-loop `GcTable` slot array. Baked as a 64-bit
-    /// immediate by the `LoadFromGcTable` genop; 0 when the trace
-    /// references no reference constants. Set before `assemble_loop` /
-    /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
-    gc_table_base: usize,
+    /// `assembler.py reserve_gcref_table`: one label per slot of the
+    /// reference-constant table reserved at the start of this code block,
+    /// which the `LoadFromGcTable` genop reads PC-relative. Empty when the
+    /// trace references no reference constants.
+    gcref_table: Vec<dynasmrt::DynamicLabel>,
     /// Address of the owning `JitCellToken.invalidated` `AtomicBool`
     /// (`history.py:443`). `GUARD_NOT_INVALIDATED` bakes it as a 64-bit
     /// immediate and loads the byte at runtime, branching to its recovery
@@ -1019,6 +1021,14 @@ pub struct CompiledCode {
     pub source_guard: Option<(u64, u32)>,
 }
 
+impl CompiledCode {
+    /// `looptoken._ll_function_addr = rawstart + functionpos`: the first
+    /// instruction, past the reserved gcref table.
+    pub fn entry_ptr(&self) -> *const u8 {
+        self.buffer.ptr(self.entry_offset)
+    }
+}
+
 /// The `genop_*` methods here are line-by-line ports of the RPython emitters
 /// (`x86/assembler.py` `genop_*`).  Emission runs through `regalloc_perform`,
 /// which works from regalloc `arglocs`, so the ports whose opcode that
@@ -1073,7 +1083,7 @@ impl<'a> Assembler386<'a> {
         let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
         Assembler386 {
-            mc: Assembler::new().unwrap(),
+            mc: Assembler::new(0),
             asm_memory_manager,
             pending_guard_tokens: Vec::new(),
             pending_malloc_nursery_gcmap: None,
@@ -1114,17 +1124,27 @@ impl<'a> Assembler386<'a> {
             jump_target_frame_depth: 0,
             malloc_slowpath_fixed,
             malloc_slowpath_headerless,
-            gc_table_base: 0,
+            gcref_table: Vec::new(),
             invalidated_flag_addr: 0,
         }
     }
 
-    /// `assembler.py:793-824` parity: hand the per-loop `GcTable`'s base
-    /// address to the assembler before emission, so `LoadFromGcTable`
-    /// genops bake it as the slot-array base immediate. 0 leaves the
-    /// trace with no reference constants (no `LoadFromGcTable` emitted).
-    pub(crate) fn set_gc_table_base(&mut self, base: usize) {
-        self.gc_table_base = base;
+    /// `assembler.py reserve_gcref_table`: reserve `n` zeroed words,
+    /// padded to a multiple of 16 bytes, at the start of the machine code,
+    /// so the `LoadFromGcTable` genop can address them PC-relative. The
+    /// runner writes the gcrefs into them once the block is materialized
+    /// (`patch_gcref_table`; `GcTable::in_code`). Must run before any
+    /// instruction is emitted.
+    pub(crate) fn reserve_gcref_table(&mut self, n: usize) {
+        assert_eq!(self.mc.offset().0, 0, "the gcref table opens the code block");
+        for _ in 0..n {
+            let slot = self.mc.new_dynamic_label();
+            dynasm!(self.mc ; =>slot ; .u64 0);
+            self.gcref_table.push(slot);
+        }
+        if n % 2 == 1 {
+            dynasm!(self.mc ; .u64 0);
+        }
     }
 
     /// `compile.py:665` parity: heap-pinned address of `self.cpu`'s
@@ -3305,14 +3325,11 @@ impl<'a> Assembler386<'a> {
                     self.regalloc_mov(src, dst);
                 }
             }
-            // `assembler.py:1545` `genop_load_from_gc_table`: load the
-            // reference constant at `gc_table_base + index*WORD`. The
-            // index arrives as an immediate (the `ConstInt(index)` arg
-            // produced by `remove_constptr`); the table base is baked
-            // absolute (x86-32 `MOV_rj` model, `assembler.py:1551-1552`)
-            // because dynasm has no code-buffer-start reservation seam.
-            // The slot value is GC-forwarded in place by the gc_table
-            // root walker, so each load observes the relocated object.
+            // `assembler.py genop_load_from_gc_table`: load the reference
+            // constant from slot `index` of the table reserved at the start
+            // of this code block (`reserve_gcref_table`), PC-relative. The
+            // gc_table root walker forwards the slot in place, so each load
+            // observes the relocated object.
             OpCode::LoadFromGcTable => {
                 let (Some(Loc::Immed(idx)), Some(Loc::Reg(dst))) = (arglocs.first(), result_loc)
                 else {
@@ -3321,15 +3338,11 @@ impl<'a> Assembler386<'a> {
                          got arglocs={arglocs:?} result={result_loc:?}"
                     );
                 };
-                debug_assert_ne!(
-                    self.gc_table_base, 0,
-                    "LoadFromGcTable emitted without a GcTable base"
-                );
-                let slot_addr = self.gc_table_base + (idx.value as usize) * WORD;
-                dynasm!(self.mc ; .arch x64
-                    ; mov Rq(dst.value), QWORD slot_addr as i64
-                    ; mov Rq(dst.value), [Rq(dst.value)]
-                );
+                let slot = *self
+                    .gcref_table
+                    .get(idx.value as usize)
+                    .expect("LoadFromGcTable index inside the reserved gcref table");
+                dynasm!(self.mc ; .arch x64 ; mov Rq(dst.value), [=>slot]);
             }
             // `assembler.py genop_cast_ptr_to_int = _genop_same_as`
             // / `:1529 genop_cast_int_to_ptr = _genop_same_as`.  PyPy's

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -1136,7 +1136,11 @@ impl<'a> Assembler386<'a> {
     /// (`patch_gcref_table`; `GcTable::in_code`). Must run before any
     /// instruction is emitted.
     pub(crate) fn reserve_gcref_table(&mut self, n: usize) {
-        assert_eq!(self.mc.offset().0, 0, "the gcref table opens the code block");
+        assert_eq!(
+            self.mc.offset().0,
+            0,
+            "the gcref table opens the code block"
+        );
         for _ in 0..n {
             let slot = self.mc.new_dynamic_label();
             dynasm!(self.mc ; =>slot ; .u64 0);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2614,7 +2614,7 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
             let meta_descr = op.getdescr();
             // `regalloc.py consider_guard_value` — stamp the per-value
             // counter here, where the native backends stamp it during guard
-            // layout, so `store_guard_hashes`' `status == 0` gate
+            // layout, so the `status == 0` gate of `store_hash`
             // (`compile.py`) leaves it alone and `must_compile` hashes
             // the (guard, failing value) pair. Without it a guard whose failing
             // value never repeats accumulates in one bucket and compiles

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2297,7 +2297,7 @@ fn residual_call_i64_arity(op: &Op, constants: &indexmap::IndexMap<u32, i64>) ->
     }
     // `getarglist()[0]` is the func pointer; the call args are `[1..]`. The
     // descr's `arg_types` describes those call args, so the counts must match.
-    let nargs = op.getarglist().len().saturating_sub(1);
+    let nargs = op.num_args().saturating_sub(1);
     if arg_types.len() != nargs {
         return None;
     }
@@ -2407,7 +2407,7 @@ fn residual_call_typed_sig(
     }
     // `getarglist()[0]` is the func pointer; the call args are `[1..]`. The
     // descr's `arg_types` describes those call args, so the counts must match.
-    let nargs = op.getarglist().len().saturating_sub(1);
+    let nargs = op.num_args().saturating_sub(1);
     if params.len() != nargs {
         return None;
     }
@@ -2448,7 +2448,7 @@ fn residual_call_void_word_arity(
     {
         return None;
     }
-    let nargs = op.getarglist().len().saturating_sub(1);
+    let nargs = op.num_args().saturating_sub(1);
     if arg_types.len() != nargs {
         return None;
     }
@@ -2487,7 +2487,7 @@ fn residual_call_void_true_arity(
     {
         return None;
     }
-    let nargs = op.getarglist().len().saturating_sub(1);
+    let nargs = op.num_args().saturating_sub(1);
     if arg_types.len() != nargs {
         return None;
     }
@@ -7892,7 +7892,7 @@ pub fn is_single_label_peeled(ops: &[Op]) -> bool {
 pub fn label_arg_counts(ops: &[Op]) -> Vec<usize> {
     ops.iter()
         .filter(|op| op.opcode == OpCode::Label)
-        .map(|op| op.getarglist().len())
+        .map(|op| op.num_args())
         .collect()
 }
 

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -873,6 +873,13 @@ pub struct CompiledWasmLoop {
     /// in the eager path.
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     pub(crate) pending_wasm_bytes: RefCell<Option<Vec<u8>>>,
+    /// The owning token metadata receives the guard-descriptor tracer only
+    /// after the host accepts this module. Deferred root traces keep this
+    /// handle until `materialize_func_handle` crosses that acceptance point.
+    pub(crate) compiled_loop_token: Arc<majit_backend::CompiledLoopToken>,
+    /// Serializes the eager and lazy acceptance paths. The wasm runtime is
+    /// single-threaded, matching the surrounding `Cell`/`RefCell` fields.
+    pub(crate) descrs_registered: Cell<bool>,
     /// This loop's own guard/finish exit descriptors (positions `[0,
     /// num_guard_cells)`, per-trace order), followed by the descr slices of
     /// every chained bridge `compile_bridge` appended (positional bookkeeping
@@ -1006,6 +1013,24 @@ impl CompiledWasmLoop {
         self.func_handle.get()
     }
 
+    /// Publish the descriptors only for a module the host can execute.
+    pub(crate) fn register_descrs_once(&self) {
+        if self.descrs_registered.replace(true) {
+            return;
+        }
+        let descrs = self.fail_descrs.borrow();
+        register_fail_descrs(&descrs);
+        let meta: Vec<DescrRef> = descrs
+            .iter()
+            .filter_map(|descr| descr.meta_descr.clone())
+            .collect();
+        let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(meta);
+        self.compiled_loop_token
+            .asmmemmgr_gcreftracers
+            .lock()
+            .push(tracer);
+    }
+
     /// Materialize a lazily-installed root trace.  The wasm host is
     /// single-threaded, matching the RefCell/Cell ownership used throughout
     /// this structure, so one trace can only cross this gate once.
@@ -1032,6 +1057,7 @@ impl CompiledWasmLoop {
                     "wasm host rejected the lazily compiled trace module".into(),
                 ));
             }
+            self.register_descrs_once();
             self.func_handle.set(handle);
             drop(pending);
             self.pending_wasm_bytes.borrow_mut().take();

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -940,8 +940,8 @@ pub struct CompiledWasmLoop {
     pub bridge_param_dispatch: bool,
     /// `(source_trace_id, source_fail_index, start, count)` ranges into
     /// `fail_descrs` for each chained bridge `compile_bridge` appended (lib.rs
-    /// extend site). Lets `compiled_bridge_fail_descr_layouts` /
-    /// `store_bridge_guard_hashes` map a source guard back to its bridge's
+    /// extend site). Lets `compiled_bridge_fail_descr_layouts` map a source
+    /// guard back to its bridge's
     /// appended descr slice — the wasm analog of dynasm's
     /// `lookup_bridge_addr` (runner.rs). Keyed by BOTH the source guard's
     /// owning trace and its per-trace fail index: with nested chaining, the

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2600,6 +2600,22 @@ impl WasmBackend {
     /// per-loop table alive for as long as the compiled trace that bakes its
     /// base address. `LIVE_GC_TABLES` holds only a `Weak`, so this strong
     /// reference is what keeps the slots rooted and forwardable.
+    /// `assembler.py gcreftracers.append(tracer)`: pin the metainterp descr
+    /// Arcs this compiled code's guards dereference onto the owning
+    /// `CompiledLoopToken.asmmemmgr_gcreftracers` (`model.py`), the same
+    /// `Vec<DescrRef>` tracer shape cranelift registers.  The frontend
+    /// keeps no per-bridge record (`compile.py send_bridge_to_backend`), so
+    /// this tracer is where the GC root walker reaches a bridge guard's
+    /// `rd_consts`, and what keeps the descr alive for the token's lifetime.
+    fn register_meta_descrs(token: &JitCellToken, descrs: &[Arc<WasmFailDescr>]) {
+        if let Some(clt) = token.compiled_loop_token() {
+            let meta: Vec<majit_ir::descr::DescrRef> =
+                descrs.iter().filter_map(|d| d.meta_descr.clone()).collect();
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = Arc::new(meta);
+            clt.asmmemmgr_gcreftracers.lock().push(tracer);
+        }
+    }
+
     fn register_gc_table(token: &JitCellToken, table: Arc<majit_gc::GcTable>) {
         if let Some(clt) = token.compiled_loop_token() {
             let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
@@ -2899,6 +2915,7 @@ impl WasmBackend {
         replacement_descrs.extend(chained_descrs);
         *compiled.fail_descrs.borrow_mut() = replacement_descrs;
         register_fail_descrs(&descrs);
+        Self::register_meta_descrs(token, &descrs);
         let guard_growth = guard_exits.len().saturating_sub(old_guard_count);
         if guard_growth != 0 {
             for (_, _, start, _) in compiled.bridge_descr_ranges.borrow_mut().iter_mut() {
@@ -3838,6 +3855,7 @@ impl majit_backend::Backend for WasmBackend {
             })
             .collect();
         register_fail_descrs(&fail_descrs);
+        Self::register_meta_descrs(token, &fail_descrs);
         if let Some(table) = gc_table {
             Self::register_gc_table(token, table);
         }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3854,8 +3854,6 @@ impl majit_backend::Backend for WasmBackend {
                 })
             })
             .collect();
-        register_fail_descrs(&fail_descrs);
-        Self::register_meta_descrs(token, &fail_descrs);
         if let Some(table) = gc_table {
             Self::register_gc_table(token, table);
         }
@@ -3955,6 +3953,8 @@ impl majit_backend::Backend for WasmBackend {
             input_types: inputargs.iter().map(|ia| ia.tp).collect(),
             func_handle: std::cell::Cell::new(func_handle),
             pending_wasm_bytes: std::cell::RefCell::new(defer_host_compile.then_some(wasm_bytes)),
+            compiled_loop_token: token.compiled_loop_token_expect(),
+            descrs_registered: std::cell::Cell::new(false),
             fail_descrs: std::cell::RefCell::new(fail_descrs),
             num_inputs: inputargs.len(),
             max_output_slots,
@@ -4003,6 +4003,12 @@ impl majit_backend::Backend for WasmBackend {
             .get()
             .and_then(|compiled| compiled.downcast_ref::<CompiledWasmLoop>())
             .expect("newly compiled wasm loop is missing");
+        // Native builds accept the encoded module as a test artifact. On the
+        // real wasm host, eager compilation crossed the acceptance check
+        // above; a deferred trace registers from `materialize_func_handle`.
+        if !defer_host_compile || cfg!(not(target_arch = "wasm32")) {
+            compiled.register_descrs_once();
+        }
         // For a pending self target this is the exact map already embedded in
         // the module's CA arm. Reuse it for the published metadata so the
         // loop and its self-callee have demonstrably identical geometry. A
@@ -4821,9 +4827,6 @@ impl majit_backend::Backend for WasmBackend {
                 })
             })
             .collect();
-        register_fail_descrs(&bridge_descrs);
-        Self::register_meta_descrs(original_token, &bridge_descrs);
-
         // Register the bridge module into the shared table, then publish its
         // descrs and flip the source guard's cell. Order matters: the descrs
         // must be resolvable (appended) before the cell makes the guard dispatch
@@ -4844,6 +4847,11 @@ impl majit_backend::Backend for WasmBackend {
                     .to_string(),
             ));
         }
+        // The host accepted the bridge. Only now publish its global exit
+        // descriptors and attach their resume-data tracer to the source CLT;
+        // a rejected module can never execute and must retain neither.
+        register_fail_descrs(&bridge_descrs);
+        Self::register_meta_descrs(original_token, &bridge_descrs);
         // Past every path that can fail with no module published: from here the
         // probe exists and its callback owns the pending entry.
         pending_guard.disarm();

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4822,6 +4822,7 @@ impl majit_backend::Backend for WasmBackend {
             })
             .collect();
         register_fail_descrs(&bridge_descrs);
+        Self::register_meta_descrs(original_token, &bridge_descrs);
 
         // Register the bridge module into the shared table, then publish its
         // descrs and flip the source guard's cell. Order matters: the descrs

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4886,9 +4886,7 @@ impl majit_backend::Backend for WasmBackend {
             // Append the bridge's exit descrs to the source loop's flat
             // `fail_descrs` and record the slice they occupy, keyed by the
             // source guard's `fail_index`. `compiled_bridge_fail_descr_layouts`
-            // / `store_bridge_guard_hashes` use that range to stamp jitcounter
-            // hashes onto these bridge-internal guards (compile.py:826-830
-            // store_hash). `start` is captured inside the same `borrow_mut`
+            // maps a source guard back to that range. `start` is captured inside the same `borrow_mut`
             // critical section as the `extend`, so the range stays in lockstep
             // with the vec.
             let count = bridge_descrs.len();
@@ -5063,10 +5061,7 @@ impl majit_backend::Backend for WasmBackend {
                         .unwrap_or(false),
                     recovery_layout: None,
                     frame_stack: None,
-                    rd_numb: meta.and_then(|fd| fd.rd_numb().map(|s| s.to_vec())),
-                    rd_consts: meta.and_then(|fd| fd.rd_consts().map(|s| s.to_vec())),
-                    rd_virtuals: meta.and_then(|fd| fd.rd_virtuals().map(|s| s.to_vec())),
-                    rd_pendingfields: meta.and_then(|fd| fd.rd_pendingfields().map(|s| s.to_vec())),
+                    descr: wfd.meta_descr.clone(),
                 }
             })
             .collect();
@@ -5074,36 +5069,10 @@ impl majit_backend::Backend for WasmBackend {
     }
 
     /// `compile.py` store_hash: stamp the jitcounter hashes assigned by
-    /// `assign_guard_hashes` onto each guard's metainterp `ResumeGuardDescr`
-    /// (`meta_descr`) — the descr `must_compile_with_values` reads the status
-    /// from. Same `ResumeDescr`-family + status-0 gate as the native backends.
-    fn store_guard_hashes(&self, token: &JitCellToken, hashes: &[u64]) {
-        let Some(compiled) = token
-            .compiled
-            .get()
-            .and_then(|c| c.downcast_ref::<CompiledWasmLoop>())
-        else {
-            return;
-        };
-        let descrs = compiled.fail_descrs.borrow();
-        for (i, &hash) in hashes.iter().enumerate() {
-            let Some(wfd) = descrs.get(i) else { break };
-            let Some(meta) = wfd.meta_descr.as_ref().and_then(|m| m.as_fail_descr()) else {
-                continue;
-            };
-            if (meta.is_resume_guard() || meta.is_resume_guard_copied()) && meta.get_status() == 0 {
-                meta.store_hash(hash);
-            }
-        }
-    }
-
-    /// `compile.py` store_hash for the guards INSIDE a compiled bridge.
     /// `compile_bridge` appends a bridge's exit descrs to the source loop's flat
     /// `fail_descrs` and records their `(source_fail_index, start, count)` slice
-    /// in `bridge_descr_ranges`. Return one layout per descr in that slice so
-    /// `assign_bridge_guard_hashes` stamps a jitcounter hash on each non-finish
-    /// bridge guard — without it they stay status 0 and collide in jitcounter
-    /// bucket 0. `fail_index` is the 0-based position within the bridge's own
+    /// in `bridge_descr_ranges`. Return one layout per descr in that slice.
+    /// `fail_index` is the 0-based position within the bridge's own
     /// exit list (matching the bridge's frontend `exit_layouts` keying and the
     /// native backends' `compiled_bridge_fail_descr_layouts`); `trace_id` is the
     /// bridge's own id, stamped on each appended `WasmFailDescr`.
@@ -5144,58 +5113,11 @@ impl majit_backend::Backend for WasmBackend {
                         .unwrap_or(false),
                     recovery_layout: None,
                     frame_stack: None,
-                    rd_numb: meta.and_then(|fd| fd.rd_numb().map(|s| s.to_vec())),
-                    rd_consts: meta.and_then(|fd| fd.rd_consts().map(|s| s.to_vec())),
-                    rd_virtuals: meta.and_then(|fd| fd.rd_virtuals().map(|s| s.to_vec())),
-                    rd_pendingfields: meta.and_then(|fd| fd.rd_pendingfields().map(|s| s.to_vec())),
+                    descr: wfd.meta_descr.clone(),
                 }
             })
             .collect();
         Some(layouts)
-    }
-
-    /// `compile.py` store_hash: stamp the hashes `assign_bridge_guard_hashes`
-    /// assigned onto the metainterp `ResumeGuardDescr` of each guard inside the
-    /// bridge attached at `source_fail_index`. Same `ResumeDescr`-family +
-    /// status-0 gate as `store_guard_hashes`; iterates the same slice in the
-    /// same order as `compiled_bridge_fail_descr_layouts` so the hash vector
-    /// lines up positionally.
-    fn store_bridge_guard_hashes(
-        &self,
-        token: &JitCellToken,
-        source_trace_id: u64,
-        source_fail_index: u32,
-        hashes: &[u64],
-    ) {
-        let Some(compiled) = token
-            .compiled
-            .get()
-            .and_then(|c| c.downcast_ref::<CompiledWasmLoop>())
-        else {
-            return;
-        };
-        let Some((start, _count)) = compiled
-            .bridge_descr_ranges
-            .borrow()
-            .iter()
-            .rev()
-            .find(|r| r.0 == source_trace_id && r.1 == source_fail_index)
-            .map(|&(_, _, start, count)| (start, count))
-        else {
-            return;
-        };
-        let descrs = compiled.fail_descrs.borrow();
-        for (i, &hash) in hashes.iter().enumerate() {
-            let Some(wfd) = descrs.get(start + i) else {
-                break;
-            };
-            let Some(meta) = wfd.meta_descr.as_ref().and_then(|m| m.as_fail_descr()) else {
-                continue;
-            };
-            if (meta.is_resume_guard() || meta.is_resume_guard_copied()) && meta.get_status() == 0 {
-                meta.store_hash(hash);
-            }
-        }
     }
 
     fn execute_token(&self, token: &JitCellToken, args: &[Value]) -> DeadFrame {

--- a/majit/majit-backend/Cargo.toml
+++ b/majit/majit-backend/Cargo.toml
@@ -13,5 +13,8 @@ majit-gc = { workspace = true }
 indexmap = { workspace = true }
 parking_lot = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
 region = { workspace = true }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -592,8 +592,9 @@ impl JitFrameDeadFrame {
     #[inline]
     fn slot_of(&self, index: usize) -> Option<usize> {
         let descr = self.fail_descr.as_fail_descr();
-        if index < descr.rd_locs().len() {
-            crate::llmodel::decode_rd_loc_slot(descr, index)
+        let locs = descr.rd_locs();
+        if let Some(&pos) = locs.get(index) {
+            (pos != 0xFFFF).then_some(pos as usize)
         } else {
             Some(index)
         }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2162,65 +2162,11 @@ impl AsmLargeBlock {
     }
 }
 
-// `rmmap.py` `Nester`: the depth of `enter_assembler_writing` brackets on
-// this thread. `pthread_jit_write_protect_np` is per-thread state, so the
-// counter is too.
+/// `rmmap.py` `enter_assembler_writing` / `leave_assembler_writing` and the
+/// bracket guard live in `majit_gc::rmmap`, shared with the reference-constant
+/// tracer (`gcreftracer.py` `gcrefs_trace`).
 #[cfg(not(target_arch = "wasm32"))]
-thread_local! {
-    static ASSEMBLER_WRITING_DEPTH: Cell<usize> = const { Cell::new(0) };
-}
-
-/// `rmmap.py` `enter_assembler_writing`: on darwin/arm64 switch this thread's
-/// `MAP_JIT` pages from executable to writable; elsewhere the JIT mapping is
-/// RWX and this only counts the bracket.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn enter_assembler_writing() {
-    ASSEMBLER_WRITING_DEPTH.with(|depth| {
-        if depth.get() == 0 {
-            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-            unsafe {
-                libc::pthread_jit_write_protect_np(0);
-            }
-        }
-        depth.set(depth.get() + 1);
-    });
-}
-
-/// `rmmap.py` `leave_assembler_writing`.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn leave_assembler_writing() {
-    ASSEMBLER_WRITING_DEPTH.with(|depth| {
-        depth.set(depth.get() - 1);
-        if depth.get() == 0 {
-            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-            unsafe {
-                libc::pthread_jit_write_protect_np(1);
-            }
-        }
-    });
-}
-
-/// The `try: ... finally: rmmap.leave_assembler_writing()` bracket
-/// (`aarch64/assembler.py` `assemble_loop`, `assemble_bridge`,
-/// `redirect_call_assembler`; `aarch64/runner.py` `invalidate_loop`) as a
-/// guard, so every return path leaves.
-#[cfg(not(target_arch = "wasm32"))]
-pub struct AssemblerWriting(());
-
-#[cfg(not(target_arch = "wasm32"))]
-impl AssemblerWriting {
-    pub fn enter() -> Self {
-        enter_assembler_writing();
-        Self(())
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Drop for AssemblerWriting {
-    fn drop(&mut self) {
-        leave_assembler_writing();
-    }
-}
+pub use majit_gc::rmmap::{AssemblerWriting, enter_assembler_writing, leave_assembler_writing};
 
 /// `rpython/jit/backend/llsupport/asmmemmgr.py:10-145`.
 ///
@@ -2876,6 +2822,15 @@ pub trait Backend: Send {
     ) -> bool {
         self.compiled_bridge_fail_descr_layouts(token, source_trace_id, source_fail_index)
             .is_some()
+    }
+
+    /// The same question asked of the guard's own descr, which is where the
+    /// backend records the attach: `patch_jump_for_descr` leaves
+    /// `faildescr.adr_jump_offset = 0` ("patched") on a guard whose jump now
+    /// targets a bridge. `None` when this backend keeps no per-descr mark, in
+    /// which case the caller falls back to [`Backend::bridge_was_compiled`].
+    fn bridge_attached(&self, _descr: &dyn majit_ir::FailDescr) -> Option<bool> {
+        None
     }
 
     /// Execute compiled code starting at the given token.

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2313,10 +2313,17 @@ impl AsmMemoryManagerInner {
         self.free_blocks.remove(&start);
         self.free_blocks_end.remove(&stop);
 
-        let allocated_stop = start + length;
-        if stop - allocated_stop >= ASM_MIN_FRAGMENT {
-            self.add_free_block(allocated_stop, stop);
-        }
+        let requested_stop = start + length;
+        let allocated_stop = if stop - requested_stop >= ASM_MIN_FRAGMENT {
+            self.add_free_block(requested_stop, stop);
+            requested_stop
+        } else {
+            // asmmemmgr.py `malloc`: a remainder below MIN_FRAGMENT stays
+            // part of the returned allocation.  Returning `requested_stop`
+            // here would lose that tail from both the live block and the free
+            // maps, preventing the two neighbours from coalescing on drop.
+            stop
+        };
         let mapped = (newly_mapped.is_some()).then_some(stop - start);
         Ok((start, allocated_stop, mapped))
     }
@@ -3036,7 +3043,7 @@ pub trait Backend: Send {
             is_exception_exit: descr.is_exit_frame_with_exception(),
             recovery_layout: None,
             frame_stack: None,
-            descr: None,
+            descr: Some(self.get_latest_descr_arc(frame)),
         })
     }
 
@@ -4637,6 +4644,24 @@ mod tests {
         assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 300));
         drop(second);
         assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 0));
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn asm_memory_manager_returns_unsplittable_tail_with_block() {
+        let stats = Arc::new(AsmMemoryManagerStats::default());
+        let manager = AsmMemoryManager::new_isolated(stats);
+
+        let requested = ASM_LARGE_ALLOC_SIZE - (ASM_MIN_FRAGMENT / 2);
+        let block = manager.allocate_aligned(requested, requested, 1).unwrap();
+        let start = block.ptr();
+        assert_eq!(block.capacity(), ASM_LARGE_ALLOC_SIZE);
+        drop(block);
+
+        // Dropping the owner returns the complete mapping, so the next block
+        // starts at the same address instead of leaving a permanent gap.
+        let reused = manager.allocate_aligned(128, 128, 1).unwrap();
+        assert_eq!(reused.ptr(), start);
     }
 
     #[test]

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -87,9 +87,9 @@ pub use finish_descrs::{
 pub use jitframe::JitFrameInfo;
 pub use rd_payload::RdPayload;
 pub use resume_guard_descr::{
-    ResumeGuardDescr, STATUS_BUSY_FLAG, STATUS_SHIFT, STATUS_SHIFT_MASK, STATUS_TY_FLOAT,
-    STATUS_TY_INT, STATUS_TY_NONE, STATUS_TY_REF, STATUS_TYPE_MASK, alloc_fail_index,
-    build_vector_info_chain, flatten_vector_info, guard_value_counter_slot,
+    BridgeDispatchCells, ResumeGuardDescr, STATUS_BUSY_FLAG, STATUS_SHIFT, STATUS_SHIFT_MASK,
+    STATUS_TY_FLOAT, STATUS_TY_INT, STATUS_TY_NONE, STATUS_TY_REF, STATUS_TYPE_MASK,
+    alloc_fail_index, build_vector_info_chain, flatten_vector_info, guard_value_counter_slot,
     make_resume_guard_descr_typed, push_vector_info, reset_fail_index_counter,
 };
 pub use resume_value::{

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -789,17 +789,10 @@ pub struct FailDescrLayout {
     /// Complete frame stack from innermost (this guard's frame) to outermost.
     /// Present when multi-frame reconstruction is supported.
     pub frame_stack: Option<Vec<ExitFrameLayout>>,
-    /// resume.py:450 — compact resume numbering (varint-encoded tagged values).
-    /// Propagated from the backend's fail descriptor so the frontend can
-    /// reconstruct the blackhole chain after a trace's `CompiledTrace` entry
-    /// has been evicted but the descriptor itself is still live.
-    pub rd_numb: Option<Vec<u8>>,
-    /// resume.py:451 — shared constant pool referenced by `rd_numb`.
-    pub rd_consts: Option<Vec<Const>>,
-    /// resume.py:488 — virtual object field info referenced by `rd_numb`.
-    pub rd_virtuals: Option<Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>>,
-    /// Deferred heap writes associated with this guard exit.
-    pub rd_pendingfields: Option<Vec<majit_ir::GuardPendingFieldEntry>>,
+    /// `cpu.get_latest_descr(deadframe)`: the exit's own descr. The resume
+    /// payload is read off it (`ResumeGuardDescr.get_resumestorage`), never
+    /// copied into the layout. `None` for a synthetic exit that has no descr.
+    pub descr: Option<majit_ir::DescrRef>,
 }
 
 /// Static layout metadata for a terminal exit within a compiled trace.
@@ -2107,6 +2100,127 @@ const ASM_LARGE_ALLOC_SIZE: usize = 1024 * 1024;
 const ASM_MIN_FRAGMENT: usize = 64;
 #[cfg(not(target_arch = "wasm32"))]
 const ASM_NUM_INDICES: usize = 32;
+/// `asmmemmgr.py` `BlockBuilderMixin.ALIGN_MATERIALIZE`: `materialize`
+/// over-allocates by `align - 1` and rounds the start up inside the block.
+#[cfg(not(target_arch = "wasm32"))]
+const ASM_ALIGN_MATERIALIZE: usize = 16;
+
+/// `rmmap.py` `alloc_hinted`: one large JIT mapping, `PROT_EXEC | PROT_READ |
+/// PROT_WRITE`, `MAP_JIT` on darwin/arm64. Blocks of different lifetimes share
+/// it back to back, so the mapping is never re-protected; on darwin/arm64 the
+/// per-thread `pthread_jit_write_protect_np` toggle in
+/// [`enter_assembler_writing`] is what separates writing from executing.
+#[cfg(all(unix, not(target_arch = "wasm32")))]
+struct AsmLargeBlock {
+    start: usize,
+    size: usize,
+}
+
+#[cfg(all(unix, not(target_arch = "wasm32")))]
+impl AsmLargeBlock {
+    fn map(size: usize) -> io::Result<Self> {
+        #[allow(unused_mut)]
+        let mut flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            flags |= libc::MAP_JIT;
+        }
+        let prot = libc::PROT_EXEC | libc::PROT_READ | libc::PROT_WRITE;
+        let ptr = unsafe { libc::mmap(std::ptr::null_mut(), size, prot, flags, -1, 0) };
+        if ptr == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            start: ptr as usize,
+            size,
+        })
+    }
+}
+
+#[cfg(all(unix, not(target_arch = "wasm32")))]
+impl Drop for AsmLargeBlock {
+    fn drop(&mut self) {
+        unsafe { libc::munmap(self.start as *mut libc::c_void, self.size) };
+    }
+}
+
+#[cfg(windows)]
+struct AsmLargeBlock {
+    start: usize,
+    _allocation: region::Allocation,
+}
+
+#[cfg(windows)]
+impl AsmLargeBlock {
+    fn map(size: usize) -> io::Result<Self> {
+        let mut allocation = region::alloc(size, region::Protection::READ_WRITE_EXECUTE)
+            .map_err(io::Error::other)?;
+        Ok(Self {
+            start: allocation.as_mut_ptr::<u8>() as usize,
+            _allocation: allocation,
+        })
+    }
+}
+
+// `rmmap.py` `Nester`: the depth of `enter_assembler_writing` brackets on
+// this thread. `pthread_jit_write_protect_np` is per-thread state, so the
+// counter is too.
+#[cfg(not(target_arch = "wasm32"))]
+thread_local! {
+    static ASSEMBLER_WRITING_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// `rmmap.py` `enter_assembler_writing`: on darwin/arm64 switch this thread's
+/// `MAP_JIT` pages from executable to writable; elsewhere the JIT mapping is
+/// RWX and this only counts the bracket.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn enter_assembler_writing() {
+    ASSEMBLER_WRITING_DEPTH.with(|depth| {
+        if depth.get() == 0 {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            unsafe {
+                libc::pthread_jit_write_protect_np(0);
+            }
+        }
+        depth.set(depth.get() + 1);
+    });
+}
+
+/// `rmmap.py` `leave_assembler_writing`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn leave_assembler_writing() {
+    ASSEMBLER_WRITING_DEPTH.with(|depth| {
+        depth.set(depth.get() - 1);
+        if depth.get() == 0 {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            unsafe {
+                libc::pthread_jit_write_protect_np(1);
+            }
+        }
+    });
+}
+
+/// The `try: ... finally: rmmap.leave_assembler_writing()` bracket
+/// (`aarch64/assembler.py` `assemble_loop`, `assemble_bridge`,
+/// `redirect_call_assembler`; `aarch64/runner.py` `invalidate_loop`) as a
+/// guard, so every return path leaves.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct AssemblerWriting(());
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AssemblerWriting {
+    pub fn enter() -> Self {
+        enter_assembler_writing();
+        Self(())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for AssemblerWriting {
+    fn drop(&mut self) {
+        leave_assembler_writing();
+    }
+}
 
 /// `rpython/jit/backend/llsupport/asmmemmgr.py:10-145`.
 ///
@@ -2124,15 +2238,15 @@ pub struct AsmMemoryManager {
 
 #[cfg(not(target_arch = "wasm32"))]
 struct AsmMemoryManagerInner {
-    allocations: Vec<region::Allocation>,
+    allocations: Vec<AsmLargeBlock>,
     allocation_ranges: Vec<(usize, usize)>,
     free_blocks: BTreeMap<usize, usize>,
     free_blocks_end: BTreeMap<usize, usize>,
     blocks_by_size: Vec<Vec<usize>>,
 }
 
-// `region::Allocation` is an owning handle to an OS mapping. Moving that
-// handle does not move the mapping or change its thread affinity; Cranelift's
+// `AsmLargeBlock` is an owning handle to an OS mapping. Moving that handle
+// does not move the mapping or change its thread affinity; Cranelift's
 // upstream `ArenaMemoryProvider` makes the same `unsafe impl Send` assertion.
 #[cfg(not(target_arch = "wasm32"))]
 unsafe impl Send for AsmMemoryManagerInner {}
@@ -2210,9 +2324,8 @@ impl AsmMemoryManagerInner {
             .ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "JIT arena size overflow")
             })?;
-        let mut allocation =
-            region::alloc(size, region::Protection::READ_WRITE).map_err(io::Error::other)?;
-        let start = allocation.as_mut_ptr::<u8>() as usize;
+        let allocation = AsmLargeBlock::map(size)?;
+        let start = allocation.start;
         let stop = start + size;
         self.allocations.push(allocation);
         self.allocation_ranges.push((start, stop));
@@ -2287,27 +2400,41 @@ impl AsmMemoryManager {
         &self.stats
     }
 
-    /// Allocate one page-isolated range. Page isolation is the W^X adaptation
-    /// needed when compiled blocks with different lifetimes share an arena.
+    /// `asmmemmgr.py` `malloc(minsize, maxsize)` as `materialize` calls it:
+    /// `size` bytes plus `ALIGN_MATERIALIZE - 1` of slack, the start rounded
+    /// up to the alignment inside the block. Blocks sit back to back in the
+    /// RWX mapping; nothing is padded to a page.
     pub fn allocate(self: &Arc<Self>, size: usize, used: usize) -> io::Result<AsmMemoryBlock> {
+        self.allocate_aligned(size, used, ASM_ALIGN_MATERIALIZE)
+    }
+
+    /// [`Self::allocate`] with the caller's alignment in place of
+    /// `ALIGN_MATERIALIZE`.
+    pub fn allocate_aligned(
+        self: &Arc<Self>,
+        size: usize,
+        used: usize,
+        align: usize,
+    ) -> io::Result<AsmMemoryBlock> {
         if used > size {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "JIT used size exceeds requested allocation",
             ));
         }
-        let page_size = region::page::size();
-        let capacity = size
-            .max(1)
-            .checked_add(page_size - 1)
-            .map(|value| value / page_size * page_size)
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "JIT block size overflow")
-            })?;
+        if !align.is_power_of_two() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "JIT alignment must be a power of two",
+            ));
+        }
+        let length = size.max(1).checked_add(align - 1).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "JIT block size overflow")
+        })?;
         let total = PROCESS_ASM_MEMORY_STATS
             .total_memory_allocated
             .load(Ordering::Relaxed);
-        let (start, stop, mapped) = self.inner.lock().allocate_block(capacity, total)?;
+        let (start, stop, mapped) = self.inner.lock().allocate_block(length, total)?;
         if let Some(mapped) = mapped {
             self.stats
                 .total_memory_allocated
@@ -2316,18 +2443,8 @@ impl AsmMemoryManager {
                 .total_memory_allocated
                 .fetch_add(mapped, Ordering::Relaxed);
         }
-        let protection_result = unsafe {
-            region::protect(
-                start as *const u8,
-                stop - start,
-                region::Protection::READ_WRITE,
-            )
-            .map_err(io::Error::other)
-        };
-        if let Err(error) = protection_result {
-            self.inner.lock().add_free_block(start, stop);
-            return Err(error);
-        }
+        // `materialize`: `rawstart = (rawstart + align - 1) & (-align)`.
+        let pad = start.next_multiple_of(align) - start;
         self.stats.total_mallocs.fetch_add(used, Ordering::Relaxed);
         PROCESS_ASM_MEMORY_STATS
             .total_mallocs
@@ -2339,6 +2456,7 @@ impl AsmMemoryManager {
                 manager: Arc::clone(self),
                 start,
                 stop,
+                pad,
             },
         })
     }
@@ -2353,8 +2471,10 @@ enum AsmMemoryBlockStorage {
     #[cfg(not(target_arch = "wasm32"))]
     Arena {
         manager: Arc<AsmMemoryManager>,
+        /// The range handed back to the free list; code starts `pad` bytes in.
         start: usize,
         stop: usize,
+        pad: usize,
     },
 }
 
@@ -2371,7 +2491,7 @@ impl AsmMemoryBlock {
     pub fn ptr(&self) -> *const u8 {
         match self.storage {
             AsmMemoryBlockStorage::AccountingOnly => std::ptr::null(),
-            AsmMemoryBlockStorage::Arena { start, .. } => start as *const u8,
+            AsmMemoryBlockStorage::Arena { start, pad, .. } => (start + pad) as *const u8,
         }
     }
 
@@ -2387,7 +2507,9 @@ impl AsmMemoryBlock {
         match self.storage {
             AsmMemoryBlockStorage::AccountingOnly => self.used,
             #[cfg(not(target_arch = "wasm32"))]
-            AsmMemoryBlockStorage::Arena { start, stop, .. } => stop - start,
+            AsmMemoryBlockStorage::Arena {
+                start, stop, pad, ..
+            } => stop - start - pad,
         }
     }
 
@@ -2396,41 +2518,41 @@ impl AsmMemoryBlock {
         let address = ptr as usize;
         match self.storage {
             AsmMemoryBlockStorage::AccountingOnly => false,
-            AsmMemoryBlockStorage::Arena { start, stop, .. } => start <= address && address < stop,
+            AsmMemoryBlockStorage::Arena {
+                start, stop, pad, ..
+            } => start + pad <= address && address < stop,
         }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        let AsmMemoryBlockStorage::Arena { start, stop, .. } = self.storage else {
+        let AsmMemoryBlockStorage::Arena { .. } = self.storage else {
             panic!("accounting-only assembler block has no storage")
         };
-        unsafe { std::slice::from_raw_parts_mut(start as *mut u8, stop - start) }
+        unsafe { std::slice::from_raw_parts_mut(self.ptr() as *mut u8, self.capacity()) }
     }
 
+    /// The mapping is RWX for its whole life (`rmmap.py` `alloc_hinted`);
+    /// there is no per-block protection to change.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn make_read_only(&mut self) -> io::Result<()> {
-        self.protect(region::Protection::READ)
+        Ok(())
     }
 
+    /// See [`Self::make_read_only`]; writing is bracketed per thread by
+    /// [`enter_assembler_writing`], not per block.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn make_writable(&mut self) -> io::Result<()> {
-        self.protect(region::Protection::READ_WRITE)
+        Ok(())
     }
 
+    /// The block is executable already; what a finished write needs is the
+    /// instruction cache flushed (`aarch64/codebuilder.py` `copy_to_raw_memory`
+    /// `clear_cache`).
     #[cfg(not(target_arch = "wasm32"))]
     pub fn make_executable(&mut self) -> io::Result<()> {
         flush_instruction_cache(self.ptr(), self.capacity());
-        self.protect(region::Protection::READ_EXECUTE)
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    fn protect(&mut self, protection: region::Protection) -> io::Result<()> {
-        let AsmMemoryBlockStorage::Arena { start, stop, .. } = self.storage else {
-            return Ok(());
-        };
-        unsafe { region::protect(start as *const u8, stop - start, protection) }
-            .map_err(io::Error::other)
+        Ok(())
     }
 }
 
@@ -2447,6 +2569,7 @@ impl Drop for AsmMemoryBlock {
             ref manager,
             start,
             stop,
+            ..
         } = self.storage
         {
             manager.free(start, stop);
@@ -2454,8 +2577,10 @@ impl Drop for AsmMemoryBlock {
     }
 }
 
+/// `clear_cache` after writing machine code: the instruction cache on aarch64
+/// and Windows; a no-op where x86 keeps the caches coherent itself.
 #[cfg(not(target_arch = "wasm32"))]
-fn flush_instruction_cache(ptr: *const u8, len: usize) {
+pub fn flush_instruction_cache(ptr: *const u8, len: usize) {
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     unsafe {
         unsafe extern "C" {
@@ -2723,12 +2848,6 @@ pub trait Backend: Send {
     /// no-op — bridges are attached to the guard's machine code directly.
     fn migrate_bridges(&self, _old_token: &JitCellToken, _new_token: &JitCellToken) {}
 
-    /// compile.py store_hash: assign jitcounter hashes to guards.
-    /// Called after compile_loop/compile_bridge with hashes from
-    /// jitcounter.fetch_next_hash(). Skips guards that already have
-    /// status set by make_a_counter_per_value (GUARD_VALUE).
-    fn store_guard_hashes(&self, _token: &JitCellToken, _hashes: &[u64]) {}
-
     /// compile.py / resume.py:1143 plumbing: publish the shared
     /// `CallInfoCollection` so the backend can resolve OS_STR_CONCAT
     /// etc. function pointers when materializing VStr/VUni
@@ -2745,16 +2864,18 @@ pub trait Backend: Send {
     ) {
     }
 
-    /// store_hash for bridge guards — same as store_guard_hashes but for
-    /// the most recently compiled bridge on the given guard.
-    /// Uses (trace_id, fail_index) for recursive descriptor lookup.
-    fn store_bridge_guard_hashes(
+    /// Whether a bridge is attached to the guard `(source_trace_id,
+    /// source_fail_index)` of `token`'s trace family. `compile.py
+    /// compile_trace` hands its caller the attached target or `None`; pyre's
+    /// trace can run on past the attach, so the caller asks afterwards.
+    fn bridge_was_compiled(
         &self,
-        _token: &JitCellToken,
-        _source_trace_id: u64,
-        _source_fail_index: u32,
-        _hashes: &[u64],
-    ) {
+        token: &JitCellToken,
+        source_trace_id: u64,
+        source_fail_index: u32,
+    ) -> bool {
+        self.compiled_bridge_fail_descr_layouts(token, source_trace_id, source_fail_index)
+            .is_some()
     }
 
     /// Execute compiled code starting at the given token.
@@ -2960,10 +3081,7 @@ pub trait Backend: Send {
             is_exception_exit: descr.is_exit_frame_with_exception(),
             recovery_layout: None,
             frame_stack: None,
-            rd_numb: None,
-            rd_consts: None,
-            rd_virtuals: None,
-            rd_pendingfields: None,
+            descr: None,
         })
     }
 

--- a/majit/majit-backend/src/libc_deadframe.rs
+++ b/majit/majit-backend/src/libc_deadframe.rs
@@ -135,8 +135,9 @@ impl LibcJitFrameDeadFrame {
     /// bound, while a late failarg still maps to a valid live frame slot.
     fn slot_of(&self, index: usize) -> Option<usize> {
         let descr = self.fail_descr.as_fail_descr()?;
-        if index < descr.rd_locs().len() {
-            crate::llmodel::decode_rd_loc_slot(descr, index)
+        let locs = descr.rd_locs();
+        if let Some(&pos) = locs.get(index) {
+            (pos != 0xFFFF).then_some(pos as usize)
         } else if index < self.num_slots {
             Some(index)
         } else {

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -233,55 +233,11 @@ pub struct ResumeGuardDescr {
     /// `CraneliftFailDescr::external_jump_target_cell` so the meta Arc
     /// is the single source of truth.
     pub external_jump_target: OnceLock<DescrRef>,
-    /// Bridge code-pointer cache (cranelift-only TODO: PyPy patches
-    /// guard JMP targets in place).  PyPy's `assembler.py:987 patch_jump_for_descr`
-    /// rewrites the guard JMP target in place when a bridge is
-    /// attached; cranelift cannot patch finalised code, so the
-    /// JIT-baked dispatch loads the bridge code-pointer from this
-    /// cell at runtime.  Migrated here from
-    /// `CraneliftFailDescr::bridge_code_ptr_cache` so the meta Arc is
-    /// the single source of truth.
-    ///
-    /// `Box` gives the `AtomicUsize` a heap-pinned address that
-    /// survives `Arc::clone` of the meta descr; cranelift's
-    /// `emit_attached_bridge_dispatch` (compiler.rs:5347) embeds this
-    /// address as an immediate.  `0` = no bridge attached.
-    pub bridge_code_ptr_cache: Box<AtomicUsize>,
-    /// Bridge body-pointer cache.  Same shape as
-    /// `bridge_code_ptr_cache`, but holds the bridge's `CallConv::Tail`
-    /// body entry (not the host-ABI wrapper).  The in-code dispatch
-    /// (`emit_attached_bridge_dispatch`) tail-calls this so a guard
-    /// failure transfers into the bridge without leaving a return frame
-    /// on the machine stack — the cranelift analogue of PyPy's
-    /// `patch_jump_for_descr` raw JMP.  The wrapper in
-    /// `bridge_code_ptr_cache` stays for the host-loop fallback dispatch.
-    pub bridge_body_ptr_cache: Box<AtomicUsize>,
-    /// Bridge dispatch cell (cranelift-only TODO: PyPy patches guard
-    /// JMP targets in place).  PyPy's `assembler.py:987 patch_jump_for_descr`
-    /// rewrites the guard JMP target in place; cranelift cannot patch
-    /// finalised code, so the runtime guard-failure dispatch loads
-    /// the published `Arc<BridgeData>` raw pointer from this cell
-    /// (via `bridge_dispatch_load` below) and reconstructs the Arc
-    /// via `Arc::increment_strong_count + Arc::from_raw`.
-    ///
-    /// Type-erased to `*mut ()` because `BridgeData` lives in
-    /// `majit-backend-cranelift` (downstream crate) and majit-backend
-    /// must not depend on it.  The matching cleanup is registered by
-    /// the backend on first `bridge_dispatch_swap` so `Drop` can
-    /// reclaim the published Arc without knowing its concrete type.
-    ///
-    /// The cell's address is not JIT-baked (runtime reads only), so a
-    /// plain `AtomicPtr<()>` suffices — `Arc::new(self)` pins the
-    /// surrounding `ResumeGuardDescr`, and the field address is then
-    /// stable across `Arc::clone` calls.  Null on construction (no
-    /// bridge attached).
-    pub bridge_dispatch_cell: AtomicPtr<()>,
-    /// Type-aware cleanup function the backend registers on first
-    /// `bridge_dispatch_swap`.  `Drop` invokes this with the cell's
-    /// final non-null payload so the published `Arc<BridgeData>` is
-    /// reclaimed by the owning crate.  `OnceLock` so the registration
-    /// is idempotent across re-attach.
-    pub bridge_dispatch_drop_fn: OnceLock<unsafe fn(*mut ())>,
+    /// `history.py AbstractFailDescr.adr_jump_offset` for cranelift, which
+    /// cannot patch a finalised jump: the cells its guard dispatch reads the
+    /// attached bridge from.  Empty until codegen asks for the cell
+    /// addresses or a bridge is attached.
+    pub bridge: OnceLock<Box<BridgeDispatchCells>>,
     /// Pyre-only: FOR_ITER green key protected by a walker-native range
     /// class guard.  `handle_fail` reads it off the failing descr
     /// (`Descr::range_foriter_green_key`) to demote the range
@@ -294,6 +250,98 @@ pub struct ResumeGuardDescr {
     /// the generic `jit_next` conversion path when it re-enters FOR_ITER.
     /// `0` means this descr did not originate in that inline route.
     pub instance_next_foriter_key: AtomicU64,
+}
+
+/// The backend's patch point for a guard that may grow a bridge.
+/// `history.py AbstractFailDescr._attrs_` gives it one word,
+/// `adr_jump_offset`, and `assembler.py patch_jump_for_descr` rewrites the
+/// guard's jump through it.  Cranelift cannot patch finalised code: its guard
+/// dispatch reads the bridge entry from cells whose addresses it baked into
+/// the guard at codegen (`emit_attached_bridge_dispatch`), and the published
+/// bridge payload from a third cell.  The cells are allocated on first use,
+/// so a descr the native backends compiled carries only the empty slot.
+#[derive(Debug)]
+pub struct BridgeDispatchCells {
+    /// Bridge host-ABI entry; `0` while no bridge is attached.
+    code: AtomicUsize,
+    /// Bridge `CallConv::Tail` body entry the in-code dispatch tail-calls.
+    body: AtomicUsize,
+    /// Published bridge payload, type-erased: the concrete type lives in
+    /// majit-backend-cranelift.  Null while no bridge is attached.
+    dispatch: AtomicPtr<()>,
+    /// Cleanup the backend registers with its first `dispatch_swap`; `Drop`
+    /// hands it the surviving payload.
+    drop_fn: OnceLock<unsafe fn(*mut ())>,
+}
+
+impl BridgeDispatchCells {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {
+            code: AtomicUsize::new(0),
+            body: AtomicUsize::new(0),
+            dispatch: AtomicPtr::new(std::ptr::null_mut()),
+            drop_fn: OnceLock::new(),
+        })
+    }
+
+    /// `(code_ptr_addr, body_ptr_addr)`: the cell addresses codegen bakes
+    /// into the guard as immediates.  The `Box` keeps them stable for the
+    /// life of the descr.
+    pub fn cache_addrs(&self) -> (usize, usize) {
+        (
+            &self.code as *const AtomicUsize as usize,
+            &self.body as *const AtomicUsize as usize,
+        )
+    }
+
+    pub fn code_ptr(&self) -> usize {
+        self.code.load(Ordering::Acquire)
+    }
+
+    /// The body cell is written first so a dispatch that observes a non-zero
+    /// code pointer also sees the body it tail-calls.
+    pub fn store_caches(&self, code_ptr: usize, body_ptr: usize) {
+        self.body.store(body_ptr, Ordering::Release);
+        self.code.store(code_ptr, Ordering::Release);
+    }
+
+    pub fn dispatch_load(&self) -> *mut () {
+        self.dispatch.load(Ordering::Acquire)
+    }
+
+    /// Publish a payload and return the previous one.  A re-attach must
+    /// register the cleanup the first attach registered: `Drop` reclaims the
+    /// survivor through it, and a different destructor would type-pun the
+    /// payload.
+    pub fn dispatch_swap(&self, new_ptr: *mut (), drop_fn: unsafe fn(*mut ())) -> *mut () {
+        if let Some(existing) = self.drop_fn.get() {
+            assert_eq!(
+                *existing as usize, drop_fn as usize,
+                "bridge_dispatch_swap re-attach registered a different cleanup fn \
+                 for the same descr — payload type-shape must be stable across \
+                 re-attach (otherwise Drop would type-pun the survivor)",
+            );
+        } else {
+            let _ = self.drop_fn.set(drop_fn);
+        }
+        self.dispatch.swap(new_ptr, Ordering::AcqRel)
+    }
+}
+
+impl Drop for BridgeDispatchCells {
+    fn drop(&mut self) {
+        let ptr = self.dispatch.swap(std::ptr::null_mut(), Ordering::AcqRel);
+        if !ptr.is_null()
+            && let Some(drop_fn) = self.drop_fn.get()
+        {
+            // Safety: `drop_fn` was registered by the `dispatch_swap` that
+            // published `ptr`, and reclaims a payload of the shape it
+            // published.
+            unsafe { drop_fn(ptr) };
+        }
+        // else: a payload published with no cleanup registered is a backend
+        // bug; leak it rather than guess its type.
+    }
 }
 
 // Safety: single-threaded JIT (RPython GIL parity).
@@ -347,10 +395,7 @@ impl Descr for ResumeGuardDescr {
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
-            bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: OnceLock::new(),
+            bridge: OnceLock::new(),
             // The clone guards the same FOR_ITER site; preserve either tag so
             // guard-failure routing survives guard copying.
             range_foriter_key: AtomicU64::new(self.range_foriter_key.load(Ordering::Relaxed)),
@@ -553,26 +598,18 @@ impl FailDescr for ResumeGuardDescr {
         }
     }
     fn bridge_cache_addrs(&self) -> Option<(usize, usize)> {
-        Some((
-            self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
-        ))
+        Some(ResumeGuardDescr::bridge_cache_addrs(self))
     }
     fn bridge_code_ptr(&self) -> usize {
-        self.bridge_code_ptr_cache.load(Ordering::Acquire)
+        ResumeGuardDescr::bridge_code_ptr(self)
     }
     fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
-        self.bridge_body_ptr_cache
-            .store(body_ptr, Ordering::Release);
-        self.bridge_code_ptr_cache
-            .store(code_ptr, Ordering::Release);
+        ResumeGuardDescr::store_bridge_caches(self, code_ptr, body_ptr)
     }
     fn bridge_dispatch_load(&self) -> *mut () {
-        self.bridge_dispatch_cell.load(Ordering::Acquire)
+        ResumeGuardDescr::bridge_dispatch_load(self)
     }
     fn bridge_dispatch_swap(&self, new_ptr: *mut (), drop_fn: unsafe fn(*mut ())) -> *mut () {
-        // Forward to the inherent method so the re-attach cleanup-fn
-        // identity assertion lives in one place.
         ResumeGuardDescr::bridge_dispatch_swap(self, new_ptr, drop_fn)
     }
 
@@ -623,10 +660,7 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
-        bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-        bridge_dispatch_drop_fn: OnceLock::new(),
+        bridge: OnceLock::new(),
         range_foriter_key: AtomicU64::new(0),
         instance_next_foriter_key: AtomicU64::new(0),
     })
@@ -724,66 +758,38 @@ impl ResumeGuardDescr {
         self.external_jump_target.get().is_some()
     }
 
-    /// Heap-pinned addresses of the two bridge-cache atomic cells
-    /// suitable for baking into JIT machine code as
-    /// immediates.  Returns `(code_ptr_addr, body_ptr_addr)`.
+    /// The cranelift bridge cells, allocated on first use.
+    pub fn bridge_cells(&self) -> &BridgeDispatchCells {
+        self.bridge.get_or_init(BridgeDispatchCells::new)
+    }
+
+    /// Cell addresses for codegen to bake as immediates
+    /// (`emit_attached_bridge_dispatch`).
     pub fn bridge_cache_addrs(&self) -> (usize, usize) {
-        (
-            self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
-        )
+        self.bridge_cells().cache_addrs()
     }
 
-    /// Atomically store the bridge code-pointer + frame-depth caches
-    /// Called from cranelift `attach_bridge` after
-    /// the bridge has been compiled.
+    /// Called from cranelift `attach_bridge` once the bridge is compiled.
     pub fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
-        self.bridge_body_ptr_cache
-            .store(body_ptr, Ordering::Release);
-        self.bridge_code_ptr_cache
-            .store(code_ptr, Ordering::Release);
+        self.bridge_cells().store_caches(code_ptr, body_ptr)
     }
 
-    /// Read the cached bridge code-pointer.  `0` when
-    /// no bridge is attached.
+    /// `0` while no bridge is attached.
     pub fn bridge_code_ptr(&self) -> usize {
-        self.bridge_code_ptr_cache.load(Ordering::Acquire)
+        self.bridge.get().map_or(0, |cells| cells.code_ptr())
     }
 
-    /// Read the type-erased bridge dispatch cell.
-    /// Returns the published raw pointer for the backend to
-    /// reconstruct its concrete `Arc<BridgeData>` via
-    /// `Arc::increment_strong_count + Arc::from_raw`.  Null when no
-    /// bridge has been attached.
+    /// The published bridge payload; null while no bridge is attached.
     pub fn bridge_dispatch_load(&self) -> *mut () {
-        self.bridge_dispatch_cell.load(Ordering::Acquire)
+        self.bridge
+            .get()
+            .map_or(std::ptr::null_mut(), |cells| cells.dispatch_load())
     }
 
-    /// Atomic-swap a new bridge dispatch payload into the cell and
-    /// register the backend-supplied cleanup function.
-    /// Returns the previous payload so the backend can reclaim its
-    /// owned `Arc`.  The cleanup function is registered once
-    /// (idempotent) and invoked by `Drop` on any payload still in the
-    /// cell at descr teardown.
+    /// Publish a bridge payload; returns the previous one for the backend
+    /// to reclaim.
     pub fn bridge_dispatch_swap(&self, new_ptr: *mut (), drop_fn: unsafe fn(*mut ())) -> *mut () {
-        // Re-attach must use the same cleanup function the first
-        // attach registered: `Drop` reclaims the surviving payload via
-        // the stored `drop_fn`, so a mismatched destructor on a later
-        // re-attach would type-pun the payload and corrupt the
-        // backend's owned Arc.  Compare function pointers by raw
-        // address — `fn` is `Copy` and equality on raw fn-pointers is
-        // well-defined for monomorphised functions baked at codegen.
-        if let Some(existing) = self.bridge_dispatch_drop_fn.get() {
-            assert_eq!(
-                *existing as usize, drop_fn as usize,
-                "bridge_dispatch_swap re-attach registered a different cleanup fn \
-                 for the same descr — payload type-shape must be stable across \
-                 re-attach (otherwise Drop would type-pun the survivor)",
-            );
-        } else {
-            let _ = self.bridge_dispatch_drop_fn.set(drop_fn);
-        }
-        self.bridge_dispatch_cell.swap(new_ptr, Ordering::AcqRel)
+        self.bridge_cells().dispatch_swap(new_ptr, drop_fn)
     }
 }
 
@@ -798,24 +804,5 @@ impl Drop for ResumeGuardDescr {
             // `set_trace_info`.
             unsafe { drop(Arc::from_raw(ptr as *const CompiledTraceInfo)) };
         }
-        // Reclaim any published bridge dispatch payload
-        // via the backend-registered cleanup function.  Swap-to-null
-        // first so a concurrent reader either sees the still-live
-        // pointer (and bumps the strong count) or null (and skips).
-        let bridge_ptr = self
-            .bridge_dispatch_cell
-            .swap(std::ptr::null_mut(), Ordering::AcqRel);
-        if !bridge_ptr.is_null()
-            && let Some(drop_fn) = self.bridge_dispatch_drop_fn.get()
-        {
-            // Safety: `drop_fn` was registered via `bridge_dispatch_swap`
-            // alongside the payload at `bridge_ptr`; the publisher's
-            // safety contract is that the function reclaims a value of
-            // the same shape the publisher published.
-            unsafe { drop_fn(bridge_ptr) };
-        }
-        // else: payload published with no cleanup registered — a
-        // backend bug.  Leaks rather than risks reading the wrong
-        // concrete type.
     }
 }

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -49,7 +49,6 @@ use majit_ir::{
 use crate::CompiledLoopToken;
 use crate::CompiledTraceInfo;
 use crate::rd_payload::RdPayload;
-use crate::resume_value::ResumeData;
 
 // `compile.py AbstractResumeGuardDescr` status-bit constants.
 //
@@ -162,12 +161,6 @@ pub struct ResumeGuardDescr {
     /// `compile.py store_final_boxes` mutates types in place; pyre
     /// uses `UnsafeCell` so identity is preserved across the optimizer.
     pub types: UnsafeCell<Vec<Type>>,
-    /// Pyre keeps `resume_data` (the RPython-style ResumeValueSource
-    /// payload used by `prepare_pendingfields` for the
-    /// `PendingFieldInfo` path) on the descr alongside the RPython
-    /// `_attrs_` rd_* slots — both representations co-exist while
-    /// the runtime resume reader is being aligned with upstream.
-    pub resume_data: ResumeData,
     /// `compile.py:855` `_attrs_ = ('rd_numb', 'rd_consts',
     /// 'rd_virtuals', 'rd_pendingfields', 'status')`.
     pub payload: RdPayload,
@@ -337,7 +330,6 @@ impl Descr for ResumeGuardDescr {
         Some(Arc::new(ResumeGuardDescr {
             fail_index: alloc_fail_index(),
             types: UnsafeCell::new(unsafe { (&*self.types.get()).clone() }),
-            resume_data: self.resume_data.clone(),
             payload: self.payload.deep_clone(),
             vector_info: UnsafeCell::new(unsafe { (&*self.vector_info.get()).clone() }),
             // `compile.py:844-846` mints a default-attributes object;
@@ -617,13 +609,6 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
     Arc::new(ResumeGuardDescr {
         fail_index: alloc_fail_index(),
         types: UnsafeCell::new(types),
-        resume_data: ResumeData {
-            vable_array: Vec::new(),
-            vref_array: Vec::new(),
-            frames: Vec::new(),
-            virtuals: Vec::new(),
-            pending_fields: Vec::new(),
-        },
         payload: RdPayload::empty(),
         vector_info: UnsafeCell::new(None),
         adr_jump_offset: UnsafeCell::new(0),

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -57,17 +57,23 @@ use std::sync::{Arc, Weak};
 
 use majit_ir::GcRef;
 
+/// `llsupport/symbolic.py` `WORD`.
+const WORD: usize = core::mem::size_of::<usize>();
+
 /// A per-loop array of reference-constant slots.
 ///
 /// `gcreftracer.py` `GCREFTRACER` stores `array_base_addr` +
-/// `array_length`; here the `Box<[Cell<GcRef>]>` *is* that array:
-/// [`base_addr`](GcTable::base_addr) is `array_base_addr` and
-/// [`len`](GcTable::len) is `array_length`. The `Box` is a stable Rust
-/// heap allocation (never relocated by the moving GC), so its base
-/// address is valid for the table's whole life — that is what the
-/// backend bakes as the `LoadFromGcTable` base immediate.
+/// `array_length`. The array itself sits at the start of the loop's
+/// machine-code block (`assembler.py reserve_gcref_table`), where the
+/// `LoadFromGcTable` genop reaches it PC-relative; a backend that keeps the
+/// array on the Rust heap instead ([`from_gcrefs`](GcTable::from_gcrefs))
+/// hands out the heap address as `array_base_addr` and bakes it as an
+/// absolute immediate. Either address is stable for the table's whole life.
 pub struct GcTable {
-    slots: Box<[Cell<GcRef>]>,
+    array_base_addr: usize,
+    array_length: usize,
+    /// The heap-owned array, when the slots do not live in a code block.
+    _owned: Option<Box<[Cell<GcRef>]>>,
 }
 
 // SAFETY: a `GcTable`'s slots are only mutated through `trace`, which
@@ -112,6 +118,17 @@ static LIVE_GC_TABLES: RwLock<Vec<Weak<GcTable>>> = RwLock::new(Vec::new());
 #[cfg(test)]
 static GC_TABLE_WALK_LOCK: RwLock<()> = RwLock::new(());
 
+/// Tables built since the last minor collection. `GCREFTRACER` is an
+/// ordinary old object upstream: writing its slots at construction puts it
+/// in MiniMark's `old_objects_pointing_to_young` for exactly one minor
+/// collection, which promotes every referent it holds, and no later minor
+/// visits it again because its slots are never written afterwards. A major
+/// collection marks through every live tracer regardless. This list is that
+/// remembered set: [`walk_all_gc_tables_inner`] drains it on a minor walk and
+/// walks the whole registry on a major one.
+static PENDING_MINOR_TABLES: parking_lot::Mutex<Vec<Weak<GcTable>>> =
+    parking_lot::Mutex::new(Vec::new());
+
 impl GcTable {
     /// Build a per-loop table from the rewrite's gcref output list and
     /// register it for GC forwarding.
@@ -132,8 +149,43 @@ impl GcTable {
         // backend init without depending on a separate init call site.
         install_gc_table_walker();
         let slots: Box<[Cell<GcRef>]> = gcrefs.iter().map(|g| Cell::new(*g)).collect();
-        let table = Arc::new(GcTable { slots });
+        let table = GcTable {
+            array_base_addr: slots.as_ptr() as usize,
+            array_length: slots.len(),
+            _owned: Some(slots),
+        };
+        Self::register(table)
+    }
+
+    /// `gcreftracer.py` `make_framework_tracer`: write the gcrefs into the
+    /// raw array reserved at `array_base_addr` inside a machine-code block
+    /// (`assembler.py patch_gcref_table`) and register the tracer. The
+    /// block is written under the assembler-writing bracket
+    /// (`rmmap.enter_assembler_writing`).
+    ///
+    /// # Safety
+    /// `array_base_addr` must address `gcrefs.len()` word-aligned words
+    /// inside a JIT mapping that outlives the returned table.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn in_code(array_base_addr: usize, gcrefs: &[GcRef]) -> Arc<GcTable> {
+        install_gc_table_walker();
+        {
+            let _writing = crate::rmmap::AssemblerWriting::enter();
+            for (i, g) in gcrefs.iter().enumerate() {
+                unsafe { *((array_base_addr + i * WORD) as *mut GcRef) = *g };
+            }
+        }
+        Self::register(GcTable {
+            array_base_addr,
+            array_length: gcrefs.len(),
+            _owned: None,
+        })
+    }
+
+    fn register(table: GcTable) -> Arc<GcTable> {
+        let table = Arc::new(table);
         register_table(&table);
+        PENDING_MINOR_TABLES.lock().push(Arc::downgrade(&table));
         table
     }
 
@@ -141,17 +193,26 @@ impl GcTable {
     /// the `LoadFromGcTable` base immediate. `gcreftracer.py:9`
     /// `array_base_addr`.
     pub fn base_addr(&self) -> usize {
-        self.slots.as_ptr() as usize
+        self.array_base_addr
     }
 
     /// Number of reference-constant slots. `gcreftracer.py:10`
     /// `array_length`.
     pub fn len(&self) -> usize {
-        self.slots.len()
+        self.array_length
     }
 
     pub fn is_empty(&self) -> bool {
-        self.slots.is_empty()
+        self.array_length == 0
+    }
+
+    /// Read slot `i`.
+    pub fn slot(&self, i: usize) -> GcRef {
+        assert!(i < self.array_length);
+        // SAFETY: `array_base_addr + i*WORD` is a slot of a live array
+        // (see the struct invariant); slots are read outside a collection
+        // and written only by `trace` inside one.
+        unsafe { *((self.array_base_addr + i * WORD) as *const GcRef) }
     }
 
     /// Forward every slot in place. `gcreftracer.py:13-23`
@@ -159,10 +220,23 @@ impl GcTable {
     /// the GC as a root; writing back through the visitor forwards the
     /// constant if the moving GC relocated the referenced object.
     pub fn trace(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        for cell in self.slots.iter() {
-            let mut r = cell.get();
-            visitor(&mut r);
-            cell.set(r);
+        // `gcrefs_trace` brackets the walk with
+        // `rmmap.enter_assembler_writing()`: an in-code array is part of a
+        // JIT mapping.
+        #[cfg(not(target_arch = "wasm32"))]
+        let _writing = self
+            ._owned
+            .is_none()
+            .then(crate::rmmap::AssemblerWriting::enter);
+        for i in 0..self.array_length {
+            let p = (self.array_base_addr + i * WORD) as *mut GcRef;
+            // SAFETY: see `slot`; this runs inside a stop-the-world
+            // collection, the only writer.
+            unsafe {
+                let mut r = *p;
+                visitor(&mut r);
+                *p = r;
+            }
         }
     }
 }
@@ -193,6 +267,17 @@ fn walk_all_gc_tables(visitor: &mut dyn FnMut(&mut GcRef)) {
 /// already holds the write side observes the registry without re-entering
 /// the lock.
 fn walk_all_gc_tables_inner(visitor: &mut dyn FnMut(&mut GcRef)) {
+    // A minor collection reaches only the tables the remembered set names
+    // (see `PENDING_MINOR_TABLES`); every other live table already holds
+    // promoted referents, which a minor collection does not move.
+    if crate::shadow_stack::extra_root_walk_kind() == crate::shadow_stack::ExtraRootWalkKind::Minor
+    {
+        let pending = std::mem::take(&mut *PENDING_MINOR_TABLES.lock());
+        for table in pending.iter().filter_map(Weak::upgrade) {
+            table.trace(visitor);
+        }
+        return;
+    }
     // Snapshot the live tables under a read guard, then release the lock
     // before tracing (same snapshot-then-iterate discipline as
     // `walk_extra_roots`, `shadow_stack.rs`). Dead `Weak`s are
@@ -242,9 +327,12 @@ mod tests {
                 r.0 = 0x9000;
             }
         });
-        assert_eq!(table.slots[0].get(), GcRef(0x9000));
-        assert_eq!(table.slots[1].get(), GcRef(0x2000));
-        assert_eq!(table.base_addr(), table.slots.as_ptr() as usize);
+        assert_eq!(table.slot(0), GcRef(0x9000));
+        assert_eq!(table.slot(1), GcRef(0x2000));
+        assert_eq!(
+            table.base_addr(),
+            table._owned.as_ref().unwrap().as_ptr() as usize
+        );
         assert_eq!(table.len(), 2);
     }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -38,6 +38,8 @@ pub mod oldgen;
 pub mod rawrefcount;
 pub mod rewrite;
 pub mod rgil;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod rmmap;
 pub mod shadow_stack;
 pub mod trace;
 pub mod weakref;

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3871,7 +3871,8 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![Op::with_descr(OpCode::New, &[], size_descr(32, 7))];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect: CallMallocNursery, GcStore (tid)
         assert_eq!(result.len(), 2);
@@ -4327,7 +4328,8 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Allocation header stores only (CallMallocNursery + tid GcStore) + Jump.
         // No delayed-zero NULL-pointer stores must be emitted because
@@ -4359,7 +4361,8 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Collect the NULL-pointer stores emitted by the pending-zero flush.
         let mut seen_offsets: Vec<i64> = result
@@ -4407,7 +4410,8 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         let null_offsets: Vec<i64> = result
             .iter()
@@ -4459,7 +4463,8 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 2)),
         ];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(result.iter().any(|o| o.opcode == OpCode::CallMallocNursery));
         assert!(
@@ -4641,7 +4646,8 @@ mod tests {
             vtable_descr(48, 3, 0xDEAD),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // CallMallocNursery + GcStore(tid) + GcStore(vtable)
         assert_eq!(result.len(), 3);
@@ -4681,7 +4687,8 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _constants, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert!(
@@ -4716,7 +4723,8 @@ mod tests {
             size_descr_with_w_class(48, 3, 0, Some(w_class), vec![w_class_field_descr_at(8)]),
         )];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _constants, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert_eq!(
@@ -4748,7 +4756,8 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _constants, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         let w_class_stores: Vec<_> = result
@@ -5062,7 +5071,8 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         let same = result
             .iter()
@@ -5089,7 +5099,8 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(10)), ro(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result.iter().all(|o| o.opcode != OpCode::GuardAlwaysFails),
@@ -5814,7 +5825,8 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(
             result.len(),
@@ -5885,7 +5897,8 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect: LEA, LEA, INT_LSHIFT(i_len, 2), CALL_N
         assert_eq!(result.len(), 4);
@@ -5941,7 +5954,8 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=0 so no INT_LSHIFT):
         //   i2b = int_add(p0, i0)
@@ -6002,7 +6016,8 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=2):
         //   i0s = int_lshift(i0, 2)
@@ -6135,7 +6150,8 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // The reference constant is collected at index 0.
         assert_eq!(gcrefs, vec![r]);
@@ -6163,7 +6179,8 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Same ref ⇒ one gcref entry (dedup) and one LoadFromGcTable (block CSE).
         assert_eq!(gcrefs, vec![r]);
@@ -6200,7 +6217,8 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Distinct refs occupy distinct, stable indices.
         assert_eq!(gcrefs, vec![r0, r1]);
@@ -6224,7 +6242,8 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(null))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py `bool(arg.value)` — a null ConstPtr stays inline.
         assert!(
@@ -6252,7 +6271,8 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Dedup persists across the block boundary (one gcref) ...
         assert_eq!(gcrefs, vec![r]);
@@ -6273,7 +6293,8 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
         assert!(gcrefs.is_empty(), "JIT_DEBUG keeps its constants inline");

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -560,7 +560,7 @@ impl RewriteState {
             out: Vec::with_capacity(hint + hint / 4),
             out_by_pos: IndexMap::default(),
             next_pos,
-            constants: ConstMap::new(),
+            constants: ConstMap::default(),
             pending_malloc_idx: None,
             pending_malloc_total: 0,
             previous_size: 0,
@@ -3147,7 +3147,7 @@ impl GcRewriterImpl {
 impl GcRewriter for GcRewriterImpl {
     fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op> {
         let (rewritten, _constants, gcrefs) =
-            self.rewrite_for_gc_with_constants(ops, &ConstMap::new());
+            self.rewrite_for_gc_with_constants(ops, &ConstMap::default());
         // This wrapper drops the gc_table output list. A non-null ConstPtr
         // operand is rewritten to LoadFromGcTable, which needs that list to
         // build the table; callers carrying one must use the
@@ -3871,7 +3871,7 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![Op::with_descr(OpCode::New, &[], size_descr(32, 7))];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect: CallMallocNursery, GcStore (tid)
         assert_eq!(result.len(), 2);
@@ -3933,7 +3933,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result
@@ -3974,7 +3974,7 @@ mod tests {
         let rw = make_rewriter();
         let num_elem = 3;
         let len_ref = OpRef::int_op(10_000);
-        let mut constants: ConstMap<Const> = ConstMap::new();
+        let mut constants: ConstMap<Const> = ConstMap::default();
         constants.insert(10_000, Const::Int(num_elem));
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
@@ -4023,7 +4023,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::CallR);
@@ -4101,7 +4101,7 @@ mod tests {
         // array_descr_ref: base_size=8, item_size=8 →
         //   total = 8 + 8*512 = 4104; gen_malloc_nursery sees
         //   round_up(GcHeader::SIZE + 4104) = 4112 > 4096 → returns None.
-        let mut constants: ConstMap<Const> = ConstMap::new();
+        let mut constants: ConstMap<Const> = ConstMap::default();
         constants.insert(10_000, Const::Int(512));
         let new_array = Op::with_descr(OpCode::NewArray, &[ro(len_ref)], array_descr_ref());
         new_array.pos.set(OpRef::ref_op(0));
@@ -4327,7 +4327,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Allocation header stores only (CallMallocNursery + tid GcStore) + Jump.
         // No delayed-zero NULL-pointer stores must be emitted because
@@ -4359,7 +4359,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Collect the NULL-pointer stores emitted by the pending-zero flush.
         let mut seen_offsets: Vec<i64> = result
@@ -4407,7 +4407,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         let null_offsets: Vec<i64> = result
             .iter()
@@ -4459,7 +4459,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 2)),
         ];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(result.iter().any(|o| o.opcode == OpCode::CallMallocNursery));
         assert!(
@@ -4641,7 +4641,7 @@ mod tests {
             vtable_descr(48, 3, 0xDEAD),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // CallMallocNursery + GcStore(tid) + GcStore(vtable)
         assert_eq!(result.len(), 3);
@@ -4681,7 +4681,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert!(
@@ -4716,7 +4716,7 @@ mod tests {
             size_descr_with_w_class(48, 3, 0, Some(w_class), vec![w_class_field_descr_at(8)]),
         )];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert_eq!(
@@ -4748,7 +4748,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _constants, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         let w_class_stores: Vec<_> = result
@@ -4780,7 +4780,7 @@ mod tests {
         ];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result.iter().any(|o| {
@@ -5062,7 +5062,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         let same = result
             .iter()
@@ -5089,7 +5089,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(10)), ro(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result.iter().all(|o| o.opcode != OpCode::GuardAlwaysFails),
@@ -5609,7 +5609,7 @@ mod tests {
         for &num_elem in &[10_i64, 200_i64] {
             let rw = make_rewriter_with_cards();
             let len_ref = OpRef::int_op(10_000);
-            let mut constants: ConstMap<Const> = ConstMap::new();
+            let mut constants: ConstMap<Const> = ConstMap::default();
             constants.insert(10_000, Const::Int(num_elem));
             let new_array =
                 Op::with_descr(OpCode::NewArrayClear, &[ro(len_ref)], array_descr_ref());
@@ -5814,7 +5814,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(
             result.len(),
@@ -5885,7 +5885,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect: LEA, LEA, INT_LSHIFT(i_len, 2), CALL_N
         assert_eq!(result.len(), 4);
@@ -5941,7 +5941,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=0 so no INT_LSHIFT):
         //   i2b = int_add(p0, i0)
@@ -6002,7 +6002,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=2):
         //   i0s = int_lshift(i0, 2)
@@ -6135,7 +6135,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // The reference constant is collected at index 0.
         assert_eq!(gcrefs, vec![r]);
@@ -6163,7 +6163,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Same ref ⇒ one gcref entry (dedup) and one LoadFromGcTable (block CSE).
         assert_eq!(gcrefs, vec![r]);
@@ -6200,7 +6200,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Distinct refs occupy distinct, stable indices.
         assert_eq!(gcrefs, vec![r0, r1]);
@@ -6224,7 +6224,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(null))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py `bool(arg.value)` — a null ConstPtr stays inline.
         assert!(
@@ -6252,7 +6252,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // Dedup persists across the block boundary (one gcref) ...
         assert_eq!(gcrefs, vec![r]);
@@ -6273,7 +6273,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
         assert!(gcrefs.is_empty(), "JIT_DEBUG keeps its constants inline");

--- a/majit/majit-gc/src/rmmap.rs
+++ b/majit/majit-gc/src/rmmap.rs
@@ -1,0 +1,65 @@
+//! `rpython/rlib/rmmap.py`: the assembler-writing bracket.
+//!
+//! On darwin/arm64 the JIT mapping is `MAP_JIT`, and
+//! `pthread_jit_write_protect_np` switches this thread's view of it between
+//! executable and writable. Everywhere else the mapping is RWX and the
+//! bracket only counts. It lives in this crate because both the assembler
+//! (`asmmemmgr.py`) and the reference-constant tracer (`gcreftracer.py`
+//! `gcrefs_trace`) take it: the tracer forwards slots that sit inside a
+//! machine-code block.
+
+use std::cell::Cell;
+
+// `rmmap.py` `Nester`: the depth of `enter_assembler_writing` brackets on
+// this thread. `pthread_jit_write_protect_np` is per-thread state, so the
+// counter is too.
+thread_local! {
+    static ASSEMBLER_WRITING_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// `rmmap.py` `enter_assembler_writing`: on darwin/arm64 switch this thread's
+/// `MAP_JIT` pages from executable to writable; elsewhere the JIT mapping is
+/// RWX and this only counts the bracket.
+pub fn enter_assembler_writing() {
+    ASSEMBLER_WRITING_DEPTH.with(|depth| {
+        if depth.get() == 0 {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            unsafe {
+                libc::pthread_jit_write_protect_np(0);
+            }
+        }
+        depth.set(depth.get() + 1);
+    });
+}
+
+/// `rmmap.py` `leave_assembler_writing`.
+pub fn leave_assembler_writing() {
+    ASSEMBLER_WRITING_DEPTH.with(|depth| {
+        depth.set(depth.get() - 1);
+        if depth.get() == 0 {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            unsafe {
+                libc::pthread_jit_write_protect_np(1);
+            }
+        }
+    });
+}
+
+/// The `try: ... finally: rmmap.leave_assembler_writing()` bracket
+/// (`aarch64/assembler.py` `assemble_loop`, `assemble_bridge`,
+/// `redirect_call_assembler`; `aarch64/runner.py` `invalidate_loop`;
+/// `gcreftracer.py` `gcrefs_trace`) as a guard, so every return path leaves.
+pub struct AssemblerWriting(());
+
+impl AssemblerWriting {
+    pub fn enter() -> Self {
+        enter_assembler_writing();
+        Self(())
+    }
+}
+
+impl Drop for AssemblerWriting {
+    fn drop(&mut self) {
+        leave_assembler_writing();
+    }
+}

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -241,6 +241,14 @@ thread_local! {
     /// by a blackhole register survive across collecting calls.
     static BH_REGS_STACK: RefCell<Vec<BhRegsEntry>> = RefCell::new(Vec::with_capacity(16));
 
+    /// Thread-local roots of every pooled blackhole interpreter, registered
+    /// once when the interpreter is built (`BlackholeInterpBuilder
+    /// .acquire_interp`) and dropped with it. `blackhole.py`'s interpreters
+    /// are GC objects: `registers_r`, `tmpreg_r`, `exception_last_value` and
+    /// `virtualizable_ptr` are traced fields for the object's whole life, not
+    /// only while `run()` is on the stack.
+    static BH_INTERP_ROOTS: RefCell<Vec<BhInterpEntry>> = RefCell::new(Vec::new());
+
     /// Thread-local stack of ref slices live only during blackhole resume
     /// construction (`resume.py blackhole_from_resumedata`).  The
     /// `virtuals_cache` and each frame's `registers_r` are filled by lazily
@@ -267,6 +275,7 @@ struct MutatorEntry {
     owner_roots: *const RefCell<Vec<Option<GcRef>>>,
     jf_root_stack: *const RefCell<JitFrameShadowStack>,
     bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
+    bh_interp_roots: *const RefCell<Vec<BhInterpEntry>>,
     resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
     extra_areas: Vec<MutatorExtraArea>,
     pruners: Vec<MutatorPruner>,
@@ -359,6 +368,7 @@ pub fn register_mutator() {
     let owner_roots = OWNER_ROOTS.with(|roots| roots as *const _);
     let jf_root_stack = JF_ROOT_STACK.with(|stack| stack as *const _);
     let bh_regs_stack = BH_REGS_STACK.with(|stack| stack as *const _);
+    let bh_interp_roots = BH_INTERP_ROOTS.with(|roots| roots as *const _);
     let resume_ref_roots_stack = RESUME_REF_ROOTS_STACK.with(|stack| stack as *const _);
 
     let mut registry = MUTATOR_REGISTRY.lock();
@@ -372,6 +382,7 @@ pub fn register_mutator() {
         owner_roots,
         jf_root_stack,
         bh_regs_stack,
+        bh_interp_roots,
         resume_ref_roots_stack,
         extra_areas: Vec::new(),
         pruners: Vec::new(),
@@ -1132,6 +1143,21 @@ struct BhRegsEntry {
     exc_ptr: *mut i64,
 }
 
+/// The traced fields of one pooled blackhole interpreter (`blackhole.py
+/// BlackholeInterpreter`: `registers_r`, `tmpreg_r`, `exception_last_value`,
+/// `virtualizable_ptr`). `regs` names the `Vec` itself, so a `setposition`
+/// that regrows the bank is followed.
+#[derive(Clone, Copy)]
+struct BhInterpEntry {
+    regs: *mut Vec<i64>,
+    tmpreg_ptr: *mut i64,
+    exc_ptr: *mut i64,
+    vable_ptr: *mut i64,
+}
+
+// Same thread-local discipline as `BhRegsEntry`.
+unsafe impl Send for BhInterpEntry {}
+
 // `*mut i64` is not `Send` by default. The thread-local storage means we
 // only ever access entries from the thread that pushed them, so this
 // `unsafe impl` is sound.
@@ -1160,6 +1186,56 @@ pub unsafe fn push_bh_regs(regs: &mut [i64], tmpreg: &mut i64, exc: &mut i64) ->
         });
         depth
     })
+}
+
+/// Register a pooled blackhole interpreter's traced fields as GC roots for
+/// its whole life; the counterpart of the interpreter being a GC object
+/// upstream. Paired with [`unregister_bh_interp`] from the interpreter's
+/// `Drop`.
+///
+/// # Safety
+/// Every pointer must stay valid, at a fixed address, until
+/// `unregister_bh_interp(regs)` runs on this thread.
+pub unsafe fn register_bh_interp(
+    regs: *mut Vec<i64>,
+    tmpreg: *mut i64,
+    exc: *mut i64,
+    vable: *mut i64,
+) {
+    BH_INTERP_ROOTS.with(|roots| {
+        roots.borrow_mut().push(BhInterpEntry {
+            regs,
+            tmpreg_ptr: tmpreg,
+            exc_ptr: exc,
+            vable_ptr: vable,
+        });
+    });
+}
+
+/// Drop the registration made by [`register_bh_interp`] for `regs`.
+pub fn unregister_bh_interp(regs: *const Vec<i64>) {
+    let _ = BH_INTERP_ROOTS.try_with(|roots| {
+        let mut roots = roots.borrow_mut();
+        if let Some(pos) = roots.iter().position(|e| std::ptr::eq(e.regs, regs)) {
+            roots.swap_remove(pos);
+        }
+    });
+}
+
+/// Visit one pooled interpreter's traced fields.
+///
+/// # Safety
+/// `entry` must have been registered by `register_bh_interp` and not yet
+/// unregistered.
+unsafe fn visit_bh_interp_entry(entry: &BhInterpEntry, visitor: &mut dyn FnMut(&mut GcRef)) {
+    let regs = unsafe { &mut *entry.regs };
+    for slot in regs.iter_mut() {
+        let gcref = unsafe { &mut *(slot as *mut i64 as *mut GcRef) };
+        visitor(gcref);
+    }
+    visitor(unsafe { &mut *(entry.tmpreg_ptr as *mut GcRef) });
+    visitor(unsafe { &mut *(entry.exc_ptr as *mut GcRef) });
+    visitor(unsafe { &mut *(entry.vable_ptr as *mut GcRef) });
 }
 
 /// Pop blackhole register entries back to the given depth.
@@ -1206,6 +1282,12 @@ pub fn walk_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
             visitor(exc);
         }
     });
+    BH_INTERP_ROOTS.with(|roots| {
+        for entry in roots.borrow().iter() {
+            // SAFETY: registered interpreters unregister from their `Drop`.
+            unsafe { visit_bh_interp_entry(entry, &mut visitor) };
+        }
+    });
 }
 
 /// Walk every registered mutator's blackhole register roots during STW.
@@ -1229,6 +1311,12 @@ pub fn walk_all_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
             visitor(tmp);
             let exc = unsafe { &mut *(entry.exc_ptr as *mut GcRef) };
             visitor(exc);
+        }
+        let interps = unsafe { &*(*mutator.bh_interp_roots).as_ptr() };
+        for entry in interps.iter() {
+            // SAFETY: as above; a registered interpreter unregisters from
+            // its `Drop`, which runs on the owning (quiesced) thread.
+            unsafe { visit_bh_interp_entry(entry, &mut visitor) };
         }
     }
 }

--- a/majit/majit-ir/Cargo.toml
+++ b/majit/majit-ir/Cargo.toml
@@ -23,3 +23,4 @@ smallvec = { workspace = true }
 serde = { workspace = true }
 vecmap_rs = { workspace = true }
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }

--- a/majit/majit-ir/src/indexmap_ext.rs
+++ b/majit/majit-ir/src/indexmap_ext.rs
@@ -5,7 +5,7 @@
 /// Backed by [`indexmap::IndexMap`] rather than a linear-scan Vec because the
 /// pool is built by inserting one entry per const-folded position (up to the
 /// full trace length) and read back by keyed lookup and in-order iteration.
-pub type ConstMap<V> = indexmap::IndexMap<u32, V>;
+pub type ConstMap<V> = indexmap::IndexMap<u32, V, rustc_hash::FxBuildHasher>;
 
 /// `entry().or_insert_with(...)` / `entry().or_default()` shortcuts.
 pub trait IndexMapExt<K, V> {

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -279,6 +279,21 @@ impl Op {
         self.args.borrow().iter().cloned().collect()
     }
 
+    /// `resoperation.py:281 AbstractResOp.getarglist` parity for a reader
+    /// that only walks the arguments: upstream returns `self._args` itself,
+    /// and only `getarglist_copy` (`N_aryOp`) returns `self._args[:]`.
+    /// [`getarglist`](Self::getarglist) has to copy so the `RefCell` borrow
+    /// does not outlive the call, which charges every read an `Operand` clone
+    /// per argument and a heap spill past the inline three; this hands the
+    /// stored slot to `f` instead.
+    ///
+    /// `f` must not call `setarg` / `initarglist` on the same op — the borrow
+    /// is live for its body, which is the invariant the copying accessor buys
+    /// its callers.
+    pub fn with_arglist<R>(&self, f: impl FnOnce(&[crate::operand::Operand]) -> R) -> R {
+        f(&self.args.borrow())
+    }
+
     /// `resoperation.py AbstractResOp.getarglist_copy` parity —
     /// `N_aryOp.getarglist_copy` returns `self._args[:]`; pyre returns
     /// an owned `SmallVec` of the stored operands.

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -279,7 +279,7 @@ impl Op {
         self.args.borrow().iter().cloned().collect()
     }
 
-    /// `resoperation.py:281 AbstractResOp.getarglist` parity for a reader
+    /// `resoperation.py AbstractResOp.getarglist` parity for a reader
     /// that only walks the arguments: upstream returns `self._args` itself,
     /// and only `getarglist_copy` (`N_aryOp`) returns `self._args[:]`.
     /// [`getarglist`](Self::getarglist) has to copy so the `RefCell` borrow

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -76,6 +76,10 @@ pub enum Operand {
     /// same one-word payload as an `Rc`, so it does not enlarge `Operand` or
     /// the three inline operand slots in every [`Op`](crate::resoperation::Op).
     SmallInt(u64),
+    /// `opencoder.py Trace._cached_const_ptr`: null is encoded as ref-pool
+    /// index zero without adding an entry. It is immutable and needs no GC
+    /// forwarding cell, so keep the global null constant allocation-free.
+    NullRef,
     /// A constant (`history.py/268/314` `ConstInt`/`ConstFloat`/
     /// `ConstPtr`). The value lives in an `Rc<Cell<Value>>`: the `Cell` lets
     /// the GC root walker forward an inline `ConstPtr` `GcRef` in place
@@ -96,6 +100,9 @@ pub enum Operand {
 impl Operand {
     #[inline]
     fn fresh_const_value(value: Value) -> Operand {
+        if value == Value::Ref(GcRef::NULL) {
+            return Operand::NullRef;
+        }
         if let Value::Int(value) = value
             && let Some(encoded) = fresh_small_int(value)
         {
@@ -150,6 +157,7 @@ impl Operand {
             OpRef::None => Operand::None,
             OpRef::ConstInt(v) => Self::fresh_const_value(Value::Int(v)),
             OpRef::ConstFloat(v) => Operand::Const(Rc::new(Cell::new(Value::Float(v)))),
+            OpRef::ConstPtr(v) if v.is_null() => Operand::NullRef,
             OpRef::ConstPtr(v) => Operand::Const(Rc::new(Cell::new(Value::Ref(v)))),
             _ => panic!(
                 "from_opref: position-only ref {r:?} has no producer to bind — \
@@ -210,6 +218,7 @@ impl Operand {
             Operand::Op(op) => op.pos.get(),
             Operand::InputArg(ia) => OpRef::input_arg_typed(ia.index, ia.tp),
             Operand::SmallInt(encoded) => OpRef::const_int(small_int_value(*encoded)),
+            Operand::NullRef => OpRef::const_ptr(GcRef::NULL),
             // Re-encodes from the live `Cell` value, so a GC-moved `ConstPtr`
             // reads back at its post-move address (forwarding.rs parity).
             Operand::Const(cell) => match cell.get() {
@@ -227,7 +236,7 @@ impl Operand {
         match self {
             Operand::Op(op) => Some(op.pos.get().raw()),
             Operand::InputArg(ia) => Some(ia.index),
-            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => None,
+            Operand::SmallInt(_) | Operand::NullRef | Operand::Const(_) | Operand::None => None,
         }
     }
 
@@ -237,6 +246,7 @@ impl Operand {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
             Operand::SmallInt(_) => Type::Int,
+            Operand::NullRef => Type::Ref,
             Operand::Const(cell) => cell.get().get_type(),
             Operand::None => Type::Void,
         }
@@ -247,6 +257,7 @@ impl Operand {
     pub fn const_value(&self) -> Option<Value> {
         match self {
             Operand::SmallInt(encoded) => Some(Value::Int(small_int_value(*encoded))),
+            Operand::NullRef => Some(Value::Ref(GcRef::NULL)),
             Operand::Const(cell) => Some(cell.get()),
             _ => None,
         }
@@ -260,6 +271,7 @@ impl Operand {
     pub fn get_value(&self) -> Option<Value> {
         match self {
             Operand::SmallInt(encoded) => Some(Value::Int(small_int_value(*encoded))),
+            Operand::NullRef => Some(Value::Ref(GcRef::NULL)),
             Operand::Const(cell) => Some(cell.get()),
             Operand::Op(op) => op.get_value(),
             Operand::InputArg(ia) => ia.get_value(),
@@ -282,7 +294,10 @@ impl Operand {
 
     /// `resoperation.py is_constant`.
     pub fn is_constant(&self) -> bool {
-        matches!(self, Operand::SmallInt(_) | Operand::Const(_))
+        matches!(
+            self,
+            Operand::SmallInt(_) | Operand::NullRef | Operand::Const(_)
+        )
     }
 
     pub fn is_inputarg(&self) -> bool {
@@ -337,7 +352,9 @@ impl Operand {
             let forwarded = match &cur {
                 Operand::Op(op) => op.get_forwarded(),
                 Operand::InputArg(ia) => ia.get_forwarded(),
-                Operand::SmallInt(_) | Operand::Const(_) | Operand::None => return cur,
+                Operand::SmallInt(_) | Operand::NullRef | Operand::Const(_) | Operand::None => {
+                    return cur;
+                }
             };
             match forwarded {
                 Forwarded::None | Forwarded::Info(_) => return cur,
@@ -383,7 +400,7 @@ impl Operand {
         match self {
             Operand::Op(op) => f(&**op),
             Operand::InputArg(ia) => f(&**ia),
-            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => default,
+            Operand::SmallInt(_) | Operand::NullRef | Operand::Const(_) | Operand::None => default,
         }
     }
 
@@ -394,7 +411,7 @@ impl Operand {
         match self {
             Operand::Op(op) => f(&**op),
             Operand::InputArg(ia) => f(&**ia),
-            Operand::SmallInt(_) | Operand::Const(_) | Operand::None => panic!(
+            Operand::SmallInt(_) | Operand::NullRef | Operand::Const(_) | Operand::None => panic!(
                 "Operand::{what} on a non-producer operand — only a bound \
                  Op/InputArg carries a _forwarded slot (box identity precondition)"
             ),
@@ -532,7 +549,11 @@ impl Operand {
                     cell.set(v);
                 }
             }
-            Operand::None | Operand::Op(_) | Operand::InputArg(_) | Operand::SmallInt(_) => {}
+            Operand::None
+            | Operand::Op(_)
+            | Operand::InputArg(_)
+            | Operand::SmallInt(_)
+            | Operand::NullRef => {}
         }
     }
 }
@@ -553,6 +574,7 @@ impl PartialEq for Operand {
             (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
             (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
             (Operand::SmallInt(a), Operand::SmallInt(b)) => a == b,
+            (Operand::NullRef, Operand::NullRef) => true,
             (Operand::Const(a), Operand::Const(b)) => Rc::ptr_eq(a, b),
             _ => false,
         }
@@ -581,8 +603,9 @@ impl std::hash::Hash for Operand {
                 3u8.hash(state);
                 encoded.hash(state);
             }
+            Operand::NullRef => 4u8.hash(state),
             Operand::Const(cell) => {
-                4u8.hash(state);
+                5u8.hash(state);
                 (Rc::as_ptr(cell) as usize).hash(state);
             }
         }
@@ -933,6 +956,22 @@ mod tests {
         // SmallInt deliberately replaces an Rc-sized payload. Pin this on the
         // two 64-bit production hosts so adding it cannot silently grow the
         // three inline Operand slots embedded in every Op.
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(std::mem::size_of::<Operand>(), 16);
+    }
+
+    /// `opencoder.py Trace._cached_const_ptr` reserves ref-pool index zero for
+    /// null, so recording and decoding it must not mint a forwarding cell.
+    #[test]
+    fn null_ref_is_inline_and_round_trips() {
+        let null = Operand::from_opref(OpRef::const_ptr(GcRef::NULL));
+        assert!(matches!(null, Operand::NullRef));
+        assert!(null.is_constant());
+        assert_eq!(null.type_(), Type::Ref);
+        assert_eq!(null.const_value(), Some(Value::Ref(GcRef::NULL)));
+        assert_eq!(null.to_opref(), OpRef::const_ptr(GcRef::NULL));
+        assert!(null.same_box(&Operand::const_(Const::Ref(GcRef::NULL))));
+
         #[cfg(target_pointer_width = "64")]
         assert_eq!(std::mem::size_of::<Operand>(), 16);
     }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1750,7 +1750,7 @@ impl<V> ConstLookup<V> for std::collections::HashMap<u32, V> {
     }
 }
 
-impl<V> ConstLookup<V> for indexmap::IndexMap<u32, V> {
+impl<V, S: std::hash::BuildHasher> ConstLookup<V> for indexmap::IndexMap<u32, V, S> {
     fn lookup(&self, key: u32) -> Option<&V> {
         self.get(&key)
     }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/regalloc.rs
@@ -40,6 +40,65 @@ impl RegisterCounts {
     }
 }
 
+/// RPython `tool/algo/unionfind.py::UnionFind`, narrowed to the symbolic
+/// registers owned by this proc-macro lowering path.
+///
+/// `majit-translate` has the same private helper for real flowspace
+/// Variables. Keeping this one local avoids making that implementation part
+/// of the cross-crate API merely for the temporary adapter that disappears
+/// once proc-macro helpers enter the normal codewriter graph.
+struct UnionFind {
+    parent: HashMap<Register, Register>,
+    weight: HashMap<Register, usize>,
+}
+
+impl UnionFind {
+    fn new() -> Self {
+        Self {
+            parent: HashMap::new(),
+            weight: HashMap::new(),
+        }
+    }
+
+    fn find_rep(&mut self, reg: Register) -> Register {
+        if !self.parent.contains_key(&reg) {
+            self.parent.insert(reg, reg);
+            self.weight.insert(reg, 1);
+            return reg;
+        }
+        let mut root = reg;
+        while self.parent[&root] != root {
+            root = self.parent[&root];
+        }
+        let mut current = reg;
+        while current != root {
+            let next = self.parent[&current];
+            self.parent.insert(current, root);
+            current = next;
+        }
+        root
+    }
+
+    fn union(&mut self, left: Register, right: Register) -> Register {
+        let left = self.find_rep(left);
+        let right = self.find_rep(right);
+        if left == right {
+            return left;
+        }
+        let left_weight = self.weight[&left];
+        let right_weight = self.weight[&right];
+        let (winner, loser) = if left_weight >= right_weight {
+            (left, right)
+        } else {
+            (right, left)
+        };
+        self.parent.insert(loser, winner);
+        self.weight.remove(&loser);
+        self.weight.insert(winner, left_weight + right_weight);
+        winner
+    }
+}
+
 fn successors(ops: &[OpMeta]) -> Vec<Vec<usize>> {
     let labels: HashMap<String, usize> = ops
         .iter()
@@ -144,6 +203,16 @@ fn coloring(
     for kind in [BindingKind::Int, BindingKind::Ref, BindingKind::Float] {
         graphs.insert(kind, DependencyGraph::new());
     }
+    // `RegAllocator.make_dependencies` starts every block with all of its
+    // inputargs live and makes that set a clique. The proc-macro ABI registers
+    // are the entry block's inputargs; seed them explicitly so even an unused
+    // parameter retains a distinct caller slot.
+    for kind in [BindingKind::Int, BindingKind::Ref, BindingKind::Float] {
+        let inputs: BTreeSet<_> = (0..reserved.for_kind(kind))
+            .map(|index| Register::new(kind, index))
+            .collect();
+        add_clique(graphs.get_mut(&kind).unwrap(), &inputs);
+    }
     for op in ops {
         for &reg in op.reads.iter().chain(op.writes.iter()) {
             graphs.get_mut(&reg.kind).unwrap().add_node(reg);
@@ -169,37 +238,86 @@ fn coloring(
         }
     }
 
+    // RPython `tool/algo/regalloc.py::RegAllocator.coalesce_variables` walks
+    // blocks from the end and coalesces each link argument with the matching
+    // target inputarg before coloring. The proc-macro CFG has already
+    // flattened those links into typed Move operations, so those moves are
+    // exactly the source/target pairs to feed to the same algorithm. This was
+    // the missing half of this adapter's claimed pre-flatten allocation: every
+    // branch join survived as a runtime `int_copy` even when its Variables did
+    // not interfere.
+    let originals: BTreeSet<Register> = ops
+        .iter()
+        .flat_map(|op| op.reads.iter().chain(&op.writes))
+        .copied()
+        .chain(return_reg)
+        .collect();
+    let mut unionfind = UnionFind::new();
+    for op in ops.iter().rev() {
+        if !matches!(op.kind, OpKind::MoveI | OpKind::MoveR | OpKind::MoveF)
+            || op.reads.len() != 1
+            || op.writes.len() != 1
+        {
+            continue;
+        }
+        let source = unionfind.find_rep(op.reads[0]);
+        let target = unionfind.find_rep(op.writes[0]);
+        if source == target || source.kind != target.kind {
+            continue;
+        }
+        let graph = graphs.get_mut(&source.kind).unwrap();
+        if graph.has_edge(&source, &target) {
+            continue;
+        }
+        let representative = unionfind.union(source, target);
+        if representative == source {
+            graph.coalesce(target, source);
+        } else {
+            graph.coalesce(source, target);
+        }
+    }
+
     let mut result = HashMap::new();
     for kind in [BindingKind::Int, BindingKind::Ref, BindingKind::Float] {
         let fixed = reserved.for_kind(kind);
         let graph = &graphs[&kind];
-        // Portal/helper ABI inputs are precolored. RPython can color its graph
-        // inputs freely because the caller mapping is generated afterwards;
-        // pyre's proc-macro ABI is already published, so retaining those slots
-        // is the minimal structural adaptation.
-        for old in 0..fixed {
-            let old = Register::new(kind, old);
-            if graph.neighbours.contains_key(&old) {
-                result.insert(old, old);
-            }
-        }
-        for old in graph.lexicographic_order() {
-            if result.contains_key(&old) {
+        let mut representative_colors = graph.find_node_coloring();
+
+        // RPython `flatten.py::GraphFlattener.enforce_input_args` does not
+        // reserve the ABI prefix while coloring. It swaps colors afterwards,
+        // which lets a temporary reuse a dead input slot while still making
+        // caller-visible inputargs dense at 0..N. The former adapter excluded
+        // the entire prefix from every temporary.
+        for input_index in 0..fixed {
+            let input = Register::new(kind, input_index);
+            let representative = unionfind.find_rep(input);
+            let Some(current_color) = representative_colors.get(&representative).copied() else {
+                continue;
+            };
+            let desired_color = usize::from(input_index);
+            if current_color == desired_color {
                 continue;
             }
-            let mut forbidden = BTreeSet::new();
-            for neighbour in &graph.neighbours[&old] {
-                if let Some(colored) = result.get(neighbour) {
-                    forbidden.insert(colored.index);
+            for color in representative_colors.values_mut() {
+                if *color == current_color {
+                    *color = desired_color;
+                } else if *color == desired_color {
+                    *color = current_color;
                 }
             }
-            let mut color = 0u8;
-            while forbidden.contains(&color) || u16::from(color) < fixed {
-                color = color
-                    .checked_add(1)
-                    .expect("JitCode register coloring exceeds u8");
+        }
+
+        for original in originals.iter().filter(|reg| reg.kind == kind) {
+            let representative = unionfind.find_rep(*original);
+            if let Some(&color) = representative_colors.get(&representative) {
+                result.insert(
+                    *original,
+                    Register {
+                        kind,
+                        index: u8::try_from(color).expect("JitCode register coloring exceeds u8"),
+                    },
+                );
             }
-            result.insert(old, Register { kind, index: color });
         }
     }
     result
@@ -356,6 +474,20 @@ pub(super) fn compact_registers(
             }
         }
     }
+    // `flatten.py::GraphFlattener.insert_renamings` compares post-regalloc
+    // source and destination colors and emits no `*_copy` when they match.
+    // Our link moves were materialized before this adapter runs, so perform
+    // the same check after rewriting and remove the now-empty links.
+    let (statements, op_metadata): (Vec<_>, Vec<_>) = std::mem::take(&mut lowerer.statements)
+        .into_iter()
+        .zip(std::mem::take(&mut lowerer.op_metadata))
+        .filter(|(_, meta)| {
+            !matches!(meta.kind, OpKind::MoveI | OpKind::MoveR | OpKind::MoveF)
+                || meta.reads != meta.writes
+        })
+        .unzip();
+    lowerer.statements = statements;
+    lowerer.op_metadata = op_metadata;
     let mut counts = reserved;
     for mapped in mapping.values() {
         counts.observe(*mapped);
@@ -408,6 +540,103 @@ mod tests {
             .map(ToString::to_string)
             .collect::<String>();
         assert!(!emitted.contains("3u16"));
+    }
+
+    /// `RegAllocator.coalesce_variables` makes a link source and its target
+    /// inputarg one Variable when they do not interfere; `flatten.py`
+    /// `GraphFlattener.insert_renamings` consequently emits no copy.
+    #[test]
+    fn noninterfering_link_move_is_coalesced_and_not_emitted() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.emit_op(
+            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(1)]),
+            quote! { __builder.load_const_i_value(1u16, 41i64); },
+        );
+        lowerer.emit_op(
+            OpMeta::linear(
+                OpKind::MoveI,
+                vec![Register::int(1)],
+                vec![Register::int(2)],
+            ),
+            quote! { __builder.move_i(2u16, 1u16); },
+        );
+        lowerer.emit_op(
+            OpMeta::terminal(vec![Register::int(2)]),
+            quote! { __builder.int_return(2u16); },
+        );
+
+        let (counts, returned) = compact_registers(
+            &mut lowerer,
+            RegisterCounts {
+                ints: 1,
+                ..RegisterCounts::default()
+            },
+            Some(Register::int(2)),
+        );
+
+        assert_eq!(counts.ints, 1, "a dead ABI input slot is reusable");
+        assert_eq!(returned, Some(Register::int(0)));
+        assert!(
+            !lowerer
+                .op_metadata
+                .iter()
+                .any(|meta| meta.kind == OpKind::MoveI)
+        );
+        assert!(
+            !lowerer
+                .statements
+                .iter()
+                .map(ToString::to_string)
+                .collect::<String>()
+                .contains("move_i")
+        );
+    }
+
+    /// A link source that stays live after the assignment interferes with the
+    /// target. Upstream `_try_coalesce` leaves that renaming for flattening.
+    #[test]
+    fn interfering_link_move_remains_a_copy() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.emit_op(
+            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(1)]),
+            quote! { __builder.load_const_i_value(1u16, 41i64); },
+        );
+        lowerer.emit_op(
+            OpMeta::linear(
+                OpKind::MoveI,
+                vec![Register::int(1)],
+                vec![Register::int(2)],
+            ),
+            quote! { __builder.move_i(2u16, 1u16); },
+        );
+        lowerer.emit_op(
+            OpMeta::linear(
+                OpKind::BinopI,
+                Register::ints(&[1, 2]),
+                vec![Register::int(3)],
+            ),
+            quote! { __builder.record_binop_i(3u16, majit_ir::OpCode::IntAdd, 1u16, 2u16); },
+        );
+        lowerer.emit_op(
+            OpMeta::terminal(vec![Register::int(3)]),
+            quote! { __builder.int_return(3u16); },
+        );
+
+        compact_registers(
+            &mut lowerer,
+            RegisterCounts {
+                ints: 1,
+                ..RegisterCounts::default()
+            },
+            Some(Register::int(3)),
+        );
+
+        assert!(
+            lowerer
+                .op_metadata
+                .iter()
+                .any(|meta| meta.kind == OpKind::MoveI)
+        );
     }
 
     /// The rewriter reaches only the arguments of a `__builder` call, so an

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -305,6 +305,10 @@ pub struct BlackholeInterpreter {
     pub position: usize,
     /// Caller frame in the blackhole frame chain.
     pub nextblackholeinterp: Option<Box<BlackholeInterpreter>>,
+    /// Whether `acquire_interp` registered this interpreter's traced fields
+    /// with `shadow_stack::register_bh_interp` for its whole life (the
+    /// pooled, boxed case). `run()` roots an unregistered one per call.
+    rooted: bool,
     /// Free-list link owned by `BlackholeInterpBuilder.blackholeinterps`.
     /// This is distinct from `nextblackholeinterp`, exactly as upstream's
     /// `back` pool link is distinct from the live caller-frame chain.
@@ -536,6 +540,14 @@ thread_local! {
     static EMPTY_JITCODE: std::sync::Arc<JitCode> = std::sync::Arc::new(JitCode::default());
 }
 
+impl Drop for BlackholeInterpreter {
+    fn drop(&mut self) {
+        if self.rooted {
+            majit_gc::shadow_stack::unregister_bh_interp(&self.registers_r);
+        }
+    }
+}
+
 impl Default for BlackholeInterpreter {
     /// Sentinel-value interpreter used by
     /// `BlackholeInterpBuilder::acquire_interp`'s `unwrap_or_default()`
@@ -566,6 +578,7 @@ impl Default for BlackholeInterpreter {
             jitcode: EMPTY_JITCODE.with(std::sync::Arc::clone),
             position: 0,
             nextblackholeinterp: None,
+            rooted: false,
             back: None,
             return_type: BhReturnType::Void,
             aborted: false,
@@ -970,6 +983,12 @@ impl BlackholeInterpreter {
                 self.setarg_f(i, val);
             }
         }
+    }
+
+    /// Whether this interpreter's traced fields are registered as GC roots
+    /// for its whole life (`acquire_interp`).
+    pub fn is_rooted(&self) -> bool {
+        self.rooted
     }
 
     /// blackhole.py cleanup_registers
@@ -1709,23 +1728,22 @@ impl BlackholeInterpreter {
         // that caller it reads a stale/zeroed frame (its `locals_cells_stack_w`
         // slot NULL) and a vable opcode dereferences it.  Rooting the full
         // pending chain here mirrors the RPython invariant.
-        let bh_depth = unsafe {
-            let depth = majit_gc::shadow_stack::push_bh_regs(
-                &mut self.registers_r,
-                &mut self.tmpreg_r,
-                &mut self.exception_last_value,
-            );
-            let mut caller = self.nextblackholeinterp.as_deref_mut();
-            while let Some(frame) = caller {
-                majit_gc::shadow_stack::push_bh_regs(
-                    &mut frame.registers_r,
-                    &mut frame.tmpreg_r,
-                    &mut frame.exception_last_value,
-                );
-                caller = frame.nextblackholeinterp.as_deref_mut();
+        // A pooled interpreter is registered for its whole life
+        // (`acquire_interp`); only one built outside the pool is rooted here.
+        let bh_depth = majit_gc::shadow_stack::bh_regs_depth();
+        unsafe {
+            let mut frame = Some(&mut *self);
+            while let Some(f) = frame {
+                if !f.rooted {
+                    majit_gc::shadow_stack::push_bh_regs(
+                        &mut f.registers_r,
+                        &mut f.tmpreg_r,
+                        &mut f.exception_last_value,
+                    );
+                }
+                frame = f.nextblackholeinterp.as_deref_mut();
             }
-            depth
-        };
+        }
         let vable_roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
         unsafe {
             let mut current = Some(&mut *self);
@@ -1747,9 +1765,11 @@ impl BlackholeInterpreter {
                 // SLOT so the walker rewrites it, the same shape
                 // `blackhole_from_resumedata` already applies to the resume
                 // reader's own `virtualizable_ptr` for the chain-build window.
-                majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
-                    &mut frame.virtualizable_ptr,
-                ));
+                if !frame.rooted {
+                    majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
+                        &mut frame.virtualizable_ptr,
+                    ));
+                }
                 if !frame.virtualizable_info.is_null() {
                     let vinfo = &*frame.virtualizable_info;
                     vinfo.push_resume_ref_roots_for_registers(&frame.registers_r);
@@ -2750,7 +2770,20 @@ impl BlackholeInterpBuilder {
             self.blackholeinterps = head.back.take();
             head
         } else {
-            Box::new(BlackholeInterpreter::default())
+            let mut bh = Box::new(BlackholeInterpreter::default());
+            // The interpreter is a GC object upstream, so its ref-holding
+            // fields are traced for as long as it exists. The box gives them
+            // a fixed address; `Drop` unregisters.
+            unsafe {
+                majit_gc::shadow_stack::register_bh_interp(
+                    &mut bh.registers_r,
+                    &mut bh.tmpreg_r,
+                    &mut bh.exception_last_value,
+                    &mut bh.virtualizable_ptr,
+                );
+            }
+            bh.rooted = true;
+            bh
         };
         // RPython blackhole.py:284-289:
         //   self.cpu = builder.cpu
@@ -3513,11 +3546,9 @@ mod tests {
     fn handler_state_field_moves_between_register_slots() {
         // Two scalars: slot 0, slot 1. load_state_field copies a scalar slot
         // into a working register; store_state_field copies back.
-        let mut bh = BlackholeInterpreter {
-            state_field_layout: StateFieldLayout::new(2, vec![], 0, 0),
-            registers_i: vec![10, 20, 0, 0],
-            ..BlackholeInterpreter::default()
-        };
+        let mut bh = BlackholeInterpreter::default();
+        bh.state_field_layout = StateFieldLayout::new(2, vec![], 0, 0);
+        bh.registers_i = vec![10, 20, 0, 0];
 
         // load_state_field/di: field_idx=1 (u16 LE) → dest reg 2.
         let next = handler_load_state_field_di(&mut bh, &[1, 0, 2], 0).unwrap();
@@ -3537,11 +3568,9 @@ mod tests {
         // arg keeps r0). load_state_field_ref copies a ref slot into a
         // working ref register; store_state_field_ref copies back. Raw
         // pointer bits round-trip.
-        let mut bh = BlackholeInterpreter {
-            state_field_layout: StateFieldLayout::with_ref_scalars(0, vec![], 0, 2, 1, 0),
-            registers_r: vec![0x9999, 0xAAAA, 0xBBBB, 0, 0],
-            ..BlackholeInterpreter::default()
-        };
+        let mut bh = BlackholeInterpreter::default();
+        bh.state_field_layout = StateFieldLayout::with_ref_scalars(0, vec![], 0, 2, 1, 0);
+        bh.registers_r = vec![0x9999, 0xAAAA, 0xBBBB, 0, 0];
 
         // load_state_field_ref/dr: field_idx=1 (u16 LE) → dest ref reg 3.
         let next = handler_load_state_field_ref_dr(&mut bh, &[1, 0, 3], 0).unwrap();
@@ -3563,12 +3592,10 @@ mod tests {
     #[test]
     fn handler_state_array_indexes_flattened_slots() {
         // 1 scalar (slot 0) + 1 fixed array of len 4 (slots 1..5).
-        let mut bh = BlackholeInterpreter {
-            state_field_layout: StateFieldLayout::new(1, vec![4], 0, 0),
-            // [scalar, a0, a1, a2, a3, idx_reg, dest_reg]
-            registers_i: vec![0, 100, 101, 102, 103, 0, 0],
-            ..BlackholeInterpreter::default()
-        };
+        let mut bh = BlackholeInterpreter::default();
+        bh.state_field_layout = StateFieldLayout::new(1, vec![4], 0, 0);
+        // [scalar, a0, a1, a2, a3, idx_reg, dest_reg]
+        bh.registers_i = vec![0, 100, 101, 102, 103, 0, 0];
 
         // load_state_array/dii: array_idx=0, index_reg=5 (holds 2), dest=6.
         bh.registers_i[5] = 2;

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -531,6 +531,42 @@ impl<'a> UnrolledLoopData<'a> {
     }
 }
 
+/// Pyre-only: stamp the per-trace `fail_index` and the trace-op index onto
+/// every guard's metainterp `ResumeGuardDescr`, so `(trace_id, fail_index)`
+/// readers resolve through the descr Arc directly.  The counter walks guards
+/// and FINISH in trace order — the numbering `find_fail_index_for_exit_op`
+/// and the assemblers' `fail_descrs` position share.  Readers compare
+/// against `fail_index_per_trace()` (this slot), not `fail_index()` (the
+/// global `alloc_fail_index()` id).
+///
+/// `ops` is the optimized frontend trace.  The backend GC rewriter inserts
+/// operations before code generation, so the assembler's prepared-op index
+/// is not an index into this slice; the descr is stamped from the frontend
+/// op, matching RPython where the `ResumeGuardDescr` stays attached to the
+/// live ResOperation rather than carrying an index into a rewritten array.
+///
+/// Non-resume FailDescrs are skipped: their `set_fail_index_per_trace`
+/// panics by default.
+pub(crate) fn stamp_guard_descr_trace_positions<T: AsRef<majit_ir::Op>>(ops: &[T]) {
+    let mut fail_index = 0u32;
+    for (op_idx, op) in ops.iter().enumerate() {
+        let op = op.as_ref();
+        let is_guard = op.opcode.is_guard();
+        if !is_guard && op.opcode != OpCode::Finish {
+            continue;
+        }
+        if is_guard
+            && let Some(descr) = op.getdescr()
+            && (descr.is_resume_guard() || descr.is_resume_guard_copied())
+            && let Some(fd) = descr.as_fail_descr()
+        {
+            fd.set_fail_index_per_trace(fail_index);
+            fd.set_source_op_index(op_idx);
+        }
+        fail_index += 1;
+    }
+}
+
 /// Build guard metadata for a compiled trace.
 ///
 /// The backend numbers every guard and finish in a single exit table, so this
@@ -561,6 +597,7 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
     let fvc = frame_value_count_fn.or_else(majit_ir::resumedata::get_frame_value_count_fn);
     let fvc_ref: Option<&dyn Fn(i32, i32) -> usize> =
         fvc.as_ref().map(|f| f as &dyn Fn(i32, i32) -> usize);
+    stamp_guard_descr_trace_positions(ops);
     // history.py:220/261/307 — each fail-arg's type is intrinsic on the Box
     // (the OpRef variant tag, `ty()`); a fail_arg carries its own type
     // regardless of trace position, so no position-keyed side table is needed.
@@ -570,46 +607,6 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
         let is_finish = op.opcode == OpCode::Finish;
         if !is_guard && !is_finish {
             continue;
-        }
-
-        if is_guard {
-            // Drop the `guard_op_indices` HashMap.
-            // Every reader is now routed through descr-side identity
-            // (`op.descr.as_fail_descr().fail_index_per_trace()`
-            // forward; op-position lookup
-            // `trace.ops[guard_index].descr.as_fail_descr()
-            // .fail_index_per_trace()` reverse).  Mirrors RPython's
-            // `compile.py:184 op.getdescr()` predicate where the descr
-            // identity replaces the side table entirely.
-            //
-            // The readers compare against `fail_index_per_trace()`
-            // (this slot, set by `set_fail_index_per_trace` below),
-            // not `fail_index()` (which is the global
-            // `alloc_fail_index()` id — a separate
-            // structural slot the readers do not consult).
-            //
-            // Pyre-only: stamp the per-trace `fail_index` onto the
-            // metainterp ResumeGuardDescr so `(trace_id, fail_index)`
-            // lookups can resolve through the descr Arc directly.
-            // Skip non-resume FailDescrs (whose
-            // `set_fail_index_per_trace` panics by default).
-            let __descr_arc = op.getdescr();
-            if let Some(fd) = __descr_arc.as_ref().and_then(|d| d.as_fail_descr())
-                && op
-                    .getdescr()
-                    .is_some_and(|d| d.is_resume_guard() || d.is_resume_guard_copied())
-            {
-                fd.set_fail_index_per_trace(fail_index);
-                // `ops` is the optimized frontend trace retained by
-                // `CompiledTrace`.  The backend GC rewriter inserts
-                // operations before code generation, so the assembler's
-                // prepared-op index is not a valid index into this slice.
-                // Re-stamp the canonical descr from the frontend op,
-                // matching RPython where the ResumeGuardDescr remains
-                // attached to the live ResOperation rather than carrying
-                // an index into a separate rewritten array.
-                fd.set_source_op_index(op_idx);
-            }
         }
 
         // RPython Box.type parity: each fail-arg's type is `livebox.type`,
@@ -895,37 +892,12 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                 rd_consts_arc.as_deref().map_or(&[], |pool| pool.as_slice());
             let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len()) as i32;
             let resolve_tagged_source = |tagged: i16| -> ExitValueSourceLayout {
-                let (val, tagbits) = majit_ir::resumedata::untag(tagged);
-                match tagbits {
-                    majit_ir::resumedata::TAGBOX => {
-                        let idx = if val >= 0 {
-                            val as usize
-                        } else {
-                            (num_failargs + val) as usize
-                        };
-                        ExitValueSourceLayout::ExitValue(idx)
-                    }
-                    majit_ir::resumedata::TAGVIRTUAL => {
-                        // resume.py:278-284 nested virtuals are numbered
-                        // negatively; resolve via negative indexing into
-                        // rd_virtuals (resume.py:951-954).
-                        let idx = if val >= 0 {
-                            val as usize
-                        } else {
-                            (num_virtuals + val) as usize
-                        };
-                        ExitValueSourceLayout::Virtual(idx)
-                    }
-                    majit_ir::resumedata::TAGINT => {
-                        ExitValueSourceLayout::Constant(val as i64, Type::Int)
-                    }
-                    majit_ir::resumedata::TAGCONST => {
-                        let idx = (val - majit_ir::resumedata::TAG_CONST_OFFSET) as usize;
-                        let c = rd_consts_ref.get(idx).copied().unwrap_or(Const::Int(0));
-                        ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
-                    }
-                    _ => ExitValueSourceLayout::Constant(0, Type::Int),
-                }
+                crate::resume::exit_source_from_tagged(
+                    tagged,
+                    num_failargs,
+                    rd_consts_ref,
+                    num_virtuals,
+                )
             };
             let resolve_fieldnums = |fieldnums: &[i16],
                                      fielddescr_indices: &[u32]|
@@ -1158,39 +1130,12 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                     entries
                         .iter()
                         .map(|pf| {
-                            // resume.py PENDINGFIELDSTRUCT.lldescr is
-                            // always present in RPython — the descr is
-                            // captured directly off the Setfield_gc /
-                            // Setarrayitem_gc op that produced the pending
-                            // field (heap.py force_lazy_sets_for_guard).
-                            // Pyre's producer in `optimizer.rs`'s
-                            // `emit_guard_operation` mirrors
-                            // this: `pf.descr = pf_op.descr.clone()` where
-                            // pf_op is always a descr-bearing setfield op.
-                            let descr = pf
-                                .descr
-                                .clone()
-                                .expect("resume.py:1000 PENDINGFIELDSTRUCT.lldescr must be set");
-                            // resume.py: itemindex >= 0 → setarrayitem.
-                            let item_index = if descr.as_array_descr().is_some() {
-                                Some(usize::try_from(pf.item_index).expect(
-                                    "resume.py:1003 setarrayitem pending field requires non-negative item_index",
-                                ))
-                            } else if descr.as_field_descr().is_some() {
-                                None
-                            } else {
-                                panic!(
-                                    "pending field descr must be FieldDescr or ArrayDescr (descr={:?})",
-                                    descr,
-                                );
-                            };
-                            majit_backend::ExitPendingFieldLayout {
-                                descr: pf.descr.clone(),
-                                is_array_item: item_index.is_some(),
-                                item_index,
-                                target: resolve_tagged_source(pf.target_tagged),
-                                value: resolve_tagged_source(pf.value_tagged),
-                            }
+                            crate::resume::exit_pending_field_layout(
+                                pf,
+                                num_failargs,
+                                rd_consts_ref,
+                                num_virtuals,
+                            )
                         })
                         .collect()
                 })

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1203,20 +1203,16 @@ pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
     ops: &[T],
 ) {
     for layout in backend_layouts {
-        // compile.py copy_all_attributes_from parity: when the backend
-        // exposes resume data (rd_numb / rd_consts / rd_virtuals /
-        // rd_pendingfields) for an exit the frontend never saw, assemble
-        // them into a `ResumeStorage` so downstream consumers
-        // (rebuild_guard_fail_state, blackhole_resume_via_rd_numb) see the
-        // same shared pool they get on the frontend-primed path.
-        let storage_from_backend = layout.rd_numb.clone().map(|numb| {
-            crate::resume::ResumeStorage::new(
-                numb,
-                layout.rd_consts.clone().unwrap_or_default(),
-                layout.rd_virtuals.clone().unwrap_or_default(),
-                layout.rd_pendingfields.clone().unwrap_or_default(),
-            )
-        });
+        // `ResumeGuardDescr.get_resumestorage`: an exit the frontend never
+        // saw still carries its payload on its own descr, so downstream
+        // consumers (rebuild_guard_fail_state, blackhole_resume_via_rd_numb)
+        // see the same pool they get on the frontend-primed path.
+        let storage_from_backend = layout
+            .descr
+            .as_ref()
+            .and_then(|descr| descr.as_fail_descr())
+            .and_then(crate::resume::ResumeStorage::from_fail_descr)
+            .map(std::sync::Arc::new);
         // Pre-resolve the source-op `descr` for backend-only entries so
         // `entry.descr` matches what `build_guard_metadata` would have
         // primed had the frontend seen this exit.  When the source op
@@ -3321,13 +3317,6 @@ pub fn make_fail_descr_with_index(fail_index: u32, num_live: usize) -> DescrRef 
     Arc::new(ResumeGuardDescr {
         fail_index,
         types: UnsafeCell::new(vec![Type::Int; num_live]),
-        resume_data: ResumeData {
-            vable_array: Vec::new(),
-            vref_array: Vec::new(),
-            frames: Vec::new(),
-            virtuals: Vec::new(),
-            pending_fields: Vec::new(),
-        },
         payload: RdPayload::empty(),
         vector_info: UnsafeCell::new(None),
         adr_jump_offset: UnsafeCell::new(0),
@@ -3415,13 +3404,6 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
     Arc::new(ResumeGuardDescr {
         fail_index: alloc_fail_index(),
         types: UnsafeCell::new(types),
-        resume_data: ResumeData {
-            vable_array: Vec::new(),
-            vref_array: Vec::new(),
-            frames: Vec::new(),
-            virtuals: Vec::new(),
-            pending_fields: Vec::new(),
-        },
         payload: RdPayload::empty(),
         vector_info: UnsafeCell::new(None),
         adr_jump_offset: UnsafeCell::new(0),
@@ -3747,13 +3729,6 @@ pub fn make_resume_at_position_descr_typed(types: Vec<Type>) -> DescrRef {
         inner: ResumeGuardDescr {
             fail_index: alloc_fail_index(),
             types: UnsafeCell::new(types),
-            resume_data: ResumeData {
-                vable_array: Vec::new(),
-                vref_array: Vec::new(),
-                frames: Vec::new(),
-                virtuals: Vec::new(),
-                pending_fields: Vec::new(),
-            },
             payload: RdPayload::empty(),
             vector_info: UnsafeCell::new(None),
             adr_jump_offset: UnsafeCell::new(0),
@@ -4032,13 +4007,6 @@ pub fn make_resume_guard_forced_descr_typed(types: Vec<Type>) -> DescrRef {
         inner: ResumeGuardDescr {
             fail_index: alloc_fail_index(),
             types: UnsafeCell::new(types),
-            resume_data: ResumeData {
-                vable_array: Vec::new(),
-                vref_array: Vec::new(),
-                frames: Vec::new(),
-                virtuals: Vec::new(),
-                pending_fields: Vec::new(),
-            },
             payload: RdPayload::empty(),
             vector_info: UnsafeCell::new(None),
             adr_jump_offset: UnsafeCell::new(0),
@@ -4298,13 +4266,6 @@ pub fn make_resume_guard_exc_descr_typed(types: Vec<Type>) -> DescrRef {
         inner: ResumeGuardDescr {
             fail_index: alloc_fail_index(),
             types: UnsafeCell::new(types),
-            resume_data: ResumeData {
-                vable_array: Vec::new(),
-                vref_array: Vec::new(),
-                frames: Vec::new(),
-                virtuals: Vec::new(),
-                pending_fields: Vec::new(),
-            },
             payload: RdPayload::empty(),
             vector_info: UnsafeCell::new(None),
             adr_jump_offset: UnsafeCell::new(0),
@@ -5317,7 +5278,6 @@ impl majit_ir::Descr for CompileLoopVersionDescr {
             inner: ResumeGuardDescr {
                 fail_index: alloc_fail_index(),
                 types: UnsafeCell::new(unsafe { (&*self.inner.types.get()).clone() }),
-                resume_data: self.inner.resume_data.clone(),
                 payload: self.inner.payload.deep_clone(),
                 vector_info: UnsafeCell::new(unsafe { (&*self.inner.vector_info.get()).clone() }),
                 adr_jump_offset: UnsafeCell::new(0),
@@ -5537,13 +5497,6 @@ fn make_compile_loop_version_descr_with_payload(types: Vec<Type>, payload: RdPay
         inner: ResumeGuardDescr {
             fail_index: alloc_fail_index(),
             types: UnsafeCell::new(types),
-            resume_data: ResumeData {
-                vable_array: Vec::new(),
-                vref_array: Vec::new(),
-                frames: Vec::new(),
-                virtuals: Vec::new(),
-                pending_fields: Vec::new(),
-            },
             payload,
             vector_info: UnsafeCell::new(None),
             adr_jump_offset: UnsafeCell::new(0),
@@ -6106,13 +6059,6 @@ mod fail_descr_tests {
             inner: ResumeGuardDescr {
                 fail_index: alloc_fail_index(),
                 types: UnsafeCell::new(vec![Type::Int]),
-                resume_data: ResumeData {
-                    vable_array: Vec::new(),
-                    vref_array: Vec::new(),
-                    frames: Vec::new(),
-                    virtuals: Vec::new(),
-                    pending_fields: Vec::new(),
-                },
                 payload: RdPayload::empty(),
                 vector_info: UnsafeCell::new(None),
                 adr_jump_offset: UnsafeCell::new(0),

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -584,11 +584,11 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
     frame_value_count_fn: Option<fn(i32, i32) -> usize>,
 ) -> (
     indexmap::IndexMap<u32, crate::resume::ResumeLayoutSummary>,
-    indexmap::IndexMap<u32, StoredExitLayout>,
+    crate::FxIndexMap<u32, StoredExitLayout>,
 ) {
     let mut result: indexmap::IndexMap<u32, crate::resume::ResumeLayoutSummary> =
         indexmap::IndexMap::new();
-    let mut exit_layouts: indexmap::IndexMap<u32, StoredExitLayout> = indexmap::IndexMap::new();
+    let mut exit_layouts: crate::FxIndexMap<u32, StoredExitLayout> = Default::default();
     let mut fail_index = 0u32;
     let mut resume_memo = ResumeDataLoopMemo::new();
     // The driver-scoped override wins: a driver whose frames are numbered
@@ -1198,7 +1198,7 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
 }
 
 pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
-    exit_layouts: &mut indexmap::IndexMap<u32, StoredExitLayout>,
+    exit_layouts: &mut crate::FxIndexMap<u32, StoredExitLayout>,
     backend_layouts: &[FailDescrLayout],
     ops: &[T],
 ) {
@@ -1309,7 +1309,7 @@ pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
 /// Guards that HAVE recovery_layout (all production guards after backend
 /// merge) must satisfy the full invariant. Guards without (only possible
 /// in unit tests with mock backends) are warned but not fatal.
-pub(crate) fn validate_exit_layouts(exit_layouts: &indexmap::IndexMap<u32, StoredExitLayout>) {
+pub(crate) fn validate_exit_layouts(exit_layouts: &crate::FxIndexMap<u32, StoredExitLayout>) {
     for (&fail_index, layout) in exit_layouts {
         if layout.resolve_is_finish() {
             continue;
@@ -2295,7 +2295,7 @@ pub(crate) fn strip_stray_overflow_guards(ops: Vec<majit_ir::OpRc>) -> Vec<majit
 
 pub(crate) fn enrich_guard_resume_layouts_for_trace(
     resume_layouts: &mut indexmap::IndexMap<u32, crate::resume::ResumeLayoutSummary>,
-    exit_layouts: &mut indexmap::IndexMap<u32, StoredExitLayout>,
+    exit_layouts: &mut crate::FxIndexMap<u32, StoredExitLayout>,
     trace_id: u64,
     inputargs: &[InputArg],
     trace_info: Option<&CompiledTraceInfo>,
@@ -2318,7 +2318,7 @@ pub(crate) fn enrich_guard_resume_layouts_for_trace(
 }
 
 pub(crate) fn patch_guard_recovery_layouts_for_trace(
-    exit_layouts: &mut indexmap::IndexMap<u32, StoredExitLayout>,
+    exit_layouts: &mut crate::FxIndexMap<u32, StoredExitLayout>,
 ) {
     // Backend no longer caches a per-descr recovery layout; the
     // metainterp's `StoredExitLayout.recovery_layout` cache is the
@@ -2692,7 +2692,7 @@ pub fn compile_tmp_callback(
     // Inline-Const carries each Const value directly on its OpRef
     // variant (history.py:227/268/314), so the backend pool is left
     // empty for `compile_tmp_callback`.
-    backend.set_constants_pool(majit_ir::ConstMap::new());
+    backend.set_constants_pool(majit_ir::ConstMap::default());
     // The backend boundary takes `&[InputArg]` by value (the flat OpRef
     // encoding survives past this point); identity ends here.
     let backend_inputargs: Vec<InputArg> =
@@ -2745,7 +2745,7 @@ mod tests {
         use crate::history::test_support::rooted_resop_operand;
         use majit_ir::OpRc;
 
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let build = |label_descr_index: u64, jump_descr_index: u64| {
             let mut label = Op::new(
                 OpCode::Label,
@@ -2980,7 +2980,7 @@ mod tests {
         };
         let mut ops: Vec<majit_ir::OpRc> = vec![op0, op1, op2];
         let mut inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         patch_new_loop_to_load_virtualizable_fields(
             &mut ops,
@@ -3057,7 +3057,7 @@ mod tests {
             InputArg::new_ref(1),
             InputArg::new_ref(2),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         patch_new_loop_to_load_virtualizable_fields(
@@ -3135,7 +3135,7 @@ mod tests {
             InputArg::new_int(2),
             InputArg::new_int(3),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
 
         patch_new_loop_to_load_virtualizable_fields(

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -3331,10 +3331,7 @@ pub fn make_fail_descr_with_index(fail_index: u32, num_live: usize) -> DescrRef 
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
-        bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-        bridge_dispatch_drop_fn: OnceLock::new(),
+        bridge: std::sync::OnceLock::new(),
         range_foriter_key: AtomicU64::new(0),
         instance_next_foriter_key: AtomicU64::new(0),
     })
@@ -3418,10 +3415,7 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
         external_jump_target: OnceLock::new(),
-        bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-        bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-        bridge_dispatch_drop_fn: OnceLock::new(),
+        bridge: std::sync::OnceLock::new(),
         range_foriter_key: AtomicU64::new(0),
         instance_next_foriter_key: AtomicU64::new(0),
     })
@@ -3743,10 +3737,7 @@ pub fn make_resume_at_position_descr_typed(types: Vec<Type>) -> DescrRef {
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
-            bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             range_foriter_key: AtomicU64::new(0),
             instance_next_foriter_key: AtomicU64::new(0),
         },
@@ -4021,10 +4012,7 @@ pub fn make_resume_guard_forced_descr_typed(types: Vec<Type>) -> DescrRef {
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
-            bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             range_foriter_key: AtomicU64::new(0),
             instance_next_foriter_key: AtomicU64::new(0),
         },
@@ -4280,10 +4268,7 @@ pub fn make_resume_guard_exc_descr_typed(types: Vec<Type>) -> DescrRef {
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
-            bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             range_foriter_key: AtomicU64::new(0),
             instance_next_foriter_key: AtomicU64::new(0),
         },
@@ -4389,32 +4374,11 @@ pub struct ResumeGuardCopiedDescr {
     /// loop-token-equivalent metadata onto each emitted descr
     /// individually; the cell is reclaimed in `Drop`.
     trace_info: std::sync::atomic::AtomicPtr<CompiledTraceInfo>,
-    /// Pyre-only per-emission cranelift bridge code-pointer cache.
-    /// `Box` heap-pins the `AtomicUsize` so its address survives
-    /// `Arc::clone` of the meta descr and can be baked into cranelift's
-    /// `emit_attached_bridge_dispatch` as an immediate.  Per-emission
-    /// because each copied descr can have its own bridge attached
-    /// (compile.py `handle_fail` applies to both
-    /// ResumeGuardDescr and ResumeGuardCopiedDescr).  `0` means no
-    /// bridge attached.
-    bridge_code_ptr_cache: Box<std::sync::atomic::AtomicUsize>,
-    /// Pyre-only per-emission cranelift bridge body-pointer cache.
-    /// Same shape as `bridge_code_ptr_cache`, but holds the bridge's
-    /// `CallConv::Tail` body entry; the in-code dispatch tail-calls it
-    /// so a guard failure transfers into the bridge without leaving a
-    /// machine-stack return frame (PyPy `patch_jump_for_descr` JMP).
-    bridge_body_ptr_cache: Box<std::sync::atomic::AtomicUsize>,
-    /// Pyre-only per-emission cranelift bridge dispatch cell.
-    /// Type-erased to `*mut ()` because `BridgeData` lives in
-    /// `majit-backend-cranelift` (downstream); the cleanup function
-    /// registered via `bridge_dispatch_swap` knows the concrete type.
-    /// Reclaimed in `Drop`.
-    bridge_dispatch_cell: std::sync::atomic::AtomicPtr<()>,
-    /// Pyre-only per-emission cranelift bridge dispatch cleanup fn.
-    /// Registered by the backend on first `bridge_dispatch_swap`;
-    /// invoked by `Drop` on the surviving payload to reclaim the
-    /// published `Arc<BridgeData>` without knowing its concrete type.
-    bridge_dispatch_drop_fn: std::sync::OnceLock<unsafe fn(*mut ())>,
+    /// Per-emission cranelift bridge cells; see
+    /// `ResumeGuardDescr::bridge`.  Per-emission because each copied descr
+    /// can have its own bridge attached (`compile.py handle_fail` applies
+    /// to both ResumeGuardDescr and ResumeGuardCopiedDescr).
+    bridge: std::sync::OnceLock<Box<majit_backend::BridgeDispatchCells>>,
     /// Pyre-only per-emission cranelift cross-loop JUMP target slot.
     /// Mirrors `ResumeGuardDescr::external_jump_target`; per-emission
     /// because each copied descr can be the JUMP exit for an
@@ -4441,23 +4405,6 @@ impl Drop for ResumeGuardCopiedDescr {
             // `set_trace_info_any`.
             unsafe { drop(Arc::from_raw(ptr as *const CompiledTraceInfo)) };
         }
-        // Reclaim any published bridge dispatch payload via the
-        // backend-registered cleanup function (mirrors
-        // `ResumeGuardDescr::drop` -Tβ12 logic).
-        let bridge_ptr = self
-            .bridge_dispatch_cell
-            .swap(std::ptr::null_mut(), Ordering::AcqRel);
-        if !bridge_ptr.is_null()
-            && let Some(drop_fn) = self.bridge_dispatch_drop_fn.get()
-        {
-            // Safety: `drop_fn` was registered via `bridge_dispatch_swap`
-            // alongside the payload at `bridge_ptr`; the publisher
-            // contracts to hand the cleanup function a payload of the
-            // same shape it published.
-            unsafe { drop_fn(bridge_ptr) };
-        }
-        // else: payload published with no cleanup registered — a
-        // backend bug.  Leaks rather than risking the wrong type.
     }
 }
 
@@ -4524,10 +4471,7 @@ impl majit_ir::Descr for ResumeGuardCopiedDescr {
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             external_jump_target: std::sync::OnceLock::new(),
         }))
     }
@@ -4764,29 +4708,32 @@ impl FailDescr for ResumeGuardCopiedDescr {
             unsafe { drop(Arc::from_raw(old_ptr as *const CompiledTraceInfo)) };
         }
     }
-    /// Per-emission cranelift bridge cells (see field comments).
-    /// Same shape and JIT-bake contract as `ResumeGuardDescr`.
+    /// Per-emission cranelift bridge cells; same contract as
+    /// `ResumeGuardDescr`.
     fn bridge_cache_addrs(&self) -> Option<(usize, usize)> {
-        Some((
-            self.bridge_code_ptr_cache.as_ref() as *const _ as usize,
-            self.bridge_body_ptr_cache.as_ref() as *const _ as usize,
-        ))
+        Some(
+            self.bridge
+                .get_or_init(majit_backend::BridgeDispatchCells::new)
+                .cache_addrs(),
+        )
     }
     fn bridge_code_ptr(&self) -> usize {
-        self.bridge_code_ptr_cache.load(Ordering::Acquire)
+        self.bridge.get().map_or(0, |cells| cells.code_ptr())
     }
     fn store_bridge_caches(&self, code_ptr: usize, body_ptr: usize) {
-        self.bridge_body_ptr_cache
-            .store(body_ptr, Ordering::Release);
-        self.bridge_code_ptr_cache
-            .store(code_ptr, Ordering::Release);
+        self.bridge
+            .get_or_init(majit_backend::BridgeDispatchCells::new)
+            .store_caches(code_ptr, body_ptr)
     }
     fn bridge_dispatch_load(&self) -> *mut () {
-        self.bridge_dispatch_cell.load(Ordering::Acquire)
+        self.bridge
+            .get()
+            .map_or(std::ptr::null_mut(), |cells| cells.dispatch_load())
     }
     fn bridge_dispatch_swap(&self, new_ptr: *mut (), drop_fn: unsafe fn(*mut ())) -> *mut () {
-        let _ = self.bridge_dispatch_drop_fn.set(drop_fn);
-        self.bridge_dispatch_cell.swap(new_ptr, Ordering::AcqRel)
+        self.bridge
+            .get_or_init(majit_backend::BridgeDispatchCells::new)
+            .dispatch_swap(new_ptr, drop_fn)
     }
 
     /// Mirror `ResumeGuardDescr::is_external_jump`
@@ -4855,10 +4802,7 @@ impl majit_ir::Descr for ResumeGuardCopiedExcDescr {
                 back_edge_poll: std::sync::atomic::AtomicBool::new(false),
                 fail_count: AtomicU32::new(0),
                 trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-                bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-                bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-                bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-                bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
+                bridge: std::sync::OnceLock::new(),
                 external_jump_target: std::sync::OnceLock::new(),
             },
         }))
@@ -5070,10 +5014,7 @@ pub fn make_resume_guard_copied_descr(prev: DescrRef) -> DescrRef {
         back_edge_poll: std::sync::atomic::AtomicBool::new(false),
         fail_count: AtomicU32::new(0),
         trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-        bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-        bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-        bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-        bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
+        bridge: std::sync::OnceLock::new(),
         external_jump_target: std::sync::OnceLock::new(),
     })
 }
@@ -5111,10 +5052,7 @@ pub fn make_resume_guard_copied_exc_descr(prev: DescrRef) -> DescrRef {
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            bridge_code_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(std::sync::atomic::AtomicUsize::new(0)),
-            bridge_dispatch_cell: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: std::sync::OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             external_jump_target: std::sync::OnceLock::new(),
         },
     })
@@ -5292,10 +5230,7 @@ impl majit_ir::Descr for CompileLoopVersionDescr {
                 fail_count: AtomicU32::new(0),
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),
                 external_jump_target: OnceLock::new(),
-                bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-                bridge_dispatch_drop_fn: OnceLock::new(),
+                bridge: std::sync::OnceLock::new(),
                 range_foriter_key: AtomicU64::new(0),
                 instance_next_foriter_key: AtomicU64::new(0),
             },
@@ -5511,10 +5446,7 @@ fn make_compile_loop_version_descr_with_payload(types: Vec<Type>, payload: RdPay
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
             external_jump_target: OnceLock::new(),
-            bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-            bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-            bridge_dispatch_drop_fn: OnceLock::new(),
+            bridge: std::sync::OnceLock::new(),
             range_foriter_key: AtomicU64::new(0),
             instance_next_foriter_key: AtomicU64::new(0),
         },
@@ -6073,10 +6005,7 @@ mod fail_descr_tests {
                 fail_count: AtomicU32::new(0),
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),
                 external_jump_target: OnceLock::new(),
-                bridge_code_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_body_ptr_cache: Box::new(AtomicUsize::new(0)),
-                bridge_dispatch_cell: AtomicPtr::new(std::ptr::null_mut()),
-                bridge_dispatch_drop_fn: OnceLock::new(),
+                bridge: std::sync::OnceLock::new(),
                 range_foriter_key: AtomicU64::new(0),
                 instance_next_foriter_key: AtomicU64::new(0),
             },

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6420,13 +6420,6 @@ impl<S: JitState> JitDriver<S> {
             // compile.py handle_fail
             let fail_index = result.fail_index;
             let trace_id = result.trace_id;
-            // Taken, not cloned: `result` is dropped a few lines below, and
-            // the finish arm above — the one that carries no layout — has
-            // already returned.
-            let exit_layout = *result
-                .exit_layout
-                .take()
-                .expect("a guard exit carries its exit layout");
             // `warmstate.py execute_assembler` reads fail values from the
             // deadframe in place. Pyre projects its typed exit buffer back to
             // machine words for the resume helpers; reuse the entry scratch's
@@ -6438,6 +6431,13 @@ impl<S: JitState> JitDriver<S> {
                 .descr_arc
                 .take()
                 .expect("a guard exit carries its descr");
+            // `compile.py handle_fail(self, deadframe, ...)`: the failing
+            // guard's own `ResumeGuardDescr` is what every read below is off
+            // — its fail-arg types, its `rd_*` resume payload — not a layout
+            // assembled per failure from the frontend's records.
+            let fd: &dyn majit_ir::FailDescr = descr_arc
+                .as_fail_descr()
+                .expect("a guard exit carries a FailDescr");
             let guard_value_operand = result.guard_value_operand;
             // `compile.py handle_fail` `resumedescr.rd_loop_token`, resolved
             // once where the run handed the descr back.
@@ -6479,22 +6479,18 @@ impl<S: JitState> JitDriver<S> {
             if crate::callee_rca_enabled() {
                 eprintln!(
                     "[callee-rca][guard-fail] fail_index={} trace_id={} raw_values={:?} exit_types={:?}",
-                    fail_index, trace_id, raw_values, exit_layout.exit_types,
+                    fail_index, trace_id, raw_values, fd.fail_arg_types(),
                 );
                 if let Some(dump) = state.debug_state_fields(&compiled_meta) {
                     eprintln!("[callee-rca][post-execute-token-state]\n{dump}");
                 }
             }
-            let fallback_green_key = if exit_layout.rd_loop_token != 0 {
-                exit_layout.rd_loop_token
-            } else {
-                green_key
-            };
             // Resolved once for the whole event, where the run handed the descr
             // back, and carried here: `compile.py handle_fail` reads
             // `resumedescr.rd_loop_token` once and hands the loop it names to
-            // both the layout it looks up and the `must_compile` call.
-            let owning_key = descr_owning_key.unwrap_or(fallback_green_key);
+            // the `must_compile` call. A descr with no owner stamped is the
+            // loop that was entered.
+            let owning_key = descr_owning_key.unwrap_or(green_key);
             let (must_compile, owning_key) = self.meta.must_compile_with_owning_key(
                 &descr_arc,
                 &raw_values,
@@ -6547,18 +6543,26 @@ impl<S: JitState> JitDriver<S> {
             }
 
             // compile.py:711 resume_in_blackhole
-            // compile.py `ResumeGuardDescr` storage — borrow
-            // `rd_numb` / `rd_consts()` / `rd_virtuals` off the shared
-            // Arc so blackhole resume observes the guard-owned pool
-            // the GC walker updates (no per-call Vec clone).
-            if let Some(storage) = exit_layout.storage.as_deref() {
-                let rd_numb = storage.rd_numb.as_ref();
-                let rd_consts_slice: &[Const] = storage.rd_consts();
+            // compile.py `ResumeGuardDescr` storage — `rd_numb` /
+            // `rd_consts` / `rd_virtuals` / `rd_pendingfields` borrowed off
+            // the failing descr itself (`get_resumestorage(): return self`),
+            // so blackhole resume observes the guard-owned pool the GC
+            // walker updates, and nothing is built per failure to hold them.
+            if let Some(rd_numb) = fd.rd_numb() {
+                let rd_consts_slice: &[Const] = fd.rd_consts().unwrap_or(&[]);
 
-                // `resume.py _prepare_virtuals` — off the guard's own storage,
-                // which builds the reader-shaped virtuals once and hands the
-                // same list to every later resume off this guard.
-                let rd_virtuals_slice = Some(storage.virtual_infos());
+                // `resume.py _prepare_virtuals` reads `storage.rd_virtuals`,
+                // the reader-shaped list built at compile time. The descr
+                // carries the compile-time `RdVirtualInfo` list; converting it
+                // here is one pass per failure, and none at all for the
+                // common guard that has no virtuals.
+                let virtual_infos: Vec<crate::resume::VirtualInfo> = fd
+                    .rd_virtuals()
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|rd| crate::resume::virtual_info_from_rd(rd))
+                    .collect();
+                let rd_virtuals_slice = Some(virtual_infos.as_slice());
 
                 // resume.py:1338-1340: `jitcode = jitcodes[jitcode_pos];
                 // curbh.setposition(jitcode, pc)`.  Per-driver
@@ -6642,9 +6646,9 @@ impl<S: JitState> JitDriver<S> {
                     rd_consts_slice,
                     all_liveness,
                     &raw_values,
-                    Some(&exit_layout.exit_types),
+                    Some(fd.fail_arg_types()),
                     rd_virtuals_slice,
-                    Some(storage.rd_pendingfields()), // rd_guard_pendingfields
+                    Some(fd.rd_pendingfields().unwrap_or(&[])), // rd_guard_pendingfields
                     Some(
                         &self.meta_interp().staticdata.virtualref_info
                             as &dyn crate::resume::VRefInfo,
@@ -7069,19 +7073,11 @@ impl<S: JitState> JitDriver<S> {
             // (`compile.py send_bridge_to_backend`); the backend stamped
             // its trace's header pc on the descr (`CompiledTraceInfo`), so
             // that is read next.
-            let guard_resume_pc = exit_layout
-                .recovery_layout
-                .as_ref()
-                .and_then(|recovery| recovery.frames.first())
-                .and_then(|frame| frame.header_pc)
-                .or_else(|| {
-                    descr_arc
-                        .as_fail_descr()
-                        .and_then(|fd| fd.trace_info_any())
-                        .and_then(|info| {
-                            info.downcast_ref::<majit_backend::CompiledTraceInfo>()
-                                .map(|info| info.header_pc)
-                        })
+            let guard_resume_pc = fd
+                .trace_info_any()
+                .and_then(|info| {
+                    info.downcast_ref::<majit_backend::CompiledTraceInfo>()
+                        .map(|info| info.header_pc)
                 })
                 .or_else(|| self.get_merge_point_pc(owning_key, trace_id, fail_index))
                 .map(|pc| pc as usize)

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6479,7 +6479,10 @@ impl<S: JitState> JitDriver<S> {
             if crate::callee_rca_enabled() {
                 eprintln!(
                     "[callee-rca][guard-fail] fail_index={} trace_id={} raw_values={:?} exit_types={:?}",
-                    fail_index, trace_id, raw_values, fd.fail_arg_types(),
+                    fail_index,
+                    trace_id,
+                    raw_values,
+                    fd.fail_arg_types(),
                 );
                 if let Some(dump) = state.debug_state_fields(&compiled_meta) {
                     eprintln!("[callee-rca][post-execute-token-state]\n{dump}");

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2649,6 +2649,20 @@ impl<S: JitState> JitDriver<S> {
             .get_resume_storage_with_slot_types(green_key, trace_id, fail_index)
     }
 
+    /// Descr-first form of [`Self::get_resume_storage_with_slot_types`]
+    /// (`ResumeGuardDescr.get_resumestorage`): a bridge guard has no
+    /// frontend record, so the storage is read off the descr itself.
+    pub fn get_resume_storage_with_slot_types_for_descr(
+        &self,
+        descr: &dyn majit_ir::FailDescr,
+        green_key: u64,
+        trace_id: u64,
+        fail_index: u32,
+    ) -> Option<(std::sync::Arc<crate::resume::ResumeStorage>, Vec<Type>)> {
+        self.meta
+            .get_resume_storage_with_slot_types_for_descr(descr, green_key, trace_id, fail_index)
+    }
+
     pub fn get_exit_types(
         &self,
         green_key: u64,
@@ -7051,11 +7065,24 @@ impl<S: JitState> JitDriver<S> {
             // which resumes at the loop entry against state the recovery has
             // already rewound. The failing guard's own layout carries the same
             // header pc, so reading it first also answers without a lookup.
+            // A bridge guard carries no frontend recovery layout
+            // (`compile.py send_bridge_to_backend`); the backend stamped
+            // its trace's header pc on the descr (`CompiledTraceInfo`), so
+            // that is read next.
             let guard_resume_pc = exit_layout
                 .recovery_layout
                 .as_ref()
                 .and_then(|recovery| recovery.frames.first())
                 .and_then(|frame| frame.header_pc)
+                .or_else(|| {
+                    descr_arc
+                        .as_fail_descr()
+                        .and_then(|fd| fd.trace_info_any())
+                        .and_then(|info| {
+                            info.downcast_ref::<majit_backend::CompiledTraceInfo>()
+                                .map(|info| info.header_pc)
+                        })
+                })
                 .or_else(|| self.get_merge_point_pc(owning_key, trace_id, fail_index))
                 .map(|pc| pc as usize)
                 .unwrap_or(target_pc);

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -2006,6 +2006,12 @@ fn guard_census_enabled() -> bool {
     *ON.get_or_init(|| std::env::var_os("MAJIT_GUARD_CENSUS").is_some())
 }
 
+/// An `IndexMap` keyed by a small integer (a green key, a trace id, a fail
+/// index, a box position): RPython's `dict` hashes an int as itself, so the
+/// lookups the guard-failure and optimizer paths make per event cost no
+/// hashing to speak of; the default `RandomState` (SipHash) does.
+pub(crate) type FxIndexMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+
 pub fn guard_census_record(green_key: u64, trace_id: u64, fail_index: u32) {
     if !guard_census_enabled() {
         return;

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -171,7 +171,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallMayForceN);
@@ -191,7 +191,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
@@ -208,7 +208,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallAssemblerI);
@@ -227,7 +227,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::GuardNotForced);
@@ -248,7 +248,7 @@ mod tests {
             let mut opt = Optimizer::new();
             opt.add_pass(Box::new(OptEarlyForce::new()));
             let result =
-                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
             assert_eq!(result.len(), 1, "{opcode:?} should be handled");
         }
     }
@@ -268,7 +268,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::SetfieldGc);

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -247,8 +247,11 @@ mod tests {
 
             let mut opt = Optimizer::new();
             opt.add_pass(Box::new(OptEarlyForce::new()));
-            let result =
-                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
+            let result = opt.optimize_with_constants_and_inputs(
+                &ops,
+                &mut majit_ir::ConstMap::default(),
+                1024,
+            );
             assert_eq!(result.len(), 1, "{opcode:?} should be handled");
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -863,7 +863,7 @@ mod tests {
         }
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), 1024)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::default(), 1024)
             .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
@@ -926,7 +926,7 @@ mod tests {
         }
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), 2)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::default(), 2)
             .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4588,7 +4588,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     // ── Test 1: SETFIELD then GETFIELD → read from cache ──
@@ -5229,7 +5229,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     #[test]
@@ -7816,7 +7816,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(crate::optimizeopt::pure::OptPure::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
         let len_count = result
             .iter()
             .filter(|o| o.opcode == OpCode::ArraylenGc)

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3355,7 +3355,7 @@ mod tests {
         // IntLt/IntAddOvf operate on Int-typed inputs — override the
         // test default (Ref) used by `optimize_with_constants_and_inputs_at`.
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(200u32, majit_ir::Value::Int(1));
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -713,7 +713,7 @@ pub struct OptContext {
     /// by pointer address. PyPy uses `new_ref_dict()`; the house rule
     /// forbids hash containers, so pyre uses a Vec-backed associative
     /// container with linear-scan lookup.
-    pub const_infos: indexmap::IndexMap<usize, crate::optimizeopt::info::PtrInfo>,
+    pub const_infos: crate::FxIndexMap<usize, crate::optimizeopt::info::PtrInfo>,
     /// Dedup imported short fact uses so the builder stays in first-use
     /// order. PyPy uses dict-as-set; pyre uses a Vec with linear-scan
     /// dedup (small per trace).
@@ -1132,19 +1132,17 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
         if opref.is_constant() {
             return true;
         }
-        if self
-            .ctx
-            .get_box_replacement_operand_opt(opref)
-            .and_then(|cb| cb.const_value())
-            .is_some()
-        {
+        // One chain walk answers both tests below; `get_box_replacement`
+        // materializes the terminal as an `Operand`, so walking twice built
+        // it twice for every live box in every guard.
+        let Some(replacement) = self.ctx.get_box_replacement_operand_opt(opref) else {
+            return false;
+        };
+        if replacement.const_value().is_some() {
             return true;
         }
         matches!(
-            self.ctx
-                .get_box_replacement_operand_opt(opref)
-                .as_ref()
-                .and_then(|b| self.ctx.peek_ptr_info(b)),
+            self.ctx.peek_ptr_info(&replacement),
             Some(crate::optimizeopt::info::PtrInfo::Constant(_))
         )
     }
@@ -1817,7 +1815,7 @@ impl OptContext {
             imported_virtual_args: None,
             imported_loop_invariant_results: Vec::new(),
             imported_short_preamble_builder: None,
-            const_infos: indexmap::IndexMap::new(),
+            const_infos: crate::FxIndexMap::default(),
             imported_short_preamble_used: Vec::new(),
 
             potential_extra_ops: indexmap::IndexMap::new(),
@@ -2435,7 +2433,7 @@ impl OptContext {
             imported_virtual_args: None,
             imported_loop_invariant_results: Vec::new(),
             imported_short_preamble_builder: None,
-            const_infos: indexmap::IndexMap::new(),
+            const_infos: crate::FxIndexMap::default(),
             imported_short_preamble_used: Vec::new(),
 
             potential_extra_ops: indexmap::IndexMap::new(),

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2397,6 +2397,13 @@ impl Optimizer {
     /// `input_ops` be seeded from them directly (`input_ops_from_ops =
     /// true`), so `find_producer_op`'s lowest-priority store is populated
     /// without any snapshot read.
+    ///
+    /// The caller transfers its argument slots: emission resolves each
+    /// argument in place through its forwarding chain
+    /// (`optimizer.py:650-652 _emit_operation`), so on return an op's
+    /// `getarglist` reads the resolved operands, not the recorded ones. A
+    /// caller that still needs the recorded arguments must read them before
+    /// the call.
     pub fn optimize_with_constants_and_inputs_oprc(
         &mut self,
         ops: &[majit_ir::OpRc],
@@ -4755,10 +4762,6 @@ impl Optimizer {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> Result<(), crate::optimize::InvalidLoop> {
-        // The canonical `OpRc` is threaded in so callers can resolve the
-        // producer directly when they need a bound operand. For this pass the
-        // body reads through this `&Op` view (Deref), behaviour-identical.
-        let op: &Op = op_rc;
         // Box.type lives intrinsically on `OpRef.ty()` (variant
         // tag, history.py:220 + resoperation.py:1693 parity) and on
         // `Op.type_` once the op lands in `new_operations`, so an external
@@ -4776,15 +4779,30 @@ impl Optimizer {
         // would be a pyre-only layer that could substitute Const refs
         // post-`make_equal_to(_, const_target)` and de-sync from the
         // numbering snapshot.
-        let mut resolved_op = op.clone();
         // optimizer.py force_box loop parity: resolve each arg
         // through its forwarding chain. Store the CANONICAL terminal box
         // (carrying the live _forwarded chain), not a fresh from_opref box,
         // so passes can read PtrInfo / IntBound / known-class directly off
         // op.arg(i) — matching RPython where get_box_replacement returns the
         // Box object itself. A from_opref box is unbound and drops the chain.
-        for i in 0..resolved_op.num_args() {
-            let arg = resolved_op.arg(i);
+        //
+        // `optimizer.py:650-652 _emit_operation` writes the resolution back
+        // with `op.setarg(i, arg)` — into the operation's own slot, because
+        // upstream's operation IS the box the passes forward. Written back
+        // onto `op_rc` here for the same reason. Two things make that sound:
+        //
+        //  - No pass reads `op_rc`'s arguments. A pass reaches `op_rc` only as
+        //    `Operand::from_bound_op(op_rc)`, the `make_equal_to` forwarding
+        //    host, so what the second parameter carries is identity, which
+        //    resolving in place does not change; the argument view every pass
+        //    reads is `current_op` below.
+        //  - The caller has handed its argument slots over. The unroll and
+        //    bridge entries walk `TraceIterator`, whose `next` mints a fresh
+        //    operation per step, so those ops are the pass's own outright;
+        //    `optimize_with_constants_and_inputs_oprc` threads the recorder's
+        //    own ops and documents the transfer on its own signature.
+        for i in 0..op_rc.num_args() {
+            let arg = op_rc.arg(i);
             // Resolve each operand to its canonical bound terminal. When no
             // producer is registered yet — a short-preamble / bridge operand
             // dispatched mid-pass through `send_extra_operation`, whose
@@ -4807,10 +4825,12 @@ impl Optimizer {
                     }
                 }
             };
-            resolved_op.setarg(i, resolved);
+            op_rc.setarg(i, resolved);
         }
 
-        let mut current_op = resolved_op;
+        // Borrowed until a pass replaces the operation; `Replace` and
+        // `Restart` mint their own, and only those need an owned copy.
+        let mut current_op: std::borrow::Cow<'_, Op> = std::borrow::Cow::Borrowed(op_rc);
 
         // optimizer.py: optimize_SAME_AS_I/R/F → make_equal_to(op, arg0)
         // SameAs ops are absorbed into forwarding, never emitted.
@@ -4885,7 +4905,7 @@ impl Optimizer {
                     // construction (1) and a typed `op.pos` so
                     // downstream `op_at` lookups resolve it directly
                     // without a side-table refresh.
-                    current_op = op;
+                    current_op = std::borrow::Cow::Owned(op);
                     replaced = true;
                 }
                 OptimizationResult::Restart(op) => {
@@ -4962,7 +4982,7 @@ impl Optimizer {
         // If no pass handled it, emit as-is. An unreplaced pass-through is the
         // recorder input op verbatim (args re-resolved), so emit may reuse that
         // input op as the producer instead of cloning.
-        self.emit_operation(current_op.clone(), ctx, !replaced)?;
+        self.emit_operation((*current_op).clone(), ctx, !replaced)?;
         // Postprocess in reverse order after emission.
         for &pp_idx in postprocess_passes.iter().rev() {
             self.passes[pp_idx].propagate_postprocess(&current_op, ctx);
@@ -5154,10 +5174,17 @@ impl Optimizer {
                 op.getarglist()
             );
         }
+        // `optimizer.py:626 _newoperations.append(op)` appends the operation
+        // itself. Captured up front so the emit can move `op` in rather than
+        // hand it a copy; everything the post-emit block reads off `op` is
+        // this opcode and the result type it implies (asserted equal by
+        // `debug_assert_box_type_invariant`).
+        let op_opcode = op.opcode;
+        let op_result_type = op.result_type();
         let emitted = if reuse {
-            ctx.emit_reusing(op.clone())
+            ctx.emit_reusing(op)
         } else {
-            ctx.emit(op.clone())
+            ctx.emit(op)
         };
         // optimizer.py `self._emittedoperations[op] = None` — record
         // the freshly emitted op so `as_operation` can later confirm it
@@ -5175,7 +5202,7 @@ impl Optimizer {
         // optimizer.py: returns_bool_result → getintbound(op).make_bool().
         // Run here (post-emit) so the now-bound op box carries the IntBound
         // write; returns_bool ops are Int-typed (asserted above).
-        if op.opcode.returns_bool() {
+        if op_opcode.returns_bool() {
             let bound_box = ctx
                 .get_box_replacement_operand_opt(emitted)
                 .expect("just-emitted op resolves to a bound operand");
@@ -5187,7 +5214,7 @@ impl Optimizer {
         //       opinfo = op.get_forwarded()  # IntBound
         //       if opinfo is not None and opinfo.is_constant():
         //           op.set_forwarded(ConstInt(opinfo.get_constant_int()))
-        if op.result_type() == majit_ir::Type::Int {
+        if op_result_type == majit_ir::Type::Int {
             let replaced = ctx.get_replacement_opref(emitted);
             // operand shim — peek_intbound_box takes an operand per optimizer.py:99-113.
             let bound = ctx
@@ -5204,7 +5231,7 @@ impl Optimizer {
         }
         if crate::majit_log_enabled()
             && matches!(
-                op.opcode,
+                op_opcode,
                 OpCode::CallMayForceI
                     | OpCode::CallMayForceR
                     | OpCode::CallMayForceF
@@ -5215,7 +5242,7 @@ impl Optimizer {
         {
             eprintln!(
                 "[opt] emit {:?} pos={:?} len={}",
-                op.opcode,
+                op_opcode,
                 emitted,
                 ctx.new_operations.len()
             );

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -573,7 +573,7 @@ pub struct Optimizer {
 pub(crate) fn lower_typed_constants_to_const_pool(
     constants: &majit_ir::ConstMap<majit_ir::Value>,
 ) -> majit_ir::ConstMap<majit_ir::Const> {
-    let mut pool = majit_ir::ConstMap::new();
+    let mut pool = majit_ir::ConstMap::default();
     for (&k, v) in constants {
         pool.insert(k, v.to_const());
     }
@@ -2336,7 +2336,7 @@ impl Optimizer {
     /// Returns the optimized operation list.
     /// optimizer.py: propagate_all_forward(trace, call_pure_results, flush)
     pub fn propagate_all_forward(&mut self, ops: &[Op]) -> Vec<Op> {
-        self.optimize_with_constants(ops, &mut majit_ir::ConstMap::new())
+        self.optimize_with_constants(ops, &mut majit_ir::ConstMap::default())
     }
 
     /// Run all optimization passes, with known constants pre-populated.
@@ -6344,7 +6344,7 @@ mod tests {
             ],
         )];
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
     }
@@ -6389,7 +6389,7 @@ mod tests {
         )];
         ops[0].pos.set(OpRef::int_op(2));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 2);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 2);
 
         assert_eq!(
             hits.get(),
@@ -6474,7 +6474,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 3);
 
         let call_count = result
             .iter()
@@ -6685,7 +6685,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 3);
 
         let call_positions: indexmap::IndexSet<_> = result
             .iter()
@@ -6734,7 +6734,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 num_inputs,
             )
             .expect("test: unexpected InvalidLoop");
@@ -6766,7 +6766,7 @@ mod tests {
         ops[1].pos.set(OpRef::int_op(4));
         ops[2].pos.set(OpRef::int_op(5));
         ops[3].pos.set(OpRef::int_op(6));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(1u32, majit_ir::Value::Int(27));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
 
@@ -6809,7 +6809,7 @@ mod tests {
         ops[1].pos.set(OpRef::int_op(4));
         ops[2].pos.set(OpRef::int_op(5));
         ops[3].pos.set(OpRef::int_op(6));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(1u32, majit_ir::Value::Int(27));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
 
@@ -6837,7 +6837,7 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(0u32, majit_ir::Value::Int(40));
         constants.insert(1u32, majit_ir::Value::Int(5));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
@@ -6859,7 +6859,7 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(0u32, majit_ir::Value::Int(40));
         constants.insert(1u32, majit_ir::Value::Int(5));
         constants.insert(3u32, majit_ir::Value::Int(1));
@@ -6889,7 +6889,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         assert_eq!(result.len(), 1);
@@ -6937,7 +6937,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 num_inputs,
             )
             .expect("test: unexpected InvalidLoop");
@@ -6965,7 +6965,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 0);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 0);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::GuardValue),
@@ -7021,7 +7021,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         // force_all_lazy_setfields emits lazy SetfieldGc before JUMP.
@@ -7108,7 +7108,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         for set_op in result.iter().filter(|op| op.opcode == OpCode::SetfieldGc) {
@@ -7168,7 +7168,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         let new_positions: indexmap::IndexSet<_> = result
@@ -7240,7 +7240,7 @@ mod tests {
         }
 
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
         let guard = result
             .iter()
             .find(|op| op.opcode == OpCode::GuardTrue)
@@ -7306,7 +7306,7 @@ mod tests {
             &[rooted_resop_operand(Type::Int, 50)],
         )));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt
             .optimize_with_constants_and_inputs_at(&[], &mut constants, 3, 0, 0, false)
             .expect("empty trace must not produce InvalidLoop");
@@ -7686,7 +7686,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 num_inputs,
             )
             .expect("test: unexpected InvalidLoop");

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2400,7 +2400,7 @@ impl Optimizer {
     ///
     /// The caller transfers its argument slots: emission resolves each
     /// argument in place through its forwarding chain
-    /// (`optimizer.py:650-652 _emit_operation`), so on return an op's
+    /// (`optimizer.py _emit_operation`), so on return an op's
     /// `getarglist` reads the resolved operands, not the recorded ones. A
     /// caller that still needs the recorded arguments must read them before
     /// the call.
@@ -4786,7 +4786,7 @@ impl Optimizer {
         // op.arg(i) — matching RPython where get_box_replacement returns the
         // Box object itself. A from_opref box is unbound and drops the chain.
         //
-        // `optimizer.py:650-652 _emit_operation` writes the resolution back
+        // `optimizer.py _emit_operation` writes the resolution back
         // with `op.setarg(i, arg)` — into the operation's own slot, because
         // upstream's operation IS the box the passes forward. Written back
         // onto `op_rc` here for the same reason. Two things make that sound:
@@ -5174,7 +5174,7 @@ impl Optimizer {
                 op.getarglist()
             );
         }
-        // `optimizer.py:626 _newoperations.append(op)` appends the operation
+        // `optimizer.py _emit_operation`'s `_newoperations.append(op)` appends the operation
         // itself. Captured up front so the emit can move `op` in rather than
         // hand it a copy; everything the post-emit block reads off `op` is
         // this opcode and the result type it implies (asserted equal by

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1583,7 +1583,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1603,7 +1603,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(2)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1621,7 +1621,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1639,7 +1639,7 @@ mod tests {
                 op_spec(OpCode::IntSub, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntSub, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1657,7 +1657,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntMul, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1677,7 +1677,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1691,7 +1691,7 @@ mod tests {
         let result = run_pure(
             2,
             &[op_spec(OpCode::CallPureI, &[Arg::In(0), Arg::In(1)])],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1725,7 +1725,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1751,7 +1751,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1784,7 +1784,7 @@ mod tests {
                     arr_descr.clone(),
                 ),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1813,7 +1813,7 @@ mod tests {
                     arr_descr.clone(),
                 ),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1831,7 +1831,7 @@ mod tests {
                 op_spec(OpCode::IntNeg, &[Arg::In(0)]),
                 op_spec(OpCode::IntNeg, &[Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1856,7 +1856,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1896,7 +1896,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 num_inputs as usize,
             )
             .expect("test: unexpected InvalidLoop");
@@ -1962,7 +1962,7 @@ mod tests {
                 op_spec(OpCode::IntXor, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntXor, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1978,7 +1978,7 @@ mod tests {
                 op_spec(OpCode::IntAnd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAnd, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -1996,7 +1996,7 @@ mod tests {
                 op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -2023,7 +2023,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -2045,7 +2045,7 @@ mod tests {
                 op_spec(OpCode::SetfieldGc, &[Arg::In(0), Arg::In(1)]), // not pure, kept
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup, eliminated
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -2070,7 +2070,7 @@ mod tests {
                 op_spec(OpCode::CallLoopinvariantI, &[func.clone(), Arg::In(0)]),
                 op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[rewrite_pass],
             false,
         );
@@ -2091,7 +2091,7 @@ mod tests {
                 op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(2)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[rewrite_pass],
             false,
         );
@@ -2112,7 +2112,7 @@ mod tests {
             let result = run_pure(
                 1,
                 &[op_spec(loopinv_op, &[Arg::In(0)])],
-                &mut majit_ir::ConstMap::new(),
+                &mut majit_ir::ConstMap::default(),
                 &[rewrite_pass],
                 false,
             );
@@ -2143,7 +2143,7 @@ mod tests {
         let result = run_pure(
             1,
             &specs,
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[rewrite_pass],
             false,
         );
@@ -2166,7 +2166,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup → removed
                 op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(2)]), // loopinv dup → removed
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[rewrite_pass],
             false,
         );
@@ -2190,7 +2190,7 @@ mod tests {
                 // Use the result in a finish to prevent dead code elimination
                 op_spec(OpCode::Finish, &[Arg::Prod(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -2212,7 +2212,7 @@ mod tests {
                 ),
                 op_spec(OpCode::Finish, &[Arg::Prod(0)]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -2233,7 +2233,7 @@ mod tests {
                 op_spec(OpCode::GuardNoOverflow, &[]),
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             true,
         );
@@ -2259,7 +2259,7 @@ mod tests {
                 op_spec(OpCode::GuardNoOverflow, &[]),
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             true,
         );
@@ -2289,7 +2289,7 @@ mod tests {
                 op_spec(OpCode::GuardNoOverflow, &[]),
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             true,
         );
@@ -2346,7 +2346,7 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&vec![Type::Ref; 1024]);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     #[test]
@@ -2411,7 +2411,7 @@ mod tests {
                 op_spec(OpCode::GuardNoException, &[]), // should be removed
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             true,
         );
@@ -2983,7 +2983,7 @@ mod tests {
                     &[Arg::In(1), Arg::In(2), Arg::In(3)],
                 ),
             ],
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             &[],
             false,
         );
@@ -3014,7 +3014,7 @@ mod tests {
         opt.record_call_pure_result(vec![Value::Int(0xCAFE), Value::Int(7)], Value::Int(42));
         opt.add_pass(Box::new(OptPure::new()));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
             .expect("test: unexpected InvalidLoop");
@@ -3087,7 +3087,7 @@ mod tests {
         );
         opt.add_pass(Box::new(OptPure::new()));
 
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
             .expect("test: unexpected InvalidLoop");

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3582,7 +3582,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.add_pass(Box::new(OptRewrite::new()));
         opt.trace_inputargs = OpRef::inputarg_refs(&[majit_ir::Type::Ref]);
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1);
@@ -4363,7 +4363,7 @@ mod tests {
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&[majit_ir::Type::Int; 2]);
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
@@ -4389,7 +4389,7 @@ mod tests {
         // mul_minus_one lives in OptIntBounds (autogenintrules.py).
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -4414,7 +4414,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -4435,7 +4435,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -4459,7 +4459,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -113,7 +113,7 @@ impl ShortPreamble {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state: None,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -286,7 +286,7 @@ impl CollectedShortPreambleBuilder {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -1267,7 +1267,7 @@ impl CollectedExtendedShortPreambleBuilder {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -2262,7 +2262,7 @@ fn build_short_preamble_struct_from_ops(
     // RPython parity: `shortpreamble.py` keeps no `loop_constants` side
     // table — `arg` IS the `Const` box, so `_map_args(mapping, args)`
     // (`unroll.py:364`) passes it through unchanged.
-    let constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+    let constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::default();
     ShortPreamble {
         ops: entries,
         inputargs: short_inputargs.to_vec(),
@@ -3458,7 +3458,7 @@ pub(crate) fn extract_short_preamble(peeled_ops: &[Op]) -> ShortPreamble {
         used_boxes: Vec::new(),
         jump_args: Vec::new(),
         exported_state: None,
-        constants: majit_ir::ConstMap::new(),
+        constants: majit_ir::ConstMap::default(),
         phase1_inputargs: None,
         inputarg_infos: Vec::new(),
     }
@@ -4669,7 +4669,7 @@ mod tests {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state: None,
-            constants: majit_ir::ConstMap::new(),
+            constants: majit_ir::ConstMap::default(),
             inputarg_infos: Vec::new(),
             phase1_inputargs: None,
         };

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -126,7 +126,7 @@ mod tests {
         let num_inputs = inputs.len();
         opt.optimize_with_constants_and_inputs_oprc(
             &ops,
-            &mut majit_ir::ConstMap::new(),
+            &mut majit_ir::ConstMap::default(),
             num_inputs,
         )
         .expect("test: unexpected InvalidLoop")

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -911,16 +911,16 @@ impl UnrollOptimizer {
                 .iter()
                 .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
                 .collect();
-            // Wrap input ops as `Vec<OpRc>` so TraceIterator's `&[OpRc]`
-            // surface receives shared identity (history.py:528). The
-            // deep-clone here corresponds to PyPy's `cls()` per-op fresh
-            // allocation inside `TraceIterator.next` (opencoder.py).
-            let ops_oprc: Vec<majit_ir::OpRc> =
-                ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
+            // `TraceIterator` walks any `Borrow<Op>` slice, and `next` already
+            // performs PyPy's `cls()` per-op fresh allocation (opencoder.py),
+            // so the recorder ops feed it directly — a pre-wrap into
+            // `Vec<OpRc>` would allocate a second copy of every op that
+            // nothing reads (the iterator caches the op it mints, not its
+            // source).
             let mut p1_iter = crate::opencoder::TraceIterator::new(
-                &ops_oprc,
+                ops,
                 0,
-                ops_oprc.len(),
+                ops.len(),
                 None,
                 &p1_inputarg_types,
                 0, // start_fresh = 0 — inputargs at [0..num_inputs)
@@ -1298,13 +1298,12 @@ impl UnrollOptimizer {
             .iter()
             .map(|op| op.ty().expect("inputarg OpRef must carry box.type"))
             .collect();
-        // Wrap into `Vec<OpRc>` for TraceIterator's `&[OpRc]` surface.
-        let ops_oprc: Vec<majit_ir::OpRc> =
-            ops.iter().map(|op| std::rc::Rc::new(op.clone())).collect();
+        // Fed straight to `TraceIterator` (a `Borrow<Op>` slice); `next` mints
+        // the fresh per-op copy, so a pre-wrap would only duplicate it.
         let mut iter = crate::opencoder::TraceIterator::new(
-            &ops_oprc,
+            ops,
             0,
-            ops_oprc.len(),
+            ops.len(),
             None,
             &p2_inputarg_types,
             phase2_inputarg_base, // fresh inputargs at [phase2_inputarg_base..)

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6537,7 +6537,7 @@ mod tests {
                 .unwrap_or_default()
         });
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     #[test]
@@ -6731,7 +6731,7 @@ mod tests {
             Operand::from_opref(old_ref),
             OpInfo::ptr(PtrInfo::Constant(old)),
         );
-        let mut constants = majit_ir::ConstMap::new();
+        let mut constants = majit_ir::ConstMap::default();
         constants.insert(0, majit_ir::Const::Ref(old));
 
         let mut state = ExportedState::new(
@@ -7238,7 +7238,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         // Expect: peeled_add, peeled_guard, Label, body_add, body_guard, Jump = 6
         assert_eq!(result.len(), 6);
@@ -7407,7 +7407,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_inputarg_operand(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 2);
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let (result, _) =
             unroll_opt.optimize_trace_with_constants_and_inputs(&ops, &mut constants, 2);
         // The optimizer processes the trace; result should not be empty
@@ -7433,7 +7433,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_inputarg_operand(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 1);
-        let mut constants = majit_ir::ConstMap::new();
+        let mut constants = majit_ir::ConstMap::default();
         let mut phase1_out = None;
 
         unroll_opt
@@ -8485,7 +8485,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             None,
             None,
         );
@@ -8546,7 +8546,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 11)]),
         ];
 
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let combined = assemble_peeled_trace(
             &p1_ops,
@@ -8626,7 +8626,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 19)]),
         ];
 
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let combined = assemble_peeled_trace(
             &p1_ops,
@@ -8703,7 +8703,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             None,
             None,
         );
@@ -8762,7 +8762,7 @@ mod tests {
             ),
         ];
         let constants =
-            majit_ir::ConstMap::from([(OpRef::void_op(857).raw(), majit_ir::Value::Int(2))]);
+            majit_ir::ConstMap::from_iter([(OpRef::void_op(857).raw(), majit_ir::Value::Int(2))]);
 
         let mut ctx = assemble_test_context(&p1_ops, &p2_ops, 1);
         let p1_ops_rc: Vec<majit_ir::OpRc> = p1_ops
@@ -8871,7 +8871,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             None,
             None,
         );
@@ -8928,7 +8928,7 @@ mod tests {
             },
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 64)]),
         ];
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -9008,7 +9008,7 @@ mod tests {
             5,
             false,
             &[],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             Some(start_descr),
             None,
         );
@@ -9074,7 +9074,7 @@ mod tests {
             2,
             false,
             &[],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             Some(start_descr),
             Some(loop_descr),
         );
@@ -9119,7 +9119,7 @@ mod tests {
                 jump
             },
         ];
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -9180,7 +9180,7 @@ mod tests {
             ),
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 0)]),
         ];
-        let constants = majit_ir::ConstMap::from([
+        let constants = majit_ir::ConstMap::from_iter([
             (2_u32, majit_ir::Value::Int(606)),
             (4_u32, majit_ir::Value::Int(611)),
         ]);
@@ -9223,7 +9223,7 @@ mod tests {
             OpCode::Jump,
             &[rooted_resop_operand(Type::Int, 10)],
         )];
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -9259,7 +9259,7 @@ mod tests {
         // The assembler is therefore a passthrough for inputarg references
         // — no source_slot input_remap needed. This test verifies that
         // pre-resolved body args survive intact.
-        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let loop_descr = TargetToken::new_loop(1).as_jump_target_descr();
         let p2_ops = vec![
             {
@@ -9350,7 +9350,7 @@ mod tests {
             6,
             true,
             &[],
-            &majit_ir::ConstMap::new(),
+            &majit_ir::ConstMap::default(),
             None,
             Some(loop_descr),
         );

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -2929,7 +2929,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         let labels = result
             .iter()
@@ -3343,7 +3343,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::Label),
@@ -3600,7 +3600,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
         assert!(!result.is_empty());
     }
 
@@ -3628,7 +3628,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024);
         assert!(result.iter().any(|op| op.opcode == OpCode::Label));
         assert!(result.iter().any(|op| op.opcode == OpCode::Jump));
     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -3865,7 +3865,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     fn run_default_pipeline(ops: &[Op]) -> Vec<Op> {
@@ -3873,7 +3873,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![Type::Ref; 1024]);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     fn run_default_pipeline_typed(ops: &[Op], int_slots: &[u32], float_slots: &[u32]) -> Vec<Op> {
@@ -3888,7 +3888,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::default(), 1024)
     }
 
     fn run_pass_with_constants(ops: &[Op], constants: &[(OpRef, Value)]) -> Vec<Op> {
@@ -4609,7 +4609,7 @@ mod tests {
             identity_input_index: Some(0),
             has_vable_token: true,
         });
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let mut ops = vec![
             Op::new(
                 OpCode::Label,
@@ -5543,7 +5543,7 @@ mod tests {
         types[61] = Type::Float;
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         opt.snapshot_boxes = snapshots;
-        let mut constants = majit_ir::ConstMap::new();
+        let mut constants = majit_ir::ConstMap::default();
         constants.insert(50u32, Value::Int(1));
         constants.insert(51u32, Value::Int(0));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
@@ -5639,7 +5639,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = seed_virtualize_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(200u32, majit_ir::Value::Int(42)); // expected class ptr matches vtable
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
         // Both NEW_WITH_VTABLE (virtual) and GuardClass (redundant) removed
@@ -6234,7 +6234,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = seed_virtualize_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(200u32, majit_ir::Value::Int(42)); // class ptr constant
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
         assert_eq!(
@@ -6951,7 +6951,7 @@ mod tests {
         ops[1].pos.set(OpRef::void_op(2));
         ops[2].pos.set(OpRef::void_op(3));
         let mut opt = Optimizer::default_pipeline();
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
 
         let opcodes: Vec<_> = result.iter().map(|op| op.opcode).collect();
@@ -7072,7 +7072,7 @@ mod tests {
         }
 
         let mut opt = Optimizer::default_pipeline();
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         constants.insert(100u32, majit_ir::Value::Int(7));
         constants.insert(101u32, majit_ir::Value::Int(11));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -570,7 +570,7 @@ pub(crate) struct CompiledTrace {
     #[allow(dead_code)]
     pub(crate) constants: majit_ir::ConstMap<majit_ir::Const>,
     /// Static exit metadata for each guard/finish in this trace.
-    pub(crate) exit_layouts: indexmap::IndexMap<u32, StoredExitLayout>,
+    pub(crate) exit_layouts: crate::FxIndexMap<u32, StoredExitLayout>,
     /// Static exit metadata for terminal FINISH/JUMP ops, keyed by op index.
     pub(crate) terminal_exit_layouts: indexmap::IndexMap<usize, StoredExitLayout>,
 }
@@ -1301,7 +1301,7 @@ pub(crate) struct CompiledEntry<M> {
     /// entry installed by any path other than a loop close.
     pub(crate) loop_header_pc: Option<usize>,
     /// Metadata for the root loop and any attached bridges, keyed by trace id.
-    pub(crate) traces: indexmap::IndexMap<u64, CompiledTrace>,
+    pub(crate) traces: crate::FxIndexMap<u64, CompiledTrace>,
     /// RPython parity: previous compiled entries for this green_key.
     /// In RPython, JitCellToken keeps all target_tokens' code alive.
     /// In majit, each retrace produces a new Cranelift function;
@@ -1606,7 +1606,7 @@ pub struct ActiveTraceSession<M: Clone> {
 pub struct MetaInterp<M: Clone> {
     pub(crate) warm_state: WarmEnterState,
     pub(crate) backend: BackendImpl,
-    pub(crate) compiled_loops: indexmap::IndexMap<u64, CompiledEntry<M>>,
+    pub(crate) compiled_loops: crate::FxIndexMap<u64, CompiledEntry<M>>,
     /// Bumped by every insertion into and removal from `compiled_loops`, in
     /// this file's non-test code. One input of [`Self::runnable_generation`].
     compiled_loops_generation: u64,
@@ -3048,7 +3048,7 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         _owning_key: u64,
         entry: CompiledEntry<M>,
-        merged_traces: &mut indexmap::IndexMap<u64, CompiledTrace>,
+        merged_traces: &mut crate::FxIndexMap<u64, CompiledTrace>,
     ) -> Vec<std::sync::Weak<JitCellToken>> {
         // `entry.token` is already `Weak<JitCellToken>`; push it directly.
         let mut previous_tokens = Vec::with_capacity(1 + entry.previous_tokens.len());
@@ -3495,7 +3495,7 @@ impl<M: Clone> MetaInterp<M> {
         let mut this = MetaInterp {
             warm_state: WarmEnterState::new(threshold),
             backend: BackendImpl::new(),
-            compiled_loops: indexmap::IndexMap::new(),
+            compiled_loops: crate::FxIndexMap::default(),
             compiled_loops_generation: 0,
             compiled_graph_minor_scan_pending: true,
             loop_header_greens: indexmap::IndexMap::new(),
@@ -7005,7 +7005,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         // Materialize Vec<Op> from the trace's `Vec<OpRc>` so the
         // optimizer's `&[Op]` surface gets owned data. The deep-clone
@@ -7996,7 +7996,7 @@ impl<M: Clone> MetaInterp<M> {
                 let mut next_global_opref = unroll_opt
                     .next_global_opref
                     .max(compute_next_global_opref(&inputargs, &compiled_ops));
-                let mut traces = indexmap::IndexMap::new();
+                let mut traces = crate::FxIndexMap::default();
                 traces.insert(
                     trace_id,
                     CompiledTrace {
@@ -8596,7 +8596,7 @@ impl<M: Clone> MetaInterp<M> {
         // The recorder carries Const values inline on the OpRef variants
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to snapshot — this typed-constant map starts fresh.
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let call_pure_results = ctx.call_pure_results.clone();
         let trace_snapshots = ctx.snapshots().to_vec();
         let (
@@ -8911,7 +8911,7 @@ impl<M: Clone> MetaInterp<M> {
             // The recorder carries Const values inline on the OpRef variants
             // (history.py:227/268/314), so there is no legacy TraceCtx
             // ConstantPool to snapshot — this typed-constant map starts fresh.
-            let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+            let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
             let initial_inputarg_consts = ctx.initial_inputarg_consts.clone();
             let call_pure_results = ctx.take_call_pure_results();
 
@@ -9433,7 +9433,7 @@ impl<M: Clone> MetaInterp<M> {
                 let mut next_global_opref = unroll_opt
                     .next_global_opref
                     .max(compute_next_global_opref(&inputargs, &combined_ops));
-                let mut traces = indexmap::IndexMap::new();
+                let mut traces = crate::FxIndexMap::default();
                 traces.insert(
                     trace_id,
                     CompiledTrace {
@@ -10034,7 +10034,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         let num_ops_before = trace_ops.len();
         let mut optimizer = if let Some(config) = vable_config {
@@ -10340,7 +10340,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 let mut next_global_opref = compute_next_global_opref(&inputargs, &optimized_ops);
-                let mut traces = indexmap::IndexMap::new();
+                let mut traces = crate::FxIndexMap::default();
                 traces.insert(
                     trace_id,
                     CompiledTrace {
@@ -10522,7 +10522,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
 
         if crate::majit_log_enabled() {
             eprintln!("--- simple loop trace (before opt) ---");
@@ -10797,7 +10797,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 let mut next_global_opref = compute_next_global_opref(&inputargs, &compiled_ops);
-                let mut traces = indexmap::IndexMap::new();
+                let mut traces = crate::FxIndexMap::default();
                 traces.insert(
                     trace_id,
                     CompiledTrace {
@@ -11609,13 +11609,23 @@ impl<M: Clone> MetaInterp<M> {
         // gated on the token holds it and calls the run directly.
         let token = self.warm_state.get_procedure_token(green_key)?;
         let meta = self.compiled_loops.get(&green_key)?.meta.clone();
-        Some(self.execute_assembler_at_dispatch_key(
+        let mut result = self.execute_assembler_at_dispatch_key(
             &token,
             green_key,
             Some(meta),
             live_values,
             dispatch_key,
-        ))
+        );
+        if let Some(descr_arc) = &result.descr_arc
+            && !Self::is_jump_exit(result.is_finish, result.fail_index)
+        {
+            let descr = descr_arc
+                .as_fail_descr()
+                .expect("a guard exit carries a FailDescr");
+            result.exit_layout =
+                Some(Box::new(self.guard_exit_layout(green_key, descr, result.rd_loop_token)));
+        }
+        Some(result)
     }
 
     /// `compile.py must_compile` reads the failing GUARD_VALUE's operand off the
@@ -11631,6 +11641,71 @@ impl<M: Clone> MetaInterp<M> {
     ) -> Option<i64> {
         majit_backend::guard_value_counter_slot(descr)
             .map(|slot| self.backend.get_value_direct(frame, slot))
+    }
+
+    /// `handle_fail`'s frontend view of a guard exit, for the detailed
+    /// runners whose callers open it (`eval.rs handle_fail`,
+    /// `DetailedDriverRunOutcome::GuardFailure`). The steady compiled entry
+    /// (`execute_assembler_at_dispatch_key`) builds none: `compile.py
+    /// handle_fail` reads the failing descr's own `rd_*` payload, and the
+    /// driver's guard arm reads the same descr.
+    fn guard_exit_layout(
+        &self,
+        green_key: u64,
+        descr: &dyn majit_ir::FailDescr,
+        rd_loop_token: Option<u64>,
+    ) -> CompiledExitLayout {
+        let fail_index = descr.fail_index();
+        let trace_id = descr.trace_id();
+        let is_finish = descr.is_finish();
+        let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
+        let exit_types: &[Type] = descr.fail_arg_types();
+        // Fresh lookup, and fallible: the run can re-enter the driver
+        // through a residual call and drop this green key (`jitdriver.rs`'s
+        // `remove_compiled_loop` on the unrecoverable-resume path), in
+        // which case the exit falls through to the `rd_loop_token` lookup
+        // and then to the synthesized default layout below.
+        let compiled = self.compiled_loops.get(&green_key);
+        // The layout comes from the failing guard's own trace, and falls
+        // back to a synthesized one per `run_compiled_detailed` when the
+        // green key no longer holds it.
+        let mut exit_layout = compiled
+            .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
+            .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
+            .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
+            .and_then(|(owning_key, resolved_id, trace)| {
+                Self::compiled_exit_layout_from_trace(
+                    trace,
+                    owning_key,
+                    resolved_id,
+                    fail_index,
+                )
+            })
+            .unwrap_or_else(|| CompiledExitLayout {
+                rd_loop_token: green_key,
+                trace_id,
+                fail_index,
+                source_op_index: descr.source_op_index(),
+                exit_types: ExitTypes::from_slice(exit_types),
+                is_finish,
+                is_exception_exit: is_exit_frame_with_exception,
+                recovery_layout: None,
+                resume_layout: None,
+                // The green-key index no longer holds this trace, but the
+                // failing descr still carries the resume payload it was
+                // compiled with (`compile.py get_resumestorage`), so a
+                // blackhole resume off this layout stays possible.
+                storage: crate::resume::ResumeStorage::from_fail_descr(descr)
+                    .map(std::sync::Arc::new),
+            });
+        // RPython: deadframe has ALL jitframe slots accessible.
+        // If the backend's descr covers more slots than the trace layout,
+        // extend exit_layout.exit_types to match (conservative Int for
+        // extras).
+        if exit_types.len() > exit_layout.exit_types.len() {
+            exit_layout.exit_types.resize(exit_types.len(), Type::Int);
+        }
+        exit_layout
     }
 
     /// `compile.py _DoneWithThisFrameDescr.get_result` and
@@ -11852,59 +11927,9 @@ impl<M: Clone> MetaInterp<M> {
             self.record_guard_failure_event(green_key, trace_id, fail_index, back_edge_poll);
         }
 
-        // Built for a guard exit only. Every reader of this field opens it past
-        // its own back-edge arm, because a JUMP exit is answered by restoring
-        // the loop-carried state and re-entering — so a layout built for one is
-        // a type-vector copy, three refcount pairs and a heap box that nothing
-        // reads.
-        let exit_layout = (!is_jump_exit).then(|| {
-            // Fresh lookup, and fallible: the run can re-enter the driver
-            // through a residual call and drop this green key (`jitdriver.rs`'s
-            // `remove_compiled_loop` on the unrecoverable-resume path), in
-            // which case the exit falls through to the `rd_loop_token` lookup
-            // and then to the synthesized default layout below.
-            let compiled = self.compiled_loops.get(&green_key);
-            // The layout comes from the failing guard's own trace, and falls
-            // back to a synthesized one per `run_compiled_detailed` when the
-            // green key no longer holds it.
-            let mut exit_layout = compiled
-                .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
-                .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
-                .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
-                .and_then(|(owning_key, resolved_id, trace)| {
-                    Self::compiled_exit_layout_from_trace(
-                        trace,
-                        owning_key,
-                        resolved_id,
-                        fail_index,
-                    )
-                })
-                .unwrap_or_else(|| CompiledExitLayout {
-                    rd_loop_token: green_key,
-                    trace_id,
-                    fail_index,
-                    source_op_index: descr.source_op_index(),
-                    exit_types: ExitTypes::from_slice(exit_types),
-                    is_finish,
-                    is_exception_exit: is_exit_frame_with_exception,
-                    recovery_layout: None,
-                    resume_layout: None,
-                    // The green-key index no longer holds this trace, but the
-                    // failing descr still carries the resume payload it was
-                    // compiled with (`compile.py get_resumestorage`), so a
-                    // blackhole resume off this layout stays possible.
-                    storage: crate::resume::ResumeStorage::from_fail_descr(descr)
-                        .map(std::sync::Arc::new),
-                });
-            // RPython: deadframe has ALL jitframe slots accessible.
-            // If the backend's descr covers more slots than the trace layout,
-            // extend exit_layout.exit_types to match (conservative Int for
-            // extras).
-            if exit_types.len() > exit_layout.exit_types.len() {
-                exit_layout.exit_types.resize(exit_types.len(), Type::Int);
-            }
-            Box::new(exit_layout)
-        });
+        // No layout on the steady entry: the guard arm in `jitdriver` reads
+        // the descr, as `compile.py handle_fail` does. The detailed runners
+        // attach one for their callers — see [`Self::guard_exit_layout`].
         let savedata = self.backend.get_savedata_ref(&frame);
         // pyjitpl.py:3119-3123: exc_class = ptr2int(exception_obj.typeptr)
         let exc_value_ref = self.backend.grab_exc_value(&frame);
@@ -11928,7 +11953,7 @@ impl<M: Clone> MetaInterp<M> {
             descr_arc: Some(descr_arc),
             is_finish,
             is_exit_frame_with_exception,
-            exit_layout,
+            exit_layout: None,
             rd_loop_token,
             savedata,
             exception,
@@ -13230,6 +13255,18 @@ impl<M: Clone> MetaInterp<M> {
     /// compilation may have attached to an earlier token that was replaced
     /// by a retrace/recompile.
     pub fn bridge_was_compiled(&self, green_key: u64, trace_id: u64, fail_index: u32) -> bool {
+        // The guard being asked about is the trace session's own origin, and
+        // its descr is in hand (`pyjitpl.py handle_guard_failure`'s
+        // `resumedescr`); the backend answers off that descr without a walk
+        // over the token's code blocks.
+        if let Some(info) = self.bridge_info()
+            && info.trace_id == trace_id
+            && info.fail_index == fail_index
+            && let Some(fd) = info.source_descr.as_fail_descr()
+            && let Some(attached) = self.backend.bridge_attached(fd)
+        {
+            return attached;
+        }
         if let Some(token) = self.warm_state.get_compiled(green_key)
             && self
                 .backend
@@ -13875,7 +13912,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 let mut next_global_opref =
                     compute_next_global_opref(&entry_inputargs, &optimized_ops);
-                let mut traces = indexmap::IndexMap::new();
+                let mut traces = crate::FxIndexMap::default();
                 traces.insert(
                     trace_id,
                     CompiledTrace {
@@ -24086,7 +24123,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
-        let mut exit_layouts = indexmap::IndexMap::new();
+        let mut exit_layouts = crate::FxIndexMap::default();
         exit_layouts.insert(
             0,
             StoredExitLayout {
@@ -24098,13 +24135,13 @@ mod tests {
                 op_arg_types_for_jump: None,
             },
         );
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             1,
             CompiledTrace {
                 inputargs: Vec::new(),
                 ops: Vec::new(),
-                constants: majit_ir::ConstMap::new(),
+                constants: majit_ir::ConstMap::default(),
                 exit_layouts,
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
@@ -24420,17 +24457,17 @@ mod tests {
                 start_descr,
             ),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::default();
         constants.insert(100, majit_ir::Const::Int(1));
         constants.insert(101, majit_ir::Const::Int(2));
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
                 inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
                 ops: ops.into_iter().map(std::rc::Rc::new).collect(),
                 constants,
-                exit_layouts: indexmap::IndexMap::new(),
+                exit_layouts: crate::FxIndexMap::default(),
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
         );
@@ -24491,17 +24528,17 @@ mod tests {
                 start_descr,
             ),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::default();
         constants.insert(100, majit_ir::Const::Int(1));
         constants.insert(101, majit_ir::Const::Int(2));
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
                 inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
                 ops: ops.into_iter().map(std::rc::Rc::new).collect(),
                 constants,
-                exit_layouts: indexmap::IndexMap::new(),
+                exit_layouts: crate::FxIndexMap::default(),
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
         );
@@ -24800,7 +24837,7 @@ mod tests {
             pending_field_layouts: vec![],
         };
 
-        let mut exit_layouts: indexmap::IndexMap<u32, StoredExitLayout> = indexmap::IndexMap::new();
+        let mut exit_layouts: crate::FxIndexMap<u32, StoredExitLayout> = Default::default();
         exit_layouts.insert(
             fail_index,
             StoredExitLayout {
@@ -24818,13 +24855,13 @@ mod tests {
             },
         );
 
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
                 inputargs: vec![],
                 ops: vec![],
-                constants: majit_ir::ConstMap::new(),
+                constants: majit_ir::ConstMap::default(),
                 exit_layouts,
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
@@ -24890,7 +24927,7 @@ mod tests {
         let trace_id = 67;
         let fail_index = 2;
 
-        let mut exit_layouts: indexmap::IndexMap<u32, StoredExitLayout> = indexmap::IndexMap::new();
+        let mut exit_layouts: crate::FxIndexMap<u32, StoredExitLayout> = Default::default();
         exit_layouts.insert(
             fail_index,
             StoredExitLayout {
@@ -24903,13 +24940,13 @@ mod tests {
             },
         );
 
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
                 inputargs: vec![],
                 ops: vec![],
-                constants: majit_ir::ConstMap::new(),
+                constants: majit_ir::ConstMap::default(),
                 exit_layouts,
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
@@ -24965,7 +25002,7 @@ mod tests {
         writer.patch_current_size(0);
         let rd_numb = writer.create_numbering();
 
-        let mut exit_layouts: indexmap::IndexMap<u32, StoredExitLayout> = indexmap::IndexMap::new();
+        let mut exit_layouts: crate::FxIndexMap<u32, StoredExitLayout> = Default::default();
         exit_layouts.insert(
             fail_index,
             StoredExitLayout {
@@ -24989,13 +25026,13 @@ mod tests {
             },
         );
 
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
                 inputargs: vec![],
                 ops: vec![],
-                constants: majit_ir::ConstMap::new(),
+                constants: majit_ir::ConstMap::default(),
                 exit_layouts,
                 terminal_exit_layouts: indexmap::IndexMap::new(),
             },
@@ -25122,7 +25159,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::ConstMap::new(),
+            majit_ir::ConstMap::default(),
         );
 
         let (trace_id, fail_index) = {
@@ -25293,7 +25330,7 @@ mod tests {
             trace_id,
             &mut terminal_exit_layouts,
         );
-        let mut traces = indexmap::IndexMap::new();
+        let mut traces = crate::FxIndexMap::default();
         traces.insert(
             trace_id,
             CompiledTrace {
@@ -25375,7 +25412,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::ConstMap::new(),
+            majit_ir::ConstMap::default(),
         );
 
         let (trace_id, fail_index) = {
@@ -25453,7 +25490,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::ConstMap::new(),
+            majit_ir::ConstMap::default(),
         );
 
         let (trace_id, fail_index, expected_source_op_index, expected_rd_numb, expected_exit_types) = {
@@ -25554,7 +25591,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::ConstMap::new(),
+            majit_ir::ConstMap::default(),
         );
 
         let (trace_id, fail_index, descr_arc) = {
@@ -25664,7 +25701,7 @@ mod tests {
             guard_op,
             mk_op(OpCode::Finish, &[OpRef::int_op(0)], OpRef::NONE.raw()),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::default();
         constants.insert(
             100,
             majit_ir::Const::Int(maybe_force_and_return_void as *const () as usize as i64),
@@ -26164,7 +26201,7 @@ mod tests {
                 front_entry_index: None,
                 front_target_source_positions: None,
                 root_trace_id: 0,
-                traces: indexmap::IndexMap::new(),
+                traces: crate::FxIndexMap::default(),
                 previous_tokens: Vec::new(),
                 loop_header_pc: None,
                 next_global_opref: 0,
@@ -26528,7 +26565,7 @@ mod tests {
                 front_entry_index: None,
                 front_target_source_positions: None,
                 root_trace_id: 101,
-                traces: indexmap::IndexMap::new(),
+                traces: crate::FxIndexMap::default(),
                 previous_tokens: Vec::new(),
                 loop_header_pc: None,
                 next_global_opref: 0,
@@ -26580,7 +26617,7 @@ mod tests {
                 front_entry_index: Some(0),
                 front_target_source_positions: None,
                 root_trace_id: 1,
-                traces: indexmap::IndexMap::new(),
+                traces: crate::FxIndexMap::default(),
                 previous_tokens: Vec::new(),
                 loop_header_pc: Some(0),
                 next_global_opref: 0,
@@ -26649,7 +26686,7 @@ mod tests {
                 front_entry_index: None,
                 front_target_source_positions: None,
                 root_trace_id: 102,
-                traces: indexmap::IndexMap::new(),
+                traces: crate::FxIndexMap::default(),
                 previous_tokens: Vec::new(),
                 loop_header_pc: None,
                 next_global_opref: 0,
@@ -26741,7 +26778,7 @@ mod tests {
             std::ptr::null(),
             &bridge_ops,
             &bridge_inputargs,
-            majit_ir::ConstMap::new(),
+            majit_ir::ConstMap::default(),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -27186,7 +27223,7 @@ mod tests {
                 OpRef::NONE.raw(),
             ),
         ];
-        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::default();
         constants.insert(100, majit_ir::Const::Int(1));
         constants.insert(101, majit_ir::Const::Int(0));
         attach_procedure_to_interp_entry(&mut meta, green_key, &inputargs, ops, constants);
@@ -27326,7 +27363,7 @@ mod bridge_cell_token_tests {
                 front_entry_index: None,
                 front_target_source_positions: None,
                 root_trace_id: green_key,
-                traces: indexmap::IndexMap::new(),
+                traces: crate::FxIndexMap::default(),
                 previous_tokens: Vec::new(),
                 loop_header_pc: None,
                 next_global_opref: 0,
@@ -27380,7 +27417,7 @@ mod loop_side_table_tests {
             front_entry_index: None,
             front_target_source_positions: None,
             root_trace_id,
-            traces: indexmap::IndexMap::new(),
+            traces: crate::FxIndexMap::default(),
             previous_tokens: Vec::new(),
             loop_header_pc: None,
             next_global_opref: 0,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -15352,32 +15352,39 @@ impl<M: Clone> MetaInterp<M> {
         exception: ExceptionState,
     ) -> Option<GuardRecovery> {
         let compiled = self.compiled_loops.get(&green_key)?;
-        let (trace_id, trace) = Self::trace_for_exit(compiled, trace_id)?;
-
-        let exit_layout =
-            Self::compiled_exit_layout_from_trace(trace, green_key, trace_id, fail_index)
-                .or_else(|| {
-                    self.compiled_exit_layout_from_backend(
-                        compiled, green_key, trace_id, fail_index,
-                    )
-                })
-                .unwrap_or_else(|| {
-                    let exit_types: ExitTypes = typed_fail_values
-                        .map(|values| values.iter().map(Value::get_type).collect())
-                        .unwrap_or_default();
-                    CompiledExitLayout {
-                        rd_loop_token: green_key, // from trace context
-                        trace_id,
-                        fail_index,
-                        source_op_index: None,
-                        is_finish: false,
-                        is_exception_exit: false,
-                        exit_types,
-                        recovery_layout: None,
-                        resume_layout: None,
-                        storage: None,
-                    }
-                });
+        let exit_layout = Self::trace_for_exit(compiled, trace_id)
+            .and_then(|(resolved_trace_id, trace)| {
+                Self::compiled_exit_layout_from_trace(
+                    trace,
+                    green_key,
+                    resolved_trace_id,
+                    fail_index,
+                )
+            })
+            // `compile.py send_bridge_to_backend` retains no frontend trace
+            // for a bridge.  Its failing descr is backend-owned, so the public
+            // recovery helper must reach that descr before considering the
+            // trace absent; otherwise every bridge guard returned `None` here.
+            .or_else(|| {
+                self.compiled_exit_layout_from_backend(compiled, green_key, trace_id, fail_index)
+            })
+            .unwrap_or_else(|| {
+                let exit_types: ExitTypes = typed_fail_values
+                    .map(|values| values.iter().map(Value::get_type).collect())
+                    .unwrap_or_default();
+                CompiledExitLayout {
+                    rd_loop_token: green_key, // from trace context
+                    trace_id,
+                    fail_index,
+                    source_op_index: None,
+                    is_finish: false,
+                    is_exception_exit: false,
+                    exit_types,
+                    recovery_layout: None,
+                    resume_layout: None,
+                    storage: None,
+                }
+            });
         // pyjitpl.py initialize_state_from_guard_failure:
         // guard failure rebuild is stack-critical code — must not be
         // interrupted by StackOverflow, otherwise jit_virtual_refs are

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3030,43 +3030,6 @@ impl<M: Clone> MetaInterp<M> {
         self.compiled_loops.get(&green_key).map(|c| c.root_trace_id)
     }
 
-    /// On-demand `ExitRecoveryLayout` reconstruction for
-    /// the cranelift overlay path.  Returns the `ExitRecoveryLayout` that
-    /// would be cached on `ResumeGuardDescr.recovery_layout` for a given
-    /// production guard, computed from the metainterp-side
-    /// `StoredExitLayout.resume_layout` (the canonical store).  Caller
-    /// supplies `caller_prefix` for CALL_ASSEMBLER overlay framing.
-    ///
-    /// Lookup path: descr → `rd_loop_token_clt()` → `CompiledLoopToken`
-    /// → `loop_token_wref.upgrade()` → `JitCellToken.green_key` →
-    /// `compiled_loops[green_key].traces[trace_id].exit_layouts[fail_index]`.
-    ///
-    /// Returns `None` for non-`ResumeDescr` descrs (synthetic FINISH /
-    /// external-JUMP / Done* / overlay synthetics with no `rd_loop_token`),
-    /// or when the descr's compiled entry has been evicted, or when the
-    /// `resume_layout` summary hasn't been built yet (codegen-time read
-    /// before metainterp publishes resume payload).
-    pub fn compute_recovery_layout_for_descr(
-        &self,
-        descr: &dyn FailDescr,
-        caller_prefix: Option<&majit_backend::ExitRecoveryLayout>,
-    ) -> Option<majit_backend::ExitRecoveryLayout> {
-        let trace_id = descr.trace_id();
-        let fail_index = descr.fail_index_per_trace();
-        let clt_any = descr.rd_loop_token_clt()?;
-        let clt = clt_any.downcast_ref::<majit_backend::CompiledLoopToken>()?;
-        let token_arc = clt.loop_token_wref.lock().upgrade()?;
-        let green_key = token_arc.green_key();
-        let compiled = self.compiled_loops.get(&green_key)?;
-        let exit_layout = compiled
-            .traces
-            .get(&trace_id)?
-            .exit_layouts
-            .get(&fail_index)?;
-        let resume_layout = exit_layout.resume_layout.as_ref()?;
-        Some(resume_layout.to_exit_recovery_layout_with_caller_prefix(caller_prefix))
-    }
-
     /// Salvage the evicted entry's per-trace metadata into the new
     /// CompiledEntry being built for the same `green_key`, and return the
     /// list of `Arc<JitCellToken>` to seed the new entry's

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3358,22 +3358,14 @@ impl<M: Clone> MetaInterp<M> {
             .and_then(|(_, trace)| Self::infer_exit_types_from_trace(trace, fail_index));
         self.backend_fail_descr_layout(compiled, trace_id, fail_index)
             .map(|layout| {
-                // compile.py copy_all_attributes_from parity:
-                // when the compiled trace has been evicted but the
-                // backend still has rd_numb / rd_consts / rd_virtuals /
-                // rd_pendingfields propagated on the fail descriptor,
-                // reassemble a `ResumeStorage` so downstream consumers
-                // (force_from_resumedata, blackhole) see the same
-                // shared pool the frontend-primed path provides.
-                // Mirrors `merge_backend_exit_layouts` in `compile.rs`.
-                let storage = layout.rd_numb.as_ref().map(|rd_numb| {
-                    crate::resume::ResumeStorage::new(
-                        rd_numb.clone(),
-                        layout.rd_consts.clone().unwrap_or_default(),
-                        layout.rd_virtuals.clone().unwrap_or_default(),
-                        layout.rd_pendingfields.clone().unwrap_or_default(),
-                    )
-                });
+                // `ResumeGuardDescr.get_resumestorage`: the payload is the
+                // descr's own; the layout only names the descr.
+                let storage = layout
+                    .descr
+                    .as_ref()
+                    .and_then(|descr| descr.as_fail_descr())
+                    .and_then(crate::resume::ResumeStorage::from_fail_descr)
+                    .map(std::sync::Arc::new);
                 // `from_vec`, so whichever arm wins hands over the buffer it
                 // already owns instead of being copied into a fresh one.
                 let exit_types = ExitTypes::from_vec(if layout.fail_arg_types.is_empty() {
@@ -7981,7 +7973,7 @@ impl<M: Clone> MetaInterp<M> {
             Ok(_) => {
                 self.last_compiled_artifact_token = Some(token.clone());
                 // compile.py `store_hash`: assign jitcounter hashes.
-                self.assign_guard_hashes(token.as_ref());
+                self.assign_guard_hashes(&compiled_ops);
                 // compile.py send_loop_to_backend registers the token
                 // with the memory manager before record_loop_or_bridge reads it.
                 self.warm_state.memory_manager.keep_loop_alive(&token);
@@ -9407,7 +9399,7 @@ impl<M: Clone> MetaInterp<M> {
         match compile_result {
             Ok(_) => {
                 self.last_compiled_artifact_token = Some(token.clone());
-                self.assign_guard_hashes(token.as_ref());
+                self.assign_guard_hashes(&combined_ops);
                 // `compile.py` `propagate_original_jitcell_token(new_loop)`,
                 // whose body at `:463-468` walks the trace's LABELs and sets
                 // each `TargetToken.original_jitcell_token` to the token this
@@ -9736,7 +9728,7 @@ impl<M: Clone> MetaInterp<M> {
             Ok(_) => {
                 self.last_compiled_artifact_token = Some(source_jct.clone());
                 // compile.py `store_hash` for bridge guards.
-                self.assign_bridge_guard_hashes(source_jct.as_ref(), source_trace_id, fail_index);
+                self.assign_guard_hashes(&combined_ops);
                 // `compile.py propagate_original_jitcell_token` — every
                 // LABEL's TargetToken in the finished trace is rebound to
                 // `new_loop.original_jitcell_token`, which
@@ -10337,7 +10329,7 @@ impl<M: Clone> MetaInterp<M> {
         match compile_loop_result {
             Ok(_) => {
                 self.last_compiled_artifact_token = Some(token.clone());
-                self.assign_guard_hashes(token.as_ref());
+                self.assign_guard_hashes(&optimized_ops);
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py record_loop_or_bridge.
                 self.record_loop_or_bridge(&token, &optimized_ops, trace_id);
@@ -10794,7 +10786,7 @@ impl<M: Clone> MetaInterp<M> {
                 if !self.last_quasi_immutable_deps.is_empty() {
                     crate::mc_diag_bump(75);
                 }
-                self.assign_guard_hashes(token.as_ref());
+                self.assign_guard_hashes(&compiled_ops);
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py record_loop_or_bridge.
                 self.record_loop_or_bridge(&token, &compiled_ops, trace_id);
@@ -13243,56 +13235,28 @@ impl<M: Clone> MetaInterp<M> {
         self.warm_state.memory_manager.keep_loop_alive(&token);
     }
 
-    /// compile.py store_hash: assign jitcounter hashes to guards
-    /// after compile_loop/compile_bridge. RPython calls store_hash during
-    /// optimizer emit (store_final_boxes_in_guard); in majit the backend
-    /// creates fail_descrs, so we assign hashes after compilation.
-    /// Only allocates hashes for real guards (not FINISH/external JUMP).
-    fn assign_guard_hashes(&mut self, token: &JitCellToken) {
-        let layouts = self.backend.compiled_fail_descr_layouts(token);
-        let hashes: Vec<u64> = layouts
-            .iter()
-            .flatten()
-            .map(|layout| {
-                if layout.is_finish {
-                    0 // FINISH/external JUMP — no hash needed
-                } else {
-                    self.warm_state.fetch_next_hash()
-                }
-            })
-            .collect();
-        self.backend.store_guard_hashes(token, &hashes);
-    }
-
-    /// compile.py store_hash for bridge guards.
-    fn assign_bridge_guard_hashes(
-        &mut self,
-        source_token: &JitCellToken,
-        source_trace_id: u64,
-        source_fail_index: u32,
-    ) {
-        let layouts = self.backend.compiled_bridge_fail_descr_layouts(
-            source_token,
-            source_trace_id,
-            source_fail_index,
-        );
-        let hashes: Vec<u64> = layouts
-            .iter()
-            .flatten()
-            .map(|layout| {
-                if layout.is_finish {
-                    0
-                } else {
-                    self.warm_state.fetch_next_hash()
-                }
-            })
-            .collect();
-        self.backend.store_bridge_guard_hashes(
-            source_token,
-            source_trace_id,
-            source_fail_index,
-            &hashes,
-        );
+    /// `compile.py store_hash`: `self.status = hash & ST_SHIFT_MASK` on every
+    /// guard descr the optimizer stored final boxes in. RPython does it from
+    /// `store_final_boxes`; pyre walks the guards of the trace it just sent
+    /// to the backend. A descr whose status is already set
+    /// (`make_a_counter_per_value`) keeps it, and FINISH descrs have none.
+    fn assign_guard_hashes<T: AsRef<majit_ir::Op>>(&mut self, ops: &[T]) {
+        for op in ops {
+            let op = op.as_ref();
+            if !op.opcode.is_guard() {
+                continue;
+            }
+            let Some(descr) = op.getdescr() else {
+                continue;
+            };
+            let Some(fd) = descr.as_fail_descr() else {
+                continue;
+            };
+            if fd.is_finish() || fd.get_status() != 0 {
+                continue;
+            }
+            fd.store_hash(self.warm_state.fetch_next_hash());
+        }
     }
 
     /// Check whether a bridge was actually compiled and attached for a guard.
@@ -13306,8 +13270,7 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(token) = self.warm_state.get_compiled(green_key)
             && self
                 .backend
-                .compiled_bridge_fail_descr_layouts(&token, trace_id, fail_index)
-                .is_some()
+                .bridge_was_compiled(&token, trace_id, fail_index)
         {
             return true;
         }
@@ -13327,8 +13290,7 @@ impl<M: Clone> MetaInterp<M> {
                 .upgrade()
                 .map(|prev| {
                     self.backend
-                        .compiled_bridge_fail_descr_layouts(&prev, trace_id, fail_index)
-                        .is_some()
+                        .bridge_was_compiled(&prev, trace_id, fail_index)
                 })
                 .unwrap_or(false)
         })
@@ -13898,7 +13860,7 @@ impl<M: Clone> MetaInterp<M> {
                 // compile.py `record_loop_or_bridge` registers every
                 // dependency against the owning token published by this compile.
                 self.last_compiled_artifact_token = Some(token.clone());
-                self.assign_guard_hashes(token.as_ref());
+                self.assign_guard_hashes(&optimized_ops);
                 self.warm_state.memory_manager.keep_loop_alive(&token);
                 // compile.py record_loop_or_bridge.
                 self.last_quasi_immutable_deps =
@@ -14789,7 +14751,7 @@ impl<M: Clone> MetaInterp<M> {
                     // fallback to root_trace_id.
                     fail_descr.trace_id()
                 };
-                self.assign_bridge_guard_hashes(source_jct.as_ref(), source_trace_id, fail_index);
+                self.assign_guard_hashes(&optimized_ops);
                 // `compile.py record_loop_or_bridge(metainterp_sd,
                 //  new_loop)` parity — `new_loop.original_jitcell_token =
                 //  metainterp.resumekey_original_loop_token` (compile.py:801).

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -545,6 +545,18 @@ fn cross_loop_cut_label_jump_null_guard_slot(ops: &[majit_ir::OpRc]) -> Option<u
     None
 }
 
+/// The frontend's view of a compiled root loop, indexed by trace id on
+/// its `CompiledEntry`.
+///
+/// Bridges are not entered here.  `compile.py send_bridge_to_backend`
+/// hands the bridge to the CPU and keeps nothing in the frontend: every
+/// later reader — `AbstractResumeGuardDescr.handle_fail`,
+/// `ResumeGuardDescr.get_resumestorage`, `compile.py` bridge retrace —
+/// reads off the guard's own `ResumeGuardDescr` (`_attrs_ = rd_numb,
+/// rd_consts, rd_virtuals, rd_pendingfields, status`), which the backend's
+/// `asmmemmgr_gcreftracers` keeps alive for the loop token's lifetime.  A
+/// per-bridge frontend record made retention grow with the bridge count
+/// and never shrink.
 pub(crate) struct CompiledTrace {
     /// Inputargs for this trace, used to recover typed exit layouts during blackhole replay.
     pub(crate) inputargs: Vec<InputArg>,
@@ -2603,6 +2615,44 @@ impl<M: Clone> MetaInterp<M> {
                         visit_pool(descr_pool.as_ref(), generation, is_minor, &mut visitor);
                     }
                 }
+                // `compile.py:ResumeGuardDescr._attrs_` traces `rd_consts` on
+                // every guard descr, and a bridge's descrs are reachable only
+                // through the backend: `assembler.py gcreftracers.append(tracer)`
+                // pins them on the loop token's `asmmemmgr_gcreftracers`
+                // (`model.py CompiledLoopToken`).  Walk those tracers so a
+                // bridge guard's pool is a root for the token's lifetime,
+                // the same way the root loop's descrs are reached above.
+                // Dynasm registers `Vec<Arc<FailDescrCell>>`, cranelift and
+                // wasm `Vec<DescrRef>`; the other tracer kinds (GcTables)
+                // are rooted through the gcreftracer registry.
+                let tokens = entry.live_token().into_iter().chain(
+                    entry
+                        .previous_tokens
+                        .iter()
+                        .filter_map(std::sync::Weak::upgrade),
+                );
+                for token in tokens {
+                    let Some(clt) = token.compiled_loop_token() else {
+                        continue;
+                    };
+                    for tracer in clt.asmmemmgr_gcreftracers.lock().iter() {
+                        let mut visit_descr = |descr: &dyn majit_ir::Descr| {
+                            let pool = descr.as_fail_descr().and_then(|fd| fd.rd_consts_arc());
+                            visit_pool(pool.as_ref(), generation, is_minor, &mut visitor);
+                        };
+                        if let Some(cells) =
+                            tracer.downcast_ref::<Vec<Arc<majit_ir::FailDescrCell>>>()
+                        {
+                            for cell in cells {
+                                visit_descr(&*cell.descr);
+                            }
+                        } else if let Some(descrs) = tracer.downcast_ref::<Vec<DescrRef>>() {
+                            for descr in descrs {
+                                visit_descr(&**descr);
+                            }
+                        }
+                    }
+                }
                 for tt in entry.front_target_tokens.iter_mut() {
                     // `history.TargetToken` is a GC object upstream. MiniMark
                     // visits it in a minor only while its write barrier is
@@ -3147,8 +3197,15 @@ impl<M: Clone> MetaInterp<M> {
         if is_finish {
             return default_layout();
         }
+        // A guard with no frontend record — every bridge guard
+        // (`compile.py send_bridge_to_backend`) — answers off its own
+        // `ResumeGuardDescr` payload.
+        let from_descr = || {
+            Self::compiled_exit_layout_from_descr(descr, green_key, trace_id, fail_index)
+                .unwrap_or_else(default_layout)
+        };
         let Some(compiled) = self.compiled_loops.get(&green_key) else {
-            return default_layout();
+            return from_descr();
         };
         Self::trace_for_exit(compiled, trace_id)
             .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
@@ -3156,7 +3213,7 @@ impl<M: Clone> MetaInterp<M> {
             .and_then(|(owning_key, resolved_id, trace)| {
                 Self::compiled_exit_layout_from_trace(trace, owning_key, resolved_id, fail_index)
             })
-            .unwrap_or_else(default_layout)
+            .unwrap_or_else(from_descr)
     }
 
     /// `compile.py ResumeGuardDescr._attrs_` parity: per-guard exit
@@ -9712,7 +9769,6 @@ impl<M: Clone> MetaInterp<M> {
                         inputargs.len()
                     );
                 }
-                let fvc = self.active_frame_value_count_fn();
                 if let Some(compiled) = self.compiled_loops.get_mut(&green_key) {
                     // `unroll.py finalize_short_preamble` appends the
                     // newly minted TargetToken to `jitcelltoken.target_tokens`
@@ -9729,64 +9785,16 @@ impl<M: Clone> MetaInterp<M> {
                                 Self::front_entry_index_for(&compiled.front_target_tokens);
                         }
                     }
-                    let (mut resume_data, mut exit_layouts) =
-                        compile::build_guard_metadata(&inputargs, &combined_ops, green_key, fvc);
-                    let mut terminal_exit_layouts =
-                        compile::build_terminal_exit_layouts(&inputargs, &combined_ops);
-                    if let Some(backend_layouts) = self.backend.compiled_bridge_fail_descr_layouts(
-                        source_jct.as_ref(),
-                        source_trace_id,
-                        fail_index,
-                    ) {
-                        compile::merge_backend_exit_layouts(
-                            &mut exit_layouts,
-                            &backend_layouts,
-                            &combined_ops,
-                        );
-                    }
-                    if let Some(backend_layouts) =
-                        self.backend.compiled_bridge_terminal_exit_layouts(
-                            source_jct.as_ref(),
-                            source_trace_id,
-                            fail_index,
-                        )
-                    {
-                        compile::merge_backend_terminal_exit_layouts(
-                            &mut terminal_exit_layouts,
-                            &backend_layouts,
-                            &combined_ops,
-                        );
-                    }
-                    let bridge_trace_info = self
-                        .backend
-                        .compiled_trace_info(source_jct.as_ref(), bridge_trace_id);
-                    compile::enrich_guard_resume_layouts_for_trace(
-                        &mut resume_data,
-                        &mut exit_layouts,
-                        bridge_trace_id,
-                        &inputargs,
-                        bridge_trace_info.as_ref(),
-                    );
-                    compile::patch_guard_recovery_layouts_for_trace(&mut exit_layouts);
-                    compile::patch_backend_terminal_recovery_layouts_for_trace(
-                        &mut self.backend,
-                        source_jct.as_ref(),
-                        bridge_trace_id,
-                        &mut terminal_exit_layouts,
-                    );
+                    // `compile.py send_bridge_to_backend`: the bridge is
+                    // handed to the CPU and nothing is indexed in the
+                    // frontend — its guards answer later failures off
+                    // their own `ResumeGuardDescr`.  Only the per-trace
+                    // `(fail_index, op index)` stamp the pyre readers key
+                    // on is applied here.
+                    compile::stamp_guard_descr_trace_positions(&combined_ops);
                     // Box Identity Phase E.2b parity: see compile_loop site.
                     let new_high_water = compute_next_global_opref(&inputargs, &combined_ops);
                     compiled.next_global_opref = compiled.next_global_opref.max(new_high_water);
-                    compiled.traces.insert(
-                        bridge_trace_id,
-                        CompiledTrace {
-                            inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
-                            ops: combined_ops,
-                            constants: compiled_constants_typed,
-                            exit_layouts,
-                            terminal_exit_layouts,
-                        },
-                    );
                 }
                 self.remember_compiled_graph_write();
                 self.warm_state.log_bridge_compile(fail_index);
@@ -11373,7 +11381,13 @@ impl<M: Clone> MetaInterp<M> {
                     fail_index: layout.fail_index,
                     source_op_index: layout
                         .source_op_index
-                        .or_else(|| trace_layout_ref.and_then(|layout| layout.source_op_index)),
+                        .or_else(|| trace_layout_ref.and_then(|layout| layout.source_op_index))
+                        .or_else(|| {
+                            result
+                                .descr_arc
+                                .as_fail_descr()
+                                .and_then(|fd| fd.source_op_index())
+                        }),
                     exit_types: ExitTypes::from_vec(layout.fail_arg_types),
                     is_finish: layout.is_finish,
                     is_exception_exit: layout.is_exception_exit,
@@ -11381,24 +11395,38 @@ impl<M: Clone> MetaInterp<M> {
                         || trace_layout_ref.and_then(|layout| layout.recovery_layout.clone()),
                     ),
                     resume_layout: resume_layout.map(std::sync::Arc::new),
-                    storage: trace_layout_ref.and_then(|layout| layout.storage.clone()),
+                    // A bridge guard has no frontend record
+                    // (`send_bridge_to_backend`); its pool is the descr's
+                    // own (`ResumeGuardDescr.get_resumestorage`).
+                    storage: trace_layout_ref
+                        .and_then(|layout| layout.storage.clone())
+                        .or_else(|| {
+                            result
+                                .descr_arc
+                                .as_fail_descr()
+                                .and_then(crate::resume::ResumeStorage::from_fail_descr)
+                                .map(Arc::new)
+                        }),
                 }
             })
             .or(trace_layout)
             .unwrap_or_else(|| {
                 let exit_types: ExitTypes =
                     result.typed_outputs.iter().map(Value::get_type).collect();
+                let fd = result.descr_arc.as_fail_descr();
                 CompiledExitLayout {
                     rd_loop_token: green_key, // from trace context
                     trace_id,
                     fail_index,
-                    source_op_index: None,
+                    source_op_index: fd.and_then(|fd| fd.source_op_index()),
                     exit_types,
                     is_finish: result.is_finish,
                     is_exception_exit: result.is_exit_frame_with_exception,
                     recovery_layout: None,
                     resume_layout: None,
-                    storage: None,
+                    storage: fd
+                        .and_then(crate::resume::ResumeStorage::from_fail_descr)
+                        .map(Arc::new),
                 }
             });
         let effective_is_finish = result.is_finish || exit_layout.is_finish;
@@ -11541,7 +11569,7 @@ impl<M: Clone> MetaInterp<M> {
                         rd_loop_token: green_key,
                         trace_id,
                         fail_index,
-                        source_op_index: None,
+                        source_op_index: descr.source_op_index(),
                         exit_types: ExitTypes::from_slice(exit_types),
                         is_finish,
                         is_exception_exit: is_exit_frame_with_exception,
@@ -11900,7 +11928,7 @@ impl<M: Clone> MetaInterp<M> {
                     rd_loop_token: green_key,
                     trace_id,
                     fail_index,
-                    source_op_index: None,
+                    source_op_index: descr.source_op_index(),
                     exit_types: ExitTypes::from_slice(exit_types),
                     is_finish,
                     is_exception_exit: is_exit_frame_with_exception,
@@ -12071,6 +12099,69 @@ impl<M: Clone> MetaInterp<M> {
             return Some(layout);
         }
         self.compiled_exit_layout_from_backend(compiled, green_key, trace_id, fail_index)
+    }
+
+    /// `AbstractResumeGuardDescr.handle_fail(self, deadframe)`: the failing
+    /// guard's exit metadata read off the descr the deadframe named.  The
+    /// root loop's frontend record is consulted first (it carries the
+    /// enriched `resume_layout` the cranelift recovery path reads); a
+    /// bridge guard has no such record (`send_bridge_to_backend`), so its
+    /// layout is assembled from the descr's own `rd_*` pool, types and
+    /// stamped trace positions.  No backend scan.
+    pub fn get_compiled_exit_layout_for_descr(
+        &self,
+        descr: &dyn majit_ir::FailDescr,
+        green_key: u64,
+        trace_id: u64,
+        fail_index: u32,
+    ) -> Option<CompiledExitLayout> {
+        if let Some(compiled) = self.compiled_loops.get(&green_key)
+            && let Some((resolved_trace_id, trace)) = Self::trace_for_exit(compiled, trace_id)
+            && let Some(layout) = Self::compiled_exit_layout_from_trace(
+                trace,
+                green_key,
+                resolved_trace_id,
+                fail_index,
+            )
+        {
+            return Some(layout);
+        }
+        if let Some(layout) =
+            Self::compiled_exit_layout_from_descr(descr, green_key, trace_id, fail_index)
+        {
+            return Some(layout);
+        }
+        // A descr that carries no resume payload of its own: only the test
+        // scaffolds mint such guards (codegen fills in the backend-side
+        // copy), so the backend index is the last place to ask.  Production
+        // guards answer above.
+        let compiled = self.compiled_loops.get(&green_key)?;
+        self.compiled_exit_layout_from_backend(compiled, green_key, trace_id, fail_index)
+    }
+
+    /// `ResumeGuardDescr` read into the exit-layout shape: `rd_numb` /
+    /// `rd_consts` / `rd_virtuals` / `rd_pendingfields` become the shared
+    /// `ResumeStorage`, `fail_arg_types` the slot types.  `None` when the
+    /// descr carries no resume payload (a non-resume FailDescr).
+    fn compiled_exit_layout_from_descr(
+        descr: &dyn majit_ir::FailDescr,
+        owning_key: u64,
+        trace_id: u64,
+        fail_index: u32,
+    ) -> Option<CompiledExitLayout> {
+        let storage = crate::resume::ResumeStorage::from_fail_descr(descr)?;
+        Some(CompiledExitLayout {
+            rd_loop_token: owning_key, // compile.py:186
+            trace_id,
+            fail_index,
+            source_op_index: descr.source_op_index(),
+            exit_types: ExitTypes::from_slice(descr.fail_arg_types()),
+            is_finish: descr.is_finish(),
+            is_exception_exit: descr.is_exit_frame_with_exception(),
+            recovery_layout: None,
+            resume_layout: None,
+            storage: Some(Arc::new(storage)),
+        })
     }
 
     /// Get the full static layout for a terminal FINISH/JUMP op in a specific trace.
@@ -13435,6 +13526,32 @@ impl<M: Clone> MetaInterp<M> {
         ))
     }
 
+    /// [`Self::get_resume_storage_with_slot_types`] answered off the
+    /// failing descr (`ResumeGuardDescr.get_resumestorage`), so a bridge
+    /// guard with no frontend record resolves without a backend scan.
+    pub fn get_resume_storage_with_slot_types_for_descr(
+        &self,
+        descr: &dyn majit_ir::FailDescr,
+        green_key: u64,
+        trace_id: u64,
+        fail_index: u32,
+    ) -> Option<(Arc<ResumeStorage>, Vec<Type>)> {
+        let layout = self
+            .get_compiled_exit_layout_for_descr(descr, green_key, trace_id, fail_index)
+            .filter(|layout| layout.storage.is_some())
+            .or_else(|| {
+                Self::compiled_exit_layout_from_descr(descr, green_key, trace_id, fail_index)
+            })?;
+        let storage = layout.storage.clone()?;
+        Some((
+            storage,
+            Self::recovery_slot_types_from_exit_types_and_layout(
+                &layout.exit_types,
+                layout.recovery_layout.as_deref(),
+            ),
+        ))
+    }
+
     /// Get exit_types for a guard (for decode_ref type dispatch).
     pub fn get_exit_types(
         &self,
@@ -14141,17 +14258,13 @@ impl<M: Clone> MetaInterp<M> {
                 source_trace_id, 0,
                 "compile_bridge expects bridge origin descr.trace_id() to be a real allocated id, not the FINISH-singleton sentinel"
             );
-            let pending = compiled.traces.get(&source_trace_id).and_then(|trace| {
-                // Route guard identity through
-                // `exit_layouts.descr` instead of `guard_op_indices →
-                // trace.ops[idx]`. The descr Arc already carries
-                // `fail_arg_types` (resume.py:467 / history.py:307 parity),
-                // so the indexed op lookup is redundant.
-                let exit_layout = trace.exit_layouts.get(&fail_index)?;
-                // compile.py `ResumeGuardDescr` storage — every
-                // guard's rd_* pool lives behind a shared Arc; the
-                // bridge deserializer borrows that same Arc.
-                let storage = exit_layout.storage.clone()?;
+            // `compile.py compile_trace` reads `resumekey.get_resumestorage()`:
+            // the source guard's rd_* pool is the descr's own, whether the
+            // guard sits in the root loop or in a bridge the frontend never
+            // indexed (`send_bridge_to_backend`).  The pool Arcs are the ones
+            // the descr holds, so the deserializer shares them.
+            let pending = crate::resume::ResumeStorage::from_fail_descr(fail_descr).and_then(|storage| {
+                let storage = Arc::new(storage);
                 // Each bridge inputarg carries its `box.type`
                 // (resoperation.py:719/727/739 InputArg{Int,Ref,Float});
                 // mint the typed `OpRef::input_arg_*` variant via
@@ -14174,11 +14287,7 @@ impl<M: Clone> MetaInterp<M> {
                 // parent guard's saved types instead so the deserializer
                 // matches the types the serializer used at memo.finish()
                 // time.
-                let positional_livebox_types: Vec<Type> = exit_layout
-                    .descr
-                    .as_ref()
-                    .and_then(|descr| descr.as_fail_descr())
-                    .map(|fd| fd.fail_arg_types().to_vec())
+                let positional_livebox_types: Vec<Type> = Some(fail_descr.fail_arg_types().to_vec())
                     .filter(|types| !types.is_empty())
                     .unwrap_or_else(|| bridge_inputargs.iter().map(|ia| ia.tp).collect());
                 // pyjitpl.py `initialize_state_from_guard_failure` removes
@@ -14693,80 +14802,15 @@ impl<M: Clone> MetaInterp<M> {
                 self.last_quasi_immutable_deps =
                     std::mem::take(&mut optimizer.quasi_immutable_deps);
                 self.record_loop_or_bridge(&source_jct, &optimized_ops, bridge_trace_id);
-                // Read before the `compiled_loops` mutable borrow below.
-                let fvc = self.active_frame_value_count_fn();
                 // Mark the bridge as compiled
                 if let Some(compiled) = self.compiled_loops.get_mut(&green_key) {
-                    // pyjitpl.py:1049 — `fail_descr.trace_id()` is the
-                    // bridge origin's allocated id (`alloc_trace_id`
-                    // starts at 1).  No `0 → root_trace_id` sentinel;
-                    // RPython resolves the source via descr identity.
-                    let source_trace_id = fail_descr.trace_id();
-                    let (mut resume_data, mut exit_layouts) = compile::build_guard_metadata(
-                        bridge_inputargs,
-                        &optimized_ops,
-                        green_key,
-                        fvc,
-                    );
-                    let mut terminal_exit_layouts =
-                        compile::build_terminal_exit_layouts(bridge_inputargs, &optimized_ops);
-                    if let Some(backend_layouts) = self.backend.compiled_bridge_fail_descr_layouts(
-                        source_jct.as_ref(),
-                        source_trace_id,
-                        fail_index,
-                    ) {
-                        compile::merge_backend_exit_layouts(
-                            &mut exit_layouts,
-                            &backend_layouts,
-                            &optimized_ops,
-                        );
-                    }
-                    if let Some(backend_layouts) =
-                        self.backend.compiled_bridge_terminal_exit_layouts(
-                            source_jct.as_ref(),
-                            source_trace_id,
-                            fail_index,
-                        )
-                    {
-                        compile::merge_backend_terminal_exit_layouts(
-                            &mut terminal_exit_layouts,
-                            &backend_layouts,
-                            &optimized_ops,
-                        );
-                    }
-                    let bridge_trace_info = self
-                        .backend
-                        .compiled_trace_info(source_jct.as_ref(), bridge_trace_id);
-                    compile::enrich_guard_resume_layouts_for_trace(
-                        &mut resume_data,
-                        &mut exit_layouts,
-                        bridge_trace_id,
-                        bridge_inputargs,
-                        bridge_trace_info.as_ref(),
-                    );
-                    compile::patch_guard_recovery_layouts_for_trace(&mut exit_layouts);
-                    compile::patch_backend_terminal_recovery_layouts_for_trace(
-                        &mut self.backend,
-                        source_jct.as_ref(),
-                        bridge_trace_id,
-                        &mut terminal_exit_layouts,
-                    );
+                    // `compile.py send_bridge_to_backend`: nothing is
+                    // indexed in the frontend for a bridge — see the
+                    // retrace site.
+                    compile::stamp_guard_descr_trace_positions(&optimized_ops);
                     let new_high_water =
                         compute_next_global_opref(bridge_inputargs, &optimized_ops);
                     compiled.next_global_opref = compiled.next_global_opref.max(new_high_water);
-                    compiled.traces.insert(
-                        bridge_trace_id,
-                        CompiledTrace {
-                            inputargs: bridge_inputargs
-                                .iter()
-                                .map(InputArg::fresh_value_copy)
-                                .collect(),
-                            ops: optimized_ops,
-                            constants: compiled_constants_typed,
-                            exit_layouts,
-                            terminal_exit_layouts,
-                        },
-                    );
                 }
                 self.remember_compiled_graph_write();
                 self.warm_state.log_bridge_compile(fail_index);
@@ -14986,7 +15030,7 @@ impl<M: Clone> MetaInterp<M> {
         // at trace start, mirroring ResumeDataBoxReader.consume_boxes
         // → rd_virtuals[i].allocate (resume.py getvirtual_ptr).
         let storage = self
-            .get_compiled_exit_layout_in_trace(green_key, norm_tid, fail_index)
+            .get_compiled_exit_layout_for_descr(fail_descr, green_key, norm_tid, fail_index)
             .and_then(|layout| layout.storage);
 
         let fail_types = bridge_input_types.to_vec();
@@ -15034,6 +15078,7 @@ impl<M: Clone> MetaInterp<M> {
         fail_values: &[i64],
     ) -> Option<(Vec<i64>, Vec<i64>)> {
         self.handle_async_forcing_with_allocator(
+            None,
             green_key,
             trace_id,
             fail_index,
@@ -15042,8 +15087,13 @@ impl<M: Clone> MetaInterp<M> {
         )
     }
 
+    /// `descr` is the forced guard's own `ResumeGuardDescr`
+    /// (`compile.py handle_async_forcing(self, deadframe)` is a method on
+    /// it); the test entry passes `None` and resolves through the root
+    /// loop's frontend record.
     fn handle_async_forcing_with_allocator(
         &mut self,
+        descr: Option<&dyn majit_ir::FailDescr>,
         green_key: u64,
         trace_id: u64,
         fail_index: u32,
@@ -15062,8 +15112,12 @@ impl<M: Clone> MetaInterp<M> {
         // compile.py:988-991: resolve metainterp_sd, vinfo, ginfo
         let _compiled = self.compiled_loops.get(&green_key)?;
         let norm_tid = trace_id;
-        let exit_layout =
-            self.get_compiled_exit_layout_in_trace(green_key, norm_tid, fail_index)?;
+        let exit_layout = match descr {
+            Some(descr) => {
+                self.get_compiled_exit_layout_for_descr(descr, green_key, norm_tid, fail_index)?
+            }
+            None => self.get_compiled_exit_layout_in_trace(green_key, norm_tid, fail_index)?,
+        };
 
         // compile.py:973-985 don't interrupt me! If the stack runs out
         // in force_from_resumedata() then we have seen cpu.force() but
@@ -15197,6 +15251,7 @@ impl<M: Clone> MetaInterp<M> {
             .collect::<Vec<_>>();
         // compile.py: faildescr.handle_async_forcing(deadframe)
         self.handle_async_forcing_with_allocator(
+            Some(descr),
             green_key,
             trace_id,
             fail_index,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3337,7 +3337,7 @@ impl<M: Clone> MetaInterp<M> {
                     layout.fail_arg_types
                 });
                 CompiledExitLayout {
-                    rd_loop_token: owning_key, // compile.py:186
+                    rd_loop_token: owning_key, // compile.py record_loop_or_bridge
                     trace_id,
                     fail_index: layout.fail_index,
                     source_op_index: layout.source_op_index,
@@ -3360,7 +3360,7 @@ impl<M: Clone> MetaInterp<M> {
     ) -> Option<CompiledExitLayout> {
         self.backend_terminal_exit_layout(compiled, trace_id, op_index)
             .map(|layout| CompiledExitLayout {
-                rd_loop_token: owning_key, // compile.py:186
+                rd_loop_token: owning_key, // compile.py record_loop_or_bridge
                 trace_id,
                 fail_index: layout.fail_index,
                 source_op_index: Some(layout.op_index),
@@ -3405,7 +3405,7 @@ impl<M: Clone> MetaInterp<M> {
                 merged.insert(
                     layout.fail_index,
                     CompiledExitLayout {
-                        rd_loop_token: owning_key, // compile.py:186
+                        rd_loop_token: owning_key, // compile.py record_loop_or_bridge
                         trace_id,
                         fail_index: layout.fail_index,
                         source_op_index: layout.source_op_index,
@@ -3459,7 +3459,7 @@ impl<M: Clone> MetaInterp<M> {
                     CompiledTerminalExitLayout {
                         op_index: layout.op_index,
                         exit_layout: CompiledExitLayout {
-                            rd_loop_token: owning_key, // compile.py:186
+                            rd_loop_token: owning_key, // compile.py record_loop_or_bridge
                             trace_id,
                             fail_index: layout.fail_index,
                             source_op_index: Some(layout.op_index),
@@ -10085,7 +10085,7 @@ impl<M: Clone> MetaInterp<M> {
 
         // Dumped before the call, not after: `Optimizer::propagate_from_pass_range`
         // resolves each argument in place on the op it is handed
-        // (`optimizer.py:650-652 _emit_operation`), so once the call returns
+        // (`optimizer.py _emit_operation`), so once the call returns
         // these ops carry resolved arguments rather than the recorded ones.
         // `compile_simple_loop` dumps at the same point for the same reason.
         if crate::majit_log_enabled() {
@@ -11622,8 +11622,11 @@ impl<M: Clone> MetaInterp<M> {
             let descr = descr_arc
                 .as_fail_descr()
                 .expect("a guard exit carries a FailDescr");
-            result.exit_layout =
-                Some(Box::new(self.guard_exit_layout(green_key, descr, result.rd_loop_token)));
+            result.exit_layout = Some(Box::new(self.guard_exit_layout(
+                green_key,
+                descr,
+                result.rd_loop_token,
+            )));
         }
         Some(result)
     }
@@ -11674,12 +11677,7 @@ impl<M: Clone> MetaInterp<M> {
             .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
             .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
             .and_then(|(owning_key, resolved_id, trace)| {
-                Self::compiled_exit_layout_from_trace(
-                    trace,
-                    owning_key,
-                    resolved_id,
-                    fail_index,
-                )
+                Self::compiled_exit_layout_from_trace(trace, owning_key, resolved_id, fail_index)
             })
             .unwrap_or_else(|| CompiledExitLayout {
                 rd_loop_token: green_key,
@@ -12131,7 +12129,7 @@ impl<M: Clone> MetaInterp<M> {
     ) -> Option<CompiledExitLayout> {
         let storage = crate::resume::ResumeStorage::from_fail_descr(descr)?;
         Some(CompiledExitLayout {
-            rd_loop_token: owning_key, // compile.py:186
+            rd_loop_token: owning_key, // compile.py record_loop_or_bridge
             trace_id,
             fail_index,
             source_op_index: descr.source_op_index(),

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10120,6 +10120,15 @@ impl<M: Clone> MetaInterp<M> {
         optimizer.snapshot_vref_boxes = snapshot_vref_map;
         optimizer.snapshot_frame_pcs = snapshot_frame_pcs;
 
+        // Dumped before the call, not after: `Optimizer::propagate_from_pass_range`
+        // resolves each argument in place on the op it is handed
+        // (`optimizer.py:650-652 _emit_operation`), so once the call returns
+        // these ops carry resolved arguments rather than the recorded ones.
+        // `compile_simple_loop` dumps at the same point for the same reason.
+        if crate::majit_log_enabled() {
+            eprintln!("--- finish trace (before opt) ---");
+            eprint!("{}", majit_ir::format_trace(&trace_ops, &constants));
+        }
         // InvalidLoop during optimization should abort the trace, not crash
         // the process. Matches compile_loop.
         let optimize_start = Instant::now();
@@ -10195,8 +10204,6 @@ impl<M: Clone> MetaInterp<M> {
                 "[jit] finish_and_compile: key={}, ops_before={}, ops_after={}",
                 green_key, num_ops_before, num_ops_after
             );
-            eprintln!("--- finish trace (before opt) ---");
-            eprint!("{}", majit_ir::format_trace(&trace_ops, &constants));
             eprintln!("--- finish trace (after opt, before unbox) ---");
             eprint!("{}", majit_ir::format_trace(&optimized_ops, &constants));
         }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2783,9 +2783,7 @@ impl<M: Clone> MetaInterp<M> {
         let Some(trace_ctx) = self.tracing.as_mut() else {
             return;
         };
-        for op in trace_ctx.recorder.ops() {
-            walk_op_const_ptr_refs(op, &mut visitor);
-        }
+        trace_ctx.recorder.walk_const_ptr_refs(&mut visitor);
         // `set_concrete_at` also stamps a runtime `Value::Ref` onto recorder
         // InputArgs (loop / bridge entry args). No other walker visits them,
         // and an InputArg carries no args / fail_args, so `.value` is the only
@@ -8519,26 +8517,16 @@ impl<M: Clone> MetaInterp<M> {
                 .close_loop_with_descr(finish_args, Some(jump_descr));
         }
 
-        // Snapshot the trace ops (including JUMP) for bridge compilation.
-        // `ctx.ops()` yields `&[OpRc]`; the bridge compile helpers consume
-        // `&[Op]`, so materialize an owned value copy here.
-        let bridge_ops: Vec<majit_ir::Op> = ctx
-            .ops()
-            .iter()
-            .map(|op| {
-                let cloned = (**op).clone();
-                // `Op::clone` resets the concrete value slot to fresh-identity
-                // empty, but the bridge trace must carry the recorded runtime
-                // values (history.py:680 `_resint`/`_resref`) so the optimizer's
-                // jump_to_existing_trace virtual-state match can read the
-                // closing-jump args (`closing_jump_runtime_boxes`). Re-stamp the
-                // value the recorder placed on the source op identity.
-                if let Some(v) = op.get_value() {
-                    cloned.set_value(v);
-                }
-                cloned
-            })
-            .collect();
+        // Keep the recorded operations (including JUMP) alive while the
+        // recorder is cut below. `compile.py compile_trace` hands the live
+        // opencoder trace straight to `UnrollOptimizer.optimize_bridge`, whose
+        // `TraceIterator` is the one and only place fresh ResOperations are
+        // materialized. A deep `Op::clone` here used to materialize every op a
+        // first time merely to survive Rust's earlier cut; retaining the
+        // canonical `Rc<Op>` handles preserves the same live trace identity
+        // and lets `prepare_bridge_trace_for_optimizer` perform the sole fresh
+        // materialization, as upstream does.
+        let bridge_ops: Vec<majit_ir::OpRc> = ctx.ops().to_vec();
         // Carry the history's live input boxes, WITHOUT carrying the values
         // the recorder's own inputargs hold.
         //
@@ -8598,14 +8586,13 @@ impl<M: Clone> MetaInterp<M> {
         // ConstantPool to snapshot — this typed-constant map starts fresh.
         let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
         let call_pure_results = ctx.call_pure_results.clone();
-        let trace_snapshots = ctx.snapshots().to_vec();
         let (
             mut snapshot_boxes,
             snapshot_frame_sizes,
             mut snapshot_vable_boxes,
             mut snapshot_vref_boxes,
             snapshot_frame_pcs,
-        ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
+        ) = snapshot_map_from_trace_snapshots(ctx.snapshots(), &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
             &mut snapshot_boxes,
             &mut snapshot_vable_boxes,
@@ -13552,14 +13539,14 @@ impl<M: Clone> MetaInterp<M> {
     /// Optimize against the already-compiled loop at `green_key`, then
     /// compile the result as a fresh interpreter entry under
     /// `original_green_key`.
-    pub fn compile_entry_bridge(
+    pub fn compile_entry_bridge<T>(
         &mut self,
         green_key: u64,
         original_green_key: u64,
         meta: M,
         driver_descriptor: Option<crate::jitdriver::JitDriverStaticData>,
         orig_vable_ptr_entry: *const u8,
-        bridge_ops: &[majit_ir::Op],
+        bridge_ops: &[T],
         bridge_inputargs: &[majit_ir::InputArg],
         bridge_constants: majit_ir::ConstMap<majit_ir::Const>,
         snapshot_boxes: SnapshotBoxes,
@@ -13567,7 +13554,10 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
-    ) -> bool {
+    ) -> bool
+    where
+        T: std::borrow::Borrow<majit_ir::Op>,
+    {
         if !self.compiled_loops.contains_key(&green_key) {
             crate::mc_diag_bump(34); // compile_entry_bridge: target has no compiled loop
             return false;
@@ -14036,12 +14026,16 @@ impl<M: Clone> MetaInterp<M> {
     /// jump arg with no recorded value (or a Void result) is passed through
     /// unchanged, leaving the corresponding virtual-state entry to match
     /// statically as before.
-    fn closing_jump_runtime_boxes(
-        bridge_ops: &[majit_ir::Op],
+    fn closing_jump_runtime_boxes<T>(
+        bridge_ops: &[T],
         bridge_inputargs: &[majit_ir::InputArg],
-    ) -> Vec<OpRef> {
+    ) -> Vec<OpRef>
+    where
+        T: std::borrow::Borrow<majit_ir::Op>,
+    {
         let jump_arg_oprefs: Vec<OpRef> = bridge_ops
             .last()
+            .map(std::borrow::Borrow::borrow)
             .filter(|op| op.opcode == OpCode::Jump)
             .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
             .unwrap_or_default();
@@ -14055,7 +14049,7 @@ impl<M: Clone> MetaInterp<M> {
                 concrete.insert(OpRef::input_arg_typed(ia.index, ia.tp), v);
             }
         }
-        for op in bridge_ops {
+        for op in bridge_ops.iter().map(std::borrow::Borrow::borrow) {
             let pos = op.pos.get();
             if !pos.is_none()
                 && let Some(v) = op.get_value()
@@ -14097,7 +14091,7 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    pub fn compile_bridge(
+    pub fn compile_bridge<T>(
         &mut self,
         green_key: u64,
         // The jitcell the closing JUMP enters (`bridge_cell_token_key`).
@@ -14114,7 +14108,7 @@ impl<M: Clone> MetaInterp<M> {
         jump_target_key: u64,
         fail_index: u32,
         fail_descr: &dyn majit_ir::FailDescr,
-        bridge_ops: &[majit_ir::Op],
+        bridge_ops: &[T],
         bridge_inputargs: &[majit_ir::InputArg],
         bridge_constants: majit_ir::ConstMap<majit_ir::Const>,
         snapshot_boxes: SnapshotBoxes,
@@ -14123,7 +14117,10 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
-    ) -> bool {
+    ) -> bool
+    where
+        T: std::borrow::Borrow<majit_ir::Op>,
+    {
         self.remember_compiled_graph_write();
         self.last_compiled_artifact_token = None;
         crate::mc_diag_bump(8); // compile_bridge entered
@@ -23922,13 +23919,15 @@ mod tests {
 
         meta.walk_partial_trace_refs(|slot| match slot.0 {
             0x4000 => slot.0 = 0x5000,
-            0 => slot.0 = 0x6000,
             _ => {}
         });
 
         let ops = &meta.partial_trace.as_ref().unwrap().ops;
         assert_eq!(ops[0].arg(0).to_opref().as_const_ptr(), Some(GcRef(0x5000)));
-        assert_eq!(ops[0].arg(1).to_opref().as_const_ptr(), Some(GcRef(0x6000)));
+        // `opencoder.py Trace._refs[0]` reserves null and never registers it
+        // with the GC root tracer. `Operand::NullRef` carries that immutable
+        // sentinel inline, so only the non-null ConstPtr above is forwarded.
+        assert_eq!(ops[0].arg(1).to_opref().as_const_ptr(), Some(GcRef::NULL));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -789,15 +789,23 @@ impl Trace {
             self.const_ptrs.insert(gcref, operand);
         }
 
+        let is_pooled_const_ptr = |arg: &Operand| {
+            let Some(Value::Ref(gcref)) = arg.const_value() else {
+                return false;
+            };
+            self.const_ptrs
+                .get(&gcref)
+                .is_some_and(|cached| cached == arg)
+        };
         for op in &self.ops {
             for arg in op.args.borrow().iter() {
-                if !self.const_ptrs.values().any(|cached| cached == arg) {
+                if !is_pooled_const_ptr(arg) {
                     arg.walk_const_ptr_refs(visitor);
                 }
             }
             if let Some(fail_args) = op.fail_args.borrow().as_ref() {
                 for arg in fail_args {
-                    if !self.const_ptrs.values().any(|cached| cached == arg) {
+                    if !is_pooled_const_ptr(arg) {
                         arg.walk_const_ptr_refs(visitor);
                     }
                 }

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -12,7 +12,7 @@
 /// `MetaInterp.history.record*` mirroring
 /// `pyjitpl.py:2455+ self.history.record2(...)`.
 use majit_ir::operand::Operand;
-use majit_ir::{DescrRef, InputArg, InputArgRc, Op, OpCode, OpRc, OpRef, Type, Value};
+use majit_ir::{DescrRef, GcRef, InputArg, InputArgRc, Op, OpCode, OpRc, OpRef, Type, Value};
 
 /// opencoder.py `cut_point()` — RPython 5-tuple
 /// `(_pos, _count, _index, len(_snapshot_data), len(_snapshot_array_data))`.
@@ -230,6 +230,13 @@ pub struct Trace {
     /// body abort whose speculative operations were cut back to the setup
     /// position (`history.cut` in `pyjitpl.py`).
     recorded_ops_total: usize,
+    /// `opencoder.py Trace._refs_dict` / `_cached_const_ptr`: one canonical
+    /// constant-ref box per non-null address for the lifetime of this trace.
+    /// The byte-stream recorder has the same pool; this copy lives
+    /// only at the legacy `Vec<Op>` boundary until that recorder is swapped
+    /// out, and prevents every repeated ConstPtr operand from allocating a
+    /// fresh `Rc<Cell<Value>>` in the meantime.
+    const_ptrs: crate::FxIndexMap<GcRef, Operand>,
 }
 
 impl Trace {
@@ -247,6 +254,7 @@ impl Trace {
             guard_count: 0,
             box_count: 0,
             recorded_ops_total: 0,
+            const_ptrs: crate::FxIndexMap::default(),
         }
     }
 
@@ -311,7 +319,7 @@ impl Trace {
     /// directly. Frame registers and the public `record_*` API stay OpRef; the
     /// optimizer bridges back with `Operand::to_opref`, which round-trips to the
     /// same `OpRef` the `from_opref` view produced.
-    fn box_args(&self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 3]> {
+    fn box_args(&mut self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 3]> {
         args.iter().map(|&a| self.box_for_operand(a)).collect()
     }
 
@@ -331,7 +339,18 @@ impl Trace {
     /// `Operand`s that compare equal under `Operand::eq` (`Rc::ptr_eq`). This is
     /// the real box object — `MIFrame.registers_r` holds these in `pyjitpl.py` —
     /// so consumers can key by box identity instead of flat `OpRef`.
-    pub(crate) fn box_for_operand(&self, r: OpRef) -> Operand {
+    pub(crate) fn box_for_operand(&mut self, r: OpRef) -> Operand {
+        if let OpRef::ConstPtr(gcref) = r {
+            if gcref.is_null() {
+                return Operand::NullRef;
+            }
+            if let Some(cached) = self.const_ptrs.get(&gcref) {
+                return cached.clone();
+            }
+            let operand = Operand::from_opref(r);
+            self.const_ptrs.insert(gcref, operand.clone());
+            return operand;
+        }
         if r.is_none() || r.is_constant() {
             return Operand::from_opref(r);
         }
@@ -578,13 +597,14 @@ impl Trace {
     /// from the snapshot via `op.store_final_boxes(liveboxes)` in the
     /// optimizer's `store_final_boxes_in_guard`.
     pub fn set_op_fail_args(&mut self, opref: OpRef, fail_args: &[OpRef]) {
+        let boxed_fail_args = self.box_args(fail_args).iter().cloned().collect();
         let op = self
             .ops
             .iter()
             .rev()
             .find(|op| op.pos.get() == opref)
             .unwrap_or_else(|| panic!("set_op_fail_args: no op with pos {:?}", opref));
-        op.setfailargs(self.box_args(fail_args).iter().cloned().collect());
+        op.setfailargs(boxed_fail_args);
     }
 
     /// Set `fail_arg_types` on the last recorded op. Used by
@@ -745,6 +765,48 @@ impl Trace {
     /// Access the recorded operations.
     pub fn ops(&self) -> &[OpRc] {
         &self.ops
+    }
+
+    /// Visit each `ConstPtr` box once and re-key `_refs_dict` after a moving
+    /// collection. RPython's `new_ref_dict` follows moved keys as part of the
+    /// translated GC; Rust's `IndexMap` does not, so the re-key is the minimal
+    /// explicit adaptation. Constants inserted by test-only direct-op helpers
+    /// are not in the pool and are visited from their operation instead.
+    pub(crate) fn walk_const_ptr_refs(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
+        let cached_len = self.const_ptrs.len();
+        for _ in 0..cached_len {
+            let (_, operand) = self
+                .const_ptrs
+                .swap_remove_index(0)
+                .expect("cached ConstPtr length changed during GC walk");
+            operand.walk_const_ptr_refs(visitor);
+            let Value::Ref(gcref) = operand
+                .const_value()
+                .expect("_refs_dict contains only ConstPtr operands")
+            else {
+                unreachable!("_refs_dict contains only ConstPtr operands")
+            };
+            self.const_ptrs.insert(gcref, operand);
+        }
+
+        for op in &self.ops {
+            for arg in op.args.borrow().iter() {
+                if !self.const_ptrs.values().any(|cached| cached == arg) {
+                    arg.walk_const_ptr_refs(visitor);
+                }
+            }
+            if let Some(fail_args) = op.fail_args.borrow().as_ref() {
+                for arg in fail_args {
+                    if !self.const_ptrs.values().any(|cached| cached == arg) {
+                        arg.walk_const_ptr_refs(visitor);
+                    }
+                }
+            }
+            if let Some(Value::Ref(mut gcref)) = op.get_value() {
+                visitor(&mut gcref);
+                op.set_value(Value::Ref(gcref));
+            }
+        }
     }
 
     /// Test-only direct append. Production callers go through
@@ -936,6 +998,25 @@ mod tests {
 
         // Distinct positions are distinct boxes.
         assert_ne!(rec.box_for_operand(i0), rec.box_for_operand(i1));
+    }
+
+    /// `opencoder.py Trace._cached_const_ptr`: repeated non-null pointers use
+    /// one box, and a moving collection re-keys the address dictionary.
+    #[test]
+    fn const_ptr_operands_share_the_trace_ref_pool_and_rekey_after_gc() {
+        let mut rec = Trace::new();
+        let old = GcRef(0x1000);
+        let first = rec.box_for_operand(OpRef::const_ptr(old));
+        let second = rec.box_for_operand(OpRef::const_ptr(old));
+        assert_eq!(first, second, "same address must reuse one ConstPtr box");
+
+        rec.walk_const_ptr_refs(&mut |gcref| gcref.0 += 0x1000);
+        let moved = rec.box_for_operand(OpRef::const_ptr(GcRef(0x2000)));
+        assert_eq!(first, moved, "moved address must resolve to the same box");
+        assert_eq!(moved.const_value(), Some(Value::Ref(GcRef(0x2000))));
+
+        let stale = rec.box_for_operand(OpRef::const_ptr(old));
+        assert_ne!(stale, moved, "the pre-move key must no longer be cached");
     }
 
     #[test]

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -245,7 +245,12 @@ impl NumberingState {
             liveboxes: LiveboxMap::new(),
             num_boxes: 0,
             num_virtuals: 0,
-            livebox_types: indexmap::IndexMap::default(),
+            // At most one entry per numbered box, and `size` counts the
+            // boxes, so the table never rehashes mid-guard.
+            livebox_types: indexmap::IndexMap::with_capacity_and_hasher(
+                size,
+                FxBuildHasher,
+            ),
         }
     }
     pub fn append_short(&mut self, item: i16) {
@@ -8415,9 +8420,12 @@ pub fn blackhole_from_resumedata<'a>(
         // bank before filling it so a materialization collection during
         // `consume_one_section` forwards the refs already written here (the
         // Vec buffer is stable — `setarg_r` only indexes — and the frame
-        // itself is already boxed, so chaining it moves a pointer).
-        unsafe {
-            majit_gc::shadow_stack::push_resume_ref_roots(&mut nextbh.registers_r);
+        // itself is already boxed, so chaining it moves a pointer). A pooled
+        // interpreter is rooted for its whole life already.
+        if !nextbh.is_rooted() {
+            unsafe {
+                majit_gc::shadow_stack::push_resume_ref_roots(&mut nextbh.registers_r);
+            }
         }
 
         // resume.py:1341

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -247,10 +247,7 @@ impl NumberingState {
             num_virtuals: 0,
             // At most one entry per numbered box, and `size` counts the
             // boxes, so the table never rehashes mid-guard.
-            livebox_types: indexmap::IndexMap::with_capacity_and_hasher(
-                size,
-                FxBuildHasher,
-            ),
+            livebox_types: indexmap::IndexMap::with_capacity_and_hasher(size, FxBuildHasher),
         }
     }
     pub fn append_short(&mut self, item: i16) {
@@ -740,8 +737,9 @@ pub fn exit_pending_field_layout(
 /// `resume.py` tag decoding of one `fieldnums` / `rd_pendingfields` entry
 /// into the exit-slot source the recovery readers consume: TAGBOX names a
 /// deadframe slot (negative counts from the end), TAGVIRTUAL an
-/// `rd_virtuals` entry (negative for the nested virtuals `resume.py:278-284`
-/// numbers that way, resolved as `resume.py:951-954` does), TAGINT an inline
+/// `rd_virtuals` entry (negative for the nested virtuals
+/// `resume.py assign_number_to_virtual` numbers that way, resolved as
+/// `resume.py AbstractResumeDataReader.getvirtual_ptr` does), TAGINT an inline
 /// int and TAGCONST an `rd_consts` entry (`resume.py` `self.consts[num -
 /// TAG_CONST_OFFSET]`).
 pub fn exit_source_from_tagged(

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -13,7 +13,8 @@ use std::cell::UnsafeCell;
 use std::sync::Arc;
 
 use majit_backend::{
-    ExitFrameLayout, ExitPendingFieldLayout, ExitRecoveryLayout, ExitVirtualLayout,
+    ExitFrameLayout, ExitPendingFieldLayout, ExitRecoveryLayout, ExitValueSourceLayout,
+    ExitVirtualLayout,
 };
 use majit_ir::{Const, GcRef, OpRef, Type};
 
@@ -691,6 +692,87 @@ impl ResumeStorage {
     }
 }
 
+/// One `resume.py` PENDINGFIELDSTRUCT entry (lldescr / num / fieldnum /
+/// itemindex) as the layout the replayers consume: `itemindex >= 0` names a
+/// setarrayitem, a field descr a setfield; target and value are the tagged
+/// resume slots decoded by [`exit_source_from_tagged`].
+pub fn exit_pending_field_layout(
+    pf: &majit_ir::GuardPendingFieldEntry,
+    num_failargs: i32,
+    rd_consts: &[Const],
+    num_virtuals: i32,
+) -> ExitPendingFieldLayout {
+    // The lldescr is always present: it is captured off the SETFIELD_GC /
+    // SETARRAYITEM_GC that produced the pending field (heap.py
+    // force_lazy_sets_for_guard); pyre's producer in `optimizer.rs`'s
+    // `emit_guard_operation` mirrors this with `pf.descr = pf_op.descr`.
+    let descr = pf
+        .descr
+        .clone()
+        .expect("resume.py:1000 PENDINGFIELDSTRUCT.lldescr must be set");
+    let item_index =
+        if descr.as_array_descr().is_some() {
+            Some(usize::try_from(pf.item_index).expect(
+                "resume.py:1003 setarrayitem pending field requires non-negative item_index",
+            ))
+        } else if descr.as_field_descr().is_some() {
+            None
+        } else {
+            panic!(
+                "pending field descr must be FieldDescr or ArrayDescr (descr={:?})",
+                descr,
+            );
+        };
+    ExitPendingFieldLayout {
+        descr: pf.descr.clone(),
+        is_array_item: item_index.is_some(),
+        item_index,
+        target: exit_source_from_tagged(pf.target_tagged, num_failargs, rd_consts, num_virtuals),
+        value: exit_source_from_tagged(pf.value_tagged, num_failargs, rd_consts, num_virtuals),
+    }
+}
+
+/// `resume.py` tag decoding of one `fieldnums` / `rd_pendingfields` entry
+/// into the exit-slot source the recovery readers consume: TAGBOX names a
+/// deadframe slot (negative counts from the end), TAGVIRTUAL an
+/// `rd_virtuals` entry (negative for the nested virtuals `resume.py:278-284`
+/// numbers that way, resolved as `resume.py:951-954` does), TAGINT an inline
+/// int and TAGCONST an `rd_consts` entry (`resume.py` `self.consts[num -
+/// TAG_CONST_OFFSET]`).
+pub fn exit_source_from_tagged(
+    tagged: i16,
+    num_failargs: i32,
+    rd_consts: &[Const],
+    num_virtuals: i32,
+) -> ExitValueSourceLayout {
+    let (val, tagbits) = majit_ir::resumedata::untag(tagged);
+    match tagbits {
+        majit_ir::resumedata::TAGBOX => {
+            let idx = if val >= 0 {
+                val as usize
+            } else {
+                (num_failargs + val) as usize
+            };
+            ExitValueSourceLayout::ExitValue(idx)
+        }
+        majit_ir::resumedata::TAGVIRTUAL => {
+            let idx = if val >= 0 {
+                val as usize
+            } else {
+                (num_virtuals + val) as usize
+            };
+            ExitValueSourceLayout::Virtual(idx)
+        }
+        majit_ir::resumedata::TAGINT => ExitValueSourceLayout::Constant(val as i64, Type::Int),
+        majit_ir::resumedata::TAGCONST => {
+            let idx = (val - majit_ir::resumedata::TAG_CONST_OFFSET) as usize;
+            let c = rd_consts.get(idx).copied().unwrap_or(Const::Int(0));
+            ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
+        }
+        _ => ExitValueSourceLayout::Constant(0, Type::Int),
+    }
+}
+
 // Pyre is single-threaded; UnsafeCell prevents auto-Send/Sync so
 // provide them explicitly (matches RPython's non-thread-safe
 // ResumeGuardDescr).
@@ -780,6 +862,19 @@ impl ResumeStorage {
                 .map(|rd| virtual_info_from_rd(rd))
                 .collect()
         })
+    }
+
+    /// `resume.py _prepare_pendingfields` read off `rd_pendingfields`: this
+    /// guard's deferred writes as exit-slot sources, ready to replay against
+    /// the deadframe.  Derived on demand from the guard-owned payload, so
+    /// nothing is kept per guard for it.
+    pub fn exit_pending_field_layouts(&self, num_failargs: i32) -> Vec<ExitPendingFieldLayout> {
+        let rd_consts = self.rd_consts();
+        let num_virtuals = self.rd_virtuals.as_slice().len() as i32;
+        self.rd_pendingfields()
+            .iter()
+            .map(|pf| exit_pending_field_layout(pf, num_failargs, rd_consts, num_virtuals))
+            .collect()
     }
 
     pub fn with_shared_consts(

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2089,7 +2089,7 @@ impl TraceCtx {
     /// the box-keyed dicts upstream (e.g. `heapcache.py` `cache_anything[ref_box]`).
     /// Deterministic: the same recorded position always yields an `Operand`
     /// wrapping the same producer `Rc`.
-    pub fn operand_for(&self, opref: OpRef) -> majit_ir::operand::Operand {
+    pub fn operand_for(&mut self, opref: OpRef) -> majit_ir::operand::Operand {
         self.recorder.box_for_operand(opref)
     }
 
@@ -2348,6 +2348,7 @@ impl TraceCtx {
                     Operand::Op(o) => format!("{:?}", o.pos.get()),
                     Operand::InputArg(ia) => format!("IA{}", ia.index),
                     Operand::SmallInt(_) => format!("C{:?}", a.const_value().unwrap()),
+                    Operand::NullRef => "CRef(NULL)".to_string(),
                     Operand::Const(c) => format!("C{:?}", c.get()),
                     Operand::None => "_".to_string(),
                 })

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -7400,8 +7400,10 @@ mod tests {
     }
 }
 
-/// `MAJIT_PROBE_SUBSCR` diagnostic gate, read once: this sits on the path
-/// every recorded call takes, and `getenv` per operation was 4% of tracing.
+/// `MAJIT_PROBE_SUBSCR` startup-only diagnostic gate, read once: changes made
+/// with `set_var` / `remove_var` after the first lookup do not take effect.
+/// This sits on the path every recorded call takes, and `getenv` per operation
+/// was 4% of tracing.
 fn probe_subscr_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var_os("MAJIT_PROBE_SUBSCR").is_some())

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1311,7 +1311,7 @@ impl TraceCtx {
         effectinfo: Option<&majit_ir::EffectInfo>,
         argboxes: &[OpRef],
     ) {
-        if std::env::var_os("MAJIT_PROBE_SUBSCR").is_some() {
+        if probe_subscr_enabled() {
             let ei_summary = effectinfo.map(|ei| {
                 format!(
                     "extraeffect={:?} forces_vorv={} can_raise={} plain_call={} oopspec={:?}",
@@ -7397,4 +7397,11 @@ mod tests {
         );
         assert!(!len.is_constant());
     }
+}
+
+/// `MAJIT_PROBE_SUBSCR` diagnostic gate, read once: this sits on the path
+/// every recorded call takes, and `getenv` per operation was 4% of tracing.
+fn probe_subscr_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("MAJIT_PROBE_SUBSCR").is_some())
 }

--- a/majit/majit-metainterp/tests/peeled_guard_isnull.rs
+++ b/majit/majit-metainterp/tests/peeled_guard_isnull.rs
@@ -73,7 +73,7 @@ fn peeled_integer_loop_drops_the_loop_invariant_null_guard() {
     optimizer.trace_inputargs = OpRef::inputarg_refs(&[Type::Int, Type::Int, Type::Ref]);
     optimizer.trace_inputarg_boxes = vec![acc, index, null];
     optimizer.snapshot_boxes = vec![Some(Vec::new()), Some(Vec::new())];
-    let mut constants: ConstMap<Value> = ConstMap::new();
+    let mut constants: ConstMap<Value> = ConstMap::default();
     let (optimized, _) =
         optimizer.optimize_trace_with_constants_and_inputs(&ops, &mut constants, 3);
 

--- a/pyre/bench/synth/exception_bridge_traceback_head.cranelift.jitstats
+++ b/pyre/bench/synth/exception_bridge_traceback_head.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=3
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=602
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2
 retraces_compiled=0

--- a/pyre/bench/synth/exception_bridge_traceback_head.dynasm.jitstats
+++ b/pyre/bench/synth/exception_bridge_traceback_head.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=3
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=602
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2
 retraces_compiled=0

--- a/pyre/bench/synth/exception_bridge_traceback_head.wasm.jitstats
+++ b/pyre/bench/synth/exception_bridge_traceback_head.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=3
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=602
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2
 retraces_compiled=0

--- a/pyre/bench/synth/nested_loop_gate_switch.cranelift.jitstats
+++ b/pyre/bench/synth/nested_loop_gate_switch.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=6
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1954
+guard_failures=1900
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/nested_loop_gate_switch.dynasm.jitstats
+++ b/pyre/bench/synth/nested_loop_gate_switch.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=6
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1954
+guard_failures=1900
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/nested_loop_gate_switch.wasm.jitstats
+++ b/pyre/bench/synth/nested_loop_gate_switch.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=6
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1954
+guard_failures=1900
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -101,7 +101,7 @@ Kept as-is; listed for completeness.
   `_GIN`, `_INLINE_RECOG`, `PYRE_WASM_DUMP_ALL_TRACES`, `_DUMP_BAD_TRACE`,
   `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `MAJIT_NBODY_DEBUG`,
   `PYRE_DEBUG_CALL`, `PYRE_DEBUG_CLASS`, `PYRE_DESCR_DEMAND`,
-  `PYRE_CENSUS_HISTOGRAM`, `PYRE_REGEX_LENGTHS`.
+  `PYRE_CENSUS_HISTOGRAM`, `PYRE_REGEX_LENGTHS`, `PYRE_REGEX_ROWS`.
   `PYRE_DESCR_DEMAND` records the distinct dense descriptor indices a run
   actually resolves, so the per-index pool loader can be measured against the
   pool size; the resolve path reads it through a `OnceLock` and pays nothing
@@ -113,6 +113,9 @@ Kept as-is; listed for completeness.
   investigation that consumes the histogram.
   `PYRE_REGEX_LENGTHS` selects the regex example input lengths used by that
   investigation. It is disabled by default and retires with the same
+  measurement-only tooling.
+  `PYRE_REGEX_ROWS` selects the regex example pattern-row indexes used by that
+  investigation. It is disabled by default and leaves with the same
   measurement-only tooling.
 - **Default-OFF experiments (0)** — every gate this bucket once held has had
   its reader and its ON path deleted, the last of them when the `LIST_APPEND`

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -8021,34 +8021,6 @@ pub fn cranelift_resumedata_deopt(
     true
 }
 
-/// Pyre-jit side of the on-demand
-/// `ExitRecoveryLayout` reconstruction callback registered into
-/// cranelift via `register_recovery_layout` (eval.rs:init_callbacks).
-/// Used by `CraneliftFailDescr::recovery_layout_ref` to derive the
-/// layout from the metainterp-side `StoredExitLayout.resume_layout`
-/// summary instead of reading the
-/// `ResumeGuardDescr.recovery_layout` cache.
-///
-/// Returns `None` for synthetic descrs (FINISH / external-JUMP /
-/// overlay) without a `ResumeGuardDescr` meta_descr or for descrs
-/// whose `compiled_loops` entry has been evicted; callers fall back
-/// to the meta-side slot read in that case.
-#[cfg(feature = "cranelift")]
-pub fn cranelift_recovery_layout_for_descr(
-    descr_addr: usize,
-    caller_prefix: Option<&majit_backend::ExitRecoveryLayout>,
-) -> Option<majit_backend::ExitRecoveryLayout> {
-    use majit_backend::Backend;
-
-    let (driver, _) = crate::eval::driver_pair();
-    let backend = driver.meta_interp().backend();
-    let descr = backend.fail_descr_arc_from_addr(descr_addr);
-    let fd = descr.as_fail_descr()?;
-    driver
-        .meta_interp()
-        .compute_recovery_layout_for_descr(fd, caller_prefix)
-}
-
 #[cfg(test)]
 mod tests_bh_normalize_raise {
     use super::*;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2223,9 +2223,12 @@ fn jit_blackhole_resume_from_guard(
     // unboxed ints are treated as pointers → SIGSEGV. Both come out of one
     // layout resolution so the storage and the types cannot describe
     // different deadframes.
-    if let Some((storage, deadframe_types)) =
-        driver.get_resume_storage_with_slot_types(actual_green_key, trace_id, fail_index)
-    {
+    if let Some((storage, deadframe_types)) = driver.get_resume_storage_with_slot_types_for_descr(
+        descr_fd,
+        actual_green_key,
+        trace_id,
+        fail_index,
+    ) {
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
                 "[blackhole-resume] rd_numb len={} rd_consts len={} raw_deadframe len={}",
@@ -4514,13 +4517,18 @@ fn jit_ca_handle_guard_failure(
     // compile.py: get exit_layout from the compiled trace.
     // Use owning_key (not green_key) — after retrace the descriptor
     // may belong to a different compiled entry than green_key.
+    // `AbstractResumeGuardDescr.handle_fail`: the layout is the failing
+    // descr's own; a bridge guard has no frontend record.
     let exit_layout = {
         let (driver, _) = crate::eval::driver_pair();
-        driver.meta_interp().get_compiled_exit_layout_in_trace(
-            owning_key,
-            source_trace_id,
-            source_fail_index,
-        )
+        descr_arc.as_fail_descr().and_then(|fd| {
+            driver.meta_interp().get_compiled_exit_layout_for_descr(
+                fd,
+                owning_key,
+                source_trace_id,
+                source_fail_index,
+            )
+        })
     };
     let Some(exit_layout) = exit_layout else {
         return false;
@@ -4630,13 +4638,18 @@ fn try_compile_ca_bridge(
         };
         return CaBridgeAttempt { terminal_declined };
     }
+    // `AbstractResumeGuardDescr.handle_fail`: the layout is the failing
+    // descr's own; a bridge guard has no frontend record.
     let exit_layout = {
         let (driver, _) = crate::eval::driver_pair();
-        driver.meta_interp().get_compiled_exit_layout_in_trace(
-            owning_key,
-            source_trace_id,
-            source_fail_index,
-        )
+        descr_arc.as_fail_descr().and_then(|fd| {
+            driver.meta_interp().get_compiled_exit_layout_for_descr(
+                fd,
+                owning_key,
+                source_trace_id,
+                source_fail_index,
+            )
+        })
     };
     let Some(exit_layout) = exit_layout else {
         return CaBridgeAttempt {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -14629,10 +14629,23 @@ fn replay_pending_fields(
     exit_layout: &CompiledExitLayout,
     virtuals_cache: &mut HashMap<usize, Value>,
 ) {
-    let Some(ref recovery) = exit_layout.recovery_layout else {
-        return;
-    };
-    if recovery.pending_field_layouts.is_empty() {
+    let num_failargs = exit_layout.exit_types.len() as i32;
+    // `resume.py _prepare_pendingfields` reads the list off the guard's
+    // `rd_pendingfields`.  The root loop's frontend record carries it
+    // pre-resolved in `recovery_layout`; a bridge guard has no such record
+    // (`compile.py send_bridge_to_backend`), so it is resolved off the
+    // descr-owned storage here.
+    let pending: std::borrow::Cow<'_, [majit_backend::ExitPendingFieldLayout]> =
+        match exit_layout.recovery_layout.as_deref() {
+            Some(recovery) => std::borrow::Cow::Borrowed(&recovery.pending_field_layouts),
+            None => match exit_layout.storage.as_deref() {
+                Some(storage) => {
+                    std::borrow::Cow::Owned(storage.exit_pending_field_layouts(num_failargs))
+                }
+                None => return,
+            },
+        };
+    if pending.is_empty() {
         return;
     }
 
@@ -14646,7 +14659,6 @@ fn replay_pending_fields(
         .storage
         .as_deref()
         .map(|s| s.rd_virtuals.as_slice());
-    let num_failargs = exit_layout.exit_types.len() as i32;
     let value_to_raw_bits = |value: Value| match value {
         Value::Int(i) => i,
         Value::Float(f) => f.to_bits() as i64,
@@ -14674,7 +14686,7 @@ fn replay_pending_fields(
         }
     };
 
-    for pf in &recovery.pending_field_layouts {
+    for pf in pending.iter() {
         let Some(target_ptr) = resolve_value(&pf.target) else {
             continue;
         };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9453,10 +9453,6 @@ fn eval_with_jit_inner(
     init_callbacks();
     #[cfg(feature = "cranelift")]
     majit_backend_cranelift::register_resumedata_deopt(crate::call_jit::cranelift_resumedata_deopt);
-    #[cfg(feature = "cranelift")]
-    majit_backend_cranelift::register_recovery_layout(
-        crate::call_jit::cranelift_recovery_layout_for_descr,
-    );
     let jit_shape = cached_unsupported_jit_shape(code);
     // Every declining shape runs the frame in the plain interpreter, so the
     // tracer never sees it. Record the decline in the census — keyed by the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -15203,6 +15203,77 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
 mod tests {
     use super::*;
 
+    #[test]
+    fn bridge_descr_storage_replays_pending_field_and_array_writes() {
+        #[repr(C)]
+        struct FieldTarget {
+            value: i64,
+        }
+
+        let mut field_target = FieldTarget { value: 1 };
+        let mut array_target = [2_i64, 3_i64];
+        let field_descr: majit_ir::DescrRef = std::sync::Arc::new(
+            majit_ir::descr::SimpleFieldDescr::new(1, 0, 8, Type::Int, false),
+        );
+        let array_descr: majit_ir::DescrRef = std::sync::Arc::new(
+            majit_ir::descr::SimpleArrayDescr::new(2, 0, 8, 0, Type::Int),
+        );
+        let tagged = |index| {
+            majit_metainterp::resume::tag(index, majit_metainterp::resume::TAGBOX)
+                .expect("small fail-argument index is taggable")
+        };
+        let pending = vec![
+            majit_ir::GuardPendingFieldEntry {
+                descr: Some(field_descr),
+                item_index: -1,
+                target: majit_ir::OpRef::input_arg_ref(0),
+                value: majit_ir::OpRef::input_arg_int(1),
+                target_tagged: tagged(0),
+                value_tagged: tagged(1),
+            },
+            majit_ir::GuardPendingFieldEntry {
+                descr: Some(array_descr),
+                item_index: 1,
+                target: majit_ir::OpRef::input_arg_ref(2),
+                value: majit_ir::OpRef::input_arg_int(3),
+                target_tagged: tagged(2),
+                value_tagged: tagged(3),
+            },
+        ];
+        let layout = CompiledExitLayout {
+            rd_loop_token: 1,
+            trace_id: 2,
+            fail_index: 3,
+            source_op_index: None,
+            exit_types: [Type::Ref, Type::Int, Type::Ref, Type::Int]
+                .into_iter()
+                .collect(),
+            is_finish: false,
+            is_exception_exit: false,
+            recovery_layout: None,
+            resume_layout: None,
+            storage: Some(majit_metainterp::resume::ResumeStorage::new(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                pending,
+            )),
+        };
+        let values = [
+            Value::Ref(majit_ir::GcRef(
+                (&mut field_target as *mut FieldTarget) as usize,
+            )),
+            Value::Int(41),
+            Value::Ref(majit_ir::GcRef(array_target.as_mut_ptr() as usize)),
+            Value::Int(42),
+        ];
+
+        replay_pending_fields(&values, &layout, &mut HashMap::new());
+
+        assert_eq!(field_target.value, 41);
+        assert_eq!(array_target, [2, 42]);
+    }
+
     /// `interp_jit.PyPyJitDriver.greens` carries the PyCode object, not the
     /// host CodeObject hidden behind pyre's wrapper.  The hash-only marker
     /// path and typed `JitCell.comparekey` path must therefore agree with


### PR DESCRIPTION
Five commits on `regex`, all measured on `majit/examples/regex` (the PyPy regular-expression JIT post). The first two are allocation and argument-passing fixes; the last two remove what majit retained per bridge and put compiled code into an arena the way `asmmemmgr.py` does.

## Per-bridge retention (the and/or row's 7x gap)

With bridges on, the example's heap grew with the input — 1,138 MiB at 1M chars, flat at 15 MiB with `MAJIT_NO_BRIDGE=1` — and chars/s followed the heap (33K at 1M vs 348K at 4K). Two causes, fixed in two commits:

1. **`metainterp: stop indexing bridges in the frontend`** — `compile.py send_bridge_to_backend` keeps nothing after a bridge is compiled; every later reader is `handle_fail` on the guard's own `ResumeGuardDescr`. majit inserted a `CompiledTrace` per bridge (ops, inputargs, constants, an exit layout per guard) into `CompiledEntry.traces` and never removed it. The bridge tails now only stamp the descrs; readers go descr-first (`ResumeStorage::from_fail_descr`, `exit_pending_field_layouts`); the GC walker reaches bridge descrs through `asmmemmgr_gcreftracers` (wasm gained `register_meta_descrs`). 1,138 → 297 MiB at 1M.
2. **`backend: pack compiled code into an RWX arena`** — every compiled block was rounded up to a page and protected on its own, so a few-hundred-byte bridge held a 16 KiB page on darwin/arm64 (164 MiB of code pages at 1M chars). Ported `asmmemmgr.py` packing (`MIN_FRAGMENT`, `materialize` align 16) into RWX `rmmap.alloc` mappings (`MAP_JIT`) with the `enter/leave_assembler_writing` bracket (`pthread_jit_write_protect_np`) at the same entry points as `aarch64/assembler.py`. Also in this commit: `FailDescrLayout` carries the descr instead of four `rd_*` copies per deopt; `store_hash` is a frontend walk (`compile.py store_hash`) so the backends' `asmmemmgr_blocks` scans are gone; `Backend::bridge_was_compiled`; dynasm `compile_bridge` patches the `fail_descr` it was handed; dead `ResumeGuardDescr.resume_data` removed. 297 → 139 MiB at 1M.

Peak RSS / median chars/s, dynasm release, and/or variant, bridges on (control = `MAJIT_NO_BRIDGE=1`, same run):

| chars | before | after | control |
|---|---|---|---|
| 4,096 | 25 MiB / 348K | 12 MiB / 453K | 10 MiB / 776K |
| 65,536 | 149 MiB / 79K | 26 MiB / 520K | 10 MiB / 770K |
| 1,048,576 | 1,138 MiB / 33K | 139 MiB / 515K | 11 MiB / 776K |

The per-length degradation is gone; the remaining constant 1.5x against the control is not a heap effect.

## Parity notes

- `store_hash` runs after compilation over the trace's guard ops rather than inside `store_final_boxes_in_guard`: pyre's optimizer holds no jit-counter handle (`Optimizer::new()` takes none), and the descr's status is only read after the guard can fail, so the end state is the same. A descr whose status `make_a_counter_per_value` already set keeps it.
- The write bracket's nesting depth is thread-local rather than `rmmap.Nester`'s global, since `pthread_jit_write_protect_np` is per thread.
- Codex review: unavailable this cycle (usage limit); the parity pass above was done by hand against `asmmemmgr.py`, `rmmap.py`, `compile.py` and `aarch64/assembler.py`.

`pyre/check.py`: dynasm 539/539, cranelift 539/539, wasm 532/532 on the pre-rebase base; CI re-runs on the current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQh1hPyg5mFdREiuVibfhm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional allocator comparisons, selective row execution, and bridge-operation diagnostics to the regex benchmark.
  * Added efficient operation-argument access and inline null-reference handling.

* **Performance**
  * Reduced unnecessary copying and allocation overhead.
  * Improved executable-memory management, register allocation, instruction-cache handling, and garbage-collection tracking.
  * Reduced regex benchmark peak memory usage and improved long-input behavior.

* **Bug Fixes**
  * Improved bridge handling, resume metadata, pending-field recovery, and garbage-collection safety across native and WebAssembly execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->