### PR TITLE
gc: close the ten rooting and analysis findings the #1669 review left, three more the analysis found, and stop that analysis costing 16 GB

### DIFF
--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,17 +1,17 @@
 {
   "darwin": {
-    "base": "78501667f5409cec286599d8d25813e879432ed6",
+    "base": "e75174702af51d97b166e0ed9765cc85ebb51057",
     "brackets_reaching_no_collection": 3,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,
     "frames_across_collecting": 10,
     "frames_across_collecting_fns": 4,
-    "tier15_calls": 131,
-    "tier15_calls_fns": 61,
+    "tier15_calls": 102,
+    "tier15_calls_fns": 56,
     "tier1_calls": 0,
     "tier1_calls_fns": 0,
-    "unbracketed_calls": 2069,
-    "unbracketed_calls_fns": 836,
+    "unbracketed_calls": 2064,
+    "unbracketed_calls_fns": 835,
     "unmatched_seeds": [
       "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
       "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7779,13 +7779,10 @@ fn emit_guard_exit(
     //
     // Both stores sit ahead of the closing-jump and attached-bridge dispatches
     // below, which tail-call and never come back. Those paths still publish the
-    // Ref fail-args above, and the frame is allocated in the old generation
-    // (`jitframe_prefer_oldgen`), so a publish that skipped this pair left an
-    // old object holding young pointers with neither a map that describes them
-    // nor a place in the remembered set: the next minor collection walked past
-    // the frame and its slots kept addresses the collection had already moved.
-    // `llmodel.py realloc_frame` fires the same barrier for the same
-    // reason after copying `jf_frame` into a fresh frame.
+    // Ref fail-args above, so this pair is what the next collection walks.
+    // A frame that spilled old (`alloc_nursery_no_collect_typed`) also needs
+    // the barrier `llmodel.py realloc_frame` fires after copying `jf_frame`,
+    // or the remembered set never sees the young fail-args.
     let gcmap_val = if info.gcmap != 0 {
         builder.ins().iconst(cl_types::I64, info.gcmap)
     } else {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -5772,7 +5772,9 @@ mod tests {
         let payload_tid = gc.register_type(TypeInfo::simple(16));
 
         let depth = 2usize;
-        // Non-moving old-gen JitFrame (jitframe_prefer_oldgen()).
+        // Pin the frame in old-gen so only the young item moves. Production
+        // `malloc_jitframe` follows `jitframe_allocate` (`lltype.malloc`)
+        // and is born in the nursery; this test is the old→young gcmap walk.
         let frame = gc.alloc_oldgen_typed(jf_tid, JitFrame::alloc_size(depth));
         assert_ne!(frame.0, 0, "old-gen JitFrame alloc failed");
         let frame_ptr = frame.0 as *mut JitFrame;

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -282,15 +282,38 @@ pub(crate) unsafe fn dealloc_off_gc_block(base: *mut u8, total: usize) {
 
 // ── The descr's frame allocation ────────────────────────────────────
 
-/// Zero-fill a frame the nursery handed back.
+/// Zero-fill a frame the collector handed back.
 ///
 /// RPython's nursery is zeroed once per reset, so `lltype.malloc(JITFRAME)`
 /// returns cleared memory and `GuardNotForced` can read `jf_descr != 0`.
-/// Ours is not, so a fresh frame is cleared here.
-fn zeroed_nursery_frame(gcref: majit_ir::GcRef, size_bytes: usize) -> *mut JitFrame {
-    assert!(!gcref.is_null(), "JITFRAME nursery allocation failed");
+/// Ours is not, so a fresh frame is cleared here. Old-gen arenas recycle
+/// bytes the same way.
+fn zeroed_gc_frame(gcref: majit_ir::GcRef, size_bytes: usize) -> *mut JitFrame {
+    assert!(!gcref.is_null(), "JITFRAME allocation failed");
     unsafe { std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes) };
     gcref.0 as *mut JitFrame
+}
+
+/// Place a GC-managed JITFRAME according to [`jitframe_prefer_oldgen`].
+///
+/// `collect` is the nursery arm of [`malloc_jitframe`]; the no-collect
+/// sibling asks for `alloc_nursery_no_collect_typed` instead, matching
+/// `llmodel.py:140`'s realloc slow path. The old-gen arm is already
+/// non-collecting (`alloc_oldgen_typed`).
+fn alloc_gc_jitframe(
+    gc: &mut dyn majit_gc::GcAllocator,
+    type_id: u32,
+    size_bytes: usize,
+    collect: bool,
+) -> *mut JitFrame {
+    let gcref = if jitframe_prefer_oldgen() {
+        gc.alloc_oldgen_typed(type_id, size_bytes)
+    } else if collect {
+        gc.alloc_nursery_typed(type_id, size_bytes)
+    } else {
+        gc.alloc_nursery_no_collect_typed(type_id, size_bytes)
+    };
+    zeroed_gc_frame(gcref, size_bytes)
 }
 
 /// `llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`,
@@ -298,21 +321,20 @@ fn zeroed_nursery_frame(gcref: majit_ir::GcRef, size_bytes: usize) -> *mut JitFr
 /// `jitframe_allocate` (`jitframe.py:48`).
 ///
 /// The descr decides where the frame lives: under its `JITFRAME` type id it
-/// is a nursery object the collector traces through `jitframe_trace` and may
-/// move; without one — an allocator with no type table, or [`HostHeapGc`]
-/// when nothing is installed — it is a host block the libc-jitframe tracer
-/// walks in place. The caller sees one frame pointer either way; what
-/// differs is only whether the deadframe that later owns it takes a root
-/// slot ([`jitframe_is_gc_object`]) and whether a store into it needs a
-/// barrier ([`jitframe_write_barrier`]).
+/// is a collector object [`jitframe_prefer_oldgen`] places — nursery, like
+/// `lltype.malloc(JITFRAME)`, unless that flag asks for old-gen — traced
+/// through `jitframe_trace`; without one — an allocator with no type table,
+/// or [`HostHeapGc`] when nothing is installed — it is a host block the
+/// libc-jitframe tracer walks in place. The caller sees one frame pointer
+/// either way; what differs is only whether the deadframe that later owns
+/// it takes a root slot ([`jitframe_is_gc_object`]) and whether a store
+/// into it needs a barrier ([`jitframe_write_barrier`]).
 ///
 /// The nursery arm may collect, so the caller must have its inputs rooted.
 /// `size_bytes` is the payload size ([`JitFrame::alloc_size`]).
 pub fn malloc_jitframe(gc: &mut dyn majit_gc::GcAllocator, size_bytes: usize) -> *mut JitFrame {
     match gc.jitframe_type_id() {
-        Some(type_id) => {
-            zeroed_nursery_frame(gc.alloc_nursery_typed(type_id, size_bytes), size_bytes)
-        }
+        Some(type_id) => alloc_gc_jitframe(gc, type_id, size_bytes, true),
         None => malloc_host_jitframe(size_bytes),
     }
 }
@@ -326,10 +348,7 @@ pub fn malloc_jitframe_no_collect(
     size_bytes: usize,
 ) -> *mut JitFrame {
     match gc.jitframe_type_id() {
-        Some(type_id) => zeroed_nursery_frame(
-            gc.alloc_nursery_no_collect_typed(type_id, size_bytes),
-            size_bytes,
-        ),
+        Some(type_id) => alloc_gc_jitframe(gc, type_id, size_bytes, false),
         None => malloc_host_jitframe(size_bytes),
     }
 }
@@ -689,12 +708,16 @@ pub fn jitframe_type_info() -> majit_gc::trace::TypeInfo {
     )
 }
 
-/// Allocate-in-oldgen flag: jitframe should NOT be nursery-allocated
-/// when possible, to avoid the cost of copying the (potentially large)
-/// trailing array during minor collection. When this returns true,
-/// the allocator should use `alloc_external` or similar.
+/// Whether a GC-managed JITFRAME should be born in the old generation.
+///
+/// `jitframe_allocate` is `lltype.malloc(JITFRAME, depth)` — a regular
+/// GcStruct malloc. Framework GC puts that in the nursery unless the
+/// request is large enough for `external_malloc`. There is no
+/// prefer-oldgen switch upstream, so this is false and
+/// [`malloc_jitframe`] reads it: a true here that the allocator ignored
+/// was a dead flag claiming the opposite of `lltype.malloc`.
 pub fn jitframe_prefer_oldgen() -> bool {
-    true
+    false
 }
 
 // ── realloc_frame (llmodel.py) ──────────────────────────────
@@ -782,6 +805,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use majit_gc::GcAllocator;
 
     /// The emitted write-barrier fast path loads one byte at
     /// `jit_wb_if_flag_byteofs` from the frame pointer, and that offset is
@@ -810,5 +834,24 @@ mod tests {
             "a fresh off-GC frame must not look like it tracks young pointers"
         );
         unsafe { free_off_gc_jitframe(frame) };
+    }
+
+    /// `jitframe_allocate` is `lltype.malloc(JITFRAME)`; a true flag that
+    /// [`malloc_jitframe`] ignored was a dead prefer-oldgen claim.
+    #[test]
+    fn malloc_jitframe_reads_prefer_oldgen() {
+        assert!(
+            !jitframe_prefer_oldgen(),
+            "lltype.malloc(JITFRAME) is a nursery GcStruct malloc"
+        );
+        let mut gc = majit_gc::collector::MiniMarkGC::new();
+        let tid = gc.register_type(jitframe_type_info());
+        gc.set_jitframe_type_id(tid);
+        let frame = malloc_jitframe(&mut gc, JitFrame::alloc_size(8));
+        assert!(!frame.is_null());
+        assert!(
+            gc.is_in_nursery(frame as usize),
+            "a false prefer-oldgen flag must not land the frame in mark-sweep old-gen"
+        );
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -712,6 +712,32 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut MiniMarkGC)) {
     });
 }
 
+/// Fork under stop-the-world, leaving the child a lock state it can unwind.
+///
+/// `fork()` gives the child one thread and every mutex the process had.  A
+/// [`Mutex`] held by a thread that did not survive stays locked with no owner,
+/// and the first thing the child does on its way out of STW is
+/// [`StwGuard::drop`], which takes [`GcSync::quiesce`] unconditionally — so a
+/// child that inherits it held never reaches [`after_fork_child`], which is
+/// what would have repaired the census.
+///
+/// The drain does not close that window.  A thread leaving an external block
+/// re-takes `quiesce` while STW is still in force ([`BlockingGuard::drop`]),
+/// and it left the RUNNING census when it blocked, so nothing waited for it;
+/// [`enter_external_callback`] and [`register_thread`] hold it across the same
+/// gate.  Taking the mutex here is the prepare half of the discipline
+/// `pthread_atfork` exists for: the one thread that survives owns it on both
+/// sides of the fork and releases it on both sides.
+pub fn fork_under_stw<R>(fork_fn: impl FnOnce() -> R) -> R {
+    gc_op(|_| {
+        let _stw = quiesce_mutators();
+        let held = GC_SYNC.quiesce.lock().unwrap();
+        let result = fork_fn();
+        drop(held);
+        result
+    })
+}
+
 /// Run a GC operation whose object argument is a translated livevar.
 ///
 /// Publish the argument on the per-mutator shadow stack first, so that a
@@ -855,6 +881,59 @@ mod tests {
         let addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
         assert_ne!(addr, 0);
         unsafe { &*(addr as *const AtomicUsize) }.load(Ordering::Relaxed)
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[ignore = "requires exclusive process — drives process-global STW state and forks"]
+    fn fork_under_stw_holds_the_quiesce_mutex_across_the_fork() {
+        ensure_gc();
+        register_test_mutator();
+
+        // A second registered mutator makes `stw_required()` true, so the fork
+        // runs under an owning `StwGuard` whose drop takes the mutex. It parks
+        // outside the RUNNING census — the population the drain never waits
+        // for, and so the one that can hold `quiesce` while STW is in force.
+        let (parked_tx, parked_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let other = std::thread::spawn(move || {
+            register_thread();
+            let blocked = before_external_block();
+            parked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            drop(blocked);
+            unregister_thread();
+        });
+        // `register_thread` takes the GIL, which this thread holds.
+        blocking(|| parked_rx.recv().unwrap());
+
+        let child = fork_under_stw(|| {
+            let pid = unsafe { libc::fork() };
+            if pid == 0 {
+                let mut code = 0;
+                if GC_SYNC.quiesce.try_lock().is_err() {
+                    code |= 1;
+                }
+                if mutators_quiesced() {
+                    code |= 2;
+                }
+                unsafe { libc::_exit(code) };
+            }
+            pid
+        });
+
+        assert!(child > 0, "fork failed");
+        let mut status = 0;
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        release_tx.send(()).unwrap();
+        blocking(|| other.join().unwrap());
+        unregister_test_mutator();
+        assert_eq!(
+            (status >> 8) & 0xff,
+            3,
+            "the child must inherit `quiesce` from the thread that survived \
+             (bit0), under a live owning guard whose drop retakes it (bit1)"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -36,8 +36,34 @@ fn write_rows(
     opts.open(path)?.write_all(rows.as_bytes())
 }
 
+/// Resident set size in MB, or `None` where the platform has no cheap answer.
+///
+/// A phase trace, not a budget: this run holds a multi-hundred-megabyte
+/// artefact and builds several indexes over it, and which of those the peak
+/// belongs to is not inferable from the total.  Off unless `GC_RSS_TRACE` is
+/// set, and written to stderr, so the gate's stdout stays exactly what it was.
+fn rss_mb() -> Option<u64> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .ok()?;
+    let kb: u64 = String::from_utf8_lossy(&out.stdout).trim().parse().ok()?;
+    Some(kb / 1024)
+}
+
+fn mark(label: &str) {
+    if std::env::var_os("GC_RSS_TRACE").is_none() {
+        return;
+    }
+    match rss_mb() {
+        Some(mb) => eprintln!("[rss] {mb:6} MB  {label}"),
+        None => eprintln!("[rss]      ?     {label}"),
+    }
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    mark("start");
     // A run that says it wrote and did not must not exit 0: the file it
     // named is what a consumer reads, and an absent one reads as no findings.
     let mut write_failed = false;
@@ -100,9 +126,13 @@ fn main() {
                     std::process::exit(1);
                 }
             };
-            (path.clone(), framework::build(&llbc))
+            mark(&format!("donor loaded  {path}"));
+            let g = framework::build(&llbc);
+            mark(&format!("donor graphed {path}"));
+            (path.clone(), g)
         })
         .collect();
+    mark("all donors graphed");
 
     for path in &args {
         let llbc = match majit_charon_reader::Llbc::load(path) {
@@ -112,7 +142,9 @@ fn main() {
                 std::process::exit(1);
             }
         };
+        mark(&format!("subject loaded  {path}"));
         let cg = framework::build(&llbc);
+        mark(&format!("subject graphed {path}"));
         let total = cg.names.len();
         println!("== {} ({} fun_decls) ==", llbc.crate_name(), total);
         // Which crates this artefact actually carries bodies for.  Charon
@@ -145,6 +177,7 @@ fn main() {
         let mut parts: Vec<&framework::CallGraph> = vec![&cg];
         parts.extend(donor_graphs.iter().map(|(_, g)| g));
         let joined = framework::Joined::build(&parts);
+        mark("joined graph built");
         for (donor, g) in &donor_graphs {
             println!(
                 "   joined with          : {} ({} fun_decls)",
@@ -212,6 +245,7 @@ fn main() {
         let mut joined_seeds = jpy;
         joined_seeds.extend(jcol);
         let reach = joined.project(0, &joined.graph.reaching(&joined_seeds));
+        mark("reachability closure done");
         // The seeds as *this* artefact spells them.  The tiering below compares
         // a finding's `callee_id`, which is an id in this artefact, so it needs
         // the local set; the closure above needs the joined one.
@@ -387,6 +421,7 @@ fn main() {
             &gc_tys,
             &movable_callees,
         );
+        mark("scan 1/4 (resolved, gc locals)");
         println!(
             "   liveness scan: {} bodies; {} with a terminator this reader could not parse; \
              {} call(s) withheld as dominated by a push_roots",
@@ -580,6 +615,7 @@ fn main() {
             &gc_tys,
             &movable_callees,
         );
+        mark("scan 2/4 (opaque-folded, gc locals)");
         let conservative_fns: std::collections::BTreeSet<&str> = found_conservative
             .iter()
             .map(|f| f.func_name.as_str())
@@ -753,6 +789,7 @@ fn main() {
         let no_movable: std::collections::HashSet<u64> = Default::default();
         let (frames, frame_stats) =
             liveness::scan(&llbc, &cg, &reach, &no_bracket, &frame_tys, &no_movable);
+        mark("scan 3/4 (resolved, frame locals)");
         let (frames_conservative, _) = liveness::scan(
             &llbc,
             &cg,
@@ -761,6 +798,7 @@ fn main() {
             &frame_tys,
             &no_movable,
         );
+        mark("scan 4/4 (opaque-folded, frame locals)");
         let frame_fns: std::collections::BTreeSet<&str> =
             frames.iter().map(|f| f.func_name.as_str()).collect();
         println!(

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -216,8 +216,16 @@ pub const MOVABLE_GC_MARKERS: &[&str] = &[
     // `PyObjectRef`, so no GC-pointer local is ever an argument of one.  The
     // same reading rules out the items-block and JITFRAME allocators, whose
     // arguments are a capacity and a type id.
+    // `w_method_` is spelled at the accessors rather than at the family
+    // prefix, because `w_method_new` takes the new method's three members --
+    // not a `Method` -- and roots and re-reads them itself.  Under the family
+    // prefix every argument of that constructor counted, so an unrelated local
+    // passed as a member was reported as addressed through a method it is only
+    // stored in.  `w_tuple_new` needs no such split: it takes a slice, so no
+    // `PyObjectRef` local is ever one of its arguments.
     "w_tuple_",
-    "w_method_",
+    "w_method_get_",
+    "w_method_set_",
     "w_gc_weakref_box_",
     "w_weakref_new",
 ];
@@ -638,13 +646,19 @@ pub fn scan(
                         }
                         continue;
                     }
+                    // Truncated rather than removed, for the same reason the
+                    // push above is a push: `RootScope::drop` truncates the
+                    // shadow stack to the length the dropped guard saved, so
+                    // dropping an outer guard retires every guard opened after
+                    // it.  Removing only the named scope would leave the stack
+                    // claiming a guard the runtime has already released.
                     TermKind::Drop { place, .. } => {
                         if let Some(scope) = place_local(place) {
                             if let Some(i) = normal.iter().position(|&s| s == scope) {
-                                normal.remove(i);
+                                normal.truncate(i);
                             }
                             if let Some(i) = unwind.iter().position(|&s| s == scope) {
-                                unwind.remove(i);
+                                unwind.truncate(i);
                             }
                         }
                     }

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -923,74 +923,174 @@ pub fn scan(
             .flat_map(HashSet::iter)
             .flat_map(|a| a.iter().copied())
             .collect();
-        let universe: HashSet<(u64, u64)> = gc_locals
-            .keys()
-            .flat_map(|l| all_scopes.iter().map(move |s| (*l, *s)))
+        // The element is a subset of `locals x scopes` and the entry value is
+        // that whole product, so a `HashSet` of pairs per block costs
+        // `blocks * locals * scopes` hash entries -- for the largest
+        // interpreter bodies, gigabytes, three times over per round because
+        // each round rebuilt both block-indexed vectors.  The same answer is
+        // `blocks * locals * scopes` **bits**.
+        //
+        // Bit `l * scopes.len() + s`, so one local's owners are contiguous:
+        // clearing every owner of a local is what a kill and a call
+        // destination each do, while retiring a scope is rarer and takes a
+        // strided mask built once.
+        let mut scopes: Vec<u64> = all_scopes.iter().copied().collect();
+        scopes.sort_unstable();
+        // The domain carries every local a pin *names*, not only the GC ones:
+        // a terminator adds `(local, owner)` for whatever it pinned.  Only the
+        // GC locals seed the entry value, which is what starting from
+        // `gc_locals x scopes` meant.
+        let mut locals: Vec<u64> = gc_locals.keys().copied().collect();
+        for pins in &term_pins {
+            locals.extend(pins.iter().copied());
+        }
+        locals.sort_unstable();
+        locals.dedup();
+        let local_at: HashMap<u64, usize> =
+            locals.iter().enumerate().map(|(i, &l)| (l, i)).collect();
+        let scope_at: HashMap<u64, usize> =
+            scopes.iter().enumerate().map(|(i, &x)| (x, i)).collect();
+        let nscopes = scopes.len();
+        let words = (locals.len() * nscopes).div_ceil(64);
+        let bit_set = |v: &mut [u64], i: usize| v[i / 64] |= 1u64 << (i % 64);
+        let bit_get = |v: &[u64], i: usize| v[i / 64] >> (i % 64) & 1 == 1;
+        // One scope's pairs, which are strided and so need a mask; a local's
+        // are a run and are cleared in place.
+        let scope_masks: Vec<Vec<u64>> = (0..nscopes)
+            .map(|si| {
+                let mut m = vec![0u64; words];
+                for li in 0..locals.len() {
+                    bit_set(&mut m, li * nscopes + si);
+                }
+                m
+            })
             .collect();
-        let out_of = |b: usize, pin: &[HashSet<(u64, u64)>]| -> HashSet<(u64, u64)> {
-            let mut s: HashSet<(u64, u64)> = pin[b]
-                .iter()
-                .filter(|(l, _)| !stmt_kills[b].contains(l))
-                .copied()
-                .collect();
-            if term_closes_root_scope[b] {
-                // `RootScope::drop` truncates the shadow stack to the length it
-                // saved, so a guard takes its own pins *and* those of every
-                // guard opened after it -- dropping out of order takes more
-                // than one scope's worth.  An enclosing guard keeps its own.
-                match (closed_scope[b], stack_at[b].as_ref()) {
-                    (Some(scope), Some(stack)) => {
-                        let retired: HashSet<u64> = match stack.iter().position(|&x| x == scope) {
-                            Some(i) => stack[i..].iter().copied().collect(),
-                            None => stack.iter().copied().collect(),
-                        };
-                        s.retain(|(_, owner)| !retired.contains(owner));
-                    }
-                    // A Drop this reader cannot place retires an unknown set.
-                    _ => s.clear(),
-                }
-            }
-            if let Some(TermKind::Call { call, .. }) = &terms[b] {
-                if let Some(d) = bare_local(&call.dest) {
-                    s.retain(|(l, _)| *l != d);
-                }
-            }
-            if let Some(owner) = owner_at[b] {
-                s.extend(term_pins[b].iter().map(|l| (*l, owner)));
-            }
-            s
-        };
-        let mut pinned_in: Vec<HashSet<(u64, u64)>> = (0..n)
+        // What each block does to the set, resolved once so the rounds below
+        // are word operations: the pairs it clears by local, the owners it
+        // retires, and the pairs its terminator adds.  Clears commute, so the
+        // call destination joins the statement kills rather than taking a
+        // pass of its own.
+        struct BlockEdit {
+            kill_locals: Vec<usize>,
+            retire_scopes: Vec<usize>,
+            retire_all: bool,
+            add_bits: Vec<usize>,
+        }
+        let edits: Vec<BlockEdit> = (0..n)
             .map(|b| {
-                if b == 0 || !reachable.contains(&b) {
-                    HashSet::new()
-                } else {
-                    universe.clone()
+                let mut kill_locals: Vec<usize> = stmt_kills[b]
+                    .iter()
+                    .filter_map(|l| local_at.get(l).copied())
+                    .collect();
+                let mut retire_scopes: Vec<usize> = Vec::new();
+                let mut retire_all = false;
+                if term_closes_root_scope[b] {
+                    // `RootScope::drop` truncates the shadow stack to the
+                    // length it saved, so a guard takes its own pins *and*
+                    // those of every guard opened after it -- dropping out of
+                    // order takes more than one scope's worth.  An enclosing
+                    // guard keeps its own.
+                    match (closed_scope[b], stack_at[b].as_ref()) {
+                        (Some(scope), Some(stack)) => {
+                            let from = stack.iter().position(|&x| x == scope).unwrap_or(0);
+                            retire_scopes = stack[from..]
+                                .iter()
+                                .filter_map(|x| scope_at.get(x).copied())
+                                .collect();
+                        }
+                        // A Drop this reader cannot place retires an unknown
+                        // set.
+                        _ => retire_all = true,
+                    }
+                }
+                if let Some(TermKind::Call { call, .. }) = &terms[b]
+                    && let Some(d) = bare_local(&call.dest)
+                    && let Some(&di) = local_at.get(&d)
+                {
+                    kill_locals.push(di);
+                }
+                let add_bits = match owner_at[b].and_then(|o| scope_at.get(&o).copied()) {
+                    Some(si) => term_pins[b]
+                        .iter()
+                        .filter_map(|l| local_at.get(l).map(|&li| li * nscopes + si))
+                        .collect(),
+                    None => Vec::new(),
+                };
+                BlockEdit {
+                    kill_locals,
+                    retire_scopes,
+                    retire_all,
+                    add_bits,
                 }
             })
             .collect();
-        for _round in 0..n + 8 {
-            let outs: Vec<HashSet<(u64, u64)>> = (0..n).map(|b| out_of(b, &pinned_in)).collect();
-            let mut changed = false;
-            let mut next: Vec<HashSet<(u64, u64)>> = Vec::with_capacity(n);
-            for b in 0..n {
-                if b == 0 || !reachable.contains(&b) {
-                    next.push(HashSet::new());
+        // Block-indexed buffers, allocated once rather than per round.
+        let mut pinned_in = vec![0u64; n * words];
+        for b in 0..n {
+            if b == 0 || !reachable.contains(&b) {
+                continue;
+            }
+            let blk = &mut pinned_in[b * words..(b + 1) * words];
+            for (li, l) in locals.iter().enumerate() {
+                if !gc_locals.contains_key(l) {
                     continue;
                 }
-                let mut acc = match preds[b].first() {
-                    Some(&p) => outs[p].clone(),
-                    None => HashSet::new(),
-                };
-                for &p in preds[b].iter().skip(1) {
-                    acc.retain(|l| outs[p].contains(l));
+                for si in 0..nscopes {
+                    bit_set(blk, li * nscopes + si);
                 }
-                if acc != pinned_in[b] {
+            }
+        }
+        let mut outs = vec![0u64; n * words];
+        let mut next = vec![0u64; n * words];
+        for _round in 0..n + 8 {
+            for b in 0..n {
+                let at = b * words;
+                outs[at..at + words].copy_from_slice(&pinned_in[at..at + words]);
+                let e = &edits[b];
+                let o = &mut outs[at..at + words];
+                for &li in &e.kill_locals {
+                    for si in 0..nscopes {
+                        let i = li * nscopes + si;
+                        o[i / 64] &= !(1u64 << (i % 64));
+                    }
+                }
+                if e.retire_all {
+                    o.fill(0);
+                } else {
+                    for &si in &e.retire_scopes {
+                        for (w, m) in o.iter_mut().zip(&scope_masks[si]) {
+                            *w &= !m;
+                        }
+                    }
+                }
+                for &i in &e.add_bits {
+                    bit_set(o, i);
+                }
+            }
+            let mut changed = false;
+            for b in 0..n {
+                let at = b * words;
+                if b == 0 || !reachable.contains(&b) {
+                    next[at..at + words].fill(0);
+                } else if let Some(&first) = preds[b].first() {
+                    let src = first * words;
+                    for w in 0..words {
+                        next[at + w] = outs[src + w];
+                    }
+                    for &p in preds[b].iter().skip(1) {
+                        let src = p * words;
+                        for w in 0..words {
+                            next[at + w] &= outs[src + w];
+                        }
+                    }
+                } else {
+                    next[at..at + words].fill(0);
+                }
+                if next[at..at + words] != pinned_in[at..at + words] {
                     changed = true;
                 }
-                next.push(acc);
             }
-            pinned_in = next;
+            std::mem::swap(&mut pinned_in, &mut next);
             if !changed {
                 break;
             }
@@ -1173,10 +1273,15 @@ pub fn scan(
                 }
                 // Drop the owner here: coverage asks only whether the local
                 // is pinned by *some* live guard.
-                let held: HashSet<u64> = pinned_in[b]
+                let blk = &pinned_in[b * words..(b + 1) * words];
+                let held: HashSet<u64> = locals
                     .iter()
-                    .map(|(l, _)| *l)
-                    .filter(|l| !stmt_kills[b].contains(l))
+                    .enumerate()
+                    .filter(|(li, l)| {
+                        !stmt_kills[b].contains(l)
+                            && (0..nscopes).any(|si| bit_get(blk, li * nscopes + si))
+                    })
+                    .map(|(_, l)| *l)
                     .collect();
                 let mut missing: Vec<String> = after
                     .iter()

--- a/pyre/extra_tests/snippets/gc_add_note_roots_its_note.py
+++ b/pyre/extra_tests/snippets/gc_add_note_roots_its_note.py
@@ -1,0 +1,79 @@
+# pyre-check: gate=1
+"""`BaseException.add_note` keeps the note across the attribute operations.
+
+The note is appended last of all.  Before that, `add_note` reads `__notes__`
+off the instance, allocates the list when the attribute is absent, and stores
+it back -- and both the read and the store dispatch through the instance, so
+either can run Python.  The note relocates, so the word `add_note` started
+with is the pre-move one, and what lands in the list is whatever took the
+freed box: before the fix this body reported
+
+    [<QQQQQQQQ... object at 0xb4e82e958>]
+
+for a note of `'1000000000000000005'`, and the next collection died walking
+the list it was stored in (`site=minor_varsize_item_target`,
+`holder_type_id=Some(9)`, `holder_offset=Some(8)` -- a list's items).
+
+A `str` literal is a prebuilt code constant and does not move, which is why
+every note here is minted by `str(int)` and is wide enough not to be a cached
+small-integer digit run.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    """Take the freed boxes, so a sweep that frees is not invisible."""
+    global KEEP
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(200)] + [bytearray(b"Q" * 96) for _ in range(120)]
+
+
+class ReadsBack(Exception):
+    """`__notes__` is absent on the first call, so the lookup `add_note` makes
+    reaches this and collects with the note live."""
+
+    def __getattr__(self, name):
+        churn()
+        raise AttributeError(name)
+
+
+class StoresBack(Exception):
+    """The store side of the same window."""
+
+    def __setattr__(self, name, value):
+        churn()
+        object.__setattr__(self, name, value)
+
+
+# The first mismatch landed on the sixth turn, so one exception is not enough
+# to see it; the loop is what walks the note into a nursery block the churn
+# above then recycles.
+for n in range(40):
+    note = str(10**18 + n)
+    e = ReadsBack("boom")
+    e.add_note(note)
+    assert e.__notes__ == [note], (n, e.__notes__)
+
+    # The second note takes the other arm: `__notes__` is present now, so the
+    # list is the one already stored rather than a freshly allocated one.
+    second = str(10**18 + 500 + n)
+    e.add_note(second)
+    assert e.__notes__ == [note, second], (n, e.__notes__)
+
+    f = StoresBack("boom")
+    note = str(10**18 + 1000 + n)
+    f.add_note(note)
+    assert f.__notes__ == [note], (n, f.__notes__)
+
+# `add_note` still rejects a non-str, and does so before any of the above.
+try:
+    ReadsBack("x").add_note(1234)
+except TypeError as exc:
+    assert "must be str" in str(exc), exc
+else:
+    raise AssertionError("add_note accepted an int")
+
+print("ok")

--- a/pyre/extra_tests/snippets/gc_sre_sub_roots_its_subject.py
+++ b/pyre/extra_tests/snippets/gc_sre_sub_roots_its_subject.py
@@ -69,4 +69,19 @@ assert pattern.sub(r"[\g<0>]", SUBJECT, Count()) == (
     "a" + ("[b]" + "z") * 3 + ("b" + "z") * 37 + "c"
 )
 
+# A `memoryview` subject is not its own storage: the view's window is gathered
+# into a fresh `bytes` and the walk matches against that object's payload, so
+# the gathered object -- not the view, and not the backing -- is what has to
+# stay rooted across the `__index__` below.  Nothing else refers to it.
+bpattern = re.compile(b"b")
+BACKING = bytearray(b"a" + (b"b" + b"z") * 40 + b"c")
+BYTES_EXPECTED = b"a" + (b"Y" + b"z") * 3 + (b"b" + b"z") * 37 + b"c"
+
+assert bpattern.sub(b"Y", memoryview(BACKING), Count()) == BYTES_EXPECTED
+assert bpattern.subn(b"Y", memoryview(BACKING), Count()) == (BYTES_EXPECTED, 3)
+# `pos` runs the same `__index__`, and `findall` / `split` keep the gathered
+# buffer for the whole walk without a `count` to hang a root on.
+assert len(bpattern.findall(memoryview(BACKING), Count())) == 39
+assert len(bpattern.split(memoryview(BACKING))) == 41
+
 print("ok")

--- a/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
+++ b/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
@@ -30,11 +30,6 @@ class Idx:
         return self.n
 
 
-class Named:
-    def __str__(self):
-        return "abcd"
-
-
 # Temporaries: nothing but the operand stack ever held these containers.
 assert [10, 20, 30][Idx(1)] == 20
 assert (10, 20, 30)[Idx(1)] == 20
@@ -48,11 +43,13 @@ assert bytearray(b"abcdefgh")[Idx(2) : Idx(6)] == bytearray(b"cdef")
 # A tuple or str *literal* is a prebuilt constant and never relocates, so the
 # two lines above exercise liveness and not staleness.  The relocating shapes
 # are the ones a program builds: `tuple()` allocates in the nursery, and
-# `str()` is the one caller of the collecting string constructor.
+# `int.__repr__` mints its digits through the collecting string constructor.
+# A user `__str__` does not qualify -- `str()` hands that result object back
+# unchanged, so a `__str__` returning a literal subscripts the code constant.
 assert tuple(range(10, 40, 10))[Idx(1)] == 20
 assert tuple(range(8))[Idx(2) :] == (2, 3, 4, 5, 6, 7)
-assert str(Named())[Idx(1)] == "b"
-assert str(Named())[Idx(1) : Idx(3)] == "bc"
+assert str(1234)[Idx(1)] == "2"
+assert str(123456)[Idx(1) : Idx(3)] == "23"
 
 # The assigned value is read after the key's `__index__` has already run.
 target = bytearray(b"abcd")

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -815,17 +815,25 @@ fn subs_tvars(
             Some(idx) => unsafe { w_tuple_getitem(argitems(), idx as i64) }.unwrap_or(param()),
             None => param(),
         };
+        // `arg` is published here rather than in the branch below, because
+        // the test that picks the branch reads `__module__` off the
+        // parameter's type: `is_typevartuple` is a collecting call, and the
+        // word `w_tuple_getitem` just returned is a pre-move address on the
+        // other side of it.
+        let arg_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(arg);
         // `if isinstance(param, TypeVarTuple): subargs.extend(arg)` — a
         // `TypeVarTuple` captures a sequence, so its bound `arg` is spliced.
         if is_typevartuple(param()) {
-            let members = crate::builtins::collect_iterable(arg)?;
+            let members = crate::builtins::collect_iterable(
+                pyre_object::gc_roots::shadow_stack_get(arg_slot),
+            )?;
             let member_base = pyre_object::gc_roots::pin_roots(&members);
             for index in 0..members.len() {
                 subarg_slots.push(member_base + index);
             }
         } else {
-            subarg_slots.push(pyre_object::gc_roots::shadow_stack_len());
-            let _ = pyre_object::gc_roots::pin_root(arg);
+            subarg_slots.push(arg_slot);
         }
     }
     let subargs: Vec<PyObjectRef> = subarg_slots

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9718,6 +9718,16 @@ pub(crate) fn make_exc_type_with_init(
                                     "add_note() argument must be str, not {got}"
                                 )));
                             }
+                            // The note is appended last of all -- after the
+                            // attribute lookup, the list allocation and the
+                            // store, and both of those attribute operations
+                            // can run Python.  A `str` a program builds mints
+                            // through the collecting constructor and so
+                            // relocates, so it is pinned across that whole
+                            // window and read back at the append.
+                            let _roots = pyre_object::gc_roots::push_roots();
+                            let note_slot = pyre_object::gc_roots::shadow_stack_len();
+                            let _ = pyre_object::gc_roots::pin_root(w_note);
                             // `interp_exceptions.py:240-254` — lazy
                             // list allocation on first call; if the
                             // attribute is already set but NOT a list,
@@ -9733,7 +9743,6 @@ pub(crate) fn make_exc_type_with_init(
                             // therefore read back out of a root slot after
                             // the store rather than reusing the word the
                             // constructor answered.
-                            let _roots = pyre_object::gc_roots::push_roots();
                             let notes_slot = pyre_object::gc_roots::shadow_stack_len();
                             let notes = match existing {
                                 Some(v) if unsafe { crate::baseobjspace::isinstance_list_w(v) } => {
@@ -9756,7 +9765,12 @@ pub(crate) fn make_exc_type_with_init(
                                     pyre_object::gc_roots::shadow_stack_get(notes_slot)
                                 }
                             };
-                            unsafe { pyre_object::w_list_append(notes, w_note) };
+                            unsafe {
+                                pyre_object::w_list_append(
+                                    notes,
+                                    pyre_object::gc_roots::shadow_stack_get(note_slot),
+                                )
+                            };
                             Ok(pyre_object::w_none())
                         },
                         2,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6467,6 +6467,15 @@ fn type_descr_new_with_metaclass(
                 crate::error::type_name_of(w_namespace_dict)
             )));
         }
+        // `bases` is the caller's tuple and a tuple relocates.  Everything
+        // from here down dispatches through user code -- the namespace
+        // backing's `keys`, the `__mro_entries__` lookups, the namespace copy,
+        // `__set_name__`, `__init_subclass__` -- so the word taken out of
+        // `args` is published once and re-read at each region below instead of
+        // carried across them.
+        let _bases_roots = pyre_object::gc_roots::push_roots();
+        let bases_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(bases);
         let w_ns_backing = unsafe { crate::type_methods::resolve_dict_backing(w_namespace_dict) };
         // typeobject.py `_check_surrogate(space, name)` — reject a lone
         // surrogate in the name before it is read as UTF-8 below.
@@ -6485,6 +6494,7 @@ fn type_descr_new_with_metaclass(
         // advertising `__mro_entries__` gets the dedicated diagnostic before
         // metaclass calculation; class statements resolve it earlier in
         // `__build_class__` and therefore never reach this branch.
+        let bases = pyre_object::gc_roots::shadow_stack_get(bases_slot);
         let n_bases = unsafe { w_tuple_len(bases) };
         for index in 0..n_bases {
             let Some(base) = (unsafe { pyre_object::w_tuple_getitem(bases, index as i64) }) else {
@@ -6501,6 +6511,7 @@ fn type_descr_new_with_metaclass(
 
         // CPython: calculate_metaclass — if bases have a custom metaclass,
         // delegate to that metaclass instead of using type.__new__ directly.
+        let bases = pyre_object::gc_roots::shadow_stack_get(bases_slot);
         if w_metaclass.is_null() && !bases.is_null() && unsafe { is_tuple(bases) } {
             let n = unsafe { w_tuple_len(bases) };
             for i in 0..n {
@@ -6677,6 +6688,7 @@ fn type_descr_new_with_metaclass(
         // it.  A tuple is nursery-allocated and every one of those collects,
         // so each use below reads the slot back instead of carrying the word.
         let _effective_bases_roots = pyre_object::gc_roots::push_roots();
+        let bases = pyre_object::gc_roots::shadow_stack_get(bases_slot);
         let w_effective_bases =
             if bases.is_null() || !unsafe { is_tuple(bases) } || unsafe { w_tuple_len(bases) } == 0
             {
@@ -6707,6 +6719,7 @@ fn type_descr_new_with_metaclass(
         // after the winner is settled — supplying it here would weigh an
         // explicit metatype against `type(object)` and report a conflict where
         // the metatype itself is what upstream goes on to refuse.
+        let bases = pyre_object::gc_roots::shadow_stack_get(bases_slot);
         let w_winner = crate::call::calculate_metaclass(default_meta, bases)?;
         if !std::ptr::eq(w_winner, default_meta) {
             // Winner is a different metaclass — delegate to its __new__
@@ -6723,6 +6736,7 @@ fn type_descr_new_with_metaclass(
                     }
                 };
                 let w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(namespace_root);
+                let bases = pyre_object::gc_roots::shadow_stack_get(bases_slot);
                 let mut new_args = vec![w_winner, name_obj, bases, w_namespace_dict];
                 if args.len() > 3 {
                     new_args.extend_from_slice(&args[3..]);
@@ -16327,6 +16341,15 @@ pub(crate) fn exec_or_eval(
         let _ = ns_roots.pin_root(w_globals);
         slot
     });
+    // The validated closure is the caller's tuple, and it is consumed last of
+    // all -- after `ensure_*_builtins`, the two namespace pins and the
+    // snapshot allocation.  It goes on the same scope as they do rather than
+    // on `_closure_root`, which opens after those calls have already run.
+    let closure_slot = inject_closure.then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(closure);
+        slot
+    });
     // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
     // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
@@ -16413,7 +16436,7 @@ pub(crate) fn exec_or_eval(
             pyre_object::gc_roots::shadow_stack_get(code_slot) as *const (),
             name,
             pyre_object::PY_NULL,
-            closure,
+            closure_slot.map_or(closure, pyre_object::gc_roots::shadow_stack_get),
         );
         let f = pyre_object::gc_roots::pin_root(f);
         Some(f)

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4779,18 +4779,26 @@ fn update_bases(
     let _entry_roots = pyre_object::gc_roots::push_roots();
     let orig_bases_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_orig_bases);
-    let mut new_bases: Option<Vec<PyObjectRef>> = None;
-    for (i, &w_base) in base_args.iter().enumerate() {
+    // The originals go on the shadow stack for the same reason `w_orig_bases`
+    // does: `getattr_str` and the `__mro_entries__` call both run Python, so a
+    // base the walk has not reached yet is a pre-move word by the time it is
+    // read.  The accumulation is a list of slot indices rather than of words,
+    // so an entry already appended is re-read at the end instead of being
+    // frozen at the address it had when it was appended.
+    let args_base = pyre_object::gc_roots::pin_roots(base_args);
+    let mut new_slots: Option<Vec<usize>> = None;
+    for i in 0..base_args.len() {
+        let w_base = pyre_object::gc_roots::shadow_stack_get(args_base + i);
         if unsafe { pyre_object::is_type(w_base) } {
-            if let Some(nb) = new_bases.as_mut() {
-                nb.push(w_base);
+            if let Some(nb) = new_slots.as_mut() {
+                nb.push(args_base + i);
             }
             continue;
         }
         match crate::baseobjspace::getattr_str(w_base, "__mro_entries__") {
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                if let Some(nb) = new_bases.as_mut() {
-                    nb.push(w_base);
+                if let Some(nb) = new_slots.as_mut() {
+                    nb.push(args_base + i);
                 }
             }
             Err(e) => return Err(e),
@@ -4813,24 +4821,36 @@ fn update_bases(
                     ));
                 }
                 let w_new_base = pyre_object::gc_roots::pin_root(w_new_base);
-                if new_bases.is_none() {
-                    new_bases = Some(base_args[..i].to_vec());
+                if new_slots.is_none() {
+                    new_slots = Some((0..i).map(|k| args_base + k).collect());
                 }
-                let nb = new_bases.as_mut().unwrap();
+                let nb = new_slots.as_mut().unwrap();
                 let n = unsafe { pyre_object::w_tuple_len(w_new_base) };
                 for j in 0..n {
                     if let Some(item) =
                         unsafe { pyre_object::w_tuple_getitem(w_new_base, j as i64) }
                     {
-                        nb.push(item);
+                        nb.push(pyre_object::gc_roots::shadow_stack_len());
+                        let _ = pyre_object::gc_roots::pin_root(item);
                     }
                 }
             }
         }
     }
-    match new_bases {
-        None => Ok((base_args.to_vec(), false)),
-        Some(nb) => Ok((nb, true)),
+    // Read back at the return, where the words are current: the caller pins
+    // them again before its own `w_tuple_new` allocates.
+    let read = |slots: &[usize]| -> Vec<PyObjectRef> {
+        slots
+            .iter()
+            .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+            .collect()
+    };
+    match new_slots {
+        None => Ok((
+            read(&(0..base_args.len()).map(|i| args_base + i).collect::<Vec<_>>()),
+            false,
+        )),
+        Some(nb) => Ok((read(&nb), true)),
     }
 }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4847,7 +4847,11 @@ fn update_bases(
     };
     match new_slots {
         None => Ok((
-            read(&(0..base_args.len()).map(|i| args_base + i).collect::<Vec<_>>()),
+            read(
+                &(0..base_args.len())
+                    .map(|i| args_base + i)
+                    .collect::<Vec<_>>(),
+            ),
             false,
         )),
         Some(nb) => Ok((read(&nb), true)),

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -867,10 +867,15 @@ pub(crate) fn encode_text_codec(
     // Python while `w_obj` is still whatever the caller handed over.
     let _roots = pyre_object::gc_roots::push_roots();
     let w_obj = pyre_object::gc_roots::pin_root(w_obj);
-    let w_codec_info = lookup_text_codec("encode", encoding)?;
+    // The codec-info tuple relocates, and the handler check below reaches
+    // the codec state's lazy construction, which allocates.  Pin it and read
+    // it back rather than indexing the word the lookup answered.
+    let info_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(lookup_text_codec("encode", encoding)?);
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;
     }
+    let w_codec_info = pyre_object::gc_roots::shadow_stack_get(info_slot);
     let w_encfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 0).unwrap_or_else(w_none) };
     let w_retval = call_codec(w_encfunc, w_obj, "encoding", encoding, Some(errors))?;
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_retval) } {
@@ -896,10 +901,15 @@ pub(crate) fn decode_text_codec(
     // move, so the pin is for liveness alone and the value is used as it is.
     let _roots = pyre_object::gc_roots::push_roots();
     let w_obj = pyre_object::gc_roots::pin_root(w_obj);
-    let w_codec_info = lookup_text_codec("decode", encoding)?;
+    // The codec-info tuple relocates, and the handler check below reaches
+    // the codec state's lazy construction, which allocates.  Pin it and read
+    // it back rather than indexing the word the lookup answered.
+    let info_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(lookup_text_codec("decode", encoding)?);
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;
     }
+    let w_codec_info = pyre_object::gc_roots::shadow_stack_get(info_slot);
     let w_decfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 1).unwrap_or_else(w_none) };
     let w_retval = call_codec(w_decfunc, w_obj, "decoding", encoding, Some(errors))?;
     if !unsafe { pyre_object::is_str(w_retval) } {

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -1544,13 +1544,24 @@ fn build_callargs(
     // every value already collected lives in a root slot across it; the list
     // is read back out of those slots once the loop is done.
     let _roots = pyre_object::gc_roots::push_roots();
+    // `paramflags` is the tuple the loop indexes on every turn, and the same
+    // arbitrary Python runs between two of those reads.  A tuple relocates, so
+    // it is pinned ahead of `base` -- the values below want a contiguous run
+    // starting there -- and read back at each index.
+    let paramflags_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(paramflags);
     let base = pyre_object::gc_roots::shadow_stack_len();
     let mut index = 0;
     for (i, &at) in argtypes.iter().enumerate() {
         let malformed =
             || crate::PyError::value_error("paramflags must have the same length as argtypes");
-        let item =
-            unsafe { pyre_object::w_tuple_getitem(paramflags, i as i64) }.ok_or_else(malformed)?;
+        let item = unsafe {
+            pyre_object::w_tuple_getitem(
+                pyre_object::gc_roots::shadow_stack_get(paramflags_slot),
+                i as i64,
+            )
+        }
+        .ok_or_else(malformed)?;
         if !unsafe { pyre_object::is_tuple(item) } {
             return Err(malformed());
         }

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -854,39 +854,39 @@ unsafe fn readbuf_obj(obj: PyObjectRef) -> PyObjectRef {
     }
 }
 
-/// The raw bytes of [`readbuf_obj`] — `BufMatchContext` matches against these.
-unsafe fn readbuf_bytes(obj: PyObjectRef) -> Option<&'static [u8]> {
-    let buf = unsafe { readbuf_obj(obj) };
-    if buf.is_null() {
-        None
-    } else {
-        Some(unsafe { pyre_object::bytesobject::bytes_like_data(buf) })
-    }
-}
-
 /// `make_ctx` (interp_sre.py) — resolve the subject and reject a
 /// pattern/subject type mismatch (a bytes pattern on a str, or a str
 /// pattern on a bytes-like object).  A `str` (or subclass) becomes a
 /// character subject; `bytes`/`bytearray` (or subclass) a byte subject; any
 /// other read-buffer object (a `memoryview`) a `BufMatchContext`-style byte
 /// subject.
-fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate::PyError> {
+///
+/// Returned with the `_buffer` object the subject borrows: a `memoryview` or
+/// other exporter is gathered into a fresh `bytes`, and the `Subject::Bytes`
+/// slice points into it, so it is the caller — not a second `readbuf_obj`
+/// call, which would materialize a *different* object — that roots the one the
+/// slice actually reads.  `PY_NULL` where the subject is its own storage.
+fn make_subject(
+    pat: PyObjectRef,
+    string: PyObjectRef,
+) -> Result<(Subject, PyObjectRef), crate::PyError> {
     if unsafe { is_str(string) } {
         if pattern_is_known_bytes(pat) {
             return Err(crate::PyError::type_error(
                 "cannot use a bytes pattern on a string-like object",
             ));
         }
-        Ok(unsafe { str_subject(string) })
+        Ok((unsafe { str_subject(string) }, pyre_object::PY_NULL))
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
                 "cannot use a string pattern on a bytes-like object",
             ));
         }
-        Ok(Subject::Bytes(unsafe {
-            pyre_object::bytesobject::bytes_like_data(string)
-        }))
+        Ok((
+            Subject::Bytes(unsafe { pyre_object::bytesobject::bytes_like_data(string) }),
+            pyre_object::PY_NULL,
+        ))
     } else {
         // `make_ctx` acquires any other readable-buffer subject through
         // `readbuf_w` → `buffer_w` (a `memoryview`, or any buffer exporter such
@@ -899,18 +899,22 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
         // *before* the pattern/subject-type check — a non-buffer object raises
         // "expected string or bytes-like object", a real buffer (memoryview /
         // array) raises the "string pattern on a bytes-like object" mismatch.
-        let Some(buf) = (unsafe { readbuf_bytes(string) }) else {
+        let w_buffer = unsafe { readbuf_obj(string) };
+        if w_buffer.is_null() {
             return Err(crate::PyError::type_error(format!(
                 "expected string or bytes-like object, got '{}'",
                 crate::baseobjspace::object_functionstr_type_name(string)
             )));
-        };
+        }
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
                 "cannot use a string pattern on a bytes-like object",
             ));
         }
-        Ok(Subject::Bytes(buf))
+        Ok((
+            Subject::Bytes(unsafe { pyre_object::bytesobject::bytes_like_data(w_buffer) }),
+            w_buffer,
+        ))
     }
 }
 
@@ -1144,8 +1148,7 @@ fn do_match(
         .copied()
         .ok_or_else(|| crate::PyError::type_error(format!("{name} requires self and string")))?;
     let code = get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
-    let subj = make_subject(pat, string)?;
-    let w_buffer = unsafe { readbuf_obj(string) };
+    let (subj, w_buffer) = make_subject(pat, string)?;
 
     let (pos, endpos) = normalize_bounds(
         subj.len(),
@@ -1300,7 +1303,8 @@ fn sre_pattern_findall(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         .ok_or_else(|| crate::PyError::type_error("findall requires self and string"))?;
     let string = required_arg_kw(args, 1, kwargs, "string", "findall")?;
     let code = get_code(pat).ok_or_else(|| crate::PyError::type_error("no code"))?;
-    let subj = make_subject(pat, string)?;
+    let (subj, w_buffer) = make_subject(pat, string)?;
+    let _ = pyre_object::gc_roots::pin_root(w_buffer);
     let (pos, endpos) = normalize_bounds(
         subj.len(),
         arg_int_kw(args, 2, kwargs, "pos", 0)?,
@@ -1352,8 +1356,7 @@ fn sre_pattern_finditer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
     // Validate the compiled code is present (matches do_match's guard).
     get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
-    let subj = make_subject(pat, string)?;
-    let w_buffer = unsafe { readbuf_obj(string) };
+    let (subj, w_buffer) = make_subject(pat, string)?;
     let (pos, endpos) = normalize_bounds(
         subj.len(),
         arg_int_kw(args, 2, kwargs, "pos", 0)?,
@@ -1414,9 +1417,9 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
     // The subject borrows the string's value box, which is `try_gc_alloc_stable`
     // and so keeps its address; the pin above is what keeps that box allocated
     // for the length of the walk.
-    let subj = make_subject(pat, string())?;
+    let (subj, w_buffer_obj) = make_subject(pat, string())?;
     let buffer_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(unsafe { readbuf_obj(string()) });
+    let _ = pyre_object::gc_roots::pin_root(w_buffer_obj);
     let w_buffer = || pyre_object::gc_roots::shadow_stack_get(buffer_slot);
     let count = arg_int_kw(args, 3, kwargs, "count", 0)?;
 
@@ -1557,7 +1560,8 @@ fn sre_pattern_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         .ok_or_else(|| crate::PyError::type_error("split requires self and string"))?;
     let string = required_arg_kw(args, 1, kwargs, "string", "split")?;
     let code = get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
-    let subj = make_subject(pat, string)?;
+    let (subj, w_buffer) = make_subject(pat, string)?;
+    let _ = pyre_object::gc_roots::pin_root(w_buffer);
     let maxsplit = arg_int_kw(args, 2, kwargs, "maxsplit", 0)?;
     let num_groups = unsafe { (*(pat as *const W_SRE_Pattern)).num_groups }.max(0) as usize;
     let w_empty = empty_subject(subj);

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -7823,12 +7823,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     // A free-threaded fork must snapshot native/Python lock
                     // state while every other mutator is parked.  Enter
                     // through the collector's full request path so no GC
-                    // operation can overlap the STW window.
-                    let mut fork_result = None;
-                    majit_gc::gc_sync::request_stw(|_| {
-                        fork_result = Some(host_posix::fork());
-                    });
-                    match fork_result.expect("fork STW closure must run") {
+                    // operation can overlap the STW window, and so the child
+                    // inherits the quiesce mutex from the thread that survives
+                    // rather than from one that vanished.
+                    match majit_gc::gc_sync::fork_under_stw(host_posix::fork) {
                         Ok(0) => {
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");
@@ -7890,8 +7888,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     drop(blocked);
                     run_fork_callbacks("before");
                     let mut master_fd = -1;
-                    let mut fork_result = None;
-                    majit_gc::gc_sync::request_stw(|_| {
+                    let fork_result = majit_gc::gc_sync::fork_under_stw(|| {
                         let pid = unsafe {
                             libc::forkpty(
                                 &mut master_fd,
@@ -7900,13 +7897,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                                 std::ptr::null_mut(),
                             )
                         };
-                        fork_result = Some(if pid == -1 {
+                        if pid == -1 {
                             Err(std::io::Error::last_os_error())
                         } else {
                             Ok(pid)
-                        });
+                        }
                     });
-                    match fork_result.expect("forkpty STW closure must run") {
+                    match fork_result {
                         Ok(0) => {
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -334,6 +334,10 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     let _roots = pyre_object::gc_roots::push_roots();
     let subject_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(subject);
+    let keys_base = pyre_object::gc_roots::shadow_stack_len();
+    for &key in &key_items {
+        let _ = pyre_object::gc_roots::pin_root(key);
+    }
     // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
     // before it binds anything; track keys already looked up and raise on
     // a duplicate. Each key is looked up with `map.get(key, sentinel)`
@@ -348,10 +352,6 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(
         crate::typedef::gettypeobject(&pyre_object::pyobject::INSTANCE_TYPE),
     ));
-    let keys_base = pyre_object::gc_roots::shadow_stack_len();
-    for &key in &key_items {
-        let _ = pyre_object::gc_roots::pin_root(key);
-    }
     let values_base = pyre_object::gc_roots::shadow_stack_len();
     let mut value_count = 0usize;
     let mut all_match = true;

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -16,7 +16,7 @@
 //!
 //! This module is the safe stepping stone: route the interpreter's int/float
 //! allocations through the *non-moving* old-gen (`try_gc_alloc_stable`, the same
-//! path dict/set/list/instances already use), so they become GC-tracked without
+//! path set/type/instance boxes already use), so they become GC-tracked without
 //! the move hazard, and trigger a full mark-sweep at a bytecode-dispatch
 //! safepoint (loop top, where the only live refs are in the frame and reachable
 //! through the registered `pyframe` root walker). When to collect is not

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -241,7 +241,7 @@ pub unsafe fn w_tuple_walk_gc_refs(obj: PyObjectRef, visitor: &mut dyn FnMut(*mu
 /// boxed. Other arities use the array-backed `W_TupleObject`.
 ///
 /// Residualized: tuple construction drives the moving collector through
-/// `push_roots` / `pin_root` / `try_gc_alloc_stable` shadow-stack
+/// `push_roots` / `pin_root` / `try_gc_alloc_nursery_raw` shadow-stack
 /// plumbing the tracer cannot model. The JIT leaves the call as a
 /// residual returning the fresh object pointer.
 #[majit_macros::dont_look_inside]


### PR DESCRIPTION
Follows #1669.  Seven commits: the ten findings that PR's review left open, a
JITFRAME generation fix a peer wrote on this branch, a refitted darwin gate
baseline, and a memory fix in the analysis that produces the baseline.

## The review fixes

Every finding was checked against source before it was believed; five were
real rooting holes, two were analysis defects, and one was a fixture that did
not exercise what its docstring claimed.

**Rooting** — an object held across a call that runs Python:

- `_pypy_generic_alias::subs_tvars` pinned `arg` only after `is_typevartuple`,
  which reaches a user `__mro_entries__`.
- `opcode_ops::match_keys_value` pinned the mapping-pattern keys after
  `w_set_new` / `w_instance_new`, both of which can collect.
- `call::update_bases` carried `base_args` across `__mro_entries__`; it now
  pins the slice up front and materializes the answer from shadow slots.
- `builtins::type_descr_new_with_metaclass` derived `w_effective_bases`,
  scanned for a metaclass and called `calculate_metaclass` from a `bases` word
  the `__mro_entries__` scan above it could have invalidated.
- `builtins::exec_or_eval` held `closure` across the namespace setup.

**`_sre`** — `make_subject` gathered a `memoryview` subject into a fresh
`bytes` and returned only the borrowed view of it, so the walk matched against
an object nothing referred to.  It now returns that object alongside the
subject and the five call sites root it; `readbuf_bytes` is gone.

**gctransform** — `RootScope::drop` truncates the shadow stack to the length
the dropped guard saved, so dropping an outer guard retires every guard opened
after it.  The scope-stack reader removed only the named scope, which left the
stack claiming a guard the runtime had already released.  Separately,
`MOVABLE_GC_MARKERS` matched `w_method_new`, which takes the new method's three
members and roots them itself; the marker is now the two accessors.

**Fixture** — `gc_subscript_roots_its_container.py` subscripted `str(Named())`,
which hands a user `__str__` result back unchanged and so subscripted a code
constant.  It now subscripts `str(1234)`, which mints through
`w_str_new_managed_collecting` and therefore actually relocates.
`gc_sre_sub_roots_its_subject.py` gains the `memoryview` regression, with the
expected values taken from CPython 3.14.

## The analysis memory fix

`gc-root-reachability` peaked at **15,740 MB**.  The cause was not the
collector: the pin-set fixpoint in `gctransform/liveness.rs` is a must-analysis
whose element is a `(local, owning scope)` pair and whose entry value is the
whole product, held as a `HashSet` of pairs per block and rebuilt from scratch
every round.  `pyre_interpreter::baseobjspace::next` is 3221 blocks x 1085
locals x 28 scopes — 2239 MB for one of the three vectors, for one function.

The same answer is that many **bits**.  Bit `local * nscopes + scope`, three
flat `Vec<u64>` allocated once and swapped, and each block's kills, retired
scopes and added pairs resolved into a `BlockEdit` before the rounds start.

**15,740 MB -> 2,951 MB, whole run 37.8s.**  This changes representation only,
so the check is that the gate does not move: all twelve metrics are identical
(`tier15 102/56`, `unbracketed 2064/835`, `tier1 0/0`, `frame_tier1 0/0`,
`frames_across_collecting 10/4`, `brackets_reaching_no_collection 3`, same two
unmatched seeds).

The example also gains a `GC_RSS_TRACE=1` phase trace on stderr — the gate's
stdout is unchanged — which is what localized the peak to the fixpoint rather
than to the artefact load.

## A second round of rooting fixes, found with the now-cheap analysis

With the analysis down to 38 s a run, its full finding set is readable per
run.  Filtering the short-bracket findings to those whose *missing* local is
movable gives 17 candidates; five of them, in three functions, are real.

- `add_note` appends the note last of all, after reading `__notes__` off the
  instance, allocating the list and storing it back.  Both attribute
  operations dispatch through the instance and so can run Python, and a `str`
  a program builds relocates.  The fixture added alongside is `rc=138` five
  runs out of five on the unfixed tree **at the default nursery**, on both
  backends; with the collector's diagnostics on, the note reads back as the
  `bytearray` the churn had put in the freed box and the next collection dies
  walking the list it was stored in (`site=minor_varsize_item_target`,
  `holder_type_id=Some(9)`, `holder_offset=Some(8)`).
- `build_callargs` indexes `paramflags` on every turn of its loop and calls
  `out_parameter` between two of those reads, which instantiates the argtype
  and so runs arbitrary Python.
- `encode_text_codec` / `decode_text_codec` hold the codec-info tuple across
  the dev-mode handler check.  Its own lazy state construction cannot fire
  (`lookup_codec` above it has already forced it), but the registry probe is a
  borrowed-`&str` lookup, which runs `dict_keys_equal` against a colliding
  bucket and so reaches a user `__eq__`.

The other twelve are false positives from two mechanisms worth recording,
because both will keep producing them: the marker hop taints *every* argument
of a `w_dict_store`-shaped callee, and **a pin made inside a Rust closure is a
separate LLBC body the per-function scan cannot see** (that is the three
`exec_or_eval` hits, from `inject_closure.then(|| ns_roots.pin_root(closure))`).
The rest are locals that provably do not move: `w_str_new` of a literal is
immortal, and types, instances and bytearrays are `try_gc_alloc_stable`.

Measured after: the `missing_movable` set goes 17 -> 12, with all five real
ones gone and the three `exec_or_eval` entries merely shifted 14 lines by the
`add_note` edit.  Gate `tier15_calls` 102 -> 101, `unbracketed_calls`
2064 -> 2063, nothing raised.  `pyre/extra_tests/run.py --gated-only` is
183/183 on cpython, dynasm and cranelift.

## Advisor items closed without a change

Four of the remaining GC advisor items did not survive reading the code, and
are recorded here so they are not re-opened:

- **`MOVABLE_GC_MARKERS` is out of sync** — all four sub-claims are wrong.
  There is no `w_str` entry at all; `w_dict_view_*` is already covered by the
  `w_dict_` prefix; and the items-block and JITFRAME allocators take
  `(cap, tid)` / `(gc, size)`, so they have no scalar `PyObjectRef` argument
  for a marker to match.  The marker list's own doc comment says this.
- **wasm skips `GcRewriterImpl`** — a documented adaptation.  Zero-filling the
  recycled nursery conservatively discharges both the `clear_gc_fields` stores
  and the clear half of `NewArrayClear`, and the codegen *declines* a trace
  carrying a `ZeroArray` rather than lean on the arm.
- **GCREFTRACER is not a managed object** — not a rooting hole.
  `remove_ref_constants` lifts the constants into a `GcTable` whose
  `Box<[Cell<GcRef>]>` is upstream's `array_base_addr` / `array_length`, and
  the extra-root walker forwards those slots in place; the `Arc<dyn Any>` is
  only the keep-alive.  `gcreftracer.rs` states the precondition for
  collapsing to a managed `GCREFTRACER`: `CompiledLoopToken` has to be
  GC-traced first.
- **`MAJIT_GC_ITEMSBLOCK=0`** — real, but a dormant rollback switch; retiring
  it costs an LLBC re-extraction and the removal of a published fnaddr.

## Gate

```
tier15_calls        131 -> 101   (fns 61 -> 55)
unbracketed_calls  2069 -> 2063  (fns 836 -> 834)
```

Nothing rose; the invariant columns stay at zero.  The darwin baseline is
recorded.  **The linux baseline still names base `903151ee679a`** and has to be
refitted from a CI run on this PR's base before it means anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection safety across exception handling, type creation, compilation, codecs, ctypes calls, regular expressions, and pattern matching.
  * Prevented potential crashes or invalid results when objects move during collection.
  * Improved handling of mutable `memoryview` subjects in regular-expression operations.
  * Standard JIT frame allocations now use nursery memory with consistent initialization.
  * Improved tracking of active garbage-collection roots during code analysis.

* **Diagnostics**
  * Added optional RSS memory tracing to the reachability example via `GC_RSS_TRACE`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->