### PR TITLE
codewriter, jit-trace: re-land the goto_if_not fusion with the four walker sites it needs

### DIFF
--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -337,7 +337,14 @@ fn is_bool_branch(block: &crate::model::Block) -> bool {
     matches!(cases, (Some(false), Some(true)) | (Some(true), Some(false)),)
 }
 
-fn bool_llexitcase(link: &Link) -> Option<bool> {
+/// The link's boolean exit case — `link.llexitcase` first, then
+/// `link.exitcase` for a direct semantic graph.
+///
+/// `jtransform::optimize_goto_if_not` reads the same fact to decide
+/// whether a block is the two-way boolean branch upstream identifies by
+/// `exitswitch.concretetype == lltype.Bool`, so both sides share this
+/// one reader rather than each spelling the source order themselves.
+pub(crate) fn bool_llexitcase(link: &Link) -> Option<bool> {
     match link.llexitcase.as_ref() {
         Some(ConstValue::Bool(value)) => return Some(*value),
         Some(_) => return None,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7387,7 +7387,28 @@ fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
         return false;
     }
     // `or v.concretetype != lltype.Bool: return False`
-    if v.concretetype() != Some(LowLevelType::Bool) {
+    //
+    // Read off the links when the type slot cannot answer.  Most graphs
+    // reach here with their kinds published through
+    // `FunctionGraph::set_concretetype_of_inline`, which canonicalises a
+    // `ConcreteType` back to one lltype apiece — and `getkind(Bool)` is
+    // `'i'`, so `concrete_to_canonical_lltype` stores a Bool-producing
+    // compare as `Signed` and the literal predicate rejects it.  The fact
+    // upstream's `lltype.Bool` stands for is that this block's two exits
+    // are the false and the true arm, which the links carry directly and
+    // which `flatten::is_bool_branch` independently requires before it
+    // will emit a two-way branch at all; both sides read it through
+    // `flatten::bool_llexitcase` so the two cannot drift.  Declining when
+    // neither witness holds leaves the block on the unfused
+    // `goto_if_not/iL`, which is what it takes today.
+    let exits_are_bool_pair = matches!(
+        (
+            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[0]),
+            crate::codewriter::flatten::bool_llexitcase(&graph.blocks[block_idx].exits[1]),
+        ),
+        (Some(false), Some(true)) | (Some(true), Some(false))
+    );
+    if v.concretetype() != Some(LowLevelType::Bool) && !exits_are_bool_pair {
         return false;
     }
 
@@ -7521,6 +7542,29 @@ fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::m
             ) =>
         {
             Some((op.clone(), vec![operand.clone()]))
+        }
+        // The truthify operator the front end emits for a condition that is
+        // not already a comparison.  `assembler::op_kind_to_opname_with_kinds`
+        // names it `int_is_true` for an `i` operand and `ptr_nonzero` for an
+        // `r` one, and that renaming runs after flatten -- so the
+        // `int_is_true` / `ptr_nonzero` arm above matches nothing the front
+        // end produces, the same gap the bare-comparison arm covers.  The
+        // fused exitswitch has to name the key the assembler will look up
+        // (`goto_if_not_int_is_true/iL`, `goto_if_not_ptr_nonzero/rL`), whose
+        // argcode comes from this operand's own register kind, so the two
+        // halves are resolved from one source here.
+        OpKind::UnaryOp { op, operand, .. } if op == "bool" => {
+            let opname = match FunctionGraph::concretetype_of(operand) {
+                crate::codewriter::type_state::ConcreteType::Signed => "int_is_true",
+                crate::codewriter::type_state::ConcreteType::GcRef => "ptr_nonzero",
+                // A Float operand is rewritten to `float_ne` against zero
+                // before reaching here, and an Unknown one takes
+                // `flatten::kind_color_of`'s fallback, which this cannot
+                // predict.  Naming the wrong half would build a key no
+                // handler is wired to, so decline and keep the unfused form.
+                _ => return None,
+            };
+            Some((opname.to_string(), vec![operand.clone()]))
         }
         _ => None,
     }
@@ -9026,6 +9070,152 @@ mod tests {
         assert!(row(&live).contains("1x"), "{}", row(&live));
         assert!(!row(&live).contains("INERT"), "{}", row(&live));
         assert!(row(&inert).contains("0x INERT"), "{}", row(&inert));
+    }
+
+    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType as LlType;
+
+    /// The shape production actually reaches this pass with: a truthify
+    /// (`OpKind::UnaryOp { op: "bool" }`) whose result carries `Signed`,
+    /// not `Bool`.  Both halves of the fuse have to hold — the two-way
+    /// branch has to be recognised from the links, and `"bool"` has to
+    /// resolve to the `int_is_true` the assembler will name.
+    #[test]
+    fn a_truthify_condition_over_an_int_fuses_as_int_is_true() {
+        let (mut graph, cond, operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
+        assert!(
+            super::optimize_goto_if_not(&mut graph, start),
+            "a truthify branch must fuse"
+        );
+        let block = &graph.blocks[start];
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "bool")),
+            "the fused truthify op must be removed"
+        );
+        match &block.exitswitch {
+            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(opname, "int_is_true");
+                assert_eq!(args, &vec![operand]);
+            }
+            other => panic!("expected a fused exitswitch, got {other:?}"),
+        }
+        let _ = cond;
+    }
+
+    /// The `r` half of the same resolution: `op_kind_to_opname_with_kinds`
+    /// names a truthify over a Ref operand `ptr_nonzero`, and
+    /// `goto_if_not_ptr_nonzero/rL` is the key that has to be built.
+    #[test]
+    fn a_truthify_condition_over_a_ref_fuses_as_ptr_nonzero() {
+        let (mut graph, _cond, operand, start) = truthify_fixture(
+            crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+            LlType::Signed,
+        );
+        assert!(super::optimize_goto_if_not(&mut graph, start));
+        match &graph.blocks[start].exitswitch {
+            Some(crate::model::ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(opname, "ptr_nonzero");
+                assert_eq!(args, &vec![operand]);
+            }
+            other => panic!("expected a fused exitswitch, got {other:?}"),
+        }
+    }
+
+    /// Control: an operand whose kind this pass cannot resolve takes
+    /// `flatten::kind_color_of`'s fallback, so naming a half here could
+    /// build a key with no handler.  It must decline, not guess.
+    #[test]
+    fn a_truthify_condition_over_an_unresolved_operand_declines() {
+        let (mut graph, _cond, _operand, start) = {
+            let (mut g, c, o, s) = truthify_fixture(LlType::Signed, LlType::Signed);
+            o.set_concretetype(None);
+            (g.clone(), c, o, s)
+        };
+        assert!(
+            !super::optimize_goto_if_not(&mut graph, start),
+            "an unresolved operand kind must decline the fuse"
+        );
+    }
+
+    /// Control: the link-side witness is what stands in for
+    /// `lltype.Bool`, so a two-way branch whose exits are not the false
+    /// and true arms must still decline.
+    #[test]
+    fn a_two_way_branch_without_bool_exitcases_declines() {
+        use crate::flowspace::model::ConstValue;
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        let (mut graph, cond, _operand, start) = truthify_fixture(LlType::Signed, LlType::Signed);
+        let targets: Vec<_> = graph.blocks[start]
+            .exits
+            .iter()
+            .map(|link| link.target)
+            .collect();
+        graph.set_control_flow_metadata(
+            crate::model::BlockId(start),
+            Some(ExitSwitch::Value(cond)),
+            vec![
+                Link::new_mixed(
+                    vec![],
+                    targets[0],
+                    Some(ExitCase::Const(ConstValue::Int(0))),
+                ),
+                Link::new_mixed(
+                    vec![],
+                    targets[1],
+                    Some(ExitCase::Const(ConstValue::Int(1))),
+                ),
+            ],
+        );
+        assert!(
+            !super::optimize_goto_if_not(&mut graph, start),
+            "an integer-cased two-way branch must decline the fuse"
+        );
+    }
+
+    /// `t = bool(x); exitswitch = t` with two bool-cased exits, the
+    /// concretetypes stamped as the caller asks.  Returns the graph, the
+    /// condition variable, the truthify operand, and the start block.
+    fn truthify_fixture(
+        operand_ty: LlType,
+        cond_ty: LlType,
+    ) -> (
+        FunctionGraph,
+        crate::flowspace::model::Variable,
+        crate::flowspace::model::Variable,
+        usize,
+    ) {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        let mut graph = FunctionGraph::new("goto_if_not_truthify");
+        let operand = graph.alloc_value_var();
+        operand.set_concretetype(Some(operand_ty));
+        let cond = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::UnaryOp {
+                    op: "bool".to_string(),
+                    operand: operand.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        // What production publishes: `getkind(Bool)` is `'i'`, so the
+        // canonicalising writer stores `Signed` here, never `Bool`.
+        cond.set_concretetype(Some(cond_ty));
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let start = graph.startblock.0;
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(cond.clone())),
+            vec![
+                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
+            ],
+        );
+        (graph, cond, operand, start)
     }
 
     /// the GotoIfNotOp lowering Stage 1: `int_lt(a, b); exitswitch = t` fuses into a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
@@ -93,10 +93,11 @@ pub(crate) fn resolve_branch_target_through_trampoline(code: &[u8], target: usiz
 /// capture rather than a mis-decode — the `Err("notgoto")` below propagates as
 /// `NO_JITCODE_PC`, and the encode self-cert refuses to tag a word whose
 /// reconstruction fails.
-/// The `L` label operand sits at index 1 (`iL`: 1B int reg, then 2B label) —
-/// the same index the `goto_if_not/iL` handler reads `target` from — re-read
-/// here from the re-derived `goto` so the arm-select is genuinely reconstructed
-/// from `orgpc` alone rather than reusing the capture-site op.
+/// The `L` label operand is the LAST one in every member of the family
+/// (`iL`, `iiL`, `rL`, `rrL`, `ffL`), so its index is one less than the
+/// argcode count — the same index the matching handler reads `target` from —
+/// re-read here from the re-derived `goto` so the arm-select is genuinely
+/// reconstructed from `orgpc` alone rather than reusing the capture-site op.
 pub(crate) fn decode_side_other_target(
     code: &[u8],
     orgpc: usize,
@@ -107,10 +108,10 @@ pub(crate) fn decode_side_other_target(
         return Err("notlive");
     }
     let goto = decode_op_at(code, live.next_pc).ok_or("notgoto")?;
-    if goto.opname != "goto_if_not" {
+    if !goto.opname.starts_with("goto_if_not") || !goto.argcodes.ends_with('L') {
         return Err("notgoto");
     }
-    let target = read_label(code, &goto, 1);
+    let target = read_label(code, &goto, goto.argcodes.len() - 1);
     let raw = if flavor_guard_true {
         target
     } else {
@@ -463,7 +464,14 @@ pub(crate) fn branch_arm_reads_unrestorable_ref(
             // arm's straight-line resume region.  A Ref read past such a
             // boundary belongs to a different resume coordinate that gets its
             // own guard check, so nothing unrestorable was found here.
-            "goto_if_not" | "jit_merge_point" | "loop_header" | "finish" | "leave_frame"
+            // Every `goto_if_not*` is a guard, and so a boundary: naming only
+            // the unfused spelling let a fused branch fall through to the
+            // operand walk below and carried the scan past the guard into a
+            // block that answers to a different resume coordinate.
+            name if name.starts_with("goto_if_not") => {
+                return false;
+            }
+            "jit_merge_point" | "loop_header" | "finish" | "leave_frame"
             | "rvmprof_code"
             // Return / raise terminators: the arm exits the jitcode entirely.
             // No further Ref reads to check.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4402,9 +4402,14 @@ pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool
         }
         match op.key {
             "goto/L" => work.push(read_label(code, &op, 0)),
-            "goto_if_not/iL" => {
-                // `iL`: 1B int register + 2B LE label.
-                work.push(read_label(code, &op, 1));
+            // Every member of the family spells its label as the FINAL
+            // operand (`iL`, `iiL`, `rL`, `rrL`, `ffL`), so the operand index
+            // is one less than the argcode count -- 1 for the plain `iL` this
+            // used to hard-code.  Naming a single key here left a fused
+            // branch's taken arm off the worklist, which this walk reads as
+            // "that block is unreachable" rather than as a decline.
+            key if key.starts_with("goto_if_not") && op.argcodes.ends_with('L') => {
+                work.push(read_label(code, &op, op.argcodes.len() - 1));
                 work.push(op.next_pc);
             }
             key if key.starts_with("switch") => {
@@ -12079,9 +12084,21 @@ fn handle<Sym: WalkSym>(
                 if jump { target } else { op.next_pc },
             ))
         }
-        // Same shape with one operand; `goto_if_not_int_is_true` has no arm
-        // because the assembler spells that condition as plain `goto_if_not`,
-        // matching the class-attribute alias upstream gives it.
+        // Same shape with one operand.  `pyjitpl.py`
+        // `opimpl_goto_if_not_int_is_true` and `opimpl_goto_if_not_int_is_zero`
+        // each `self.execute` their unary and hand the fresh condbox to
+        // `opimpl_goto_if_not(..., replace=False)`, so each records its own op
+        // instead of branching on the value.
+        //
+        // Only `blackhole.py` aliases the pair
+        // (`bhimpl_goto_if_not_int_is_true = bhimpl_goto_if_not`).  The walker
+        // is the metainterp side, where the difference is observable twice
+        // over: the plain arm records no `int_is_true`, and its `replace`
+        // rewrites the *value* box to a constant -- for the fused form that box
+        // is `x`, not the boolean the branch tested.
+        "goto_if_not_int_is_true/iL" => {
+            fused_goto_if_not_int_unary(code, op, ctx, OpCode::IntIsTrue)
+        }
         "goto_if_not_int_is_zero/iL" => {
             fused_goto_if_not_int_unary(code, op, ctx, OpCode::IntIsZero)
         }


### PR DESCRIPTION
Re-lands `0dacccbfe2d`, the `optimize_goto_if_not` fusion that #1664 measured,
found green in the shipped jitcode and then backed out because it broke the
JIT. The revert was right about the symptom and wrong about the cause: the
fusion is fine, and four walker sites did not know the opname it produces.

## Why the revert was necessary, and what it actually was

The revert recorded `pyre/check.py --backend dynasm` at **478 passed / 60
failed** with the fusion against 535 / 3 without, with this signature across
the 57 it added:

* `loops_aborted 0 -> N`, `loops_compiled` down,
  `fbw_blackhole_adopted_single_frame 0 -> N`
* `pyre/bench/synth/listcomp_hot.py` raising
  `TypeError: 'int' object is not an iterator` from `for j in range(n)`

That is the same signature as the `int_is_zero` walker gap fixed in #1664, and
the same cause. `goto_if_not_int_is_true/iL` is its own byte
(`BC_GOTO_IF_NOT_INT_IS_TRUE` = 15, against `BC_GOTO_IF_NOT` = 18), and pyre's
walker matches on the **key string**, not the byte. The fusion put 9284 of that
key into the shipped jitcodes; every site naming only the unfused spelling
stopped recognizing the branch.

## Four sites — and two of them compare the bare opname

Searching for the full key `"goto_if_not/iL"` finds two. Two more compare
`op.opname` *without* argcodes, which is why the revert's own investigation
("`body_branch_targets` decodes any `L` argcode") cleared the scans wrongly:

| site | what it does | what missing the key does |
| --- | --- | --- |
| `jitcode_dispatch/mod.rs` dispatch | the arm | `UnsupportedOpname`, walk aborts mid-body |
| `jitcode_dispatch/mod.rs` reachability scan (`op.key`) | enqueues branch targets | the taken arm never reaches the worklist, which reads as an unreachable block |
| `branch.rs decode_side_other_target` (`op.opname`) | rebuilds a guard's not-taken arm from `orgpc` | `Err("notgoto")` |
| `branch.rs branch_arm_reads_unrestorable_ref` (`op.opname`) | straight-line boundary | the scan runs past the guard into a block belonging to another resume coordinate |

The three non-dispatch sites now recognize the family by prefix and read the
label as the **final** operand, which every member spells the same way (`iL`,
`iiL`, `rL`, `rrL`, `ffL`), so the index is `argcodes.len() - 1`.

## The dispatch arm is not an alias of the plain one

`blackhole.py` aliases them — `bhimpl_goto_if_not_int_is_true =
bhimpl_goto_if_not` — and the walker's old comment cited exactly that alias as
the reason it needed no arm. But the walker is the metainterp side, and
`pyjitpl.py opimpl_goto_if_not_int_is_true` executes `rop.INT_IS_TRUE` and
hands the fresh condbox to `opimpl_goto_if_not(..., replace=False)`. Routing
the fused key to the plain arm would record no `int_is_true` **and** let
`replace` rewrite the value box to a constant — and for the fused form that box
holds `x`, not the boolean the branch tested. So it uses
`fused_goto_if_not_int_unary(.., OpCode::IntIsTrue)`, the exact sibling of the
existing `int_is_zero` arm.

## Measured

Counting `body.code[pos]` for every `pos in body.startpoints` across the
shipped `jit_metadata.json`:

| | before | after | delta |
| --- | ---: | ---: | ---: |
| total instructions | 152,888 | 142,164 | **−10,724 (−7.0%)** |
| `goto_if_not/iL` | 9,284 | 0 | −9,284 |
| `goto_if_not_int_is_true/iL` | 0 | 9,284 | +9,284 |
| standalone `int_is_true/i>i` | 9,348 | **80** | **−9,268** |
| `live/` | 31,726 | 30,052 | **−1,674** |
| `ptr_ne/rr>i` → `goto_if_not_ptr_ne/rrL` | 228 / 8 | 213 / 23 | −15 / +15 |

9,268 standalone `int_is_true` ops disappear along with the 1,674 `-live-`
markers that preceded them, and each frees its destination register.
`jit_metadata.json` is 726 KB smaller.

## Gates

* `pyre/check.py --backend dynasm` — **541 / 541 ALL PASSED**
* `pyre/check.py --backend cranelift` — **541 / 541 ALL PASSED**

Both runs report **no `jit-stats change` at all**: the counters the `.jitstats`
sidecars record did not move, so nothing needed `--snapshot` despite the 7%
instruction cut. The one `within band (not gated)` line
(`synth/foriter_load_special_with`) is present on the base too.

**Runtime is not claimed here.** The static reduction above is deterministic;
the local bench ratios were taken under a loaded machine on the "before" side
and are not a measurement. The CI `pyre/check.py` jobs on this PR against
main's own run at `de7e1a70159` are the apples-to-apples comparison.

— *authored by Claude*
