### PR TITLE
interp: drop format_value_dispatch_w, which the object path left callerless

### DIFF
--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3152,32 +3152,8 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, c
     }
 }
 
-/// `PyObject_Format` returning the formatted object rather than its bytes.
-///
-/// `format_string` (newformat.py) hands the receiver's own utf8
-/// storage to `self.wrap(...)` once `_parse_spec("s", "<")` reports the
-/// defaults — which only an empty spec does — so `format(s, "")` shares its
-/// operand's storage and `is_w` (unicodeobject.py) reports the result
-/// identical to `s`.  An exact `str` is the whole of that case: a subclass is
-/// converted by `space.str(w_string)` (newformat.py) to a fresh base
-/// `str` first, and `is_w` rejects a `user_overridden_class` operand anyway
-/// (unicodeobject.py:106).  Any other receiver, or any non-empty spec, builds
-/// a new string through [`format_value_dispatch`].
-pub fn format_value_dispatch_w(
-    val: PyObjectRef,
-    spec: &Wtf8,
-) -> Result<PyObjectRef, crate::PyError> {
-    if spec.is_empty() && unsafe { pyre_object::is_exact_type(val, &pyre_object::STR_TYPE) } {
-        return Ok(val);
-    }
-    Ok(pyre_object::w_str_from_wtf8_managed(format_value_dispatch(
-        val, spec,
-    )?))
-}
-
-/// `space.format(w_obj, w_format_spec)` (descroperation.py:399) — the
-/// object-to-object form of [`format_value_dispatch_w`], for the callers that
-/// already hold the spec as an object.
+/// `space.format(w_obj, w_format_spec)` (descroperation.py:399) — `PyObject_Format`
+/// returning the formatted object rather than its bytes.
 ///
 /// Upstream threads the spec from the caller to `__format__` and returns
 /// `w_res` unchanged, so nothing is rebuilt at either end.  Going through a
@@ -3196,6 +3172,14 @@ pub fn format_w(val: PyObjectRef, w_spec: PyObjectRef) -> Result<PyObjectRef, cr
 
     // The empty-spec fast paths of `format_value_dispatch`: an exact `str` or
     // `int` cannot carry a `__format__` override, so resolve and call nothing.
+    // `format_string` (newformat.py) hands the receiver's own utf8 storage to
+    // `self.wrap(...)` once `_parse_spec("s", "<")` reports the defaults —
+    // which only an empty spec does — so `format(s, "")` shares its operand's
+    // storage and `is_w` (unicodeobject.py) reports the result identical to
+    // `s`.  An exact `str` is the whole of that case: a subclass is converted
+    // by `space.str(w_string)` (newformat.py) to a fresh base `str` first, and
+    // `is_w` rejects a `user_overridden_class` operand anyway
+    // (unicodeobject.py:106).
     if spec_is_empty {
         if unsafe { pyre_object::is_exact_type(val, &pyre_object::STR_TYPE) } {
             return Ok(val);
@@ -3302,7 +3286,7 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     if spec.is_empty() {
         // `format_string` (newformat.py) wraps the receiver's own utf8
         // storage when the spec parses to the defaults, so an exact `str`
-        // comes back identical (see [`format_value_dispatch_w`]).
+        // comes back identical (see [`format_w`]).
         if unsafe { pyre_object::is_exact_type(args[0], &pyre_object::STR_TYPE) } {
             return Ok(args[0]);
         }


### PR DESCRIPTION
Follow-up to #1673, from auditing whether that PR covered every path.

#1673 rewired `runtime_ops::format_value` (FORMAT_SIMPLE, FORMAT_WITH_SPEC and
both JIT residuals), the `format()` builtin and `PyObject_Format` onto
`format_w`. Those were `format_value_dispatch_w`'s only three callers, and
nothing else in the tree names it:

```
$ git grep -n 'format_value_dispatch_w' -- '*.rs'
pyre/pyre-interpreter/src/type_methods.rs:  (definition + two doc references)
```

It is `pub`, so no dead-code warning fires, and what it still contains is the
byte round trip `format_w` was added to remove — a caller added later would
silently inherit the three wrong answers #1673 fixed (spec argument identity,
result identity, `str` subclass result).

Removed rather than left standing. The `format(s, "")` identity reasoning its
doc carried moves onto the empty-spec fast path in `format_w`, which owns that
case now, and `builtin_value_format`'s reference is repointed.

`cargo check` clean.

## What the audit found still standing (not changed here)

Every route that reaches `__format__`:

| route | shape | state |
|---|---|---|
| `format()`, f-strings, `PyObject_Format`, JIT residuals | object → object | fixed in #1673 |
| weakref `proxy_format` → `forward_to_dunder` | object → object | already correct |
| `str.format` field builder, import machinery | bytes → bytes | unchanged, see below |

`str.format`'s field builder appends into a buffer, so the result object is
never handed back. That is observable, and it is a place the two upstreams
disagree rather than a place pyre is simply wrong:

```python
class MyStr(str): pass
R = MyStr("res")
class P:
    def __format__(self, spec): return R

"{}".format(P())        # CPython 3.14.2: R itself, type MyStr
                        # PyPy 7.3.23:    a fresh str
"{}{}".format(P(), "")  # both: a fresh str
f"{P()}"                # both: R itself  -- this is what #1673 fixed
```

CPython returns the field's own object only when the format string is exactly
one replacement field and nothing else; pypy never does. pyre matches pypy
here. Worth a decision of its own, so it is left alone in this PR.

— *authored by Claude*
