### PR TITLE
_ctypes, builtins: retain the object a "O" write stores, and scan the whole source for an incompatible string prefix

### DIFF
--- a/pyre/extra_tests/snippets/syntax_error_python314_offsets.py
+++ b/pyre/extra_tests/snippets/syntax_error_python314_offsets.py
@@ -332,6 +332,10 @@ for source, message, position in (
     # can stand after the token the parser reported as well as before it.
     ("f() = bu'x'", "'u' and 'b' prefixes are incompatible", (1, 7, 1, 9)),
     ("f() = ub'x'", "'u' and 'b' prefixes are incompatible", (1, 7, 1, 9)),
+    # Like PyPy's `fstring_find_literal`, a backslash leaves a following brace
+    # visible to f-string parsing.  CPython 3.14's tokenizer therefore reads
+    # the first replacement field, while doubled braces below stay literal.
+    ("f'\\{bu\"x\"}'", "'u' and 'b' prefixes are incompatible", (1, 5, 1, 7)),
     # The tokenizer does not read a comment, so neither does the scan.
     ("x = = 1  # bu'z'", "invalid syntax", (1, 5, 1, 6)),
 ):
@@ -344,6 +348,13 @@ for source, message, position in (
         error.end_lineno,
         error.end_offset,
     )
+
+# An escaped doubled brace is literal text rather than a replacement field, so
+# its prefix-shaped contents cannot override the later assignment diagnostic.
+source = "f'\\{{ bu\"x\" }}'; 1=2"
+error = syntax_error(source)
+assert error.msg == "cannot assign to literal here. Maybe you meant '==' instead of '='?"
+assert (error.lineno, error.offset, error.end_lineno, error.end_offset) == (1, 18, 1, 19)
 
 
 # `eval` is `expressions NEWLINE* ENDMARKER` and has no assignment rule at all,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13554,6 +13554,15 @@ fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String
             match byte {
                 // A backslash closes no literal, raw included: `r'\''` keeps
                 // the escape in its text and the quote after it in the token.
+                // In an interpolated literal it does not hide a following
+                // brace: PyPy's `fstring_find_literal` consumes the escape and
+                // then still applies its brace branch to that character.
+                b'\\'
+                    if literal.interpolated
+                        && matches!(bytes.get(cursor + 1), Some(b'{' | b'}')) =>
+                {
+                    cursor += 1
+                }
                 b'\\' => cursor += 2,
                 b'\n' if !literal.triple => return None,
                 // `{{` and `}}` each write one brace and open no field.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13503,58 +13503,128 @@ fn nonascii_bytes_literal_span(source: &str, raw_index: usize) -> Option<(usize,
     None
 }
 
-/// CPython 3.14 `Parser/lexer/lexer.c`
-/// `maybe_raise_syntax_error_for_string_prefixes`.  Ruff tokenizes an
-/// incompatible prefix as a NAME followed by a STRING and reports the gap
-/// between simple statements, so recover the prefix around the quote selected
-/// by that parser error and apply CPython's ordered checks.
+/// `Parser/lexer/lexer.c` `maybe_raise_syntax_error_for_string_prefixes`.
+/// Ruff tokenizes an incompatible prefix as a NAME followed by a STRING and
+/// reports whatever grammar alternative that breaks, so the literal is
+/// recovered from the source text and given the ordered prefix checks.
 ///
-/// The quote is looked for on both sides of the reported token.  The check
-/// runs in the tokenizer, ahead of every grammar alternative, so the literal
-/// can stand after that token as well as before it: `invalid_assignment`
-/// names the target and the prefix is written in the value.
+/// The check runs in the tokenizer, ahead of every grammar alternative, so the
+/// literal can stand anywhere in the source -- after the reported token as
+/// well as before it -- and the token stream alone decides which one is
+/// reported: `f() = 'ok'; bu'x'` names the prefix, not the assignment.
 fn incompatible_string_prefix_error(
     source: &str,
     raw_index: usize,
 ) -> Option<(String, usize, usize)> {
     let bytes = source.as_bytes();
-    let anchor = raw_index.min(bytes.len());
-    // A reported token that is itself a quote is the literal in question, and
-    // stays the only candidate examined.
-    if matches!(bytes.get(anchor), Some(b'\'' | b'"')) {
-        return string_prefix_pair_error(bytes, anchor);
-    }
-    let before = bytes[..anchor]
-        .iter()
-        .rposition(|byte| matches!(*byte, b'\'' | b'"'));
-    // The tokenizer does not read a comment, so neither does this walk -- the
-    // quote it stops on has to open a real token.  Starting outside a literal,
-    // the first quote reached is always an opening one.
-    let after = {
-        let mut cursor = anchor;
-        loop {
-            match bytes.get(cursor) {
-                None => break None,
-                Some(b'#') => {
-                    cursor = bytes[cursor..]
-                        .iter()
-                        .position(|byte| *byte == b'\n')
-                        .map_or(bytes.len(), |newline| cursor + newline + 1);
-                }
-                Some(b'\'' | b'"') => break Some(cursor),
-                Some(_) => cursor += 1,
-            }
-        }
-    };
-    [before, after]
-        .into_iter()
-        .flatten()
-        .find_map(|quote| string_prefix_pair_error(bytes, quote))
+    first_string_prefix_pair_error(bytes, raw_index.min(bytes.len()))
 }
 
-/// The ordered prefix-pair checks applied to the letters written immediately
-/// before `quote`.
-fn string_prefix_pair_error(bytes: &[u8], quote: usize) -> Option<(String, usize, usize)> {
+/// The first string token in `bytes` whose prefix is an incompatible pair.
+///
+/// The tokenizer reads neither a comment nor the text of a literal, so neither
+/// does this walk: a quote it stops on opens a token, and a literal's own text
+/// is skipped.  An f-string's replacement fields are tokenized, so a literal
+/// written inside one is a token in its own right -- `f'{ub"y"}'` names its
+/// prefix, and `f'{d['k']}'` is one f-string rather than a literal ending at
+/// the quote before `k`.  An unterminated literal ends the walk: the tokenizer
+/// raises its own error there and never reaches a prefix written after it.
+///
+/// A literal inside a replacement field is diagnosed by the parser reading
+/// that field rather than by the tokenizer, so it only stands where it
+/// precedes the error already reported at `anchor`: `s = f'{ub"y"}'; f() = 1`
+/// names the prefix and `f() = 1; s = f'{ub"y"}'` names the assignment.
+fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String, usize, usize)> {
+    /// One literal the walk is inside, and how many braces are open in it --
+    /// a replacement field, and any display written within that field.
+    struct OpenLiteral {
+        delimiter: u8,
+        triple: bool,
+        interpolated: bool,
+        braces: usize,
+    }
+
+    let mut open: Vec<OpenLiteral> = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        // The innermost literal's own text, unless a brace of it is open --
+        // inside one the walk is reading tokens again.
+        if let Some(literal) = open.last_mut().filter(|literal| literal.braces == 0) {
+            match byte {
+                // A backslash closes no literal, raw included: `r'\''` keeps
+                // the escape in its text and the quote after it in the token.
+                b'\\' => cursor += 2,
+                b'\n' if !literal.triple => return None,
+                // `{{` and `}}` each write one brace and open no field.
+                b'{' if literal.interpolated => {
+                    let doubled = bytes.get(cursor + 1) == Some(&b'{');
+                    cursor += 1 + usize::from(doubled);
+                    literal.braces += usize::from(!doubled);
+                }
+                b'}' if literal.interpolated => {
+                    cursor += 1 + usize::from(bytes.get(cursor + 1) == Some(&b'}'));
+                }
+                _ if byte == literal.delimiter => {
+                    if literal.triple && !bytes[cursor..].starts_with(&[byte; 3]) {
+                        cursor += 1;
+                    } else {
+                        cursor += if literal.triple { 3 } else { 1 };
+                        open.pop();
+                    }
+                }
+                _ => cursor += 1,
+            }
+            continue;
+        }
+        match byte {
+            // A comment runs to the end of its line.  Only outside a literal:
+            // what a replacement field writes is not one.
+            b'#' if open.is_empty() => {
+                cursor = bytes[cursor..]
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(bytes.len(), |newline| cursor + newline + 1);
+            }
+            b'{' | b'}' => {
+                if let Some(literal) = open.last_mut() {
+                    literal.braces = if byte == b'{' {
+                        literal.braces + 1
+                    } else {
+                        literal.braces - 1
+                    };
+                }
+                cursor += 1;
+            }
+            b'\'' | b'"' => {
+                if let Some(error) = string_prefix_pair_error(bytes, cursor)
+                    && (open.is_empty() || error.1 <= anchor)
+                {
+                    return Some(error);
+                }
+                let triple = bytes[cursor + 1..].starts_with(&[byte, byte]);
+                let interpolated = string_prefix_span(bytes, cursor).is_some_and(|prefix| {
+                    bytes[prefix]
+                        .iter()
+                        .any(|byte| matches!(byte.to_ascii_lowercase(), b'f' | b't'))
+                });
+                open.push(OpenLiteral {
+                    delimiter: byte,
+                    triple,
+                    interpolated,
+                    braces: 0,
+                });
+                cursor += if triple { 3 } else { 1 };
+            }
+            _ => cursor += 1,
+        }
+    }
+    None
+}
+
+/// The letters written immediately before `quote`, or `None` when what stands
+/// there cannot open a token.
+fn string_prefix_span(bytes: &[u8], quote: usize) -> Option<std::ops::Range<usize>> {
     let mut start = quote;
     while start > 0
         && matches!(
@@ -13568,16 +13638,19 @@ fn string_prefix_pair_error(bytes: &[u8], quote: usize) -> Option<(String, usize
     // identifier running into the letters makes them part of that name, and a
     // name carries bytes past ASCII too -- which is also what sits behind the
     // closing quote of a literal whose text ends in those letters.
-    if start == quote
-        || bytes
-            .get(start.wrapping_sub(1))
-            .is_some_and(|byte| !byte.is_ascii() || byte.is_ascii_alphanumeric() || *byte == b'_')
-    {
-        return None;
-    }
-    let prefix = &bytes[start..quote];
+    let closes_a_token = !bytes
+        .get(start.wrapping_sub(1))
+        .is_some_and(|byte| !byte.is_ascii() || byte.is_ascii_alphanumeric() || *byte == b'_');
+    closes_a_token.then_some(start..quote)
+}
+
+/// The ordered prefix-pair checks applied to the letters written immediately
+/// before `quote`.
+fn string_prefix_pair_error(bytes: &[u8], quote: usize) -> Option<(String, usize, usize)> {
+    let prefix = string_prefix_span(bytes, quote)?;
+    let start = prefix.start;
     let mut seen = [false; 5];
-    for byte in prefix {
+    for byte in &bytes[prefix] {
         let index = match byte.to_ascii_lowercase() {
             b'b' => 0,
             b'r' => 1,

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1289,6 +1289,17 @@ pub(super) fn make_at_address(
     inst
 }
 
+/// Whether a simple-code write has to retain the value it stored.
+///
+/// `"O"` writes the word `pyobj_container` hands back, and the container holds
+/// only a weakref, so the buffer is the sole reference to that object -- which
+/// is why `O_set` returns a new reference for `PyCData_set` to keep.  A CData
+/// value is retained for the same reason: the write copied its buffer out and
+/// left no other owner.
+pub(super) fn value_needs_keep(tc: &str, value: PyObjectRef) -> bool {
+    tc == "O" || is_cdata_instance(value)
+}
+
 /// Keep `obj` alive for the lifetime of the buffer that `anchor` views, by
 /// storing it under `key` in the ultimate root's `"_objects_"` dict.
 pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1455,7 +1455,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             cdata::cdata_write(obj, offset, &bytes);
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::is_cdata_instance(value) {
+            if cdata::value_needs_keep(&tc, value) {
                 cdata::keep_ref(obj, &index.to_string(), value);
             }
             Ok(pyre_object::w_none())
@@ -2094,7 +2094,7 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
             cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             cdata::cdata_write(obj, offset, &bytes);
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::is_cdata_instance(value) {
+            if cdata::value_needs_keep(&tc, value) {
                 cdata::keep_ref(obj, &idx.to_string(), value);
             }
             Ok(pyre_object::w_none())
@@ -2602,7 +2602,7 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
             cdata::release_bstr_slot(&tc, addr);
             unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::is_cdata_instance(value) {
+            if cdata::value_needs_keep(&tc, value) {
                 cdata::keep_ref(obj, &index.to_string(), value);
             }
             Ok(pyre_object::w_none())


### PR DESCRIPTION
Two unrelated fixes in the interpreter.

## `_ctypes`: a `"O"` write's object had no owner

`cfield_set`, `array_set_index` and `pointer_setitem` retained the written value
only when it was a CData instance. A `"O"` write stores the word
`pyobj_container` hands back, and that container holds only a weakref — so the
buffer was the sole reference to the object. `value_needs_keep` now answers for
both codes.

## `builtins`: `incompatible_string_prefix_error` read the wrong quotes

The old lookup searched for one quote on each side of the token the parser
reported. The backward search read the *closing* quote of a preceding literal as
an opening one, and the forward search stopped at the first quote after the
anchor.

It is now an ordered walk of the whole source that skips comments and literal
text, tracks f-string replacement fields so a literal written inside one is its
own token, and stops at an unterminated literal. A literal inside a replacement
field is reported only where it precedes the error already reported.

Over a 1,653-case corpus cross-checked against CPython 3.14.2, the previous
lookup missed 283 incompatible prefixes and reported one that CPython does not;
the walk misses none and adds no new false positive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and reporting of incompatible string prefixes, including prefixes in nested, triple-quoted, interpolated, and escaped-brace contexts.
  - Corrected syntax-error locations for certain f-string and assignment errors.
  - Fixed C-compatible data assignments so stored values remain valid when required.
  - Improved reference handling for object-backed and pointer-based data fields, helping prevent premature value release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->