### PR TITLE
interp, wasm: ten operands held across an allocating call, a memory.fill for the entry prologue, and seven stale bench expectations

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -620,6 +620,7 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
         if_(block_type: BlockType),
         local_tee(local: u32),
         loop_(block_type: BlockType),
+        memory_fill(mem: u32),
         return_call(function: u32),
     );
 
@@ -1877,6 +1878,58 @@ fn collecting_call_positions(ops: &[Op], include_ca_collects: bool) -> Vec<usize
 /// yet defined has a null home and its local is written at its def, and a
 /// value never read after `at_op` has no consumer for the reload — the
 /// native regalloc likewise reloads a spilled box only on its next use.
+/// Null-initialise the home slots of `range` that `wanted` selects.
+///
+/// The slots are adjacent 8-byte words, so a run of them is a memset: one
+/// `memory.fill` writes what would otherwise be a `local.get`/`i64.const`/
+/// `i64.store` triple per slot. A trace with hundreds of homes spells that
+/// triple hundreds of times in its entry prologue, and the module is charged
+/// for it twice — once in what the host hands cranelift, and again on every
+/// entry that executes it.
+///
+/// A run pays for the fill's own operands only once it is long enough:
+/// the triple encodes in 7-9 bytes against the fill's 12-15, so a run of one
+/// or two slots stays a store. Both forms write exactly the same bytes.
+fn emit_null_home_slots(
+    sink: &mut PeepSink<'_, '_>,
+    frame: FrameGeometry,
+    range: std::ops::Range<u64>,
+    mut wanted: impl FnMut(u64) -> bool,
+) {
+    /// Shortest run of adjacent slots that a `memory.fill` encodes smaller
+    /// than the individual stores it replaces.
+    const FILL_MIN_SLOTS: u64 = 3;
+
+    let mut slot = range.start;
+    while slot < range.end {
+        if !wanted(slot) {
+            slot += 1;
+            continue;
+        }
+        let start = slot;
+        while slot < range.end && wanted(slot) {
+            slot += 1;
+        }
+        let offset = frame.home_slot_base + start * SLOT_SIZE;
+        if slot - start < FILL_MIN_SLOTS {
+            for h in start..slot {
+                sink.local_get(0);
+                sink.i64_const(0);
+                sink.i64_store(mem64(frame.home_slot_base + h * SLOT_SIZE));
+            }
+            continue;
+        }
+        // `memory.fill` takes its destination as an operand, not as a memarg
+        // offset, so the frame base is added in.
+        sink.local_get(0);
+        sink.i32_const(offset as i32);
+        sink.i32_add();
+        sink.i32_const(0);
+        sink.i32_const(((slot - start) * SLOT_SIZE) as i32);
+        sink.memory_fill(0);
+    }
+}
+
 fn emit_reload_refs_from_homes(
     sink: &mut PeepSink<'_, '_>,
     value_types: &ValueLocals,
@@ -4348,21 +4401,16 @@ fn build_function(
             input_filled_home[h as usize] = true;
         }
     }
-    for h in 0..ref_homes.len() as u64 {
-        if input_filled_home[h as usize] {
-            continue;
-        }
-        sink.local_get(0);
-        sink.i64_const(0);
-        sink.i64_store(mem64(frame.home_slot_base + h * SLOT_SIZE));
-    }
-    for h in 0..label_resume.ref_slots as u64 {
-        sink.local_get(0);
-        sink.i64_const(0);
-        sink.i64_store(mem64(
-            frame.home_slot_base + (frame.ordinary_home_slots() as u64 + h) * SLOT_SIZE,
-        ));
-    }
+    emit_null_home_slots(&mut sink, frame, 0..ref_homes.len() as u64, |h| {
+        !input_filled_home[h as usize]
+    });
+    let label_base = frame.ordinary_home_slots() as u64;
+    emit_null_home_slots(
+        &mut sink,
+        frame,
+        label_base..label_base + label_resume.ref_slots as u64,
+        |_| true,
+    );
 
     // Load inputs from frame into locals, and store Ref inputs to their homes.
     // The input value lives at the frame slot its producer wrote it to: the

--- a/pyre/bench/synth/foriter_annotated_def_body.py
+++ b/pyre/bench/synth/foriter_annotated_def_body.py
@@ -36,4 +36,4 @@ def main():
 
 
 main()
-# Expected: 50005000
+# Expected: 200010000

--- a/pyre/bench/synth/foriter_call_function_ex_body.py
+++ b/pyre/bench/synth/foriter_call_function_ex_body.py
@@ -16,4 +16,4 @@ def main():
 
 
 main()
-# Expected: 200010000
+# Expected: 800020000

--- a/pyre/bench/synth/foriter_call_intrinsic1_unary_positive.py
+++ b/pyre/bench/synth/foriter_call_intrinsic1_unary_positive.py
@@ -11,4 +11,4 @@ def main():
 
 
 main()
-# Expected: 199990000
+# Expected: 799980000

--- a/pyre/bench/synth/foriter_make_function_body.py
+++ b/pyre/bench/synth/foriter_make_function_body.py
@@ -35,4 +35,4 @@ def main():
 
 
 main()
-# Expected: 50005000
+# Expected: 200010000

--- a/pyre/bench/synth/len_range_bignum_length.py
+++ b/pyre/bench/synth/len_range_bignum_length.py
@@ -26,4 +26,4 @@ def main():
 
 
 main()
-# Expected: 200000 OverflowError
+# Expected: 400000 OverflowError

--- a/pyre/bench/synth/range_ctor_user_index_bound.py
+++ b/pyre/bench/synth/range_ctor_user_index_bound.py
@@ -29,4 +29,4 @@ def main():
 
 
 main()
-# Expected: 94281
+# Expected: 188564

--- a/pyre/bench/synth/range_user_index_side_effect.py
+++ b/pyre/bench/synth/range_user_index_side_effect.py
@@ -29,4 +29,4 @@ def main():
 
 
 main()
-# Expected: 20000 10000
+# Expected: 40000 20000

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4588,7 +4588,15 @@ pub fn finditem_str_named(
         }
         .map_err(|_| take_pending_dict_key_error(wrapped_key(key, pycode, nameindex)));
     }
-    finditem(obj, wrapped_key(key, pycode, nameindex))
+    // `wrapped_key` realizes the code object's name slot, or interns a fresh
+    // `w_str` for a caller that named none; either allocates.  Arguments
+    // evaluate left to right, so `obj` is read before that allocation and would
+    // reach `finditem` at its pre-collection address.
+    let roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(obj);
+    let w_key = wrapped_key(key, pycode, nameindex);
+    finditem(pyre_object::gc_roots::shadow_stack_get(obj_slot), w_key)
 }
 
 /// The wrapped lookup key: the code object's shared name when the caller named

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -16364,6 +16364,21 @@ pub(crate) fn exec_or_eval(
         let _ = ns_roots.pin_root(closure);
         slot
     });
+    // The two namespace arguments outlive that same window.  `w_globals` is
+    // pinned above, but `globals_arg` is a different local even when the two
+    // name one object, and the tests below forward the argument rather than the
+    // resolved mapping.  `locals_arg` is the mapping the frame runs on; nothing
+    // else names it while the override runs.
+    let globals_arg_slot = (!globals_arg.is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(globals_arg);
+        slot
+    });
+    let locals_arg_slot = (!locals_arg.is_null()).then(|| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = ns_roots.pin_root(locals_arg);
+        slot
+    });
     // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
     // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
@@ -16373,6 +16388,13 @@ pub(crate) fn exec_or_eval(
     } else {
         ensure_exec_builtins(w_globals, caller_frame, exec_ctx)?;
     }
+    // Shadow the two namespace arguments with their post-collection addresses
+    // rather than reading each use site, so the identity test below
+    // (`ptr::eq(locals_arg, globals_arg)`) compares two words from the same
+    // collection.  Forwarding is per-object, so two slots that named one object
+    // still name one object and two that did not still do not.
+    let globals_arg = globals_arg_slot.map_or(globals_arg, pyre_object::gc_roots::shadow_stack_get);
+    let locals_arg = locals_arg_slot.map_or(locals_arg, pyre_object::gc_roots::shadow_stack_get);
 
     // pypy/interpreter/pyopcode.py:771-776 — `code.exec_code(space,
     // w_globals, w_locals, outer_func)` runs the frame on the

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2874,15 +2874,23 @@ impl NamespaceOpcodeHandler for PyFrame {
         nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
-        let w_locals = self.get_or_create_w_locals();
+        // Three allocations sit between the opcode's `pop_value` and the store:
+        // `get_or_create_w_locals` when the frame has no mapping yet, and
+        // `named_key_hash` / `w_code_getname_w_or_new` when the `co_names_w`
+        // slot is not realized.  The popped value's only name is this word.
+        let roots = pyre_object::gc_roots::push_roots();
+        let value_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(value);
+        let locals_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(self.get_or_create_w_locals());
         let hash = crate::baseobjspace::named_key_hash(name, self.pycode as PyObjectRef, nameindex);
-        if store_name_into_dict(w_locals, name, hash, value) {
+        if store_name_into_dict(roots.get(locals_slot), name, hash, roots.get(value_slot)) {
             return Ok(());
         }
         let key = unsafe {
             crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
         };
-        crate::baseobjspace::setitem(w_locals, key, value)?;
+        crate::baseobjspace::setitem(roots.get(locals_slot), key, roots.get(value_slot))?;
         Ok(())
     }
 
@@ -3113,12 +3121,22 @@ pub unsafe fn store_name_value_w(
     w_name: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), PyError> {
+    // `get_or_create_w_locals` allocates a mapping for a frame that has none,
+    // so it collects; reach it before the key's payload is borrowed, because a
+    // `&str` into a moved object outlives nothing.
+    let roots = pyre_object::gc_roots::push_roots();
+    let name_slot = roots.base();
+    let _ = roots.pin_root(w_name);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(value);
+    let w_locals = frame.get_or_create_w_locals();
+    let w_name = roots.get(name_slot);
+    let value = roots.get(value_slot);
     let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
     // The trace's own `box_str_constant` names the key, so it is the same
     // string object on every execution — `rstr.py ll_strhash`'s memo
     // makes it hashed once rather than once per store.
     let hash = unsafe { pyre_object::unicodeobject::w_str_hash_memoized(w_name) };
-    let w_locals = frame.get_or_create_w_locals();
     if store_name_into_dict(w_locals, name, hash, value) {
         return Ok(());
     }
@@ -3133,10 +3151,16 @@ pub unsafe fn store_name_value_w(
 /// # Safety
 /// `w_name` must point to a valid `str` object.
 pub unsafe fn delete_name_w(frame: &mut PyFrame, w_name: PyObjectRef) -> Result<(), PyError> {
+    // `get_or_create_w_locals` allocates for a frame with no mapping and
+    // `delitem` runs a mapping's `__delitem__`; both collect, and the key is
+    // read after each.
+    let roots = pyre_object::gc_roots::push_roots();
+    let name_slot = roots.base();
+    let _ = roots.pin_root(w_name);
     let w_locals = frame.get_or_create_w_locals();
-    crate::baseobjspace::delitem(w_locals, w_name).map_err(|err| {
+    crate::baseobjspace::delitem(w_locals, roots.get(name_slot)).map_err(|err| {
         if matches!(err.kind, PyErrorKind::KeyError) {
-            let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+            let name = unsafe { pyre_object::unicodeobject::w_str_get_value(roots.get(name_slot)) };
             PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
         } else {
             err
@@ -4115,10 +4139,21 @@ impl OpcodeStepExecutor for PyFrame {
         // `if not self.space.finditem_str(w_locals, '__annotations__')`:
         // probe by item lookup, not membership — a custom mapping's
         // `__contains__` can disagree with `__getitem__`/KeyError.
-        let w_locals = self.get_or_create_w_locals();
-        if crate::baseobjspace::finditem_str(w_locals, "__annotations__")?.is_none() {
-            let key = unsafe { pyre_object::w_str_new("__annotations__") };
-            crate::baseobjspace::setitem(w_locals, key, pyre_object::w_dict_new())?;
+        // The probe can run a mapping's `__getitem__`, and the key and the empty
+        // dict are two more allocations; the mapping is read after every one of
+        // them and the key after the dict.
+        let roots = pyre_object::gc_roots::push_roots();
+        let locals_slot = roots.base();
+        let _ = roots.pin_root(self.get_or_create_w_locals());
+        if crate::baseobjspace::finditem_str(roots.get(locals_slot), "__annotations__")?.is_none() {
+            let key_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = roots.pin_root(unsafe { pyre_object::w_str_new("__annotations__") });
+            let w_annotations = pyre_object::w_dict_new();
+            crate::baseobjspace::setitem(
+                roots.get(locals_slot),
+                roots.get(key_slot),
+                w_annotations,
+            )?;
         }
         Ok(())
     }
@@ -5119,11 +5154,15 @@ impl OpcodeStepExecutor for PyFrame {
         // `space.delitem(w_locals, w_name)`; at module scope `w_locals` is the
         // globals dict, so a module DELETE_NAME routes through the canonical
         // W_DictObject too.  KeyError → NameError.
-        let w_locals = self.get_or_create_w_locals();
+        // `w_code_getname_w_or_new` realizes the `co_names_w` slot on its first
+        // read, so the mapping crosses an allocation before the delete.
+        let roots = pyre_object::gc_roots::push_roots();
+        let locals_slot = roots.base();
+        let _ = roots.pin_root(self.get_or_create_w_locals());
         let key = unsafe {
             crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
         };
-        crate::baseobjspace::delitem(w_locals, key).map_err(|err| {
+        crate::baseobjspace::delitem(roots.get(locals_slot), key).map_err(|err| {
             if matches!(err.kind, PyErrorKind::KeyError) {
                 PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
             } else {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3746,7 +3746,13 @@ impl PyFrame {
         let locals_slot = roots.base();
         let _ = roots.pin_root(unsafe { pyre_object::w_dict_new() });
         let frame = unsafe { &mut *frame_anchor.live() };
-        frame.getorcreate_debug_data(-1).w_locals = roots.get(locals_slot);
+        // `getorcreate_debug_data` allocates the debug block this frame does not
+        // have yet, and an assignment evaluates its value before its place, so
+        // combining the two reads the dict's address before that allocation and
+        // stores it after — leaving the caller the live word and the frame the
+        // dead one.
+        let debug = frame.getorcreate_debug_data(-1);
+        debug.w_locals = roots.get(locals_slot);
         roots.get(locals_slot)
     }
 
@@ -3936,7 +3942,16 @@ impl PyFrame {
     /// through `space.setitem` / `space.getitem` / `space.delitem` on it.
     #[inline]
     pub fn setdictscope(&mut self, w_locals: PyObjectRef) -> Result<(), crate::PyError> {
-        self.getorcreate_debug_data(-1).w_locals = w_locals;
+        // A frame with no debug block yet allocates one below, which
+        // `getorcreate_debug_data` names as a collection point.  It anchors the
+        // frame it is called on; `w_locals` is the caller's word and nothing
+        // else names it, and an assignment evaluates its value before its
+        // place, so writing it directly would store a pre-collection address.
+        let roots = pyre_object::gc_roots::push_roots();
+        let locals_slot = roots.base();
+        let _ = roots.pin_root(w_locals);
+        let debug = self.getorcreate_debug_data(-1);
+        debug.w_locals = roots.get(locals_slot);
         self.locals2fast(false)
     }
 


### PR DESCRIPTION
Four commits on `origin/main` `e9467f7cf90`.

## `exec()`'s namespace arguments, and eight more name-binding paths

`pyre/bench/synth/exec_namespace_code_object_rooting_regression.py` — added by
#1664 and verified there on dynasm only — fails its `exec-separate-locals`
check on the wasm backend at round 0, with `TypeError: '' object is not
subscriptable` raised by the module-scope `LOAD_NAME` inside the exec'd source.

`exec` plants `__builtins__` through `space.call_method(w_globals,
'setdefault', ...)`, dispatched on the caller's own mapping, so a `dict`
subclass's override runs Python and can collect. `exec_or_eval` pins
`w_globals` across that window and #1677 pinned `closure` on the same bracket,
but `globals_arg` and `locals_arg` are two more locals that are read after it,
and `w_globals` being pinned does not cover `globals_arg` — it is a different
local even when the two name one object, and the tests below forward the
argument rather than the resolved mapping. The separate locals mapping the
frame runs on does not survive the plant.

The JIT is not implicated. With the fixture's thresholds raised until
`PYRE_WASM_JIT_STATS` reports `compiles=0`, wasm still fails and dynasm still
passes:

|  | JIT on | JIT off (`compiles=0`) |
|---|---|---|
| wasm | FAIL | FAIL |
| dynasm | PASS | PASS |

What differs between the backends is `Nursery::reset_range`, whose `wasm32` arm
zeroes recycled nursery unconditionally while the native arm writes a poison
pattern only under `MAJIT_GC_NURSERY_POISON`. On wasm the stale word reads back
as an object with a null `ob_type`, and `type_name_of`'s double deref answers
`''` out of the module's zeroed low memory rather than faulting; on dynasm
under that env var the same case is a SIGSEGV, which is how it was bisected.
With the fix that run exits 0 and the fixture passes on both backends.

Reading the same window found eight more sites of one shape — an operand is
read, then a call allocates, then the operand read first is used:

| site | operand held | across |
|---|---|---|
| `PyFrame::setdictscope` | the caller's `w_locals` | the debug block `getorcreate_debug_data` allocates |
| `PyFrame::get_or_create_w_locals` | the fresh mapping | the same allocation |
| `finditem_str_named` | `obj` | `wrapped_key`, which realizes a `co_names_w` slot or interns a key |
| `store_name_value` | the popped value, the mapping | `get_or_create_w_locals`, `named_key_hash`, `w_code_getname_w_or_new` |
| `delete_name` | the mapping | `w_code_getname_w_or_new` |
| `setup_annotations` | the mapping, then the key | the `__annotations__` probe, `w_str_new`, `w_dict_new` |
| `store_name_value_w` | the key and value | `get_or_create_w_locals` |
| `delete_name_w` | the key | `get_or_create_w_locals`, then `delitem` |

Two of those are sharper than a plain missing pin. `setdictscope` and
`get_or_create_w_locals` each wrote the mapping in one combined statement, and
a Rust assignment evaluates its value before its place — so the address was
read before the allocation and stored after it, leaving
`get_or_create_w_locals`'s caller the live word and the frame the dead one.
`store_name_value_w` borrowed the key's payload as a `&str` *before*
`get_or_create_w_locals`, so the reference outlived the object it pointed into;
the borrow now happens after.

Every site publishes its operands to the shadow stack and reads them back. Only
the `exec_or_eval` one has a repro; the other eight were found by reading.

## `memory.fill` for the entry prologue's home slots

A trace module's entry prologue null-initialises its ref home slots one
`i64.store` at a time. Bulk memory is available in both engines the runner
uses, so a run of three or more adjacent slots is emitted as a single
`memory.fill` instead — `memory.fill` takes its destination as an operand
rather than a memarg, so the frame base needs an explicit `i32.add`.

Compile cost is linear in module bytes (0.6–0.85 ms/KB, measured across all 22
modules of the `pickle_terminal_raise_resume` run), so the byte saving is the
whole effect: 756082 → 747418 bytes on that fixture and 96982 → 95464 on
`float_subclass_binop_dispatch`, or 1.15%. Exactly one fill per module.

## Seven stale `# Expected:` comments

Seven `pyre/bench/synth` fixtures had their iteration counts doubled without
their `# Expected:` comments following, so the comment named a value the
fixture can no longer print.

## Verification

`python3 pyre/check.py --backend dynasm,wasm` was green on the pre-rebase tree
carrying the first four sites — dynasm 541/541, wasm 534/534, with the wasm
failure above resolved. The re-run covering the rebase and the five later sites
is still building locally on a heavily loaded host; CI grades this tree.
