### PR TITLE
Perf-gate refit after the startup subtraction change; MAJIT_CL_BRIDGE_MERGE's four miscompiles; mmap.find's pattern buffer export

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -17,7 +17,7 @@ cover the condition they diagnose.
 | `MAJIT_CALLEE_CENSUS` | OFF | Reports resolved and unresolved translation callees; remove when every supported callee is classified. |
 | `MAJIT_CALLEE_CENSUS_ROWS` | value | Limits rows printed by `MAJIT_CALLEE_CENSUS`; remove with that census. |
 | `MAJIT_CALLEE_RCA` | OFF | Reports metainterpreter callee-resolution decisions; remove when those decisions are covered by focused tests. |
-| `MAJIT_CL_BRIDGE_MERGE` | OFF | Re-emits a bridge that closes onto its owner loop into that loop's own Cranelift function, so the guard reaches it by a block jump instead of a recovery stub and an indirect call; measured faster on every branching row, but it miscompiles (16 `pyre/check.py` checks separate the two arms), so it stays off until that is found and the route can become the default. |
+| `MAJIT_CL_BRIDGE_MERGE` | OFF | Re-emits a bridge that closes onto its owner loop into that loop's own Cranelift function, so the guard reaches it by a block jump instead of a recovery stub and an indirect call; every `pyre/bench/synth` fixture now reads the same with the gate set and unset, and 103 of the 203 that request a merge take one, so it stays off until the route is measured against the out-of-line one. |
 | `MAJIT_CL_BRIDGE_MERGE_LOG` | OFF | Prints one line per merge attempt — merged, or the reason it was declined — for the gate above; remove it with that gate. |
 | `MAJIT_CL_NO_CLOSING_JUMP` | OFF | Disables Cranelift's in-code closing jump to exercise external jump dispatch; remove when that fallback no longer needs comparison coverage. |
 | `MAJIT_DESCR_POOL_CENSUS` | OFF | Reports descriptor interning and duplication; remove when descriptor identity is covered by ordinary tests. |

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4809,6 +4809,7 @@ fn validate_oprefs_for_compile(
     inputargs: &[InputArg],
     ops: &[Op],
     constants: &majit_ir::ConstMap<majit_ir::Const>,
+    region_entries: &[MergedRegionEntry],
 ) -> Result<(), BackendError> {
     let num_inputs = inputargs.len();
     // RPython rewrite.py:397 + regalloc invariant: at the current op,
@@ -4824,6 +4825,16 @@ fn validate_oprefs_for_compile(
         seen.insert(input.index);
     }
     for (op_idx, op) in ops.iter().enumerate() {
+        // A merged region's ops are the tail of the stream and take their
+        // entry values from the block its owner guard branches to, so its
+        // inputargs are bound where the region opens — the same point
+        // `emit_body` declares them at.
+        if let Some(entry) = region_entries
+            .iter()
+            .find(|entry| entry.ops_start == op_idx)
+        {
+            seen.extend(entry.inputargs.iter().map(|ia| ia.index));
+        }
         if op.opcode == majit_ir::OpCode::Label {
             // LABEL params are introduced at the label block.
             // Const operands (history.py) are not body-namespace
@@ -5472,6 +5483,7 @@ fn build_ref_root_slots(
     type_index: &OpTypeIndex<'_>,
     overrides: &IndexMap<u32, Type>,
     force_tokens: &IndexSet<u32>,
+    region_entries: &[MergedRegionEntry],
 ) -> Result<Vec<(u32, usize)>, BackendError> {
     let mut seen = IndexSet::new();
     let mut slots = Vec::new();
@@ -5494,7 +5506,19 @@ fn build_ref_root_slots(
     // line-by-line analog is `arg.0 == inputargs[i].index`. Key
     // `used_inputargs` by the InputArg's raw OpRef value so the downstream
     // loop's `contains(&input.index)` checks line up with the keys inserted.
-    let inputarg_oprefs: IndexSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
+    // A merged region is entered on block parameters rather than through the
+    // entry prologue, so its inputargs stay out of `inputargs` — but its ops
+    // read them, and a Ref among them needs the root slot the bridge's own
+    // compile gave it. Without one the collector never sees the value and
+    // never forwards it across the allocations the region itself makes.
+    let entry_args = || {
+        inputargs.iter().chain(
+            region_entries
+                .iter()
+                .flat_map(|entry| entry.inputargs.iter()),
+        )
+    };
+    let inputarg_oprefs: IndexSet<u32> = entry_args().map(|ia| ia.index).collect();
 
     // The one JUMP whose target *is* part of this trace does have to line up
     // type-for-type with the LABEL it writes into. RPython cannot express a
@@ -5527,7 +5551,7 @@ fn build_ref_root_slots(
             }
         }
     }
-    for input in inputargs {
+    for input in entry_args() {
         if input.tp == Type::Ref
             && !force_tokens.contains(&input.index)
             && used_inputargs.contains(&input.index)
@@ -7294,8 +7318,10 @@ struct MergedRegionEntry {
     source_fail_index: u32,
     /// Index in the merged `ops` of the region's first operation.
     ops_start: usize,
-    /// Value ids the region's inputargs occupy after the rebase, in order.
-    inputarg_ids: Vec<u32>,
+    /// The region's inputargs after the rebase, in order: the value ids its
+    /// entry block's parameters bind, and the types that say which of them is
+    /// a GC root.
+    inputargs: Vec<InputArg>,
 }
 
 /// The owner's stream with every region appended to it.
@@ -7314,30 +7340,57 @@ const MAX_MERGED_REGIONS: usize = 8;
 /// Operations the merged stream may reach before further merges are declined.
 const MAX_MERGED_OPS: usize = 4096;
 
-/// Whether `bridge` leaves through a LABEL that `owner` publishes, with the
-/// arity that LABEL was compiled at.
+/// Whether `bridge` leaves through the same LABEL `owner`'s own closing JUMP
+/// names, with the arity that LABEL was compiled at.
 ///
 /// That is what makes the merge worth taking: `do_compile`'s Jump lowering
 /// resolves such a target to a local block and emits a plain `jump`, so the
 /// region's exit becomes a branch. A JUMP naming a LABEL of another loop, or
-/// naming one of these with a different arg count, still lowers as an external
-/// jump — a tail call through the frame — and merging buys nothing.
+/// naming one with a different arg count, still lowers as an external jump — a
+/// tail call through the frame — and merging buys nothing.
+///
+/// Owning the label is not enough; it has to be the one the owner already
+/// branches to. A trace can publish more labels than that — an unrolled loop
+/// keeps the peeled entry label beside the body header — and an external JUMP
+/// naming one of those is served by `lookup_loop_target`, which resolves the
+/// TargetToken at the moment the exit is taken and can name a different
+/// compiled loop than the one holding the label. A local branch fixes the
+/// target at compile time; only the label the owner's own back edge already
+/// fixes carries no redirect a merge would drop.
 fn bridge_closes_onto(owner_ops: &[Op], bridge_ops: &[Op]) -> bool {
-    let label_arity: IndexMap<u32, usize> = owner_ops
+    // The label the owner's own closing JUMP names, keyed by
+    // `descr_identity` for the reason `collect_guards` keys by it: `d.index()`
+    // is not unique across the TargetTokens of one trace.
+    let Some(header) = owner_ops
         .iter()
-        .filter(|op| op.opcode == OpCode::Label)
-        .filter_map(|op| op.getdescr().map(|d| (d.index(), op.num_args())))
-        .collect();
-    if label_arity.is_empty() {
+        .rev()
+        .find(|op| op.opcode == OpCode::Jump)
+        .and_then(|op| op.getdescr())
+        .as_ref()
+        .map(majit_ir::descr_identity)
+    else {
         return false;
-    }
+    };
+    let Some(arity) = owner_ops
+        .iter()
+        .find(|op| {
+            op.opcode == OpCode::Label
+                && op
+                    .getdescr()
+                    .as_ref()
+                    .is_some_and(|d| majit_ir::descr_identity(d) == header)
+        })
+        .map(Op::num_args)
+    else {
+        return false;
+    };
     bridge_ops.iter().any(|op| {
         op.opcode == OpCode::Jump
-            && op.getdescr().is_some_and(|d| {
-                label_arity
-                    .get(&d.index())
-                    .is_some_and(|&arity| arity == op.num_args())
-            })
+            && op.num_args() == arity
+            && op
+                .getdescr()
+                .as_ref()
+                .is_some_and(|d| majit_ir::descr_identity(d) == header)
     })
 }
 
@@ -7469,6 +7522,55 @@ fn rebase_merged_region(
     Ok((inputargs, ops, width))
 }
 
+/// The identity a re-emission stamps onto a guard descr, taken before the
+/// attempt so a declined one can put it back.
+///
+/// `collect_guards` restamps every guard it walks with the trace id and the
+/// fail index of the stream being compiled. For the owner's own guards that is
+/// a no-op — the merge is append-only, so they keep the numbers their first
+/// compile gave them — but a region's guards belong to a bridge that was
+/// compiled out of line, and until the merged body is published that bridge is
+/// still installed and still keyed by its own numbering. Leaving the merged
+/// numbers on a declined attempt sends every later lookup of one of those
+/// descrs, `find_fail_descr_in_fail_descrs` included, to the wrong guard.
+struct StampedGuardIdentity {
+    descr: DescrRef,
+    trace_id: u64,
+    fail_index_per_trace: u32,
+    source_op_index: Option<usize>,
+}
+
+fn snapshot_guard_identities(streams: &[&[Op]]) -> Vec<StampedGuardIdentity> {
+    let mut saved = Vec::new();
+    for ops in streams {
+        for op in ops.iter() {
+            let Some(descr) = op.getdescr() else { continue };
+            if !(descr.is_resume_guard() || descr.is_resume_guard_copied()) {
+                continue;
+            }
+            let fd = as_fd(&descr);
+            saved.push(StampedGuardIdentity {
+                trace_id: fd.trace_id(),
+                fail_index_per_trace: fd.fail_index_per_trace(),
+                source_op_index: fd.source_op_index(),
+                descr,
+            });
+        }
+    }
+    saved
+}
+
+fn restore_guard_identities(saved: &[StampedGuardIdentity]) {
+    for entry in saved {
+        let fd = as_fd(&entry.descr);
+        fd.set_trace_id(entry.trace_id);
+        fd.set_fail_index_per_trace(entry.fail_index_per_trace);
+        if let Some(source_op_index) = entry.source_op_index {
+            fd.set_source_op_index(source_op_index);
+        }
+    }
+}
+
 /// Refuse a merge whose region cannot be entered on block parameters.
 ///
 /// The out-of-line bridge takes its inputargs out of jitframe slots, so a slot
@@ -7482,7 +7584,7 @@ fn check_region_entry_slots(
     guard_infos: &[GuardInfo],
 ) -> Result<(), BackendError> {
     for entry in region_entries {
-        let arity = entry.inputarg_ids.len();
+        let arity = entry.inputargs.len();
         let decline = |why: &str| {
             Err(BackendError::Unsupported(format!(
                 "cranelift backend: merged region off guard {} {why}",
@@ -7552,13 +7654,13 @@ fn merge_regions(
         entries.push(MergedRegionEntry {
             source_fail_index: region.source_fail_index,
             ops_start: merged_ops.len(),
-            inputarg_ids: region_inputargs.iter().map(|ia| ia.index).collect(),
+            inputargs: region_inputargs,
         });
         // The region's own inputargs deliberately stay out of `merged_inputargs`:
         // a region is entered on block parameters, so counting them into
         // `num_inputs` would grow the entry layout every caller of this loop
         // passes and every `input_types` check made against it. `do_compile`
-        // declares their variables off `MergedRegionEntry::inputarg_ids`.
+        // declares their variables off `MergedRegionEntry::inputargs`.
         merged_ops.extend(region_ops);
     }
     Ok(MergedStream {
@@ -9970,6 +10072,7 @@ impl CraneliftBackend {
     fn merge_bridge_into_owner(
         &mut self,
         original_token: &JitCellToken,
+        source_trace_id: u64,
         source_fail_index: u32,
         inputargs: &[InputArg],
         ops: &[Op],
@@ -10007,12 +10110,29 @@ impl CraneliftBackend {
         let Some(mut seed) = owner.reemit.borrow_mut().take() else {
             return Err("owner has no retained stream");
         };
-        let declined = if ops.iter().any(|op| op.opcode == OpCode::Label) {
+        let declined = if source_trace_id != owner.trace_id {
+            // `source_fail_index` numbers the guards of the trace the failing
+            // guard belongs to, and a region is entered through the owner guard
+            // that number names. A guard inside an out-of-line bridge numbers
+            // its own trace, so merging one here would hand the region whatever
+            // owner guard shares the number and that guard's live values.
+            Some("guard belongs to another trace")
+        } else if ops.iter().any(|op| op.opcode == OpCode::Label) {
             // A region is entered through the block its owner guard branches
             // to, never through a header of its own. A LABEL inside one would
             // take over `loop_block`, the preamble split and the entry
             // `br_table` — all of which belong to the owner loop.
             Some("region carries a LABEL")
+        } else if seed
+            .regions
+            .iter()
+            .any(|r| r.source_fail_index == source_fail_index)
+        {
+            // The block a region is entered through is looked up by this index
+            // alone, so a second region off the same guard would take the
+            // first's entry block and leave the first bound to parameters the
+            // guard never passes.
+            Some("guard already carries a region")
         } else if seed.regions.len() >= MAX_MERGED_REGIONS {
             Some("region budget spent")
         } else if seed.ops.len()
@@ -10037,6 +10157,12 @@ impl CraneliftBackend {
             constants,
             gc_table_base: 0,
         });
+        // Every guard the re-emission walks, the new region's included.
+        let stamped = snapshot_guard_identities(
+            &std::iter::once(seed.ops.as_slice())
+                .chain(seed.regions.iter().map(|region| region.ops.as_slice()))
+                .collect::<Vec<_>>(),
+        );
         self.constants = seed.constants.clone();
         // A re-emission is the same trace, not a new one. Its identity is what
         // every descr the merged stream re-stamps carries, and what the
@@ -10058,10 +10184,20 @@ impl CraneliftBackend {
         self.next_trace_id = None;
         self.next_header_pc = None;
         self.next_frame_value_count_fn = None;
-        let Ok(mut compiled) = compiled else {
-            seed.regions.pop();
-            *owner.reemit.borrow_mut() = Some(seed);
-            return Err("merged stream did not compile");
+        let mut compiled = match compiled {
+            Ok(compiled) => compiled,
+            Err(err) => {
+                if std::env::var_os("MAJIT_CL_BRIDGE_MERGE_LOG").is_some() {
+                    eprintln!(
+                        "[cl-merge] loop {} guard {source_fail_index}: compile error: {err:?}",
+                        original_token.number
+                    );
+                }
+                restore_guard_identities(&stamped);
+                seed.regions.pop();
+                *owner.reemit.borrow_mut() = Some(seed);
+                return Err("merged stream did not compile");
+            }
         };
         compiled.green_key = original_token.green_key();
         if register_call_assembler_target(original_token, &compiled, self.attached_descr_ptrs())
@@ -10074,6 +10210,7 @@ impl CraneliftBackend {
         {
             // The owner's own registration still names the superseded body,
             // which is live and correct; nothing was published for the new one.
+            restore_guard_identities(&stamped);
             seed.regions.pop();
             *owner.reemit.borrow_mut() = Some(seed);
             return Err("merged stream could not be published");
@@ -10103,6 +10240,9 @@ impl CraneliftBackend {
         // The re-emission carries the retained stream forward: the next merge
         // replays the owner plus every region taken so far.
         *compiled.reemit.borrow_mut() = Some(seed);
+        // No restore past this point: the merged body is registered and its
+        // fail descrs already name its own loop token, so the numbering the
+        // re-emission stamped is the one live code is looked up by.
         match owner.superseded_by.set(Box::new(compiled)) {
             Ok(()) => Ok(()),
             Err(_) => Err("owner already superseded"),
@@ -10223,7 +10363,7 @@ impl CraneliftBackend {
         // back to the blackhole resume path. This pre-pass replaces
         // the silent `iconst(0)` fallback that previously turned
         // undefined OpRefs into runtime SIGSEGVs.
-        validate_oprefs_for_compile(inputargs, ops, &self.constants)?;
+        validate_oprefs_for_compile(inputargs, ops, &self.constants, region_entries)?;
         let trace_id = self.next_trace_id.take().unwrap_or_else(|| {
             let trace_id = self.trace_counter;
             self.trace_counter += 1;
@@ -10352,8 +10492,14 @@ impl CraneliftBackend {
         let used_vars = build_used_vars_set(ops);
         let type_index = OpTypeIndex::new(inputargs, ops);
         let (type_overrides, _op_def_positions) = build_type_overrides(ops, &type_index);
-        let ref_root_slots =
-            build_ref_root_slots(inputargs, ops, &type_index, &type_overrides, &force_tokens)?;
+        let ref_root_slots = build_ref_root_slots(
+            inputargs,
+            ops,
+            &type_index,
+            &type_overrides,
+            &force_tokens,
+            region_entries,
+        )?;
 
         // Hoisted before the entry-prologue frame sizing so the reserved frame
         // tail (`reserved_tail`) accounts for demoted non-ref homes.
@@ -10868,9 +11014,9 @@ impl CraneliftBackend {
         // word, and this must run before the op-argument loop below, which
         // would otherwise type them off their OpRef variant.
         for entry in region_entries {
-            for &id in &entry.inputarg_ids {
-                var_types.insert(id, cl_types::I64);
-                declared_vars.insert(id);
+            for ia in &entry.inputargs {
+                var_types.insert(ia.index, cl_types::I64);
+                declared_vars.insert(ia.index);
             }
         }
         // Declare variables for op results
@@ -11169,7 +11315,7 @@ impl CraneliftBackend {
             .iter()
             .map(|entry| {
                 let block = builder.create_block();
-                for _ in 0..entry.inputarg_ids.len() {
+                for _ in 0..entry.inputargs.len() {
                     builder.append_block_param(block, cl_types::I64);
                 }
                 // A region runs only when its guard fails, which is why the
@@ -11390,9 +11536,40 @@ impl CraneliftBackend {
                 let block = region_blocks[&entry.source_fail_index];
                 builder.switch_to_block(block);
                 builder.seal_block(block);
-                for (i, &value_id) in entry.inputarg_ids.iter().enumerate() {
+                // Nothing the owner or an earlier region defined is live here:
+                // the rebase leaves a region reading only its own namespace,
+                // and the branch its guard takes hands it exactly these
+                // values. Carrying the walk's ref-root bookkeeping across the
+                // boundary would spill and reload variables the region never
+                // reads, and the reload's `def_var` on an edge that ends at
+                // the owner's LABEL is what makes Cranelift carry them around
+                // the loop as parameters the trace entry has no value for.
+                defined_ref_vars.clear();
+                stale_ref_vars.clear();
+                // Same reason the standalone compile of this bridge starts
+                // with no flag: the op that set one is the owner's, and the
+                // region's own overflow guards follow their own producer.
+                last_ovf_flag = None;
+                let mut region_root_jf_ptr = None;
+                for (i, ia) in entry.inputargs.iter().enumerate() {
                     let param = builder.block_params(block)[i];
-                    builder.def_var(var(value_id), param);
+                    builder.def_var(var(ia.index), param);
+                    if ia.tp == Type::Ref && !force_tokens.contains(&ia.index) {
+                        defined_ref_vars.insert(ia.index);
+                        // Seeded here for the reason the entry prologue seeds
+                        // an inputarg's root slot: a guard can publish, or a
+                        // call can collect, before anything has spilled it.
+                        sync_ref_root_var(
+                            &mut builder,
+                            ptr_type,
+                            &mut region_root_jf_ptr,
+                            &ref_root_slots,
+                            ia.index,
+                            param,
+                            ref_root_base_ofs,
+                            &mut synced_ref_vars,
+                        );
+                    }
                 }
                 preamble_phase = false;
             }
@@ -18091,6 +18268,7 @@ impl majit_backend::Backend for CraneliftBackend {
             let fail_index = fail_descr.fail_index_per_trace();
             let merged = self.merge_bridge_into_owner(
                 original_token,
+                source_trace_id,
                 fail_index,
                 inputargs,
                 ops,
@@ -18102,7 +18280,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     Err(why) => format!("declined: {why}"),
                 };
                 eprintln!(
-                    "[cl-merge] loop {} guard {fail_index}: {outcome}",
+                    "[cl-merge] loop {} trace {source_trace_id} guard {fail_index}: {outcome}",
                     original_token.number
                 );
             }

--- a/pyre/bench/synth/math_folds_hot.py
+++ b/pyre/bench/synth/math_folds_hot.py
@@ -1,6 +1,4 @@
-# pyre-check: max-pypy-ratio=2.4
-# Ubuntu run 33279264115: 0.7-1.2x; the ceiling is twice the slowest,
-# rounded up to one decimal place.
+# pyre-check: max-pypy-ratio=1.8
 # pyre-check: spec-folds=math_ceil,math_fabs,math_float1,math_float2,math_floor,math_isclose,math_log_trig,math_trunc,math_sqrt,float_call
 # pyre-check: skip-cpython
 # This fixture carried a wasm allowance of 13, fitted to a darwin-arm64

--- a/pyre/bench/synth/property_getattr_exceptions.py
+++ b/pyre/bench/synth/property_getattr_exceptions.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=30
+# pyre-check: max-pypy-ratio=4
 # Property getter/setter exceptions and __getattr__ hook exceptions
 # propagate out of attribute access instead of being swallowed. Only the
 # exception type is printed so the line matches across CPython/PyPy/Pyre.

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -248,7 +248,7 @@ BENCH_COMPARE_BUFFER_S = 0.005
 # Windows process CPU accounting advances in scheduler ticks (normally 1/64 s).
 # Keep the execution floor at least one observable tick on that platform.
 WIN_TIMER_QUANTUM_S = 1.0 / 64
-# Empty-program user-CPU startup is MEASURED (median of STARTUP_SAMPLES runs)
+# Empty-program user-CPU startup is MEASURED (mean of STARTUP_SAMPLES runs)
 # and subtracted from every timed run before ratios and perf gates are
 # computed, so a fixed per-process cost does not inflate the ratio/gate of a
 # short bench. Never hardcode the startup.
@@ -270,21 +270,53 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # denominator and inflates every ratio computed against it.  A CI runner
 # measured pypy startup at 0.031s where the same job on the same platform had
 # measured 0.013s, and three unrelated benches failed their gates in that run
-# while their pyre exec times had gone *down*.  Five samples make the median
-# robust to two outliers instead of one.
+# while their pyre exec times had gone *down*.  That reading is the one the
+# estimator below is chosen against: 0.031s is what a loaded sampling window
+# reports, and the pass that carried it also saw 0.013s.
 #
-# The estimator is the MEDIAN and not the minimum, even though the quantity is a
-# fixed per-process cost whose error sources are all one-sided — contention,
-# cache pressure and page faults only ever add user CPU.  The minimum does
-# recover that cost, but it recovers it for an *idle* machine, and it is
-# subtracted from bench runs that were not idle: under load a bench carries an
-# inflated startup inside it, and taking the unloaded minimum away leaves that
-# inflation behind in `exec`.  Pairing median with median cancels it; pairing an
-# idle minimum with a loaded bench does not.  Measured on one CI job, the
-# minimum came in 15ms under the median for dynasm and 13ms for cranelift, which
-# carried nine short benches whose baseline was pinned to EXEC_TIME_FLOOR_S over
-# their gates at once.  The estimate has to come from the same load conditions
-# as the run it is subtracted from.
+# The estimator is the MEAN, and the reason is that on one platform the samples
+# are quantised far more coarsely than the quantity they measure.  Windows
+# charges process CPU by sampling at WIN_TIMER_QUANTUM_S, so a single reading is
+# a count of ticks the process happened to be caught running for -- an unbiased
+# estimate of the true cost, but one that can only take lattice values.
+# Measured here over 40 empty-program runs, pypy read 0.000s 31 times, 0.016s 8
+# times and 0.031s once: mean 0.0039s against a wall-clock mean of 0.026s.  The
+# cost is about four milliseconds, and NO sample ever reports that.  A median
+# picks a lattice point and so reads 0.016s, four times the cost; across 47 CI
+# sampling passes it reads two ticks, 0.031s, in 19 of them.  A minimum picks
+# the other lattice point and reads 0.000s.  Averaging is what recovers the
+# value between them, and it is the only one of the three that converges on the
+# quantity as samples are added.
+#
+# Off windows the reading is not quantised and the three estimators agree to
+# within a millisecond -- ubuntu 0.012s median against a 0.009s minimum, macos
+# 0.016s against 0.014s -- so this changes almost nothing there.  It is a
+# correction to one platform's instrument, not a policy about how much to
+# subtract, which is why it is not a widening: on the platform it moves, the
+# value it replaces was four times the cost it claimed to be.
+#
+# What rides on it is the denominator.  A startup estimate is subtracted from a
+# baseline whose whole execution time is often the same size: measured across
+# ten CI runs the median `exec` for pypy is 8ms on ubuntu, 10ms on macos and
+# 16ms on windows.  An estimate that lands high collapses that denominator onto
+# EXEC_TIME_FLOOR_S, and a baseline pinned there is not a measurement --
+# `failed_bound` declines BOTH bounds on it, so the fixture's recorded ceiling
+# goes unapplied.  Over-subtraction does not make the gate stricter; it makes
+# the gate absent.
+#
+# The mean is the one estimator of the three that a single slow sample can move,
+# which is what STARTUP_SAMPLES answers: the sampling error of a mean of N falls
+# as sqrt(N), and each pass prints the range it was drawn from so an outlier is
+# visible rather than inferred.
+#
+# This supersedes the MINIMUM, taken here briefly, and the MEDIAN recorded
+# through `bc67f721c42`.  That commit's counter-example -- nine short benches
+# carried over their gates by an estimate 15ms under the median -- described
+# benches gated on a baseline pinned to EXEC_TIME_FLOOR_S, and `6a098e07ce2`
+# later made a pinned baseline decline both bounds, so it no longer describes
+# this code.  What survives of it is that an estimate from an idle window is
+# subtracted from benches that were not idle; the mean is drawn from the same
+# window as the median was, so that argument does not distinguish them.
 #
 # That last condition is what STARTUP_REFRESH_S exists to meet.  A single
 # upfront measurement is subtracted from benches that run for the rest of the
@@ -296,7 +328,7 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # it is taken from, and every pass prints the samples it was drawn from
 # ([min..max]) so the drift is readable in the log rather than inferred from a
 # neighbouring job.
-STARTUP_SAMPLES = 5
+STARTUP_SAMPLES = 7
 # Re-measured no more often than this, and only at a fixture boundary: the
 # pairing argument above requires a fixture's numerator and denominator to be
 # reduced by the SAME estimate, which a refresh between one fixture's backends
@@ -312,7 +344,7 @@ STARTUP_SAMPLES = 5
 # allowed to drift further from what it is subtracted from.
 STARTUP_REFRESH_S = 120
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
-# `exec` is `bench - startup`, and startup is a measured median rather than a
+# `exec` is `bench - startup`, and startup is a measured mean rather than a
 # constant, so whatever the estimate is off by lands whole in `exec`.  That
 # error is real, but NO allowance is granted for it, and a standing allowance
 # was tried and removed.  It read `0.5 * startup`, added to the baseline on
@@ -3188,7 +3220,7 @@ class Check:
         parts = []
         for key, got in samples.items():
             if got:
-                self.startup[key] = statistics.median(got)
+                self.startup[key] = statistics.fmean(got)
                 spread = f"[{min(got):.3f}..{max(got):.3f}]"
             else:
                 spread = "[unsampled]"
@@ -3200,7 +3232,7 @@ class Check:
         """Measure each baseline interpreter's empty-program user-CPU cost.
 
         Runs an empty script STARTUP_SAMPLES times per interpreter, records
-        the median user-CPU in self.startup and prints it beside the range its
+        the mean user-CPU in self.startup and prints it beside the range its
         samples spanned. This is the fixed per-process cost of interpreter
         init, added to every bench regardless of workload; subtracting it
         yields a comparison of the work the fixture asked for. Re-measured
@@ -3211,8 +3243,8 @@ class Check:
             return
         samples, cost = self._sample_startups()
         print(dim(
-            f"startup (empty-program user-CPU, median {STARTUP_SAMPLES} "
-            f"in {cost:.1f}s, shown as median[min..max]; ratios/gates are "
+            f"startup (empty-program user-CPU, mean of {STARTUP_SAMPLES} "
+            f"in {cost:.1f}s, shown as mean[min..max]; ratios/gates are "
             f"execution-only): "
             + self._adopt_startups(samples)
         ))
@@ -3231,7 +3263,7 @@ class Check:
             return
         samples, cost = self._sample_startups()
         print(dim(
-            f"startup re-measured in {cost:.1f}s (median[min..max]): "
+            f"startup re-measured in {cost:.1f}s (mean[min..max]): "
             + self._adopt_startups(samples)
         ))
 

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -400,6 +400,78 @@ fn mmap_index_w(
     Ok(index)
 }
 
+/// The search pattern of `find` and `rfind`, held the way the `view: Py_buffer`
+/// converter holds it: the export is acquired before `start` and `end` are
+/// converted and released once the search is over.
+///
+/// `mmap_gfind_lock_held` reads `view->buf` and `view->len` after
+/// `_As_Py_ssize_t` has run both conversions, so a `bytearray` pattern that one
+/// of their `__index__` hooks edits in place is what the search compares
+/// against, and one such a hook resizes is refused with `BufferError`.  Reading
+/// the bytes back out of the object is what makes the edit visible; the export
+/// is what makes the resize impossible, so the address cannot go stale between
+/// the two.
+#[cfg(any(unix, windows))]
+struct MmapPattern {
+    /// Shadow-stack slot the pattern is pinned in.  The bytes live in storage
+    /// the object owns, so the object has to outlive every read of them.
+    slot: usize,
+    /// Whether the acquisition took an export to pair with a release; an
+    /// immutable `bytes` pattern has no count to keep.
+    held: bool,
+}
+
+#[cfg(any(unix, windows))]
+impl MmapPattern {
+    /// The root scope the pin lands in belongs to the caller, as it does for
+    /// `SocketWritableBuffer::acquire`.
+    ///
+    /// # Safety
+    /// The caller must uphold every validity, runtime-type, aliasing, and
+    /// lifetime invariant required by the object arguments for the entire call.
+    unsafe fn acquire(
+        obj: pyre_object::PyObjectRef,
+        who: &str,
+    ) -> Result<Self, crate::PyError> {
+        if !unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
+            return Err(crate::PyError::type_error(format!(
+                "{who}: pattern must be bytes-like"
+            )));
+        }
+        let _ = pyre_object::gc_roots::pin_root(obj);
+        let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let held = unsafe {
+            crate::builtins::buffer_export_incref(pyre_object::gc_roots::shadow_stack_get(slot))
+        };
+        Ok(Self { slot, held })
+    }
+
+    /// The pattern's bytes as they stand now.  Read this after everything that
+    /// can run Python: the export refuses a resize, but an in-place edit is
+    /// allowed and the search has to see it.
+    ///
+    /// # Safety
+    /// The caller must uphold every validity, runtime-type, aliasing, and
+    /// lifetime invariant required by the object arguments for the entire call.
+    unsafe fn data(&self) -> &'static [u8] {
+        unsafe {
+            pyre_object::bytesobject::bytes_like_data(pyre_object::gc_roots::shadow_stack_get(
+                self.slot,
+            ))
+        }
+    }
+}
+
+#[cfg(any(unix, windows))]
+impl Drop for MmapPattern {
+    fn drop(&mut self) {
+        if self.held {
+            let obj = pyre_object::gc_roots::shadow_stack_get(self.slot);
+            unsafe { crate::builtins::buffer_export_decref(obj) };
+        }
+    }
+}
+
 /// Sweep-time counterpart of PyPy `W_MMap.__del__` / `rmmap.MMap.close`.
 #[cfg(any(unix, windows))]
 pub unsafe fn w_mmap_dealloc(obj: pyre_object::PyObjectRef) {
@@ -901,19 +973,14 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let (_, len_at_entry) = mmap_ptr(obj)?;
-            // `interp_mmap.py find` is handed `space.bufferstr_w(w_tofind)`, a
-            // copy.  The pattern's own storage is not held across the
-            // `getindex_w` calls below: a `bytearray` pattern reallocated by
-            // one of their `__index__` hooks would leave a borrowed slice
-            // naming freed memory.
-            let needle = unsafe {
-                if !pyre_object::bytesobject::is_bytes_like(args[1]) {
-                    return Err(crate::PyError::type_error(
-                        "find: pattern must be bytes-like",
-                    ));
-                }
-                pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
-            };
+            let _roots = pyre_object::gc_roots::push_roots();
+            // Taken before the conversions below, which run `__index__`, and
+            // released when this returns — `mmap.mmap.find` reaches its pattern
+            // through the `Py_buffer` converter, whose export brackets the
+            // whole call.  `interp_mmap.py find` snapshots
+            // `space.bufferstr_w(w_tofind)` here instead, which neither sees an
+            // in-place edit made by one of those hooks nor refuses a resize.
+            let pattern = unsafe { MmapPattern::acquire(args[1], "find") }?;
             // `interp_mmap.py find(w_tofind, w_start=None,
             // w_end=None)` defaults w_start to `self.mmap.pos` then
             // routes through rmmap.find which handles negative start /
@@ -950,6 +1017,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             if start > end {
                 return Ok(pyre_object::w_int_new(-1));
             }
+            let needle = unsafe { pattern.data() };
             if needle.is_empty() {
                 return Ok(pyre_object::w_int_new(start as i64));
             }
@@ -958,7 +1026,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
                 return Ok(pyre_object::w_int_new(-1));
             }
             let pos = (0..=hay.len().saturating_sub(needle.len()))
-                .find(|&i| &hay[i..i + needle.len()] == needle.as_slice())
+                .find(|&i| &hay[i..i + needle.len()] == needle)
                 .map(|i| (start + i) as i64)
                 .unwrap_or(-1);
             Ok(pyre_object::w_int_new(pos))
@@ -974,19 +1042,14 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let (_, len_at_entry) = mmap_ptr(obj)?;
-            // `interp_mmap.py rfind` is handed `space.bufferstr_w(w_tofind)`, a
-            // copy.  The pattern's own storage is not held across the
-            // `getindex_w` calls below: a `bytearray` pattern reallocated by
-            // one of their `__index__` hooks would leave a borrowed slice
-            // naming freed memory.
-            let needle = unsafe {
-                if !pyre_object::bytesobject::is_bytes_like(args[1]) {
-                    return Err(crate::PyError::type_error(
-                        "rfind: pattern must be bytes-like",
-                    ));
-                }
-                pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
-            };
+            let _roots = pyre_object::gc_roots::push_roots();
+            // Taken before the conversions below, which run `__index__`, and
+            // released when this returns — `mmap.mmap.rfind` reaches its pattern
+            // through the `Py_buffer` converter, whose export brackets the
+            // whole call.  `interp_mmap.py rfind` snapshots
+            // `space.bufferstr_w(w_tofind)` here instead, which neither sees an
+            // in-place edit made by one of those hooks nor refuses a resize.
+            let pattern = unsafe { MmapPattern::acquire(args[1], "rfind") }?;
             // `interp_mmap.py rfind(w_tofind, w_start=None,
             // w_end=None)` defaults w_start to `self.mmap.pos`, not 0.
             // Negative args run through rmmap.find which adds `size`
@@ -1016,6 +1079,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             if start > end {
                 return Ok(pyre_object::w_int_new(-1));
             }
+            let needle = unsafe { pattern.data() };
             if needle.is_empty() {
                 return Ok(pyre_object::w_int_new(end as i64));
             }
@@ -1025,7 +1089,7 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
             }
             let pos = (0..=hay.len().saturating_sub(needle.len()))
                 .rev()
-                .find(|&i| &hay[i..i + needle.len()] == needle.as_slice())
+                .find(|&i| &hay[i..i + needle.len()] == needle)
                 .map(|i| (start + i) as i64)
                 .unwrap_or(-1);
             Ok(pyre_object::w_int_new(pos))


### PR DESCRIPTION
Five commits: a perf-gate refit round that follows `6aabe927ce1`'s change to how
startup is subtracted, and two fix rounds — the four defects behind
`MAJIT_CL_BRIDGE_MERGE`'s miscompiles, and the one surviving finding from
#1650's review.

### The startup subtrahend, and the two ceilings that moved with it

`6aabe927ce1` made every pyre backend subtract **pypy's** startup instead of its
own, so what a pyre process spends above pypy to reach the first bytecode now
stays in the numerator. Readings taken before it are not comparable to readings
taken after, and every ceiling fitted on the old ones has to be re-derived. Two
were.

`math_folds_hot` reads 0.38x–0.54x on windows, 0.80x–0.96x on ubuntu and
0.84x–1.47x on macOS over three runs and both native backends. Its ceiling was
2.4, from which `perf_gate_floor` derives 0.4x — inside the windows band rather
than under it, which is what tripped run 33650098582's windows job. 2.4 → 1.8:
the geometric centre of the band and a quarter over its slowest reading both
give 1.84, and none of the 15 readings fails either bound.

`property_getattr_exceptions` is the other shape — not a spread, a baseline that
had been too small to measure. The same commit raised its trip count, so pypy's
execution-only time now clears `FLOOR_GATE_MIN_BASELINE_S` and **arms** the floor
its ceiling derives. The ceiling was 30, fitted while every reading was a lower
bound, and 30 derives a floor of 1x. 30 → 4.

The third commit fixes the instrument rather than a fixture. Windows charges
process CPU by sampling at `WIN_TIMER_QUANTUM_S`, so a startup reading there is a
count of ticks the process was caught running for: unbiased, but only ever a
lattice value. Over 40 empty-program runs on one windows host pypy read 0.000s 31
times, 0.016s 8 times and 0.031s once — mean 0.0039s against a wall-clock mean of
0.026s. No single sample reports the cost; a median picks one lattice point and a
minimum the other. `STARTUP_SAMPLES` 5 → 7 and `_adopt_startups` takes
`statistics.fmean` where it took `statistics.median`. Replaying `failed_bound`
over the 14155 ceiling-carrying non-wasm rows of ten CI runs, the median
estimator produces 47 gate failures the mean does not.

### The four defects behind `MAJIT_CL_BRIDGE_MERGE`'s miscompiles

The gate stays **off**; this makes the arm behind it correct so the route can be
measured. Running every fixture under `pyre/bench/synth` with the gate set and
unset, 13 of 531 disagreed: five access violations, three GC invalid-child
panics, three aborts inside a JIT helper, one wrong total, and one fixture that
prints nanosecond timings. Twelve now read the same either way; the timings
fixture reaches the same verdict on both arms and differs run to run with the
gate unset too.

**Cross-trace guard attach.** `compile_bridge` named the guard a region is
entered through by `fail_index_per_trace` alone. That number indexes the guards
of the trace the *failing* guard belongs to, so a bridge born from a guard inside
another bridge was attached to whatever owner guard shared the number, and
`check_region_entry_slots` accepted it whenever the two happened to carry the
same number of live fail args. `source_trace_id` is computed one screen above the
call; it is passed now, and the merge declines when it is not the owner's own.

**The validator rejected every legitimate merge.** `validate_oprefs_for_compile`
seeded `seen` from `inputargs`, which a region's inputargs deliberately stay out
of, so the first region op reading one failed the walk. Every merge whose region
read an entry value died there — which is why the ones that *did* compile were
the mis-attached ones above.

**Region ref rooting and live-in set.** `build_ref_root_slots` walked
`inputargs` and the op results, so a region's Ref inputargs got no root slot, no
`defined_ref_vars` entry and no gcmap bit, while the same values are rooted in
the bridge's own compile. Separately, the walk carried the owner's
`defined_ref_vars` and overflow flag into the region, whose live-in set is
exactly its own inputargs; the spill and reload that produced put a `def_var` on
an edge ending at the owner's LABEL, and Cranelift answered by carrying seven
more variables around the loop as block parameters the trace entry had no value
for. `loops_comprehension`'s label block went 18 → 25 → 18.

**`bridge_closes_onto` matched the wrong label.** It accepted a JUMP naming any
LABEL the owner publishes, keyed by `Descr::index()`. `LoopTargetDescr::index()`
is the token id and `ensure_preamble_target_token` mints every loop's preamble
target with id 0, so that key is **0 for every peeled loop in the process** and
arity was the only discriminator left. An unrolled owner publishes its peeled
entry label beside the body header, and a region closing onto the first was
lowered as a local branch into it — fixing at compile time a target
`lookup_loop_target` resolves when the exit is taken. The predicate now names the
label the owner's own closing JUMP names, matched by `descr_identity`.

Two smaller ones: a second region off one guard would have taken the first's
entry block, since `region_blocks` is keyed by the source fail index alone; and a
declined merge left the owner's guard descrs restamped with the merged numbering,
which is what `find_fail_descr_in_fail_descrs` reads.

203 fixtures request a merge and 103 take one, up from 93 — 32 gained from the
validator fix, 22 lost to the two tightenings.

### `mmap.find` holds the search pattern's buffer export

#1650's review left one finding that holds up. `mmap.mmap.find` and `rfind`
declare their pattern `view: Py_buffer`, so the export is acquired before `start`
and `end` are bound and released only once the impl has returned. Both
conversions run inside `mmap_gfind_lock_held`, which then reads `view->buf` and
`view->len`: a `bytearray` pattern that one of their `__index__` hooks edits in
place is what the search compares against, and one such a hook resizes raises
`BufferError`.

pyre copied the pattern at entry, the way `interp_mmap.py find` snapshots
`space.bufferstr_w(w_tofind)`, and so answered as PyPy does. Against a 32-byte
mapping and a one-byte `bytearray` pattern an `__index__` hook rewrites to
`b"Z"`, measured on one host:

|  | CPython 3.14.2 | PyPy 7.3.22 |
|---|---|---|
| `find`, hook edits in place | 25 | 0 |
| `rfind`, hook edits in place | 25 | 0 |
| `find`, hook resizes | `BufferError` | 0 |
| `rfind`, hook resizes | `BufferError` | 0 |

pyre now reads CPython's column on all four. `MmapPattern` pins the pattern,
takes one export through `buffer_export_incref` and releases it in `Drop` — so a
raising `__index__` and a hook that closes the mapping each release exactly once
— and the bytes are read back out of the object after the conversions rather than
before them. An immutable `bytes` pattern takes no count, which is what
`buffer_export_incref` already reports. The copy this replaces was not
gratuitous: `bytes_like_data` borrows the bytearray's own storage, which a resize
would reallocate; the export is what makes that resize impossible.

The review's other standing item — that a custom raw `readinto` can retain a
writable window into buffered-I/O storage — does not reproduce.
`W_BufferedReader::raw_read` binds the call's result *without* `?`, releases the
window, and only then applies `?`, so both the Ok and the Err path release, and
`w_memoryview_set_released` destroys the `Buffer::External` descriptor rather
than only flipping a flag. `_bufferedreader_raw_read` in 3.14 does
`Py_DECREF(memobj)` and never releases at all, so pyre is strictly stricter here;
derived views escape in both.

Three adjacent `mmap` gaps came out of the same reading and are **not** touched
here: `is_bytes_like` rejects a `memoryview` or `array.array` pattern that the
`Py_buffer` converter accepts; a fourth positional argument is silently ignored
where 3.14 raises `find expected at most 3 arguments, got 4`; and
`mmap_gfind_lock_held` reads `end_obj` only when `start_obj != Py_None`, so
`m.find(b"Z", None, 5)` answers 25 there while pyre routes the explicit `None`
into `space_index`. pyre matches PyPy on the last one, so it wants the
`[3.14-spec]` adjudication rather than a straight fix.

### Gates

Run on the tree at `4716d60aa8e` — the same five patches over `f8817c90db7`,
identical in diff to what is here after the rebase onto `18b5a501c16`:

- `python pyre/check.py --backend cranelift` — **ALL PASSED 543/543**
- `cargo test --all --no-default-features --features dynasm` — 9019 passed, 0 failed
- `cargo test --all --no-default-features --features cranelift` — 171 passed, 0 failed
- `cargo fmt --all -- --check` and `scripts/check-new-line-citations.py --base origin/main` — clean
- `lib-python/3/test/test_mmap.py` — 40 errors, every one the pre-existing
  `PermissionError WinError 32` cascade this host already shows; no assertion
  failure and no new error
- A 17-case `mmap` probe under `python3.14.exe`, `pypy3.exe` and
  `pyre-cranelift.exe`: pyre matches 3.14 on every case except the pre-existing
  `TypeError` wording noted above

The dynasm arm of `check.py` and the wasm legs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mmap.find()` and `mmap.rfind()` behavior when search patterns are modified during conversion.
  * Resizing a search pattern during conversion now correctly raises `BufferError`.
  * Fixed bridge merging to prevent incorrect execution and preserve guard behavior when merges are declined or fail.

* **Performance**
  * Refined benchmark startup and performance measurements for more consistent results.
  * Updated benchmark thresholds and gate criteria to better reflect observed runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->