### PR TITLE
gc: root two more objects the reviews and the analysis named, and refit both bracket baselines

### DIFF
--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -18,18 +18,18 @@
     ]
   },
   "linux": {
-    "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
+    "base": "de7e1a70159ef1aa2a4d8b1900cfb10006b0f905",
     "brackets_reaching_no_collection": 3,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,
     "frames_across_collecting": 10,
     "frames_across_collecting_fns": 4,
-    "tier15_calls": 0,
-    "tier15_calls_fns": 0,
-    "tier1_calls": 9,
-    "tier1_calls_fns": 7,
-    "unbracketed_calls": 2078,
-    "unbracketed_calls_fns": 832,
+    "tier15_calls": 101,
+    "tier15_calls_fns": 55,
+    "tier1_calls": 0,
+    "tier1_calls_fns": 0,
+    "unbracketed_calls": 2068,
+    "unbracketed_calls_fns": 836,
     "unmatched_seeds": [
       "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
       "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,17 +1,17 @@
 {
   "darwin": {
-    "base": "e75174702af51d97b166e0ed9765cc85ebb51057",
+    "base": "5f2c4f688230346ec908bbeae5b9db580380d80e",
     "brackets_reaching_no_collection": 3,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,
     "frames_across_collecting": 10,
     "frames_across_collecting_fns": 4,
-    "tier15_calls": 102,
-    "tier15_calls_fns": 56,
+    "tier15_calls": 101,
+    "tier15_calls_fns": 55,
     "tier1_calls": 0,
     "tier1_calls_fns": 0,
-    "unbracketed_calls": 2064,
-    "unbracketed_calls_fns": 835,
+    "unbracketed_calls": 2057,
+    "unbracketed_calls_fns": 832,
     "unmatched_seeds": [
       "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
       "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10552,6 +10552,7 @@ impl CraneliftBackend {
 
         let gc_nursery_addrs =
             with_cranelift_gc(|gc| (gc.nursery_free_addr(), gc.nursery_top_addr()));
+        let gc_max_nursery_object_size = with_cranelift_gc(|gc| gc.max_nursery_object_size());
         // llmodel.py:64-69 self.vtable_offset — backend property used by
         // bh_new_with_vtable. Capture for use in NEW_WITH_VTABLE codegen.
         let vtable_offset = self.vtable_offset;
@@ -14300,11 +14301,14 @@ impl CraneliftBackend {
                     let ad = descr
                         .as_array_descr()
                         .expect("CallMallocNurseryVarsize descr must be an ArrayDescr");
-                    let base_size = builder.ins().iconst(cl_types::I64, ad.base_size() as i64);
-                    let item_size = builder.ins().iconst(cl_types::I64, ad.item_size() as i64);
+                    let base_size_i64 = ad.base_size() as i64;
+                    let item_size_i64 = ad.item_size() as i64;
+                    let base_size = builder.ins().iconst(cl_types::I64, base_size_i64);
+                    let item_size = builder.ins().iconst(cl_types::I64, item_size_i64);
                     // The descr's tid, not 0: a varsize object typed 0 is
                     // traced with the layout of whatever registered first.
-                    let type_id = builder.ins().iconst(cl_types::I64, ad.type_id() as i64);
+                    let type_id_i64 = ad.type_id() as i64;
+                    let type_id = builder.ins().iconst(cl_types::I64, type_id_i64);
                     // rewrite.py:858: args = [ConstInt(kind), ConstInt(itemsize), v_length]
                     let length = resolve_opref_or_imm(
                         &mut builder,
@@ -14312,29 +14316,128 @@ impl CraneliftBackend {
                         &known_values,
                         op.arg(2).to_opref(),
                     );
-                    let result = emit_collecting_gc_call(
+                    // x86/aarch64 `malloc_cond_varsize`: reject negative or
+                    // implausibly large lengths before multiplying, then try
+                    // the nursery bump.  Only either failing edge spills the
+                    // live refs, installs the gcmap, and calls the collecting
+                    // helper.  The two comparisons are one combined SSA
+                    // predicate here; their control-flow contract is the same.
+                    let (nf_addr, nt_addr) =
+                        gc_nursery_addrs.ok_or_else(|| missing_gc_runtime(op.opcode))?;
+                    let max_young =
+                        gc_max_nursery_object_size.ok_or_else(|| missing_gc_runtime(op.opcode))?;
+                    let word = std::mem::size_of::<usize>();
+                    // x86/regalloc.py `consider_call_malloc_nursery_varsize`
+                    // passes this byte-derived value directly as the length
+                    // precheck; `malloc_cond_varsize`'s nursery-top comparison
+                    // rejects a product that is still too large.
+                    let max_length = max_young.saturating_sub(2 * word);
+                    debug_assert!(ad.item_size() > 0);
+                    debug_assert!(
+                        ad.base_size() + GcHeader::SIZE >= GcHeader::MIN_NURSERY_OBJ_SIZE
+                    );
+                    let flags = MemFlagsData::trusted();
+                    let max_length_value = builder.ins().iconst(cl_types::I64, max_length as i64);
+                    let length_fits = builder.ins().icmp(
+                        IntCC::UnsignedLessThanOrEqual,
+                        length,
+                        max_length_value,
+                    );
+                    let scaled = builder.ins().imul(length, item_size);
+                    let unaligned_total = builder
+                        .ins()
+                        .iadd_imm_s(scaled, base_size_i64 + GcHeader::SIZE as i64 + 7);
+                    let align_mask = builder.ins().iconst(cl_types::I64, -8);
+                    let total = builder.ins().band(unaligned_total, align_mask);
+                    let nf_ptr = builder.ins().iconst(ptr_type, nf_addr as i64);
+                    let nt_ptr = builder.ins().iconst(ptr_type, nt_addr as i64);
+                    let free = builder.ins().load(ptr_type, flags, nf_ptr, 0);
+                    let new_free = builder.ins().iadd(free, total);
+                    let top = builder.ins().load(ptr_type, flags, nt_ptr, 0);
+                    let nursery_fits =
+                        builder
+                            .ins()
+                            .icmp(IntCC::UnsignedLessThanOrEqual, new_free, top);
+                    let fits = builder.ins().band(length_fits, nursery_fits);
+
+                    let live_refs: Vec<(u32, usize)> = ref_root_slots
+                        .iter()
+                        .filter(|(var_idx, _)| defined_ref_vars.contains(var_idx))
+                        .copied()
+                        .collect();
+                    let fast_block = builder.create_block();
+                    let slow_block = builder.create_block();
+                    let merge_block = builder.create_block();
+                    builder.append_block_param(merge_block, ptr_type); // result
+                    builder.append_block_param(merge_block, ptr_type); // jf_ptr
+                    for _ in &live_refs {
+                        builder.append_block_param(merge_block, cl_types::I64);
+                    }
+                    builder.ins().brif(fits, fast_block, &[], slow_block, &[]);
+
+                    builder.switch_to_block(fast_block);
+                    builder.seal_block(fast_block);
+                    builder.ins().store(flags, new_free, nf_ptr, 0);
+                    builder.ins().store(flags, type_id, free, 0);
+                    let header_size = builder.ins().iconst(ptr_type, GcHeader::SIZE as i64);
+                    let fast_result = builder.ins().iadd(free, header_size);
+                    let mut fast_args: Vec<BlockArg> =
+                        vec![BlockArg::from(fast_result), BlockArg::from(jf_ptr)];
+                    for &(var_idx, _) in &live_refs {
+                        fast_args.push(BlockArg::from(builder.use_var(var(var_idx))));
+                    }
+                    builder.ins().jump(merge_block, &fast_args);
+
+                    builder.switch_to_block(slow_block);
+                    builder.seal_block(slow_block);
+                    builder.set_cold_block(slow_block);
+                    spill_ref_roots(
                         &mut builder,
-                        ptr_type,
-                        call_conv,
                         jf_ptr,
                         &live_ref_root_slots,
                         &defined_ref_vars,
                         &stale_ref_vars,
                         &demoted_failarg_slots,
                         ref_root_base_ofs,
-                        per_call_gcmap,
+                    );
+                    emit_push_gcmap(&mut builder, jf_ptr, per_call_gcmap);
+                    let slow_result = emit_host_call(
+                        &mut builder,
+                        ptr_type,
+                        call_conv,
                         gc_alloc_varsize_shim as *const () as usize,
                         &[base_size, item_size, length, type_id],
                         Some(cl_types::I64),
                     )
                     .expect("GC varsize allocation helper must return a value");
-                    jf_ptr = emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
+                    let jf_ptr_slow =
+                        emit_reload_frame_if_necessary(&mut builder, ptr_type, call_conv);
+                    emit_pop_gcmap(&mut builder, jf_ptr_slow, per_call_gcmap);
+                    reload_ref_roots(
+                        &mut builder,
+                        jf_ptr_slow,
+                        &live_ref_root_slots,
+                        &defined_ref_vars,
+                        &demoted_failarg_slots,
+                        ref_root_base_ofs,
+                    );
+                    let mut slow_args: Vec<BlockArg> =
+                        vec![BlockArg::from(slow_result), BlockArg::from(jf_ptr_slow)];
+                    for &(var_idx, _) in &live_refs {
+                        slow_args.push(BlockArg::from(builder.use_var(var(var_idx))));
+                    }
+                    builder.ins().jump(merge_block, &slow_args);
+
+                    builder.switch_to_block(merge_block);
+                    builder.seal_block(merge_block);
+                    let params = builder.block_params(merge_block).to_vec();
+                    let result = params[0];
+                    jf_ptr = params[1];
                     builder.ins().set_pinned_reg(jf_ptr);
+                    for (i, &(var_idx, _)) in live_refs.iter().enumerate() {
+                        builder.def_var(var(var_idx), params[2 + i]);
+                    }
                     builder.def_var(var(vi), result);
-                    // malloc_cond_varsize parity: the varsize slow path
-                    // (gc_alloc_varsize_shim) returns NULL on `PYPY_GC_MAX`
-                    // out-of-memory; propagate before the following
-                    // header/item stores dereference it.
                     emit_memory_error_check(
                         &mut builder,
                         ptr_type,
@@ -26284,6 +26387,15 @@ mod tests {
         let obj = backend.get_ref_value(&frame, 0);
         assert!(!obj.is_null());
         assert_eq!(unsafe { *(obj.0 as *const i64) }, 3);
+
+        // `malloc_cond_varsize` sends over-threshold lengths through the
+        // collecting helper.  The result is a born-old external allocation.
+        let large_length = 140_000;
+        let frame = backend.execute_token(&token, &[Value::Int(large_length)]);
+        let obj = backend.get_ref_value(&frame, 0);
+        assert!(!obj.is_null());
+        assert_eq!(unsafe { *(obj.0 as *const i64) }, large_length);
+        assert!(!majit_gc::can_move(obj));
     }
 
     #[test]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -334,6 +334,9 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         typeid_is_object: Some(typeid_is_object_via_active_runtime),
         is_registered_type_id: Some(is_registered_type_id_via_active_runtime),
         can_move: Some(can_move_via_active_runtime),
+        pin: Some(pin_via_active_runtime),
+        unpin: Some(unpin_via_active_runtime),
+        is_pinned: Some(is_pinned_via_active_runtime),
         supports_guard_gc_type,
     });
     // No `set_active_gc_deadframe_hooks` call here, and the omission is the
@@ -383,6 +386,11 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         subgraph_has_pending_finalizer_via_active_runtime,
     ));
     majit_gc::set_active_is_tracked(Some(is_tracked_via_active_runtime));
+    majit_gc::set_active_gcflag_hooks(
+        Some(get_gcflag_extra_via_active_runtime),
+        Some(toggle_gcflag_extra_via_active_runtime),
+        Some(get_gcflag_dummy_via_active_runtime),
+    );
     majit_gc::set_active_get_rpy_memory_usage(Some(get_rpy_memory_usage_via_active_runtime));
     majit_gc::set_active_get_rpy_type_index(Some(get_rpy_type_index_via_active_runtime));
     majit_gc::set_active_get_rpy_roots(Some(get_rpy_roots_via_active_runtime));
@@ -1622,6 +1630,18 @@ fn can_move_via_active_runtime(gcref: GcRef) -> bool {
     with_cranelift_gc(|gc| gc.can_move(gcref)).unwrap_or(false)
 }
 
+fn pin_via_active_runtime(gcref: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.pin(gcref)).unwrap_or(false)
+}
+
+fn unpin_via_active_runtime(gcref: GcRef) {
+    with_cranelift_gc_required(|gc| gc.unpin(gcref));
+}
+
+fn is_pinned_via_active_runtime(gcref: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.is_pinned(gcref)).unwrap_or(false)
+}
+
 /// `majit_gc::SubclassRangeFn` installed by `set_gc_allocator`.
 /// Resolves the codegen-time `rclass.CLASSTYPE.subclassrange_{min,max}`
 /// lookup from x86/assembler.py:1971-1974 through the GC's
@@ -1782,6 +1802,18 @@ fn is_tracked_via_active_runtime(obj: GcRef) -> bool {
         return majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.is_tracked(obj));
     }
     false
+}
+
+fn get_gcflag_extra_via_active_runtime(obj: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.get_gcflag_extra(obj)).unwrap_or(false)
+}
+
+fn toggle_gcflag_extra_via_active_runtime(obj: GcRef) {
+    with_cranelift_gc(|gc| gc.toggle_gcflag_extra(obj));
+}
+
+fn get_gcflag_dummy_via_active_runtime(obj: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.get_gcflag_dummy(obj)).unwrap_or(false)
 }
 
 fn get_rpy_memory_usage_via_active_runtime(obj: GcRef) -> Option<usize> {

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3532,6 +3532,74 @@ impl<'a> AssemblerARM64<'a> {
                     Some(Loc::Immed(i)) => i.value,
                     _ => 8,
                 };
+                // aarch64/assembler.py `malloc_cond_varsize`: x0 is the
+                // nursery/result register and x1 the size temporary reserved
+                // by regalloc.  Only the two failing comparisons enter the
+                // collecting helper; a short array commits the bump, stamps
+                // its tid, and returns the payload directly.
+                let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+                let max_young = crate::runner::dynasm_max_size_of_young_obj();
+                let slow_path = self.mc.new_dynamic_label();
+                let done = self.mc.new_dynamic_label();
+                let word = std::mem::size_of::<usize>();
+                // `consider_call_malloc_nursery_varsize` passes this value
+                // directly as `maxlength`; the following nursery-top check
+                // rejects a scaled size that is still too large.
+                let max_length = max_young.saturating_sub(2 * word);
+                let header_size = majit_gc::header::GcHeader::SIZE as i64;
+                debug_assert!(itemsize > 0);
+                debug_assert!(
+                    base_size as usize + majit_gc::header::GcHeader::SIZE
+                        >= majit_gc::header::GcHeader::MIN_NURSERY_OBJ_SIZE
+                );
+                if nf_addr == 0 || nt_addr == 0 || max_length == 0 {
+                    dynasm!(self.mc ; .arch aarch64 ; b =>slow_path);
+                } else {
+                    match arglocs.first() {
+                        Some(Loc::Reg(len_r)) => {
+                            debug_assert_ne!(len_r.value, 0);
+                            debug_assert_ne!(len_r.value, 1);
+                            dynasm!(self.mc ; .arch aarch64 ; mov x1, X(len_r.value));
+                        }
+                        Some(Loc::Immed(len_i)) => self.emit_mov_imm64(1, len_i.value),
+                        Some(Loc::Frame(len_f)) => self.emit_ldr_fp(1, len_f.ebp_loc.value),
+                        Some(Loc::Ebp(len_e)) => self.emit_ldr_fp(1, len_e.value),
+                        other => {
+                            panic!("CallMallocNurseryVarsize length is not a value: {other:?}")
+                        }
+                    }
+                    self.emit_mov_imm64(16, max_length as i64);
+                    dynasm!(self.mc ; .arch aarch64
+                        ; cmp x1, x16
+                        ; b.hi =>slow_path
+                    );
+                    self.emit_mov_imm64(0, nf_addr as i64);
+                    dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x0]);
+                    self.emit_mov_imm64(16, itemsize);
+                    dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x16);
+                    self.emit_mov_imm64(16, base_size + header_size + 7);
+                    dynasm!(self.mc ; .arch aarch64 ; add x1, x1, x16);
+                    self.emit_mov_imm64(16, -8);
+                    dynasm!(self.mc ; .arch aarch64
+                        ; and x1, x1, x16
+                        ; add x1, x1, x0
+                    );
+                    self.emit_mov_imm64(16, nt_addr as i64);
+                    dynasm!(self.mc ; .arch aarch64
+                        ; ldr x16, [x16]
+                        ; cmp x1, x16
+                        ; b.hi =>slow_path
+                    );
+                    self.emit_mov_imm64(16, nf_addr as i64);
+                    dynasm!(self.mc ; .arch aarch64 ; str x1, [x16]);
+                    self.emit_mov_imm64(16, type_id);
+                    dynasm!(self.mc ; .arch aarch64
+                        ; str x16, [x0]
+                        ; add x0, x0, header_size as u32
+                        ; b =>done
+                    );
+                }
+                dynasm!(self.mc ; .arch aarch64 ; =>slow_path);
                 // assembler.py:254 `_push_all_regs_to_jitframe` — the helper
                 // below can collect, and `emit_malloc_slowpath_helper_call`
                 // only saves the volatiles to the *stack*, where the
@@ -3624,6 +3692,7 @@ impl<'a> AssemblerARM64<'a> {
                     let rv = r.value;
                     dynasm!(self.mc ; .arch aarch64 ; mov X(rv), x0);
                 }
+                dynasm!(self.mc ; .arch aarch64 ; =>done);
             }
             // aarch64/opassembler.py `emit_op_check_memory_error` →
             // assembler.py:342-346 `propagate_memoryerror_if_reg_is_null`

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3542,10 +3542,11 @@ impl<'a> AssemblerARM64<'a> {
                 let slow_path = self.mc.new_dynamic_label();
                 let done = self.mc.new_dynamic_label();
                 let word = std::mem::size_of::<usize>();
-                // `consider_call_malloc_nursery_varsize` passes this value
-                // directly as `maxlength`; the following nursery-top check
-                // rejects a scaled size that is still too large.
-                let max_length = max_young.saturating_sub(2 * word);
+                // aarch64/regalloc.py `consider_call_malloc_nursery_varsize`:
+                // `maxlength = (max_size_of_young_obj - WORD * 2) / itemsize`.
+                // The compare below is against the item count, not the byte
+                // bound x86's precheck uses.
+                let max_length = max_young.saturating_sub(2 * word) / itemsize as usize;
                 let header_size = majit_gc::header::GcHeader::SIZE as i64;
                 debug_assert!(itemsize > 0);
                 debug_assert!(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -528,6 +528,13 @@ pub(crate) fn dynasm_nursery_addrs() -> (usize, usize) {
     with_dynasm_active_gc(|gc| (gc.nursery_free_addr(), gc.nursery_top_addr())).unwrap_or((0, 0))
 }
 
+/// `GcLLDescr_framework.max_size_of_young_obj`, consumed by
+/// `malloc_cond_varsize` before it computes `itemsize * length`.  Zero is the
+/// no-GC sentinel, paired with [`dynasm_nursery_addrs`]'s `(0, 0)` answer.
+pub(crate) fn dynasm_max_size_of_young_obj() -> usize {
+    with_dynasm_active_gc(|gc| gc.max_nursery_object_size()).unwrap_or(0)
+}
+
 /// Head of the recycle list an inline allocation takes from before it bumps.
 /// Zero when the bound GC keeps none, and when none is bound.
 pub(crate) fn dynasm_nursery_recycle_list_addr() -> usize {
@@ -4115,6 +4122,7 @@ mod tests {
     use majit_gc::collector::{GcConfig, MiniMarkGC};
     use majit_gc::header::header_of;
     use majit_gc::trace::TypeInfo;
+    use majit_ir::descr::SimpleArrayDescr;
     use majit_ir::operand::Operand;
     use majit_ir::{
         CallDescr, DescrRef, EffectInfo, ExtraEffect, InputArg, OopSpecIndex, OpCode, Type, Value,
@@ -4439,6 +4447,80 @@ mod tests {
         assert_eq!(unsafe { (*header_of(obj.0)).type_id() }, 1);
         assert_eq!(unsafe { *(obj.0 as *const u64) }, 0xDEAD);
         assert_eq!(unsafe { *((obj.0 + 16) as *const i64) }, 1);
+    }
+
+    #[test]
+    fn test_gc_varsize_alloc_and_length_init_with_configured_runtime() {
+        install_test_libc_jitframe_tracer();
+        let mut gc = MiniMarkGC::with_config(GcConfig {
+            nursery_size: 1 << 20,
+            large_object_threshold: 1 << 20,
+            ..GcConfig::default()
+        });
+        let array_tid = gc.register_type(TypeInfo::varsize(8, 8, 0, false, Vec::new()));
+
+        let mut backend = DynasmBackend::new();
+        backend.attach_default_test_descrs();
+        let mut consts: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+        consts.insert(10000, 0_i64); // FLAG_ARRAY
+        consts.insert(10001, 8_i64); // item size / length-store width
+        consts.insert(10002, 0_i64); // length offset
+        backend.set_constants(consts);
+        register_jitframe_type(&mut gc);
+        backend.set_gc_allocator(Box::new(gc));
+
+        let alloc = mk_op(
+            OpCode::CallMallocNurseryVarsize,
+            &[
+                OpRef::int_op(10000),
+                OpRef::int_op(10001),
+                OpRef::input_arg_int(0),
+            ],
+            1,
+        );
+        alloc.setdescr(Arc::new(SimpleArrayDescr::new(
+            0,
+            8,
+            8,
+            array_tid,
+            Type::Int,
+        )));
+        let inputargs = vec![InputArg::new_int(0)];
+        let ops = vec![
+            mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
+            alloc,
+            mk_op(
+                OpCode::GcStore,
+                &[
+                    OpRef::ref_op(1),
+                    OpRef::int_op(10002),
+                    OpRef::input_arg_int(0),
+                    OpRef::int_op(10001),
+                ],
+                OpRef::NONE.raw(),
+            ),
+            mk_op(OpCode::Finish, &[OpRef::ref_op(1)], OpRef::NONE.raw()),
+        ];
+
+        let token = JitCellToken::new(1501);
+        backend.compile_loop(&inputargs, &ops, &token).unwrap();
+        let frame = backend.execute_token(&token, &[Value::Int(3)]);
+        let obj = backend.get_ref_value(&frame, 0);
+
+        assert!(!obj.is_null());
+        assert_eq!(unsafe { (*header_of(obj.0)).type_id() }, array_tid);
+        assert_eq!(unsafe { *(obj.0 as *const i64) }, 3);
+
+        // A length beyond `max_size_of_young_obj` must take the collecting
+        // helper edge, not overflow the inline size calculation or bump past
+        // the nursery top.  `external_malloc` returns this object born-old.
+        let large_length = 140_000;
+        let frame = backend.execute_token(&token, &[Value::Int(large_length)]);
+        let obj = backend.get_ref_value(&frame, 0);
+        assert!(!obj.is_null());
+        assert_eq!(unsafe { (*header_of(obj.0)).type_id() }, array_tid);
+        assert_eq!(unsafe { *(obj.0 as *const i64) }, large_length);
+        assert!(!majit_gc::can_move(obj));
     }
 
     #[test]

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -361,6 +361,9 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         typeid_is_object: Some(dynasm_typeid_is_object),
         is_registered_type_id: Some(dynasm_is_registered_type_id),
         can_move: Some(dynasm_can_move),
+        pin: Some(dynasm_pin),
+        unpin: Some(dynasm_unpin),
+        is_pinned: Some(dynasm_is_pinned),
         supports_guard_gc_type,
     });
     // The jitframe a compiled run returns stays alive as the deadframe until
@@ -392,6 +395,11 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         dynasm_subgraph_has_pending_finalizer,
     ));
     majit_gc::set_active_is_tracked(Some(dynasm_is_tracked));
+    majit_gc::set_active_gcflag_hooks(
+        Some(dynasm_get_gcflag_extra),
+        Some(dynasm_toggle_gcflag_extra),
+        Some(dynasm_get_gcflag_dummy),
+    );
     majit_gc::set_active_get_rpy_memory_usage(Some(dynasm_get_rpy_memory_usage));
     majit_gc::set_active_get_rpy_type_index(Some(dynasm_get_rpy_type_index));
     majit_gc::set_active_get_rpy_roots(Some(dynasm_get_rpy_roots));
@@ -490,6 +498,18 @@ fn dynasm_get_actual_typeid(gcref: GcRef) -> Option<u32> {
 
 fn dynasm_can_move(gcref: GcRef) -> bool {
     with_dynasm_active_gc(|gc| gc.can_move(gcref)).unwrap_or(false)
+}
+
+fn dynasm_pin(gcref: GcRef) -> bool {
+    with_dynasm_active_gc_mut(|gc| gc.pin(gcref)).unwrap_or(false)
+}
+
+fn dynasm_unpin(gcref: GcRef) {
+    with_dynasm_active_gc_mut(|gc| gc.unpin(gcref)).expect("missing active GC runtime");
+}
+
+fn dynasm_is_pinned(gcref: GcRef) -> bool {
+    with_dynasm_active_gc(|gc| gc.is_pinned(gcref)).unwrap_or(false)
 }
 
 fn dynasm_subclass_range(classptr: usize) -> Option<(i64, i64)> {
@@ -825,6 +845,22 @@ fn dynasm_is_tracked(obj: majit_ir::GcRef) -> bool {
         return tracked;
     }
     majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.is_tracked(obj))
+}
+
+fn dynasm_get_gcflag_extra(obj: majit_ir::GcRef) -> bool {
+    gc_box::with_mut(|g| g.get_gcflag_extra(obj))
+        .unwrap_or_else(|| majit_gc::gc_sync::gc_op(|g| g.get_gcflag_extra(obj)))
+}
+
+fn dynasm_toggle_gcflag_extra(obj: majit_ir::GcRef) {
+    if gc_box::with_mut(|g| g.toggle_gcflag_extra(obj)).is_none() {
+        majit_gc::gc_sync::gc_op(|g| g.toggle_gcflag_extra(obj));
+    }
+}
+
+fn dynasm_get_gcflag_dummy(obj: majit_ir::GcRef) -> bool {
+    gc_box::with_mut(|g| g.get_gcflag_dummy(obj))
+        .unwrap_or_else(|| majit_gc::gc_sync::gc_op(|g| g.get_gcflag_dummy(obj)))
 }
 
 fn dynasm_get_rpy_memory_usage(obj: majit_ir::GcRef) -> Option<usize> {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4487,6 +4487,74 @@ impl<'a> Assembler386<'a> {
                     Some(Loc::Immed(i)) => i.value,
                     _ => 8,
                 };
+                // x86/assembler.py `malloc_cond_varsize`: keep the common
+                // short-array allocation in generated code.  The unsigned
+                // length precheck sends negative and implausibly large values
+                // to the checked helper before `itemsize * length`; the second
+                // check sends a merely-full nursery there.  ECX/EDX are the
+                // exact result/temp pair reserved by
+                // `consider_call_malloc_nursery_varsize`, so the original
+                // length location remains intact for the slow arm.
+                let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
+                let max_young = crate::runner::dynasm_max_size_of_young_obj();
+                let slow_path = self.mc.new_dynamic_label();
+                let done = self.mc.new_dynamic_label();
+                let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+                let header_size = majit_gc::header::GcHeader::SIZE as i64;
+                let word = std::mem::size_of::<usize>();
+                // `consider_call_malloc_nursery_varsize` passes this value
+                // directly as `maxlength`; the following nursery-top check
+                // rejects a scaled size that is still too large.
+                let max_length = max_young.saturating_sub(2 * word);
+                debug_assert!(itemsize > 0);
+                debug_assert!(
+                    base_size as usize + majit_gc::header::GcHeader::SIZE
+                        >= majit_gc::header::GcHeader::MIN_NURSERY_OBJ_SIZE
+                );
+                if nf_addr == 0 || nt_addr == 0 || max_length == 0 {
+                    dynasm!(self.mc ; .arch x64 ; jmp =>slow_path);
+                } else {
+                    match arglocs.first() {
+                        Some(Loc::Reg(len_r)) => {
+                            debug_assert_ne!(len_r.value, crate::regloc::ECX.value);
+                            debug_assert_ne!(len_r.value, crate::regloc::EDX.value);
+                            dynasm!(self.mc ; .arch x64 ; mov rdx, Rq(len_r.value));
+                        }
+                        Some(Loc::Immed(len_i)) => {
+                            dynasm!(self.mc ; .arch x64 ; mov rdx, QWORD len_i.value);
+                        }
+                        Some(Loc::Frame(len_f)) => {
+                            dynasm!(self.mc ; .arch x64 ; mov rdx, [rbp + len_f.ebp_loc.value]);
+                        }
+                        Some(Loc::Ebp(len_e)) => {
+                            dynasm!(self.mc ; .arch x64 ; mov rdx, [rbp + len_e.value]);
+                        }
+                        other => {
+                            panic!("CallMallocNurseryVarsize length is not a value: {other:?}")
+                        }
+                    }
+                    dynasm!(self.mc ; .arch x64
+                        ; mov Rq(scratch), QWORD max_length as i64
+                        ; cmp rdx, Rq(scratch)
+                        ; ja =>slow_path
+                        ; mov Rq(scratch), QWORD nf_addr as i64
+                        ; mov rcx, [Rq(scratch)]
+                        ; imul rdx, rdx, itemsize as i32
+                        ; add rdx, (base_size + header_size + 7) as i32
+                        ; and rdx, -8
+                        ; add rdx, rcx
+                        ; mov Rq(scratch), QWORD nt_addr as i64
+                        ; cmp rdx, [Rq(scratch)]
+                        ; ja =>slow_path
+                        ; mov Rq(scratch), QWORD nf_addr as i64
+                        ; mov [Rq(scratch)], rdx
+                        ; mov Rq(scratch), QWORD type_id
+                        ; mov [rcx], Rq(scratch)
+                        ; add rcx, header_size as i32
+                        ; jmp =>done
+                    );
+                }
+                dynasm!(self.mc ; .arch x64 ; =>slow_path);
                 // x86/assembler.py:254 `_push_all_regs_to_jitframe` — the
                 // helper below can collect, and unlike the fixed-size path it
                 // is called directly rather than through the trampoline that
@@ -4585,6 +4653,7 @@ impl<'a> Assembler386<'a> {
                     let rv = r.value;
                     dynasm!(self.mc ; .arch x64 ; mov Rq(rv), rax);
                 }
+                dynasm!(self.mc ; .arch x64 ; =>done);
             }
             // x86/assembler.py `genop_discard_check_memory_error`
             // — emit `TEST reg, reg` + `JNZ skip` and inline the

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5979,8 +5979,8 @@ fn build_function(
             // GUARD_GC_TYPE: args[0] = object ref, args[1] = expected
             // type_id. The majit runtime stores the typeid in the GC
             // header word placed immediately before the object payload
-            // (`majit_gc::header::GcHeader::tid_and_flags`, lower 32
-            // bits). The cranelift backend lowers the same op this way
+            // (`majit_gc::header::GcHeader::tid_and_flags`, lower
+            // `TYPE_ID_BITS`). The cranelift backend lowers the same op this way
             // (compiler.rs GuardGcType branch). This is NOT the RPython
             // gcremovetypeptr layout — pyre's GC keeps the typeid in the
             // header, not at `obj[0]`.
@@ -5992,7 +5992,9 @@ fn build_function(
                     sink.i64_const(GcHeader::SIZE as i64);
                     sink.i64_sub();
                     sink.i32_wrap_i64();
-                    // Load 8-byte header word (tid_and_flags)
+                    // Load the physical header prefix. On wasm32 its upper
+                    // four bytes are ABI padding; TYPE_ID_MASK selects the
+                    // 16-bit type-id half of the logical RPython word.
                     sink.i64_load(mem64(0));
                     // Mask lower TYPE_ID_BITS to extract the type id
                     sink.i64_const(TYPE_ID_MASK as i64);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1091,7 +1091,10 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         typeid_subclass_range: Some(wasm_typeid_subclass_range),
         typeid_is_object: Some(wasm_typeid_is_object),
         is_registered_type_id: Some(wasm_is_registered_type_id),
-        can_move: None,
+        can_move: Some(wasm_can_move),
+        pin: Some(wasm_pin),
+        unpin: Some(wasm_unpin),
+        is_pinned: Some(wasm_is_pinned),
         supports_guard_gc_type,
     });
     majit_gc::set_active_alloc_nursery_typed(Some(wasm_alloc_nursery_typed));
@@ -1117,6 +1120,11 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_get_referents(Some(wasm_get_referents));
     majit_gc::set_active_subgraph_has_pending_finalizer(Some(wasm_subgraph_has_pending_finalizer));
     majit_gc::set_active_is_tracked(Some(wasm_is_tracked));
+    majit_gc::set_active_gcflag_hooks(
+        Some(wasm_get_gcflag_extra),
+        Some(wasm_toggle_gcflag_extra),
+        Some(wasm_get_gcflag_dummy),
+    );
     majit_gc::set_active_get_rpy_memory_usage(Some(wasm_get_rpy_memory_usage));
     majit_gc::set_active_get_rpy_type_index(Some(wasm_get_rpy_type_index));
     majit_gc::set_active_get_rpy_roots(Some(wasm_get_rpy_roots));
@@ -1371,6 +1379,18 @@ fn wasm_is_tracked(obj: GcRef) -> bool {
     with_wasm_active_gc_mut(|gc| gc.is_tracked(obj)).unwrap_or(false)
 }
 
+fn wasm_get_gcflag_extra(obj: GcRef) -> bool {
+    with_wasm_active_gc_mut(|gc| gc.get_gcflag_extra(obj)).unwrap_or(false)
+}
+
+fn wasm_toggle_gcflag_extra(obj: GcRef) {
+    with_wasm_active_gc_mut(|gc| gc.toggle_gcflag_extra(obj));
+}
+
+fn wasm_get_gcflag_dummy(obj: GcRef) -> bool {
+    with_wasm_active_gc_mut(|gc| gc.get_gcflag_dummy(obj)).unwrap_or(false)
+}
+
 fn wasm_get_rpy_memory_usage(obj: GcRef) -> Option<usize> {
     with_wasm_active_gc_mut(|gc| gc.get_rpy_memory_usage(obj)).flatten()
 }
@@ -1444,6 +1464,22 @@ fn wasm_is_tagged_immediate(addr: usize) -> bool {
 
 fn wasm_get_actual_typeid(gcref: GcRef) -> Option<u32> {
     with_wasm_active_gc(|gc| gc.get_actual_typeid(gcref)).flatten()
+}
+
+fn wasm_can_move(gcref: GcRef) -> bool {
+    with_wasm_active_gc(|gc| gc.can_move(gcref)).unwrap_or(false)
+}
+
+fn wasm_pin(gcref: GcRef) -> bool {
+    with_wasm_active_gc_mut(|gc| gc.pin(gcref)).unwrap_or(false)
+}
+
+fn wasm_unpin(gcref: GcRef) {
+    with_wasm_active_gc_mut(|gc| gc.unpin(gcref)).expect("missing active GC runtime");
+}
+
+fn wasm_is_pinned(gcref: GcRef) -> bool {
+    with_wasm_active_gc(|gc| gc.is_pinned(gcref)).unwrap_or(false)
 }
 
 fn wasm_subclass_range(classptr: usize) -> Option<(i64, i64)> {

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2961,16 +2961,17 @@ fn enabled_guard_gc_type_info() -> codegen::GuardGcTypeInfo {
     // Pretend the TYPE_INFO table sits at a small in-memory address;
     // wasm validation only checks the bytecode shape, not the actual
     // load addresses, so any value works for codegen testing.
-    // majit `TypeEntry` stride = 32 bytes (TypeInfoLayout 16 + ClassTypeLayout 16).
-    // shift_by = log2(32) = 5, sizeof_ti = rffi.sizeof(TYPE_INFO) = 16.
+    // majit `TypeEntry` stride = 64 bytes (the four-word TYPE_INFO plus the
+    // four-word VARSIZE_TYPE_INFO/CLASSTYPE union tail).
+    // shift_by = log2(64) = 6, sizeof_ti = rffi.sizeof(TYPE_INFO) = 32.
     // gc.py _setup_guard_is_object: T_IS_RPYTHON_INSTANCE
     // = 0x100000 (gctypelayout.py:196), packed little-endian into a
     // Signed word — byte at offset +2 carries the flag, mask = 0x10.
     codegen::GuardGcTypeInfo {
         supports_guard_gc_type: true,
         base_type_info: 0x1000,
-        shift_by: 5,
-        sizeof_ti: 16, // size_of::<TypeInfoLayout>()
+        shift_by: 6,
+        sizeof_ti: 32, // size_of::<TypeInfoLayout>()
         infobits_offset: 2,
         is_object_flag: 0x10,
         subclassrange_min_offset: 0, // offset within ClassTypeLayout

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1006,12 +1006,15 @@ pub struct MiniMarkGC {
     /// incminimark.py:388-390.  Registrations first enter the probably-young
     /// deque as `(object, finalizer-handler-index)` pairs and are promoted by
     /// the next minor collection.
-    probably_young_objects_with_finalizers: VecDeque<(usize, usize)>,
+    probably_young_objects_with_finalizers: VecDeque<(usize, isize)>,
     /// incminimark.py:392-393.  Old objects still waiting to become
     /// unreachable, paired with their translated FinalizerQueue handler.
-    old_objects_with_finalizers: VecDeque<(usize, usize)>,
+    old_objects_with_finalizers: VecDeque<(usize, isize)>,
     /// gc/base.py finalizer handlers: one death deque and trigger per queue.
     finalizer_handlers: Vec<FinalizerHandler>,
+    /// `GCBase.run_old_style_finalizers`: heavyweight finalizers use the
+    /// historical queue index -1 and are invoked after new-style triggers.
+    run_old_style_finalizers: VecDeque<usize>,
     finalizer_lock: bool,
     /// incminimark.py:394 `self.enabled = True`.
     enabled: bool,
@@ -1301,6 +1304,7 @@ impl MiniMarkGC {
             probably_young_objects_with_finalizers: VecDeque::new(),
             old_objects_with_finalizers: VecDeque::new(),
             finalizer_handlers: Vec::new(),
+            run_old_style_finalizers: VecDeque::new(),
             finalizer_lock: false,
             enabled: true,
             oldgen_nonmoving_active: false,
@@ -1482,7 +1486,13 @@ impl MiniMarkGC {
             return (0, GcFlags::empty());
         }
         let extra_words = self.card_marking_words_for_length(length);
-        let card_header_bytes = 8 * extra_words; // WORD * extra_words
+        // incminimark.py `external_malloc`: `cardheadersize = WORD *
+        // extra_words`.  On wasm32 `GcHeader` retains an eight-byte physical
+        // prefix solely to align native Rust payloads, so round the logical
+        // card bytes up to that physical alignment; the bytes adjacent to the
+        // object remain the real card bitmap and any leading bytes are pad.
+        let logical_card_bytes = std::mem::size_of::<usize>() * extra_words;
+        let card_header_bytes = logical_card_bytes.div_ceil(GcHeader::ALIGN) * GcHeader::ALIGN;
         let mut extra_flags = GcFlags::GCFLAG_HAS_CARDS | GcFlags::GCFLAG_TRACK_YOUNG_PTRS;
         // incminimark.py:1032-1035: "if 'alloc_young', then we also
         // immediately set GCFLAG_CARDS_SET, but without adding the object to
@@ -1636,6 +1646,13 @@ impl MiniMarkGC {
         let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
             return GcRef(0);
         };
+
+        // incminimark.py `malloc_fixedsize`: a heavyweight old-style
+        // finalizer can allocate, collect and resurrect, so its object must
+        // never move. `finish_alloc_in_oldgen` performs the -1 registration.
+        if self.type_has_old_style_finalizer(type_id) {
+            return self.alloc_in_oldgen_clear(type_id, total_size);
+        }
 
         if total_size < self.config.large_object_threshold {
             let ptr = self.nursery.alloc(total_size);
@@ -1808,6 +1825,11 @@ impl MiniMarkGC {
         let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
             return GcRef(0);
         };
+
+        if !FAST && self.type_has_old_style_finalizer(type_id) {
+            unsafe { *needs_write_barrier = true };
+            return self.alloc_in_oldgen_clear(type_id, total_size);
+        }
 
         if total_size < self.config.large_object_threshold {
             let ptr = self.nursery.alloc(total_size);
@@ -2078,6 +2100,10 @@ impl MiniMarkGC {
             return GcRef(0);
         };
 
+        if self.type_has_old_style_finalizer(type_id) {
+            return self.alloc_in_oldgen_nursery_substitute(type_id, total_size);
+        }
+
         // Both fallbacks stand in for the nursery bump below, which clears
         // nothing — the same reading `spill_to_oldgen_or_null` takes for this
         // function's fallible counterpart.
@@ -2215,6 +2241,10 @@ impl MiniMarkGC {
             return GcRef(0);
         };
 
+        if !FAST && self.type_has_old_style_finalizer(type_id) {
+            return self.spill_to_oldgen_or_null(type_id, total_size);
+        }
+
         if total_size < self.config.large_object_threshold {
             let ptr = self.nursery.alloc(total_size);
             if !ptr.is_null() {
@@ -2260,6 +2290,50 @@ impl MiniMarkGC {
         }
         if let Some(destructor) = self.types.get(type_id).destructor {
             unsafe { destructor(obj_addr) };
+        }
+    }
+
+    /// `q_is_old_style_finalizer(typeid)` from gctypelayout.py.
+    #[inline]
+    fn type_has_old_style_finalizer(&self, type_id: u32) -> bool {
+        (type_id as usize) < self.types.len()
+            && self.types.get(type_id).old_style_finalizer.is_some()
+    }
+
+    /// `GCBase.mark_finalizer_to_run` keeps the historical -1 queue index for
+    /// old-style finalizers and non-negative indexes for FinalizerQueue.
+    fn register_finalizer_index(&mut self, fq_index: isize, obj: GcRef) {
+        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+            return;
+        }
+        // `register_finalizer` is contracted to run at most once per object
+        // (`rgc.py:648-649`). A second deque entry survives the first
+        // `deal_with_objects_with_finalizers` pass through `new_with_finalizer`
+        // (incminimark.py:2944-2946) and delivers the object a second time on
+        // the next major collection, so honour the contract here rather than
+        // leaving it to every caller.
+        let hdr = unsafe { header_of(obj.0) };
+        if unsafe { (*hdr).has_flag(GcFlags::FINALIZER_REGISTERED) } {
+            return;
+        }
+        unsafe { (*hdr).set_flag(GcFlags::FINALIZER_REGISTERED) };
+        // `oldgen.contains` is not the "is it old" question on its own: both
+        // raw-malloc births share `try_rawmalloc_block`, so a young one is in
+        // `rawmalloced_payloads` as well and answers yes. It has to be excluded
+        // here, because filing it as old skips the GCFLAG_VISITED_RMY stamp
+        // `deal_with_young_objects_with_finalizers` owes a raw-malloced member,
+        // and `free_young_rawmalloced_objects` then releases the block at the
+        // end of that minor with its address still on the old deque.
+        if self.oldgen.contains(obj.0) && !self.is_young_rawmalloced(obj.0) {
+            // Pyre's host allocations can be born directly in old-gen and an
+            // explicit non-moving major intentionally skips the leading minor.
+            // This is the post-`_trace_drag_out1` destination of PyPy's
+            // probably-young deque, reached immediately for an already-old obj.
+            self.old_objects_with_finalizers
+                .push_back((obj.0, fq_index));
+        } else {
+            self.probably_young_objects_with_finalizers
+                .push_back((obj.0, fq_index));
         }
     }
 
@@ -2816,6 +2890,9 @@ impl MiniMarkGC {
                 self.old_objects_with_weakrefs.push(obj_addr);
             }
         }
+        if self.type_has_old_style_finalizer(type_id) {
+            self.register_finalizer_index(-1, GcRef(obj_addr));
+        }
         crate::note_bh_object(
             obj_addr,
             total_size - GcHeader::SIZE,
@@ -2961,7 +3038,11 @@ impl MiniMarkGC {
         if (type_id as usize) >= self.types.len() {
             return true;
         }
-        let contains_weakptr = self.types.get(type_id).is_weakref;
+        let info = self.types.get(type_id);
+        let contains_weakptr = info.is_weakref;
+        if info.old_style_finalizer.is_some() {
+            return false;
+        }
         debug_assert!(
             !contains_weakptr,
             "'contains_weakptr' specified for a large object"
@@ -5571,6 +5652,7 @@ impl MiniMarkGC {
         for addr in pending {
             result.push(GcRef(addr));
         }
+        result.extend(self.run_old_style_finalizers.iter().copied().map(GcRef));
         result
     }
 
@@ -5600,6 +5682,12 @@ impl MiniMarkGC {
                 .iter()
                 .flat_map(|handler| handler.deque.iter().copied())
                 .map(|addr| (GcRef(addr), "finalizer_death_queue")),
+        );
+        roots.extend(
+            self.run_old_style_finalizers
+                .iter()
+                .copied()
+                .map(|addr| (GcRef(addr), "old_style_finalizer_death_queue")),
         );
         for (gcref, site) in roots {
             self.seed_major_root(gcref, site);
@@ -7390,7 +7478,9 @@ impl MiniMarkGC {
     /// and code object is on those lists and a predicate that counted them
     /// would never answer zero.
     pub(crate) fn registered_finalizer_count(&self) -> usize {
-        self.probably_young_objects_with_finalizers.len() + self.old_objects_with_finalizers.len()
+        self.probably_young_objects_with_finalizers.len()
+            + self.old_objects_with_finalizers.len()
+            + self.run_old_style_finalizers.len()
     }
 
     /// Whether a collection could still hand control back to the program.
@@ -7516,7 +7606,13 @@ impl MiniMarkGC {
 
         while let Some((obj_addr, fq_index)) = marked.pop_front() {
             if self.finalization_state(obj_addr) == 2 {
-                self.finalizer_handlers[fq_index].deque.push_back(obj_addr);
+                if fq_index == -1 {
+                    self.run_old_style_finalizers.push_back(obj_addr);
+                } else {
+                    self.finalizer_handlers[fq_index as usize]
+                        .deque
+                        .push_back(obj_addr);
+                }
                 self.recursively_clear_finalization_ordering(obj_addr);
             } else {
                 new_with_finalizer.push_back((obj_addr, fq_index));
@@ -7534,6 +7630,22 @@ impl MiniMarkGC {
             if !handler.deque.is_empty() {
                 (handler.trigger)();
             }
+        }
+        // GCBase.execute_finalizers runs old-style callbacks only after every
+        // new-style queue trigger. Pop before calling so a nested collection
+        // cannot invoke the same object twice. PyPy's GC transform keeps the
+        // popped `obj` local alive across `call_destructor`; register the Rust
+        // local explicitly for that same re-entrant-collection contract.
+        while let Some(obj_addr) = self.run_old_style_finalizers.pop_front() {
+            let mut obj = GcRef(obj_addr);
+            unsafe { self.roots.add(&mut obj) };
+            let type_id = unsafe { (*header_of(obj.0)).type_id() };
+            if (type_id as usize) < self.types.len()
+                && let Some(finalizer) = self.types.get(type_id).old_style_finalizer
+            {
+                unsafe { finalizer(obj.0) };
+            }
+            self.roots.remove(&mut obj);
         }
         self.finalizer_lock = false;
     }
@@ -8800,7 +8912,7 @@ impl GcAllocator for MiniMarkGC {
     fn type_alloc_is_plain(&self, type_id: u32) -> bool {
         (type_id as usize) < self.types.len() && {
             let info = self.types.get(type_id);
-            info.destructor.is_none() && !info.is_weakref
+            info.destructor.is_none() && info.old_style_finalizer.is_none() && !info.is_weakref
         }
     }
 
@@ -8963,35 +9075,8 @@ impl GcAllocator for MiniMarkGC {
                 trigger,
             });
         }
-        // `register_finalizer` is contracted to run at most once per object
-        // (`rgc.py:648-649`). A second deque entry survives the first
-        // `deal_with_objects_with_finalizers` pass through `new_with_finalizer`
-        // (incminimark.py:2944-2946) and delivers the object a second time on
-        // the next major collection, so honour the contract here rather than
-        // leaving it to every caller.
-        let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(GcFlags::FINALIZER_REGISTERED) } {
-            return;
-        }
-        unsafe { (*hdr).set_flag(GcFlags::FINALIZER_REGISTERED) };
-        // `oldgen.contains` is not the "is it old" question on its own: both
-        // raw-malloc births share `try_rawmalloc_block`, so a young one is in
-        // `rawmalloced_payloads` as well and answers yes. It has to be excluded
-        // here, because filing it as old skips the GCFLAG_VISITED_RMY stamp
-        // `deal_with_young_objects_with_finalizers` owes a raw-malloced member,
-        // and `free_young_rawmalloced_objects` then releases the block at the
-        // end of that minor with its address still on the old deque.
-        if self.oldgen.contains(obj.0) && !self.is_young_rawmalloced(obj.0) {
-            // Pyre's host allocations can be born directly in old-gen and an
-            // explicit non-moving major intentionally skips the leading minor.
-            // This is the post-`_trace_drag_out1` destination of PyPy's
-            // probably-young deque, reached immediately for an already-old obj.
-            self.old_objects_with_finalizers
-                .push_back((obj.0, fq_index));
-        } else {
-            self.probably_young_objects_with_finalizers
-                .push_back((obj.0, fq_index));
-        }
+        let fq_index = isize::try_from(fq_index).expect("finalizer queue index exceeds Signed");
+        self.register_finalizer_index(fq_index, obj);
     }
 
     fn ignore_finalizer(&mut self, obj: GcRef) {
@@ -15094,6 +15179,41 @@ cache size\t: 8192 kB\n";
         // ArenaCollection::contains is intentionally an arena-range query and
         // can stay true for a freed block while the current arena is retained.
         // The allocator's exact live count verifies reclamation here.
+        assert_eq!(gc.oldgen.object_count(), 0);
+    }
+
+    /// incminimark.py `malloc_fixedsize(..., is_finalizer_light=False)` and
+    /// GCBase.execute_finalizers: an old-style finalizer is born old, runs only
+    /// after finalization ordering, and leaves the resurrectable object alive
+    /// until a later major cycle.
+    #[test]
+    fn old_style_finalizer_is_born_old_and_runs_from_its_distinct_queue() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static RUNS: AtomicUsize = AtomicUsize::new(0);
+        unsafe fn finalizer(_obj_addr: usize) {
+            RUNS.fetch_add(1, Ordering::Relaxed);
+        }
+
+        RUNS.store(0, Ordering::Relaxed);
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_old_style_finalizer(16, finalizer));
+        let obj = gc.alloc_with_type(tid, 16);
+
+        assert!(!gc.is_in_nursery(obj.0));
+        assert_eq!(
+            gc.old_objects_with_finalizers,
+            VecDeque::from([(obj.0, -1)])
+        );
+        assert!(gc.young_objects_with_destructors.is_empty());
+
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(RUNS.load(Ordering::Relaxed), 1);
+        assert!(gc.run_old_style_finalizers.is_empty());
+        assert_eq!(gc.oldgen.object_count(), 1);
+
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(RUNS.load(Ordering::Relaxed), 1);
         assert_eq!(gc.oldgen.object_count(), 0);
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -638,7 +638,7 @@ fn estimate_best_nursery_size() -> usize {
 /// `nonlarge_max + 1` directly as the large-object cutoff, so the doubling is
 /// of the cutoff itself.  A nursery below this cannot hold one non-large
 /// object, which is why upstream never lets the environment configure one.
-const LARGE_OBJECT_THRESHOLD: usize = (16384 + 512) * 8;
+const LARGE_OBJECT_THRESHOLD: usize = (16384 + 512) * std::mem::size_of::<usize>();
 
 /// incminimark.py:459-473 — the environment-configured nursery size, and the
 /// `debug_tiny_nursery` budget a request below `minsize` turns into.
@@ -675,7 +675,11 @@ fn default_nursery_size() -> (usize, Option<usize>) {
 /// env.py `addressable_size = float(2**63)` for a 64-bit host: the most
 /// memory the process could address, used as the fallback / upper clamp when
 /// the real total-memory probe is unavailable or larger.
-const ADDRESSABLE_SIZE: f64 = 9_223_372_036_854_775_808.0; // 2**63
+const ADDRESSABLE_SIZE: f64 = if usize::BITS == 64 {
+    9_223_372_036_854_775_808.0 // 2**63
+} else {
+    2_147_483_648.0 // 2**31
+};
 
 /// env.py `get_total_memory_darwin`. Clamp a sysctl-probed total:
 /// fall back to the addressable size when the probe failed (`<= 0`) and cap it
@@ -890,6 +894,11 @@ struct IncrementalMarkState {
     /// only the small fixed offsets and streams variable-part items one at a
     /// time, so a large varsize GC-pointer array is never retained here.
     mark_offsets: Vec<usize>,
+    /// Reusable `VARSIZE_TYPE_INFO.varofstoptrs` buffer for the same walk.
+    /// Its size is the number of pointer fields in one item, not the array
+    /// length, so major marking still streams items without proportional
+    /// temporary storage.
+    mark_var_offsets: Vec<usize>,
 }
 
 impl IncrementalMarkState {
@@ -905,6 +914,7 @@ impl IncrementalMarkState {
             objects_marked: 0,
             mark_budget_per_step,
             mark_offsets: Vec::new(),
+            mark_var_offsets: Vec::new(),
         }
     }
 }
@@ -952,6 +962,11 @@ pub struct MiniMarkGC {
     /// and it runs over every registered root on every major cycle.  A `Cell`
     /// because the snapshot is a `&self` reader.
     root_snapshot_capacity: std::cell::Cell<usize>,
+    /// `gc/base.py:_totalroots_rpy`, the non-shrinking raw-list capacity used
+    /// by `inspector.py:get_rpy_roots`. The raw result deliberately retains
+    /// NULL padding; `pypy/module/gc/referents.py:get_rpy_roots` filters it at
+    /// the app-level boundary.
+    totalroots_rpy: usize,
     /// incminimark.py: objects with GCFLAG_CARDS_SET bit.
     /// Card bits are stored inline before each object's GcHeader.
     /// This list tracks which objects have at least one card bit set.
@@ -1017,8 +1032,10 @@ pub struct MiniMarkGC {
     oldgen_nonmoving_active: bool,
     /// Nursery payload addresses greyed during the current non-moving major
     /// (only populated while `oldgen_nonmoving_active`). Drained by the final
-    /// VISITED-clear pass.
-    oldgen_nonmoving_young_marks: Vec<usize>,
+    /// VISITED-clear pass. The boolean records whether this visit also added
+    /// TRACK_YOUNG_PTRS, so the adaptation restores the young object's exact
+    /// incoming flag contract afterwards.
+    oldgen_nonmoving_young_marks: Vec<(usize, bool)>,
     /// incminimark.py:3160,3175-3182 — the raw-refcount lists, identity tables
     /// and dead queue, empty until the embedder calls
     /// [`rawrefcount_init`](MiniMarkGC::rawrefcount_init).
@@ -1275,6 +1292,7 @@ impl MiniMarkGC {
             old_objects_pointing_to_young: Vec::new(),
             prebuilt_root_objects: Vec::new(),
             root_snapshot_capacity: std::cell::Cell::new(0),
+            totalroots_rpy: 0,
             old_objects_with_cards_set: Vec::new(),
             young_objects_with_weakrefs: Vec::new(),
             old_objects_with_weakrefs: Vec::new(),
@@ -1358,8 +1376,8 @@ impl MiniMarkGC {
 
     /// incminimark.py:1292-1299: number of machine words needed for card bits.
     fn card_marking_words_for_length(&self, length: usize) -> usize {
-        const LONG_BIT: usize = 64;
-        const LONG_BIT_SHIFT: usize = 6;
+        const LONG_BIT: usize = usize::BITS as usize;
+        const LONG_BIT_SHIFT: usize = usize::BITS.trailing_zeros() as usize;
         (length + (LONG_BIT << self.card_page_shift) - 1)
             >> (self.card_page_shift as usize + LONG_BIT_SHIFT)
     }
@@ -1671,7 +1689,7 @@ impl MiniMarkGC {
             return GcRef(0);
         }
         let ptr = self.nursery.alloc(total_size);
-        let ptr = if ptr.is_null() {
+        let mut ptr = if ptr.is_null() {
             self.reserve_nursery_gap(total_size)
         } else {
             ptr
@@ -1682,6 +1700,18 @@ impl MiniMarkGC {
             // independently; retain their external-allocation fallback
             // only for an object that cannot physically fit anywhere.
             return self.alloc_in_oldgen_clear(type_id, total_size);
+        }
+        if ptr.is_null() {
+            // `IncrementalMiniMarkGC.collect_and_reserve`: finalizer or
+            // rawrefcount work run by the wrapper may have filled the nursery
+            // again.  The second attempt is exactly `_minor_collection()` —
+            // no major step and no second callback — so the retry sees an
+            // empty nursery apart from pinned barriers.
+            self.minor_collection_only();
+            ptr = self.nursery.alloc(total_size);
+            if ptr.is_null() {
+                ptr = self.reserve_nursery_gap(total_size);
+            }
         }
         assert!(
             !ptr.is_null(),
@@ -1831,21 +1861,33 @@ impl MiniMarkGC {
         self.pending_reserving_size = total_size;
         unsafe { self.roots.add(root) };
         self.do_collect_nursery();
-        self.roots.remove(root);
         self.pending_reserving_size = 0;
         if std::mem::take(&mut self.oom_pending) {
+            self.roots.remove(root);
             return GcRef(0);
         }
         let ptr = self.nursery.alloc(total_size);
-        let ptr = if ptr.is_null() {
+        let mut ptr = if ptr.is_null() {
             self.reserve_nursery_gap(total_size)
         } else {
             ptr
         };
         if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
+            self.roots.remove(root);
             unsafe { *needs_write_barrier = true };
             return self.alloc_in_oldgen_clear(type_id, total_size);
         }
+        if ptr.is_null() {
+            // Keep the exceptional native-stack slot registered across the
+            // second bare minor as well; it is precisely another moving
+            // collection, even though no major/callback tail follows it.
+            self.minor_collection_only();
+            ptr = self.nursery.alloc(total_size);
+            if ptr.is_null() {
+                ptr = self.reserve_nursery_gap(total_size);
+            }
+        }
+        self.roots.remove(root);
         assert!(
             !ptr.is_null(),
             "collect_and_reserve could not find nursery space for a non-large object"
@@ -3054,19 +3096,15 @@ impl MiniMarkGC {
             .retain(|&obj_addr| !oldgen.young_rawmalloced_contains(obj_addr));
     }
 
-    /// Perform a minor (nursery) collection.
+    /// `IncrementalMiniMarkGC._minor_collection`: perform only the nursery
+    /// collection, without major progress or the rawrefcount callback.
     ///
-    /// 1. Scan roots: copy referenced nursery objects to old gen.
-    /// 2. Process remembered set: copy nursery objects referenced by old-gen objects.
-    /// 3. Iteratively process newly discovered references until stable.
-    /// 4. Reset nursery.
-    pub fn do_collect_nursery(&mut self) {
+    /// The public wrapper below owns the stop-the-world guard.  Keeping this
+    /// body separate is load-bearing for `collect_and_reserve`: if a finalizer
+    /// or rawrefcount callback refills the nursery after the first collection,
+    /// upstream performs one more bare `_minor_collection()` before retrying.
+    fn minor_collection_body(&mut self) {
         let start = GcClock::start();
-        let _stw = if crate::gc_sync::stw_required() {
-            Some(crate::gc_sync::quiesce_mutators())
-        } else {
-            None
-        };
         let walk_all_mutators = crate::gc_sync::mutators_quiesced();
         if crate::majit_log_enabled() {
             eprintln!(
@@ -3513,14 +3551,32 @@ impl MiniMarkGC {
             self.get_total_memory_used(),
             self.pinned_objects_in_nursery,
         );
+    }
 
-        // Minor collections must also drive incremental major-collection
-        // progress. Like incminimark, take one or more major steps until
-        // promoted bytes are back under the current step credit.
+    /// `IncrementalMiniMarkGC._minor_collection`, including pyre's
+    /// stop-the-world ownership but deliberately excluding the wrapper tail.
+    fn minor_collection_only(&mut self) {
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        self.minor_collection_body();
+    }
+
+    /// Perform `minor_collection_with_major_progress(force_enabled=False)`.
+    ///
+    /// 1. Scan roots and evacuate the nursery.
+    /// 2. Advance the incremental major until both target invariants hold.
+    /// 3. Schedule rawrefcount work queued by either collection.
+    pub fn do_collect_nursery(&mut self) {
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        self.minor_collection_body();
         self.run_major_progress_after_minor();
-
-        // incminimark.py — `minor_collection_with_major_progress` is where
-        // upstream schedules the drain of whatever this collection queued.
         self.rrc_invoke_callback();
     }
 
@@ -3537,10 +3593,11 @@ impl MiniMarkGC {
     /// The young raw-malloced target is the second branch
     /// (incminimark.py:3083-3090): it survives without moving, so the slot
     /// needs no update and only its death has to be written. RPython's
-    /// pinned-target NULL semantics and prebuilt-target skipping still have no
-    /// pyre analog (no pinned-weakref code path, no immortal prebuilt objects
-    /// with `GCFLAG_NO_HEAP_PTRS`), so those filters remain out of scope until
-    /// the matching surfaces land.
+    /// PyPy deliberately does not support weakrefs to pinned targets (the XXX
+    /// immediately above this routine says so). Its prebuilt-target branch is
+    /// part of the contract, however: a `GCFLAG_NO_HEAP_PTRS` target is
+    /// immortal and never receives VISITED, so registering it for the next
+    /// major would make that major clear a live weakref.
     fn invalidate_young_weakrefs(&mut self) {
         while let Some(obj_addr) = self.young_objects_with_weakrefs.pop() {
             // incminimark.py:3065-3066: if not forwarded → weakref died.
@@ -3595,7 +3652,9 @@ impl MiniMarkGC {
             // does not own). Either way, the minor cycle leaves the
             // weakptr untouched and the major cycle gets
             // the chance to invalidate it later.
-            if self.oldgen.contains(pointing_to) {
+            if self.oldgen.contains(pointing_to)
+                && unsafe { !(*header_of(pointing_to)).has_flag(GcFlags::GCFLAG_NO_HEAP_PTRS) }
+            {
                 self.old_objects_with_weakrefs.push(new_obj);
             }
         }
@@ -3667,6 +3726,12 @@ impl MiniMarkGC {
         self.rrc.finalizer_claim = Some(claim);
     }
 
+    /// Register the allocator-matched release used by `_rrc_free` for an
+    /// exact [`rawrefcount::REFCNT_FROM_PYPY_LIGHT`] mirror.
+    pub fn rawrefcount_set_light_free(&mut self, free: rawrefcount::LightFreeFn) {
+        self.rrc.light_free = Some(free);
+    }
+
     /// Take this collection's edges from the embedder and count, per mirror,
     /// how many of its references the reporting blocks supply.
     ///
@@ -3687,18 +3752,21 @@ impl MiniMarkGC {
 
     /// Whether `mirror`'s count makes it root its linked object.
     ///
-    /// `incminimark.py:3264` is `rc == REFCNT_FROM_PYPY or rc ==
-    /// REFCNT_FROM_PYPY_LIGHT` — every reference above the link share is one C
-    /// holds, and holding it is what roots.  The light disjunct is dropped
-    /// because no mirror carries that count (see
-    /// [`rawrefcount::REFCNT_IMMORTAL`]); with one, the base share to subtract
-    /// below would have to be the light constant for such a mirror.  The subtraction is [`rawrefcount::CEdgeCensusFn`]'s: a reference
+    /// `incminimark.py:_rrc_minor_trace` treats either exact link share as
+    /// unreferenced. Every count above its corresponding share is one C holds,
+    /// and holding it is what roots. The subtraction after that is
+    /// [`rawrefcount::CEdgeCensusFn`]'s: a reference
     /// another block in the census supplies is not one from outside the heap,
     /// and whether *that* block's own object lives is settled by the trace, in
     /// [`Self::mark_c_edges`], rather than assumed here.
     fn rrc_roots_link(&self, mirror: usize) -> bool {
         let rc = unsafe { (*rawrefcount::pyobj(mirror)).ob_refcnt };
-        let held = rc - rawrefcount::REFCNT_FROM_PYPY;
+        let share = if rc >= rawrefcount::REFCNT_FROM_PYPY_LIGHT {
+            rawrefcount::REFCNT_FROM_PYPY_LIGHT
+        } else {
+            rawrefcount::REFCNT_FROM_PYPY
+        };
+        let held = rc - share;
         held > self.rrc.c_discount.get(&mirror).copied().unwrap_or(0)
     }
 
@@ -4181,22 +4249,37 @@ impl MiniMarkGC {
     /// incminimark.py `_rrc_free`.
     ///
     /// The linked object has died, so the interpreter's share of the count goes
-    /// away.  incminimark.py:3325-3332's `REFCNT_FROM_PYPY_LIGHT` branch has no
-    /// port, for the reason [`rawrefcount::REFCNT_IMMORTAL`] records: no
-    /// translated `cpyext` creates a light mirror, so upstream never takes that
-    /// branch either.  The immortal branch is pyre's own and is unreachable,
-    /// because a count above the link share forces the linked object alive in
-    /// both trace passes.
+    /// away. `incminimark.py:_rrc_free` releases an exact LIGHT mirror directly
+    /// with raw `free`; a LIGHT mirror with external references is merely
+    /// unlinked. The ordinary share still queues a zero-count mirror for its
+    /// type-specific C deallocator.
     fn _rrc_free(&mut self, mirror: usize) {
         let header = rawrefcount::pyobj(mirror);
         let mut rc = unsafe { (*header).ob_refcnt };
-        debug_assert!(
-            rc < rawrefcount::REFCNT_IMMORTAL,
-            "an immortal mirror reached the rawrefcount free pass"
-        );
+        debug_assert!(rc < rawrefcount::REFCNT_IMMORTAL);
+        if rc >= rawrefcount::REFCNT_FROM_PYPY_LIGHT {
+            rc -= rawrefcount::REFCNT_FROM_PYPY_LIGHT;
+            if rc == 0 {
+                let free = self
+                    .rrc
+                    .light_free
+                    .expect("rawrefcount LIGHT mirror has no allocator release callback");
+                free(mirror);
+            } else {
+                unsafe {
+                    (*header).ob_refcnt = rc;
+                    (*header).ob_link = 0;
+                }
+            }
+            return;
+        }
         debug_assert!(
             rc >= rawrefcount::REFCNT_FROM_PYPY,
             "rawrefcount refcount underflow"
+        );
+        debug_assert!(
+            (rc as f64) < (rawrefcount::REFCNT_FROM_PYPY_LIGHT as f64 * 0.99),
+            "refcount underflow from REFCNT_FROM_PYPY_LIGHT"
         );
         rc -= rawrefcount::REFCNT_FROM_PYPY;
         unsafe { (*header).ob_link = 0 };
@@ -5022,7 +5105,7 @@ impl MiniMarkGC {
             } {
                 unsafe { (*hdr).set_flag(GcFlags::GCFLAG_VISITED) };
                 self.incr_state.more_gray_stack.push(gcref.0);
-                self.note_nonmoving_young_mark(gcref.0);
+                self.note_nonmoving_young_mark(gcref.0, false);
             }
         }
     }
@@ -5090,6 +5173,7 @@ impl MiniMarkGC {
 
         let type_info = self.types.get(type_id);
         let noffsets = type_info.gc_ptr_offsets.len();
+        let n_var_offsets = type_info.var_gc_ptr_offsets.len();
         let items_have_gc_ptrs = type_info.items_have_gc_ptrs;
         let item_size = type_info.item_size;
         let length_offset = type_info.length_offset;
@@ -5134,28 +5218,32 @@ impl MiniMarkGC {
             let length = unsafe { *((obj_addr + length_offset) as *const usize) };
             let items_start = obj_addr + base_size;
             for i in 0..length {
-                let slot = (items_start + i * item_size) as *mut GcRef;
-                let field_ref = unsafe { *slot };
-                self.assert_traced_slot_initialized(
-                    field_ref,
-                    slot as usize,
-                    obj_addr,
-                    "minor_varsize_item",
-                    site,
-                );
-                if self.is_nursery_object_start(field_ref.0) {
-                    let new_ref = self.copy_nursery_object(
-                        field_ref.0,
-                        "minor_varsize_item_target",
-                        site,
-                        obj_addr,
+                let item = items_start + i * item_size;
+                for j in 0..n_var_offsets {
+                    let offset = self.types.get(type_id).var_gc_ptr_offsets[j];
+                    let slot = (item + offset) as *mut GcRef;
+                    let field_ref = unsafe { *slot };
+                    self.assert_traced_slot_initialized(
+                        field_ref,
                         slot as usize,
+                        obj_addr,
+                        "minor_varsize_item",
+                        site,
                     );
-                    unsafe {
-                        *slot = new_ref;
+                    if self.is_nursery_object_start(field_ref.0) {
+                        let new_ref = self.copy_nursery_object(
+                            field_ref.0,
+                            "minor_varsize_item_target",
+                            site,
+                            obj_addr,
+                            slot as usize,
+                        );
+                        unsafe {
+                            *slot = new_ref;
+                        }
+                    } else if self.is_young_rawmalloced(field_ref.0) {
+                        self.visit_young_rawmalloced_object(field_ref.0);
                     }
-                } else if self.is_young_rawmalloced(field_ref.0) {
-                    self.visit_young_rawmalloced_object(field_ref.0);
                 }
             }
         }
@@ -5250,9 +5338,19 @@ impl MiniMarkGC {
         self.validate_type_id(unsafe { (*hdr).type_id() }, gcref.0, site);
         // SAFETY: header_of returns a raw pointer; keep each access
         // short-lived to avoid creating overlapping exclusive borrows.
+        let track_was_set = unsafe { (*hdr).has_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS) };
         let newly_marked = unsafe {
-            if !(*hdr).has_flag(GcFlags::GCFLAG_VISITED) {
+            if !(*hdr).has_flag(GcFlags::GCFLAG_VISITED)
+                && !(*hdr).has_flag(GcFlags::GCFLAG_NO_HEAP_PTRS)
+            {
                 (*hdr).set_flag(GcFlags::GCFLAG_VISITED);
+                // `IncrementalMiniMarkGC.visit`: the first visit makes the
+                // object black *and* arms its write barrier.  The latter is
+                // what lets a mutation between incremental steps turn the
+                // black object gray again.
+                if !self.is_in_nursery(gcref.0) {
+                    (*hdr).set_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS);
+                }
                 true
             } else {
                 false
@@ -5260,7 +5358,7 @@ impl MiniMarkGC {
         };
         if newly_marked {
             self.incr_state.gray_stack.push(gcref.0);
-            self.note_nonmoving_young_mark(gcref.0);
+            self.note_nonmoving_young_mark(gcref.0, !self.is_in_nursery(gcref.0) && !track_was_set);
 
             // incminimark.py:1322-1340 requires marking worklists to
             // contain no nursery objects after a minor. Pyre JITFRAME
@@ -5270,10 +5368,7 @@ impl MiniMarkGC {
             // mutator barrier. Arm this newly seeded old root in the
             // existing old_objects_pointing_to_young shape once, so that
             // minor forwards any such spill before resetting nursery.
-            if !self.is_in_nursery(gcref.0)
-                && unsafe { (*hdr).has_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS) }
-            {
-                unsafe { (*hdr).clear_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS) };
+            if !self.is_in_nursery(gcref.0) {
                 self.old_objects_pointing_to_young.push(gcref.0);
                 if crate::gc_lifetime_log_enabled() {
                     eprintln!(
@@ -5329,11 +5424,12 @@ impl MiniMarkGC {
     /// that as "already greyed", never pushes it, and never traces its
     /// children.
     #[inline]
-    fn note_nonmoving_young_mark(&mut self, addr: usize) {
+    fn note_nonmoving_young_mark(&mut self, addr: usize, armed_track_young_ptrs: bool) {
         if self.oldgen_nonmoving_active
             && (self.is_in_nursery(addr) || self.is_young_rawmalloced(addr))
         {
-            self.oldgen_nonmoving_young_marks.push(addr);
+            self.oldgen_nonmoving_young_marks
+                .push((addr, armed_track_young_ptrs));
         }
     }
 
@@ -5538,7 +5634,7 @@ impl MiniMarkGC {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
         self.validate_type_id(type_id, obj_addr, "object_is_tracked");
         let type_info = self.types.get(type_id);
-        type_info.has_gc_ptrs || (type_info.items_have_gc_ptrs && type_info.item_size > 0)
+        type_info.has_gc_ptrs
     }
 
     /// `inspector.py:get_rpy_referents`: trace one object's direct GC
@@ -5565,7 +5661,10 @@ impl MiniMarkGC {
             let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
             let items_start = obj_addr + type_info.size;
             for i in 0..length {
-                visitor((items_start + i * type_info.item_size) as *mut GcRef);
+                let item = items_start + i * type_info.item_size;
+                for &offset in &type_info.var_gc_ptr_offsets {
+                    visitor((item + offset) as *mut GcRef);
+                }
             }
         }
     }
@@ -5648,10 +5747,12 @@ impl MiniMarkGC {
             let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
             let items_start = obj_addr + type_info.size;
             for i in 0..length {
-                let field_ref =
-                    unsafe { *((items_start + i * type_info.item_size) as *const GcRef) };
-                if !field_ref.is_null() {
-                    visitor(field_ref);
+                let item = items_start + i * type_info.item_size;
+                for &offset in &type_info.var_gc_ptr_offsets {
+                    let field_ref = unsafe { *((item + offset) as *const GcRef) };
+                    if !field_ref.is_null() {
+                        visitor(field_ref);
+                    }
                 }
             }
         }
@@ -5728,10 +5829,15 @@ impl MiniMarkGC {
         } else {
             None
         };
-        for root in self.enumerate_all_root_values() {
-            if !root.is_null() {
-                visitor(root);
-            }
+        let roots = self.enumerate_all_root_values();
+        if roots.len() > self.totalroots_rpy {
+            self.totalroots_rpy = roots.len() + roots.len() / 8 + 10;
+        }
+        for root in roots.iter().copied() {
+            visitor(root);
+        }
+        for _ in roots.len()..self.totalroots_rpy {
+            visitor(GcRef::NULL);
         }
         true
     }
@@ -6095,7 +6201,8 @@ impl MiniMarkGC {
         if !self.enabled {
             return;
         }
-        if self.gc_state == GcState::Scanning && !self.threshold_reached(0) {
+        let extrasize = self.pending_reserving_size;
+        if self.gc_state == GcState::Scanning && !self.threshold_reached(extrasize) {
             return;
         }
 
@@ -6107,12 +6214,18 @@ impl MiniMarkGC {
                 break;
             }
 
-            // incminimark.py:849-860 target (A2). Keep pyre's existing
-            // consecutive-step credit loop: the enclosing call has already
-            // completed the minor collection that supplied these promotions.
-            if self.bytes_made_old_since_cycle <= self.threshold_bytes_made_old {
+            // `minor_collection_with_major_progress` target (A2).  The
+            // allocation being reserved does not exist yet but must already
+            // fit under the credit line, hence the `threshold - extrasize`
+            // comparison.  If promotions still outrun credit, PyPy performs
+            // another bare `_minor_collection()` before the next major step;
+            // repeating only the major step lets a high-survival nursery keep
+            // growing faster than marking observes it.
+            let threshold = self.threshold_bytes_made_old.saturating_sub(extrasize);
+            if self.bytes_made_old_since_cycle <= threshold {
                 break;
             }
+            self.minor_collection_body();
         }
     }
 
@@ -6585,10 +6698,23 @@ impl MiniMarkGC {
                     self.major_collections,
                 );
             }
-            if unsafe { !(*hdr).has_flag(GcFlags::GCFLAG_VISITED) } {
-                unsafe { (*hdr).set_flag(GcFlags::GCFLAG_VISITED) };
+            let track_was_set = unsafe { (*hdr).has_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS) };
+            if unsafe {
+                !(*hdr).has_flag(GcFlags::GCFLAG_VISITED)
+                    && !(*hdr).has_flag(GcFlags::GCFLAG_NO_HEAP_PTRS)
+            } {
+                unsafe {
+                    (*hdr).set_flag(GcFlags::GCFLAG_VISITED);
+                    // `IncrementalMiniMarkGC.visit` sets both bits on the
+                    // first visit.  A nursery object exists here only during
+                    // pyre's non-moving-major adaptation; nursery objects do
+                    // not participate in the old-object write barrier.
+                    if !self.is_in_nursery(addr) {
+                        (*hdr).set_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS);
+                    }
+                };
                 self.incr_state.gray_stack.push(addr);
-                self.note_nonmoving_young_mark(addr);
+                self.note_nonmoving_young_mark(addr, !self.is_in_nursery(addr) && !track_was_set);
             }
         }
     }
@@ -6637,7 +6763,9 @@ impl MiniMarkGC {
         let custom_trace;
         let (item_size, length_offset, fixed_size, items_have_gc_ptrs);
         let mut offsets = std::mem::take(&mut self.incr_state.mark_offsets);
+        let mut var_offsets = std::mem::take(&mut self.incr_state.mark_var_offsets);
         offsets.clear();
+        var_offsets.clear();
         {
             let type_info = self.types.get(type_id);
             custom_trace = type_info.custom_trace;
@@ -6647,6 +6775,7 @@ impl MiniMarkGC {
             items_have_gc_ptrs = type_info.items_have_gc_ptrs;
             if custom_trace.is_none() {
                 offsets.extend_from_slice(&type_info.gc_ptr_offsets);
+                var_offsets.extend_from_slice(&type_info.var_gc_ptr_offsets);
             }
         }
 
@@ -6685,14 +6814,13 @@ impl MiniMarkGC {
                 let length = unsafe { *((obj_addr + length_offset) as *const usize) };
                 let items_start = obj_addr + fixed_size;
                 for i in 0..length {
-                    let field_ref = unsafe { *((items_start + i * item_size) as *const GcRef) };
-                    if !field_ref.is_null() {
-                        self.grey_child(
-                            field_ref.0,
-                            obj_addr,
-                            items_start + i * item_size,
-                            "major_varsize_item",
-                        );
+                    let item = items_start + i * item_size;
+                    for &offset in &var_offsets {
+                        let slot = item + offset;
+                        let field_ref = unsafe { *(slot as *const GcRef) };
+                        if !field_ref.is_null() {
+                            self.grey_child(field_ref.0, obj_addr, slot, "major_varsize_item");
+                        }
                     }
                 }
             }
@@ -6700,6 +6828,7 @@ impl MiniMarkGC {
 
         // Return the (small) offsets buffer for reuse.
         self.incr_state.mark_offsets = offsets;
+        self.incr_state.mark_var_offsets = var_offsets;
     }
 
     /// incminimark.py:1793-1799 + :2461-2470 — final snapshot-at-the-beginning
@@ -7227,9 +7356,12 @@ impl MiniMarkGC {
             let length = unsafe { *((obj_addr + info.length_offset) as *const usize) };
             let items_start = obj_addr + info.size;
             for i in 0..length {
-                let child = unsafe { *((items_start + i * info.item_size) as *const GcRef) };
-                if !child.is_null() && self.is_managed_heap_object(child.0) {
-                    children.push(child.0);
+                let item = items_start + i * info.item_size;
+                for &offset in &info.var_gc_ptr_offsets {
+                    let child = unsafe { *((item + offset) as *const GcRef) };
+                    if !child.is_null() && self.is_managed_heap_object(child.0) {
+                        children.push(child.0);
+                    }
                 }
             }
         }
@@ -7487,12 +7619,8 @@ impl MiniMarkGC {
         // This is the `_minor_collection()` performed by upstream's
         // `gc_step_until(STATE_MARKING)` before it starts the fresh cycle.
         // Upstream calls the low-level `_minor_collection`, which has no
-        // major-progress tail, so suppress this wrapper's tail the way
-        // `gc_step_until_scanning_with_minors` does.
-        let was_enabled = self.enabled;
-        self.enabled = false;
-        self.do_collect_nursery();
-        self.enabled = was_enabled;
+        // major-progress or rawrefcount-callback tail.
+        self.minor_collection_body();
 
         // The rest of that same `gc_step_until(STATE_MARKING)` iteration.
         // Reaching MARKING through `major_collection_step` is what runs the
@@ -7552,9 +7680,7 @@ impl MiniMarkGC {
             // called too often, the memory usage will keep increasing, because
             // we'll never completely fill the nursery (and so never run
             // anything about the major collection)."
-            let was_enabled = std::mem::replace(&mut self.enabled, false);
-            self.do_collect_nursery();
-            self.enabled = was_enabled;
+            self.minor_collection_body();
         } else {
             self.minor_collection_with_major_progress(true);
             // gen == 1 is gen == 0 plus "if no major collection is running,
@@ -7601,10 +7727,7 @@ impl MiniMarkGC {
         // `_minor_collection`, not `minor_collection_with_major_progress`:
         // the explicit `major_collection_step` below is the one and only
         // state transition performed by this call.
-        let was_enabled = self.enabled;
-        self.enabled = false;
-        self.do_collect_nursery();
-        self.enabled = was_enabled;
+        self.minor_collection_body();
         self.major_collection_step();
 
         // incminimark.py:821.
@@ -7676,13 +7799,18 @@ impl MiniMarkGC {
     /// objects and skip their old-generation children.
     fn clear_oldgen_nonmoving_young_marks(&mut self) {
         let marks = std::mem::take(&mut self.oldgen_nonmoving_young_marks);
-        for addr in marks {
+        for (addr, clear_track_young_ptrs) in marks {
             // Nothing moved and nothing young was freed, so each addr is still
             // where it was noted; the guard is defensive against a duplicate
             // already cleared.
             if self.is_in_nursery(addr) || self.is_young_rawmalloced(addr) {
                 let hdr = unsafe { header_of(addr) };
-                unsafe { (*hdr).clear_flag(GcFlags::GCFLAG_VISITED) };
+                unsafe {
+                    (*hdr).clear_flag(GcFlags::GCFLAG_VISITED);
+                    if clear_track_young_ptrs {
+                        (*hdr).clear_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS);
+                    }
+                };
             }
         }
     }
@@ -7700,15 +7828,9 @@ impl MiniMarkGC {
     /// place.
     fn gc_step_until_scanning_with_minors(&mut self) {
         while self.gc_state != GcState::Scanning {
-            // `do_collect_nursery` is pyre's public
-            // `minor_collection_with_major_progress`, whereas upstream calls
-            // the lower-level `_minor_collection` here and then advances one
-            // explicit step.  Suppress that wrapper's automatic progress so
-            // this remains the literal one-minor/one-major loop.
-            let was_enabled = self.enabled;
-            self.enabled = false;
-            self.do_collect_nursery();
-            self.enabled = was_enabled;
+            // Upstream calls the lower-level `_minor_collection` here and
+            // then advances one explicit step.
+            self.minor_collection_body();
             self.major_collection_step();
         }
     }
@@ -7988,14 +8110,9 @@ impl MiniMarkGC {
     /// the card bits stay where they are, so the per-card record is no longer
     /// true of the object and only the whole-object record is.
     ///
-    /// Nothing calls this outside tests, and nothing could act on it if it
-    /// did: `CARDS_SET` is only ever set behind a `HAS_CARDS` test, and the
-    /// one non-test place that sets `HAS_CARDS`, `alloc_in_oldgen_with_cards`,
-    /// has no production caller. So the guard above rejects every object pyre
-    /// can build today.
-    ///
-    /// It stops rejecting them the moment a production caller of that
-    /// allocator lands, and the sites that owe this call are the item moves in
+    /// `alloc_varsize_typed` reaches
+    /// `alloc_varsize_nonmoving_prefer_young`, so production list storage can
+    /// carry cards. The sites that owe this call are the item moves in
     /// `pyre_object::listobject`'s `W_ListObject` — `object_insert`,
     /// `object_remove` and `object_drain` each shift items with a bare
     /// `ptr::copy`, and `object_reverse` permutes them with a bare
@@ -8151,6 +8268,7 @@ impl MiniMarkGC {
             if type_info.items_have_gc_ptrs && type_info.item_size > 0 {
                 let item_size = type_info.item_size;
                 let base_size = type_info.size;
+                let n_var_offsets = type_info.var_gc_ptr_offsets.len();
                 let items_start = obj + base_size;
                 let card_page_indices = 1usize << self.card_page_shift;
 
@@ -8174,28 +8292,32 @@ impl MiniMarkGC {
                             }
                             // trace_and_drag_out_of_nursery_partial
                             for i in interval_start..interval_stop {
-                                let slot = (items_start + i * item_size) as *mut GcRef;
-                                let field_ref = unsafe { *slot };
-                                self.assert_traced_slot_initialized(
-                                    field_ref,
-                                    slot as usize,
-                                    obj,
-                                    "minor_dirty_card_item",
-                                    "minor_dirty_card",
-                                );
-                                if self.is_nursery_object_start(field_ref.0) {
-                                    let new_ref = self.copy_nursery_object(
-                                        field_ref.0,
-                                        "minor_dirty_card_item_target",
-                                        "minor_dirty_card",
-                                        obj,
+                                let item = items_start + i * item_size;
+                                for j in 0..n_var_offsets {
+                                    let offset = self.types.get(type_id).var_gc_ptr_offsets[j];
+                                    let slot = (item + offset) as *mut GcRef;
+                                    let field_ref = unsafe { *slot };
+                                    self.assert_traced_slot_initialized(
+                                        field_ref,
                                         slot as usize,
+                                        obj,
+                                        "minor_dirty_card_item",
+                                        "minor_dirty_card",
                                     );
-                                    unsafe {
-                                        *slot = new_ref;
+                                    if self.is_nursery_object_start(field_ref.0) {
+                                        let new_ref = self.copy_nursery_object(
+                                            field_ref.0,
+                                            "minor_dirty_card_item_target",
+                                            "minor_dirty_card",
+                                            obj,
+                                            slot as usize,
+                                        );
+                                        unsafe {
+                                            *slot = new_ref;
+                                        }
+                                    } else if self.is_young_rawmalloced(field_ref.0) {
+                                        self.visit_young_rawmalloced_object(field_ref.0);
                                     }
-                                } else if self.is_young_rawmalloced(field_ref.0) {
-                                    self.visit_young_rawmalloced_object(field_ref.0);
                                 }
                             }
                         }
@@ -8277,6 +8399,15 @@ impl MiniMarkGC {
     /// flag test on the object header.
     pub fn can_optimize_cond_call(&self) -> bool {
         true
+    }
+
+    /// `IncrementalMiniMarkGC.can_optimize_clean_setarrayitems`.
+    ///
+    /// A clean bulk store is barrier-free only when card marking is disabled.
+    /// With cards, clearing array items without marking their pages can hide
+    /// young references from the next minor collection.
+    pub fn can_optimize_clean_setarrayitems(&self) -> bool {
+        self.config.card_page_indices == 0
     }
 
     /// Perform one incremental GC step. Called from JIT safepoints.
@@ -8401,6 +8532,48 @@ impl MiniMarkGC {
         }
         let hdr = unsafe { &*header_of(obj.0) };
         !hdr.is_forwarded() && hdr.has_flag(GcFlags::GCFLAG_PINNED)
+    }
+
+    /// `rgc.get_gcflag_extra`: read RPython's temporary traversal bit from a
+    /// managed or translated-prebuilt object.
+    pub fn get_gcflag_extra(&self, obj: GcRef) -> bool {
+        assert!(!obj.is_null(), "get_gcflag_extra(NULL)");
+        self.gcflag_header(obj)
+            .is_some_and(|hdr| unsafe { (*hdr).has_flag(GcFlags::GCFLAG_EXTRA) })
+    }
+
+    /// `rgc.toggle_gcflag_extra`: toggle the traversal bit in place. As in
+    /// upstream, the argument must be a non-NULL GC object.
+    pub fn toggle_gcflag_extra(&self, obj: GcRef) {
+        assert!(!obj.is_null(), "toggle_gcflag_extra(NULL)");
+        let hdr = self
+            .gcflag_header(obj)
+            .expect("toggle_gcflag_extra called for a non-GC object");
+        unsafe {
+            if (*hdr).has_flag(GcFlags::GCFLAG_EXTRA) {
+                (*hdr).clear_flag(GcFlags::GCFLAG_EXTRA);
+            } else {
+                (*hdr).set_flag(GcFlags::GCFLAG_EXTRA);
+            }
+        }
+    }
+
+    /// `rgc.get_gcflag_dummy`: whether this is the low-level dummy value used
+    /// by translated hash tables.
+    pub fn get_gcflag_dummy(&self, obj: GcRef) -> bool {
+        if obj.is_null() {
+            return false;
+        }
+        self.gcflag_header(obj)
+            .is_some_and(|hdr| unsafe { (*hdr).has_flag(GcFlags::GCFLAG_DUMMY) })
+    }
+
+    fn gcflag_header(&self, obj: GcRef) -> Option<*mut GcHeader> {
+        if self.is_managed_heap_object(obj.0) {
+            Some(unsafe { header_of(obj.0) })
+        } else {
+            self.registered_external_header(obj.0)
+        }
     }
 
     /// Number of objects in the remembered set (for testing / diagnostics).
@@ -8711,6 +8884,18 @@ impl GcAllocator for MiniMarkGC {
         self.object_is_tracked(obj.0)
     }
 
+    fn get_gcflag_extra(&mut self, obj: GcRef) -> bool {
+        MiniMarkGC::get_gcflag_extra(self, obj)
+    }
+
+    fn toggle_gcflag_extra(&mut self, obj: GcRef) {
+        MiniMarkGC::toggle_gcflag_extra(self, obj)
+    }
+
+    fn get_gcflag_dummy(&mut self, obj: GcRef) -> bool {
+        MiniMarkGC::get_gcflag_dummy(self, obj)
+    }
+
     fn get_rpy_memory_usage(&mut self, obj: GcRef) -> Option<usize> {
         self.rpy_memory_usage(obj)
     }
@@ -8871,6 +9056,10 @@ impl GcAllocator for MiniMarkGC {
 
     fn can_optimize_cond_call(&self) -> bool {
         self.can_optimize_cond_call()
+    }
+
+    fn can_optimize_clean_setarrayitems(&self) -> bool {
+        self.can_optimize_clean_setarrayitems()
     }
 
     fn gc_step(&mut self) -> bool {
@@ -10241,6 +10430,8 @@ mod tests {
         let mut roots = Vec::new();
         assert!(gc.do_get_rpy_roots(&mut |root| roots.push(root)));
         assert!(roots.contains(&holder));
+        assert_eq!(roots.last(), Some(&GcRef::NULL));
+        assert!(roots.len() > roots.iter().filter(|root| !root.is_null()).count());
 
         let mut referents = Vec::new();
         assert!(gc.do_get_rpy_referents(holder, &mut |child| { referents.push(child) }));
@@ -10282,6 +10473,23 @@ mod tests {
         let mut off_heap = 0usize;
         assert!(!gc.object_is_tracked(&mut off_heap as *mut usize as usize));
         gc.roots.clear();
+    }
+
+    #[test]
+    fn public_rgc_flags_use_the_objects_header_without_a_side_table() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::object(32));
+        let obj = gc.alloc_with_type(tid, 32);
+
+        assert!(!gc.get_gcflag_extra(obj));
+        gc.toggle_gcflag_extra(obj);
+        assert!(gc.get_gcflag_extra(obj));
+        gc.toggle_gcflag_extra(obj);
+        assert!(!gc.get_gcflag_extra(obj));
+
+        assert!(!gc.get_gcflag_dummy(obj));
+        unsafe { (*header_of(obj.0)).set_flag(GcFlags::GCFLAG_DUMMY) };
+        assert!(gc.get_gcflag_dummy(obj));
     }
 
     #[test]
@@ -11389,7 +11597,8 @@ mod tests {
         // arm has no other route onto the list a major collection drains.
         assert!(gc.old_objects_with_destructors.contains(&obj.0));
         // `allocsize = cardheadersize + round_up_for_allocation(totalsize)`.
-        let card_header_bytes = 8 * gc.card_marking_words_for_length(length);
+        let card_header_bytes =
+            std::mem::size_of::<usize>() * gc.card_marking_words_for_length(length);
         assert!(card_header_bytes > 0);
         assert_eq!(
             gc.bytes_made_old_since_cycle - bytes_before,
@@ -12165,6 +12374,49 @@ mod tests {
     }
 
     #[test]
+    fn varsize_struct_item_offsets_survive_minor_major_and_inspection() {
+        let word = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(8192);
+        let array_tid = gc.register_type(TypeInfo::varsize_with_gc_ptr_offsets(
+            word,
+            3 * word,
+            0,
+            vec![word, 2 * word],
+            Vec::new(),
+        ));
+        let leaf_tid = gc.register_type(TypeInfo::simple(word));
+        let mut array = GcAllocator::alloc_varsize_typed(&mut gc, array_tid, word, 3 * word, 2);
+        let items = array.0 + word;
+        let markers = [0xA11CEusize, 0xB0Busize, 0xCAFEusize, 0xD00Dusize];
+        for (index, marker) in markers.into_iter().enumerate() {
+            let child = gc.alloc_with_type(leaf_tid, word);
+            unsafe { *(child.0 as *mut usize) = marker };
+            let item = items + (index / 2) * 3 * word;
+            let offset = (1 + index % 2) * word;
+            unsafe { *((item + offset) as *mut GcRef) = child };
+        }
+        unsafe { gc.roots.add(&mut array) };
+
+        gc.do_collect_nursery();
+
+        let mut referents = Vec::new();
+        gc.visit_referents(array.0, &mut |child| referents.push(child));
+        assert_eq!(referents.len(), markers.len());
+        for (child, marker) in referents.iter().zip(markers) {
+            assert_eq!(unsafe { *(child.0 as *const usize) }, marker);
+        }
+
+        gc.do_collect_full();
+        let mut referents_after_major = Vec::new();
+        gc.visit_referents(array.0, &mut |child| referents_after_major.push(child));
+        assert_eq!(referents_after_major.len(), markers.len());
+        for (child, marker) in referents_after_major.iter().zip(markers) {
+            assert_eq!(unsafe { *(child.0 as *const usize) }, marker);
+        }
+        gc.roots.clear();
+    }
+
+    #[test]
     fn test_data_integrity_across_collections() {
         // Allocate objects with distinctive data, collect, verify data.
         let mut gc = test_gc(2048);
@@ -12500,7 +12752,7 @@ mod tests {
     }
 
     #[test]
-    fn test_minor_collection_can_take_multiple_major_steps_when_promotions_outpace_credit() {
+    fn test_major_progress_repeats_minor_when_promotions_outpace_credit() {
         let ptr_size = std::mem::size_of::<GcRef>();
         let mut gc = test_gc(1024);
         let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
@@ -12528,14 +12780,51 @@ mod tests {
         // of objects so incminimark-style accounting demands extra progress.
         gc.bytes_made_old_since_cycle = gc.config.nursery_size;
         gc.threshold_bytes_made_old = 0;
+        let minors_before = gc.minor_collections;
         gc.run_major_progress_after_minor();
 
+        assert!(
+            gc.minor_collections > minors_before,
+            "target A2 failure must run another bare minor before its next major step"
+        );
         assert!(
             gc.incremental_objects_marked() >= 2
                 || gc.threshold_bytes_made_old > gc.config.nursery_size / 2,
             "major progress should take multiple steps when promoted bytes outpace credit"
         );
 
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn reserving_size_is_subtracted_from_major_progress_credit() {
+        let word = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(1024);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(word, vec![0]));
+
+        let mut previous = GcRef::NULL;
+        for _ in 0..4 {
+            let object = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + word);
+            unsafe { *(object.0 as *mut GcRef) = previous };
+            previous = object;
+        }
+        let mut root = previous;
+        unsafe { gc.roots.add(&mut root) };
+        gc.set_mark_budget(1);
+        gc.start_incremental_cycle();
+
+        // One step grants 512 bytes. The promoted total fits that unadjusted
+        // credit, but not the 512 - 256 bytes left after accounting for the
+        // allocation that is waiting for `collect_and_reserve`.
+        gc.bytes_made_old_since_cycle = gc.config.nursery_size / 2 - 1;
+        gc.threshold_bytes_made_old = 0;
+        gc.pending_reserving_size = gc.config.nursery_size / 4;
+        let minors_before = gc.minor_collections;
+
+        gc.run_major_progress_after_minor();
+
+        assert!(gc.minor_collections > minors_before);
+        gc.pending_reserving_size = 0;
         gc.roots.clear();
     }
 
@@ -13210,6 +13499,69 @@ mod tests {
     // ── Write barrier + incremental marking interaction tests ──
 
     #[test]
+    fn first_major_visit_arms_child_for_incremental_write_barrier() {
+        let word = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let holder_tid = gc.register_type(TypeInfo::with_gc_ptrs(word, vec![0]));
+        let leaf_tid = gc.register_type(TypeInfo::simple(word));
+
+        let grandparent = gc.alloc_in_oldgen_clear(holder_tid, GcHeader::SIZE + word);
+        let holder = gc.alloc_in_oldgen_clear(holder_tid, GcHeader::SIZE + word);
+        let white_child = gc.alloc_in_oldgen_clear(leaf_tid, GcHeader::SIZE + word);
+        unsafe {
+            *(grandparent.0 as *mut GcRef) = holder;
+            *(holder.0 as *mut GcRef) = GcRef::NULL;
+        }
+        let mut root = grandparent;
+        unsafe { gc.roots.add(&mut root) };
+
+        gc.start_incremental_cycle();
+        gc.old_objects_pointing_to_young.clear();
+        let root_work = gc.incr_state.gray_stack.pop().expect("root was seeded");
+        gc.mark_object(root_work);
+        let holder_work = gc.incr_state.gray_stack.pop().expect("child was greyed");
+        assert_eq!(holder_work, holder.0);
+        gc.mark_object(holder_work);
+
+        assert!(unsafe { (*header_of(holder.0)).has_flag(GcFlags::GCFLAG_TRACK_YOUNG_PTRS) });
+        assert!(!unsafe { (*header_of(white_child.0)).has_flag(GcFlags::GCFLAG_VISITED) });
+
+        gc.do_write_barrier(holder);
+        unsafe { *(holder.0 as *mut GcRef) = white_child };
+        assert!(gc.old_objects_pointing_to_young.contains(&holder.0));
+
+        while gc.gc_state != GcState::Scanning {
+            gc.major_collection_step();
+        }
+        assert!(gc.oldgen.contains(white_child.0));
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn major_visit_ignores_no_heap_ptrs_objects_without_stamping_visited() {
+        let word = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let holder_tid = gc.register_type(TypeInfo::with_gc_ptrs(word, vec![0]));
+        let leaf_tid = gc.register_type(TypeInfo::simple(word));
+        let holder = gc.alloc_in_oldgen_clear(holder_tid, GcHeader::SIZE + word);
+        let clean_prebuilt = gc.alloc_in_oldgen_clear(leaf_tid, GcHeader::SIZE + word);
+        unsafe {
+            *(holder.0 as *mut GcRef) = clean_prebuilt;
+            (*header_of(clean_prebuilt.0)).set_flag(GcFlags::GCFLAG_NO_HEAP_PTRS);
+        }
+        let mut root = holder;
+        unsafe { gc.roots.add(&mut root) };
+
+        gc.start_incremental_cycle();
+        let root_work = gc.incr_state.gray_stack.pop().expect("root was seeded");
+        gc.mark_object(root_work);
+
+        assert!(!unsafe { (*header_of(clean_prebuilt.0)).has_flag(GcFlags::GCFLAG_VISITED) });
+        assert!(!gc.incr_state.gray_stack.contains(&clean_prebuilt.0));
+        gc.roots.clear();
+    }
+
+    #[test]
     fn test_write_barrier_during_incremental_marking() {
         // Verify that write barriers fired during an active incremental
         // marking cycle correctly add old-gen objects to the remembered set.
@@ -13616,6 +13968,20 @@ mod tests {
         assert!(gc.can_optimize_cond_call());
     }
 
+    #[test]
+    fn clean_setarrayitems_optimization_follows_card_configuration() {
+        let cards = test_gc(4096);
+        assert!(!cards.can_optimize_clean_setarrayitems());
+
+        let no_cards = MiniMarkGC::with_config(GcConfig {
+            nursery_size: 4096,
+            large_object_threshold: 2048,
+            card_page_indices: 0,
+            ..GcConfig::default()
+        });
+        assert!(no_cards.can_optimize_clean_setarrayitems());
+    }
+
     /// env.py `get_L2cache_linux2_cpuinfo`: use the smallest valid
     /// per-CPU K/k value, ignore another unit and malformed lines, and retain
     /// the upstream `_findend('\n' + label)` first-line behavior.
@@ -13695,6 +14061,7 @@ cache size\t: 8192 kB\n";
         let gc = test_gc(4096);
         let alloc: &dyn GcAllocator = &gc;
         assert!(alloc.can_optimize_cond_call());
+        assert!(!alloc.can_optimize_clean_setarrayitems());
     }
 
     #[test]
@@ -14358,6 +14725,36 @@ cache size\t: 8192 kB\n";
         };
         assert_eq!(after.0, target_root.0);
 
+        gc.roots.clear();
+    }
+
+    /// incminimark.py `invalidate_young_weakrefs`: a clean prebuilt target is
+    /// immortal but intentionally never marked VISITED. Carrying its weakref
+    /// into `old_objects_with_weakrefs` would therefore clear a live edge at
+    /// the next major collection.
+    #[test]
+    fn young_weakref_to_no_heap_ptrs_target_skips_old_weakref_queue() {
+        let mut gc = test_gc(4096);
+        let target_tid = gc.register_type(TypeInfo::simple(16));
+        let wref_tid = gc.register_type(TypeInfo::weakref());
+
+        let target = gc.alloc_in_oldgen_clear(target_tid, GcHeader::SIZE + 16);
+        unsafe { (*header_of(target.0)).set_flag(GcFlags::GCFLAG_NO_HEAP_PTRS) };
+        let wref = gc.alloc_with_type(wref_tid, crate::weakref::SIZEOF_WEAKREF);
+        unsafe {
+            *((wref.0 + crate::weakref::WEAKPTR_OFFSET) as *mut GcRef) = target;
+        }
+
+        let mut wref_root = wref;
+        unsafe { gc.roots.add(&mut wref_root) };
+        gc.do_collect_nursery();
+
+        assert!(gc.oldgen.contains(wref_root.0));
+        assert!(gc.old_objects_with_weakrefs.is_empty());
+        let after = unsafe {
+            crate::weakref::ll_weakref_deref(wref_root.0 as *const crate::weakref::Weakref)
+        };
+        assert_eq!(after, target);
         gc.roots.clear();
     }
 
@@ -15258,15 +15655,22 @@ cache size\t: 8192 kB\n";
         /// `fn`, and a `static` would be shared with every test the harness
         /// runs concurrently.  The collector calls it on the calling thread.
         static RRC_TRIGGER_FIRED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+        static RRC_LIGHT_FREED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     }
 
     fn rrc_test_trigger() {
         RRC_TRIGGER_FIRED.with(|fired| fired.set(fired.get() + 1));
     }
 
+    fn rrc_test_light_free(mirror: usize) {
+        unsafe { drop(Box::from_raw(rawrefcount::pyobj(mirror))) };
+        RRC_LIGHT_FREED.with(|freed| freed.set(freed.get() + 1));
+    }
+
     fn rrc_test_gc() -> MiniMarkGC {
         let mut gc = test_gc(1 << 16);
         gc.rawrefcount_init(rrc_test_trigger);
+        gc.rawrefcount_set_light_free(rrc_test_light_free);
         assert!(gc.rawrefcount_enabled());
         gc
     }
@@ -15325,6 +15729,41 @@ cache size\t: 8192 kB\n";
             1,
             "incminimark.py:3248-3250 schedules the drain for a non-empty queue"
         );
+    }
+
+    /// incminimark.py `_rrc_free`: LIGHT means the mirror needs no C
+    /// deallocator. With external references remaining, subtract the light
+    /// share and unlink it without putting it on the deallocation queue.
+    #[test]
+    fn a_light_mirror_is_unlinked_without_deallocator_queueing() {
+        let mut gc = rrc_test_gc();
+        let tid = gc.register_type(TypeInfo::object(64));
+        let object = gc.alloc_with_type(tid, 64);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY_LIGHT + 2);
+        gc.rawrefcount_create_link_pyobj(object.0, mirror);
+
+        gc.do_collect_nursery();
+
+        assert_eq!(mirror_link(mirror), 0);
+        assert_eq!(mirror_refcnt(mirror), 2);
+        assert_eq!(gc.rawrefcount_next_dead(), 0);
+    }
+
+    /// `incminimark.py _rrc_free`: an exact LIGHT share needs no deallocator
+    /// queue and returns the raw mirror through the embedder's allocator.
+    #[test]
+    fn an_exact_light_mirror_is_freed_immediately() {
+        let mut gc = rrc_test_gc();
+        let tid = gc.register_type(TypeInfo::object(64));
+        let object = gc.alloc_with_type(tid, 64);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY_LIGHT);
+        gc.rawrefcount_create_link_pyobj(object.0, mirror);
+
+        RRC_LIGHT_FREED.with(|freed| freed.set(0));
+        gc.do_collect_nursery();
+
+        assert_eq!(RRC_LIGHT_FREED.with(|freed| freed.get()), 1);
+        assert_eq!(gc.rawrefcount_next_dead(), 0);
     }
 
     /// incminimark.py:3359-3375 and :3397-3409: the same two outcomes, decided

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -1,30 +1,36 @@
 //! Object header layout for GC-managed objects.
 //!
-//! Each GC object starts with a single machine word that stores both
-//! the type ID (lower 32 bits) and GC flags (upper 32 bits), matching
-//! incminimark's HDR.tid layout where `first_gcflag = 1 << (LONG_BIT//2)`.
+//! Each GC object starts with one logical RPython word that stores both the
+//! type ID (lower half) and GC flags (upper half), matching incminimark's
+//! `HDR.tid` layout where `first_gcflag = 1 << (LONG_BIT//2)`.
+//!
+//! The Rust storage remains `u64` on wasm32 because GC payloads include
+//! Rust values with eight-byte alignment.  Shrinking the physical prefix to
+//! four bytes would misalign those payloads.  Only the low native-word-sized
+//! part is semantically occupied there: 16 type-id bits followed by 16 flag
+//! bits, just like a translated 32-bit PyPy.  The upper four bytes are ABI
+//! padding, not an extension of either field.
 
 use crate::GcFlags;
 
 /// Number of bits reserved for the type ID in the lower half.
-pub const TYPE_ID_BITS: u32 = 32;
+pub const TYPE_ID_BITS: u32 = usize::BITS / 2;
 pub const TYPE_ID_MASK: u64 = (1u64 << TYPE_ID_BITS) - 1;
 
 /// Shift applied to `GcFlags` to position it in the upper half of the
-/// header word. `GcFlags` declares each flag at position 0..N, but in the
-/// header they live at positions 32..32+N.
+/// logical header word. `GcFlags` declares each flag at position 0..N.
 pub const FLAG_SHIFT: u32 = TYPE_ID_BITS;
 
 /// The sentinel value written into a forwarded nursery object's header.
-/// Equivalent to incminimark's tid = -42 marker (all bits set as i64 -42,
-/// but we just use a distinctive pattern).
-pub const FORWARDED_MARKER: u64 = 0xFFFF_FFFF_FFFF_FFD6; // -42 as u64
+/// Equivalent to incminimark's `tid = -42` in a native Signed word.
+pub const FORWARDED_MARKER: u64 = (usize::MAX - 41) as u64;
 
 /// GC object header, placed immediately before the object payload.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct GcHeader {
-    /// Lower 32 bits: type ID. Upper 32 bits: GC flags (shifted).
+    /// Low native-word half: type ID. Next half: GC flags (shifted).
+    /// On wasm32 the upper 32 bits are physical ABI padding and stay zero.
     pub tid_and_flags: u64,
 }
 
@@ -42,6 +48,10 @@ impl GcHeader {
 
     /// Create a new header with the given type ID and no flags set.
     pub fn new(type_id: u32) -> Self {
+        assert!(
+            u64::from(type_id) <= TYPE_ID_MASK,
+            "GC type id {type_id} does not fit the {TYPE_ID_BITS}-bit header field"
+        );
         GcHeader {
             tid_and_flags: type_id as u64,
         }
@@ -49,6 +59,15 @@ impl GcHeader {
 
     /// Create a new header with the given type ID and initial flags.
     pub fn with_flags(type_id: u32, raw_flags: GcFlags) -> Self {
+        assert!(
+            u64::from(type_id) <= TYPE_ID_MASK,
+            "GC type id {type_id} does not fit the {TYPE_ID_BITS}-bit header field"
+        );
+        assert_eq!(
+            raw_flags.bits() & !(TYPE_ID_MASK),
+            0,
+            "GC flags do not fit the {TYPE_ID_BITS}-bit header field"
+        );
         GcHeader {
             tid_and_flags: (raw_flags.bits() << FLAG_SHIFT) | (type_id as u64),
         }
@@ -292,6 +311,13 @@ mod tests {
     #[test]
     fn test_header_size() {
         assert_eq!(GcHeader::SIZE, 8);
+    }
+
+    #[test]
+    fn logical_header_halves_follow_rpython_word_size() {
+        assert_eq!(TYPE_ID_BITS, usize::BITS / 2);
+        assert_eq!(FLAG_SHIFT, usize::BITS / 2);
+        assert_eq!(FORWARDED_MARKER, (usize::MAX - 41) as u64);
     }
 
     #[test]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3684,6 +3684,14 @@ pub fn gc_rawrefcount_init(dealloc_trigger: rawrefcount::DeallocTriggerFn) {
     gc_sync::gc_op(|gc| gc.rawrefcount_init(dealloc_trigger));
 }
 
+/// Whether [`gc_rawrefcount_init`] has run on the live collector.
+///
+/// `as_pyobj` / `create_ref` must not invent a link before this is true:
+/// `rawrefcount_create_link_pypy` asserts the table exists.
+pub fn gc_rawrefcount_enabled() -> bool {
+    gc_sync::is_initialized() && gc_sync::gc_query_reentrant(|gc| gc.rawrefcount_enabled())
+}
+
 /// Register the [`rawrefcount::CEdgeCensusFn`] the collector reads a block's
 /// own references from.  Upstream has no counterpart; see the type.
 pub fn gc_rawrefcount_set_c_edge_census(census: rawrefcount::CEdgeCensusFn) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -10,7 +10,10 @@ pub use gcreftracer::{GcTable, install_gc_table_walker};
 ///
 /// Reference: rpython/memory/gc/incminimark.py, rpython/jit/backend/llsupport/gc.py
 use majit_ir::{Const, ConstMap, GcRef, Op};
-pub use trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout};
+pub use trace::{
+    ClassTypeLayout, CustomDataLayout, TypeEntry, TypeEntryTail, TypeInfo, TypeInfoLayout,
+    VarSizeTypeInfoLayout,
+};
 
 /// Runtime layout of one registered variable-size GC object.
 ///

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -869,6 +869,21 @@ pub trait GcAllocator: Send {
         false
     }
 
+    /// `rgc.get_gcflag_extra` / `toggle_gcflag_extra` /
+    /// `get_gcflag_dummy`. Collectors without RPython header flags report the
+    /// two queries false and reject mutation.
+    fn get_gcflag_extra(&mut self, _obj: GcRef) -> bool {
+        false
+    }
+
+    fn toggle_gcflag_extra(&mut self, _obj: GcRef) {
+        panic!("toggle_gcflag_extra is unsupported by this collector")
+    }
+
+    fn get_gcflag_dummy(&mut self, _obj: GcRef) -> bool {
+        false
+    }
+
     /// `inspector.py:get_rpy_memory_usage`: size of the object's translated
     /// payload, excluding the GC header and anything reachable from it.
     /// `None` is the untranslated equivalent of inspector.py returning `-1`
@@ -1093,6 +1108,14 @@ pub trait GcAllocator: Send {
     /// When true, the JIT emits COND_CALL_GC_WB (inline flag test +
     /// conditional call) instead of a full barrier call.
     fn can_optimize_cond_call(&self) -> bool {
+        false
+    }
+
+    /// `GCBase.can_optimize_clean_setarrayitems`: whether the GC transform may
+    /// omit barriers for stores that only clear a freshly allocated array.
+    /// Collectors with card marking must return false because those stores can
+    /// otherwise leave the card bitmap clean while overwriting young edges.
+    fn can_optimize_clean_setarrayitems(&self) -> bool {
         false
     }
 
@@ -1581,6 +1604,15 @@ impl GcAllocator for GcHandle {
         // managed-heap object of the type the answer is read out of.
         gc_sync::gc_op_with_root(obj, |gc, obj| gc.is_tracked(obj))
     }
+    fn get_gcflag_extra(&mut self, obj: GcRef) -> bool {
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_gcflag_extra(obj))
+    }
+    fn toggle_gcflag_extra(&mut self, obj: GcRef) {
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.toggle_gcflag_extra(obj))
+    }
+    fn get_gcflag_dummy(&mut self, obj: GcRef) -> bool {
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_gcflag_dummy(obj))
+    }
     fn get_rpy_memory_usage(&mut self, obj: GcRef) -> Option<usize> {
         gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_rpy_memory_usage(obj))
     }
@@ -1677,6 +1709,10 @@ impl GcAllocator for GcHandle {
     }
     fn can_optimize_cond_call(&self) -> bool {
         gc_sync::gc_query_reentrant(|gc| gc.can_optimize_cond_call())
+    }
+
+    fn can_optimize_clean_setarrayitems(&self) -> bool {
+        gc_sync::gc_query_reentrant(|gc| gc.can_optimize_clean_setarrayitems())
     }
     fn gc_step(&mut self) -> bool {
         gc_sync::gc_op(|gc| gc.gc_step())
@@ -1872,6 +1908,11 @@ pub type IsRegisteredTypeIdFn = fn(typeid: u32) -> bool;
 /// const-baking site (`x86/regalloc.py convert_to_imm`) consults
 /// this before baking a `ConstPtr` immediate.
 pub type CanMoveFn = fn(GcRef) -> bool;
+/// Active-collector implementations of `rgc.pin`, `rgc.unpin`, and
+/// `rgc._is_pinned` (`rpython/rlib/rgc.py`).
+pub type PinFn = fn(GcRef) -> bool;
+pub type UnpinFn = fn(GcRef);
+pub type IsPinnedFn = fn(GcRef) -> bool;
 
 global_hook!(static ACTIVE_CHECK_IS_OBJECT: CheckIsObjectFn);
 global_hook!(static ACTIVE_IS_TAGGED_IMMEDIATE: IsTaggedImmediateFn);
@@ -1881,6 +1922,9 @@ global_hook!(static ACTIVE_TYPEID_SUBCLASS_RANGE: TypeidSubclassRangeFn);
 global_hook!(static ACTIVE_TYPEID_IS_OBJECT: TypeidIsObjectFn);
 global_hook!(static ACTIVE_IS_REGISTERED_TYPE_ID: IsRegisteredTypeIdFn);
 global_hook!(static ACTIVE_CAN_MOVE: CanMoveFn);
+global_hook!(static ACTIVE_PIN: PinFn);
+global_hook!(static ACTIVE_UNPIN: UnpinFn);
+global_hook!(static ACTIVE_IS_PINNED: IsPinnedFn);
 static ACTIVE_SUPPORTS_GUARD_GC_TYPE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
@@ -1898,6 +1942,9 @@ pub struct ActiveGcGuardHooks {
     pub typeid_is_object: Option<TypeidIsObjectFn>,
     pub is_registered_type_id: Option<IsRegisteredTypeIdFn>,
     pub can_move: Option<CanMoveFn>,
+    pub pin: Option<PinFn>,
+    pub unpin: Option<UnpinFn>,
+    pub is_pinned: Option<IsPinnedFn>,
     pub supports_guard_gc_type: bool,
 }
 
@@ -1917,6 +1964,9 @@ pub fn set_active_gc_guard_hooks(hooks: ActiveGcGuardHooks) {
     ACTIVE_TYPEID_IS_OBJECT.set(hooks.typeid_is_object);
     ACTIVE_IS_REGISTERED_TYPE_ID.set(hooks.is_registered_type_id);
     ACTIVE_CAN_MOVE.set(hooks.can_move);
+    ACTIVE_PIN.set(hooks.pin);
+    ACTIVE_UNPIN.set(hooks.unpin);
+    ACTIVE_IS_PINNED.set(hooks.is_pinned);
     ACTIVE_SUPPORTS_GUARD_GC_TYPE.store(
         hooks.supports_guard_gc_type,
         std::sync::atomic::Ordering::Release,
@@ -1935,6 +1985,9 @@ fn current_gc_guard_hooks() -> ActiveGcGuardHooks {
         typeid_is_object: ACTIVE_TYPEID_IS_OBJECT.get(),
         is_registered_type_id: ACTIVE_IS_REGISTERED_TYPE_ID.get(),
         can_move: ACTIVE_CAN_MOVE.get(),
+        pin: ACTIVE_PIN.get(),
+        unpin: ACTIVE_UNPIN.get(),
+        is_pinned: ACTIVE_IS_PINNED.get(),
         supports_guard_gc_type: supports_guard_gc_type(),
     }
 }
@@ -2089,6 +2142,34 @@ pub fn can_move(gcref: GcRef) -> bool {
         Some(f) => f(gcref),
         None => false,
     }
+}
+
+/// `rgc.pin(gcref)` shim. A missing collector has the untranslated
+/// `llheap.pin` behaviour and declines the request.
+pub fn pin(gcref: GcRef) -> bool {
+    if gcref.is_null() {
+        return false;
+    }
+    ACTIVE_PIN.get().is_some_and(|f| f(gcref))
+}
+
+/// `rgc.unpin(gcref)` shim. `rgc.unpin` is only valid after a successful
+/// [`pin`], so reaching an absent collector is a caller-contract violation,
+/// just as untranslated `llheap.unpin` is.
+pub fn unpin(gcref: GcRef) {
+    let f = ACTIVE_UNPIN
+        .get()
+        .expect("unpin() called without an active collector");
+    f(gcref);
+}
+
+/// `rgc._is_pinned(gcref)` shim. A missing collector is non-moving and has
+/// no pinned nursery objects.
+pub fn is_pinned(gcref: GcRef) -> bool {
+    if gcref.is_null() {
+        return false;
+    }
+    ACTIVE_IS_PINNED.get().is_some_and(|f| f(gcref))
 }
 
 /// x86/assembler.py:1971-1974 codegen-time bounds lookup shim used by
@@ -2781,6 +2862,56 @@ pub fn is_tracked(obj: GcRef) -> bool {
         Some(f) => f(obj),
         None => false,
     }
+}
+
+/// Active-backend hooks for `rgc`'s temporary traversal flags.
+pub type GetGcFlagFn = fn(GcRef) -> bool;
+pub type ToggleGcFlagFn = fn(GcRef);
+
+global_hook!(static ACTIVE_GET_GCFLAG_EXTRA: GetGcFlagFn);
+global_hook!(static ACTIVE_TOGGLE_GCFLAG_EXTRA: ToggleGcFlagFn);
+global_hook!(static ACTIVE_GET_GCFLAG_DUMMY: GetGcFlagFn);
+
+pub fn set_active_gcflag_hooks(
+    get_extra: Option<GetGcFlagFn>,
+    toggle_extra: Option<ToggleGcFlagFn>,
+    get_dummy: Option<GetGcFlagFn>,
+) {
+    ACTIVE_GET_GCFLAG_EXTRA.set(get_extra);
+    ACTIVE_TOGGLE_GCFLAG_EXTRA.set(toggle_extra);
+    ACTIVE_GET_GCFLAG_DUMMY.set(get_dummy);
+}
+
+/// `rgc.has_gcflag_extra`: IncrementalMiniMark exposes `GCFLAG_EXTRA`.
+pub const fn has_gcflag_extra() -> bool {
+    true
+}
+
+pub fn get_gcflag_extra(obj: GcRef) -> bool {
+    ACTIVE_GET_GCFLAG_EXTRA.get().is_some_and(|f| f(obj))
+}
+
+pub fn toggle_gcflag_extra(obj: GcRef) {
+    let toggle = ACTIVE_TOGGLE_GCFLAG_EXTRA
+        .get()
+        .expect("toggle_gcflag_extra called without an active collector");
+    toggle(obj);
+}
+
+pub fn get_gcflag_dummy(obj: GcRef) -> bool {
+    ACTIVE_GET_GCFLAG_DUMMY.get().is_some_and(|f| f(obj))
+}
+
+/// Translated `rgc.hide_nonmovable_gcref`: after the non-moving assertion,
+/// the representation change is just GCREF-to-address.
+pub fn hide_nonmovable_gcref(obj: GcRef) -> usize {
+    assert!(obj.is_null() || !can_move(obj));
+    obj.0
+}
+
+/// Translated `rgc.reveal_gcref`: address-to-GCREF inverse.
+pub const fn reveal_gcref(addr: usize) -> GcRef {
+    GcRef(addr)
 }
 
 /// Active-backend trampolines for `inspector.py:get_rpy_memory_usage` and
@@ -3562,6 +3693,11 @@ pub fn gc_rawrefcount_set_finalizer_claim(claim: rawrefcount::FinalizerClaimFn) 
     gc_sync::gc_op(|gc| gc.rawrefcount_set_finalizer_claim(claim));
 }
 
+/// Register the allocator-matched release for an exact LIGHT mirror.
+pub fn gc_rawrefcount_set_light_free(free: rawrefcount::LightFreeFn) {
+    gc_sync::gc_op(|gc| gc.rawrefcount_set_light_free(free));
+}
+
 /// `rawrefcount.py:create_link_pypy` — `mirror` is a mirror of `obj`, and
 /// `obj` owns it: the mirror lives as long as the interpreter object does, plus
 /// as long afterwards as the C side still holds a reference.
@@ -4095,6 +4231,7 @@ pub fn bh_probe_type_name(addr: usize) -> Option<&'static str> {
 #[cfg(test)]
 mod headerless_no_collect_tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// A `GcAllocator` that only implements the collecting headerless form, so
     /// the default `alloc_nursery_headerless_no_collect` has to forward to it.
@@ -4171,6 +4308,39 @@ mod headerless_no_collect_tests {
 
         set_active_alloc_nursery_headerless_no_collect(None);
         assert_eq!(alloc_nursery_headerless_no_collect(16), GcRef(0));
+    }
+
+    static LAST_UNPINNED: AtomicUsize = AtomicUsize::new(0);
+
+    fn stub_pin(obj: GcRef) -> bool {
+        obj == GcRef(0x5010)
+    }
+
+    fn stub_unpin(obj: GcRef) {
+        LAST_UNPINNED.store(obj.0, Ordering::SeqCst);
+    }
+
+    fn stub_is_pinned(obj: GcRef) -> bool {
+        obj == GcRef(0x5010)
+    }
+
+    #[test]
+    fn active_pin_hooks_expose_the_rgc_surface() {
+        LAST_UNPINNED.store(0, Ordering::SeqCst);
+        let _guard = override_gc_guard_hooks_for_test(ActiveGcGuardHooks {
+            pin: Some(stub_pin),
+            unpin: Some(stub_unpin),
+            is_pinned: Some(stub_is_pinned),
+            ..Default::default()
+        });
+
+        assert!(!pin(GcRef::NULL));
+        assert!(pin(GcRef(0x5010)));
+        assert!(!pin(GcRef(0x6010)));
+        assert!(is_pinned(GcRef(0x5010)));
+        assert!(!is_pinned(GcRef::NULL));
+        unpin(GcRef(0x5010));
+        assert_eq!(LAST_UNPINNED.load(Ordering::SeqCst), 0x5010);
     }
 
     /// incminimark.py names each `GCFLAG_*` at a position, and so does

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -19,6 +19,11 @@ const ARENA_ALIGN: usize = if crate::header::GcHeader::ALIGN > WORD {
 struct ArenaReference {
     base: *mut u8,
     layout: Layout,
+    /// Pyre's hybrid heap needs an exact answer to "is this an allocated GC
+    /// block?", a question RPython's typed pointers never ask. One bit per
+    /// arena word keeps that adaptation on the allocator which owns the
+    /// lifetime, without an address-keyed side table.
+    live_words: Vec<usize>,
     nfreepages: usize,
     totalpages: usize,
     freepages: *mut u8,
@@ -53,7 +58,7 @@ pub struct ArenaCollection {
     /// retain minimarkpage.py's allocator shape; this flat range index avoids
     /// pointer-chasing every bucket for arbitrary-word validity checks.
     /// It changes only when an arena is allocated or freed.
-    arena_ranges: Vec<(usize, usize)>,
+    arena_ranges: Vec<(usize, usize, *mut ArenaReference)>,
     /// The range [`contains`] matched last.  Every field store that reaches the
     /// write barrier asks the membership question once, and consecutive stores
     /// name the same arena nearly always, so re-testing the previous answer
@@ -61,7 +66,7 @@ pub struct ArenaCollection {
     /// can only be stale if the range left `arena_ranges`, so `free_arena`
     /// clears it; inserting leaves every existing range where it was.
     /// `(usize::MAX, 0)` is the empty state — no address satisfies it.
-    last_range_hit: std::cell::Cell<(usize, usize)>,
+    last_range_hit: std::cell::Cell<(usize, usize, *mut ArenaReference)>,
     min_empty_nfreepages: usize,
     pub num_uninitialized_pages: usize,
     pub total_memory_used: usize,
@@ -117,7 +122,7 @@ impl ArenaCollection {
             old_arenas_lists: vec![ptr::null_mut(); max_pages_per_arena],
             current_arena: ptr::null_mut(),
             arena_ranges: Vec::new(),
-            last_range_hit: std::cell::Cell::new((usize::MAX, 0)),
+            last_range_hit: std::cell::Cell::new((usize::MAX, 0, ptr::null_mut())),
             min_empty_nfreepages: max_pages_per_arena,
             num_uninitialized_pages: 0,
             total_memory_used: 0,
@@ -160,6 +165,7 @@ impl ArenaCollection {
                 (*page).nextpage = self.full_page_for_size[size_class];
                 self.full_page_for_size[size_class] = page;
             }
+            Self::set_block_live((*page).arena, result as usize, true);
             result
         }
     }
@@ -251,6 +257,7 @@ impl ArenaCollection {
         let arena = Box::into_raw(Box::new(ArenaReference {
             base: arena_base,
             layout,
+            live_words: vec![0; self.arena_size.div_ceil(WORD * usize::BITS as usize)],
             nfreepages: 0,
             totalpages: npages,
             freepages: firstpage as *mut u8,
@@ -259,10 +266,10 @@ impl ArenaCollection {
         self.num_uninitialized_pages = npages;
         self.current_arena = arena;
         self.arenas_count += 1;
-        let range = (arena_base as usize, arena_end);
+        let range = (arena_base as usize, arena_end, arena);
         let index = self
             .arena_ranges
-            .binary_search_by_key(&range.0, |&(start, _)| start)
+            .binary_search_by_key(&range.0, |&(start, _, _)| start)
             .unwrap_err();
         self.arena_ranges.insert(index, range);
     }
@@ -285,12 +292,12 @@ impl ArenaCollection {
     pub(crate) fn mass_free_incremental(
         &mut self,
         ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
-        mut max_pages: usize,
+        mut max_pages: isize,
     ) -> bool {
         let mut size_class = self.size_class_with_old_pages;
         while size_class >= 1 {
             max_pages = self.mass_free_in_pages(size_class as usize, ok_to_free_func, max_pages);
-            if max_pages == 0 {
+            if max_pages <= 0 {
                 self.size_class_with_old_pages = size_class;
                 return false;
             }
@@ -306,7 +313,7 @@ impl ArenaCollection {
     /// `ArenaCollection.mass_free`, the non-incremental STW entry point.
     pub fn mass_free(&mut self, mut ok_to_free_func: impl FnMut(*mut u8) -> bool) {
         self.mass_free_prepare();
-        let complete = self.mass_free_incremental(&mut ok_to_free_func, usize::MAX);
+        let complete = self.mass_free_incremental(&mut ok_to_free_func, isize::MAX);
         assert!(
             complete,
             "non-incremental mass_free_in_pages returned false"
@@ -342,8 +349,8 @@ impl ArenaCollection {
         &mut self,
         size_class: usize,
         ok_to_free_func: &mut impl FnMut(*mut u8) -> bool,
-        mut max_pages: usize,
-    ) -> usize {
+        mut max_pages: isize,
+    ) -> isize {
         let nblocks = self.nblocks_for_size[size_class];
         let block_size = size_class * WORD;
         let mut remaining_partial_pages = self.page_for_size[size_class];
@@ -371,7 +378,7 @@ impl ArenaCollection {
                     self.free_page(page);
                 }
                 max_pages -= 1;
-                if max_pages == 0 {
+                if max_pages <= 0 {
                     if step == 0 {
                         self.old_full_page_for_size[size_class] = nextpage;
                     } else {
@@ -433,6 +440,7 @@ impl ArenaCollection {
                         "freeblocks are not ordered"
                     );
                     if ok_to_free_func(obj) {
+                        Self::set_block_live((*page).arena, obj as usize, false);
                         *prevfreeblockat = obj;
                         prevfreeblockat = obj as *mut *mut u8;
                         *prevfreeblockat = freeblock;
@@ -499,25 +507,58 @@ impl ArenaCollection {
         }
     }
 
-    /// Arena-owned address-range membership, matching the answer available to
-    /// incminimark from its arena pages.  It intentionally does not distinguish
-    /// live blocks from free/uninitialized bytes inside a live arena.  The
-    /// allocator's bucketed arena lists remain the source of allocation state;
-    /// this sorted flat index serves pyre's arbitrary-word membership query.
+    /// Exact allocated-block membership for the arena allocator.
+    ///
+    /// RPython never needs this query: the translated pointer type proves that
+    /// an edge names a GC object. Pyre's hybrid heap must reject host pointers,
+    /// freed blocks, and uninitialized arena bytes before reading a GC header.
+    /// The sorted range index finds the arena and its word bitmap distinguishes
+    /// the one valid block start from every other address in that range.
     #[inline]
     pub fn contains(&self, addr: usize) -> bool {
-        let (start, end) = self.last_range_hit.get();
+        let (start, end, arena) = self.last_range_hit.get();
         if addr >= start && addr < end {
-            return true;
+            return unsafe { Self::block_is_live(arena, addr) };
         }
         let index = self
             .arena_ranges
-            .partition_point(|&(start, _)| start <= addr);
+            .partition_point(|&(start, _, _)| start <= addr);
         if index > 0 && addr < self.arena_ranges[index - 1].1 {
-            self.last_range_hit.set(self.arena_ranges[index - 1]);
-            true
+            let range = self.arena_ranges[index - 1];
+            self.last_range_hit.set(range);
+            unsafe { Self::block_is_live(range.2, addr) }
         } else {
             false
+        }
+    }
+
+    #[inline]
+    unsafe fn block_is_live(arena: *mut ArenaReference, addr: usize) -> bool {
+        debug_assert!(!arena.is_null());
+        let base = unsafe { (*arena).base as usize };
+        let offset = addr - base;
+        if offset % WORD != 0 {
+            return false;
+        }
+        let bit = offset / WORD;
+        let word = bit / usize::BITS as usize;
+        let mask = 1usize << (bit % usize::BITS as usize);
+        unsafe { (&(*arena).live_words)[word] & mask != 0 }
+    }
+
+    #[inline]
+    unsafe fn set_block_live(arena: *mut ArenaReference, addr: usize, live: bool) {
+        let base = unsafe { (*arena).base as usize };
+        let offset = addr - base;
+        debug_assert_eq!(offset % WORD, 0);
+        let bit = offset / WORD;
+        let word = bit / usize::BITS as usize;
+        let mask = 1usize << (bit % usize::BITS as usize);
+        if live {
+            unsafe { (&mut (*arena).live_words)[word] |= mask };
+        } else {
+            debug_assert!(unsafe { (&(*arena).live_words)[word] & mask != 0 });
+            unsafe { (&mut (*arena).live_words)[word] &= !mask };
         }
     }
 
@@ -549,10 +590,10 @@ impl ArenaCollection {
             }
             let index = self
                 .arena_ranges
-                .binary_search_by_key(&base, |&(start, _)| start)
+                .binary_search_by_key(&base, |&(start, _, _)| start)
                 .expect("freed arena missing from range index");
             self.arena_ranges.remove(index);
-            self.last_range_hit.set((usize::MAX, 0));
+            self.last_range_hit.set((usize::MAX, 0, ptr::null_mut()));
             alloc::dealloc((*arena).base, (*arena).layout);
             self.total_memory_alloced -= self.arena_size;
             self.arenas_count -= 1;
@@ -627,8 +668,33 @@ mod tests {
         ac.mass_free(|obj| obj != survivor);
         assert_eq!(ac.total_memory_used, block_size);
         assert!(ac.contains(survivor as usize));
+        assert!(!ac.contains(objects[1] as usize));
+        assert!(!ac.contains(survivor as usize + WORD));
         let reused = ac.malloc(block_size);
         assert_ne!(reused, survivor);
+    }
+
+    #[test]
+    fn zero_page_incremental_budget_does_not_underflow() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let block_size = 2 * WORD;
+        let _objects: Vec<_> = (0..8).map(|_| ac.malloc(block_size)).collect();
+        let used_before = ac.total_memory_used;
+        ac.mass_free_prepare();
+        let mut visited = 0;
+
+        assert!(!ac.mass_free_incremental(
+            &mut |_| {
+                visited += 1;
+                true
+            },
+            0,
+        ));
+        assert_eq!(visited, 0);
+        assert_eq!(ac.total_memory_used, used_before);
+
+        while !ac.mass_free_incremental(&mut |_| false, 1) {}
+        assert_eq!(ac.total_memory_used, used_before);
     }
 
     #[test]

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -469,7 +469,7 @@ impl OldGen {
                     true
                 }
             },
-            max_pages,
+            isize::try_from(max_pages).unwrap_or(isize::MAX),
         )
     }
 
@@ -503,17 +503,15 @@ impl OldGen {
         self.old_rawmalloced_objects.len()
     }
 
-    /// Arena membership is intentionally an address-range answer, not a live
-    /// block answer.  Rawmalloced objects retain exact payload membership.
-    ///
-    /// Split so the arena range test can inline into the caller and the payload
-    /// set cannot. Major marking asks this question once per root and once per
-    /// traced edge, and the arena answer settles almost all of them; keeping the
-    /// hashed lookup in the same body made the whole thing too large to inline,
-    /// so every edge paid a call.
+    /// Exact old-generation payload membership. `ArenaCollection` records its
+    /// returned block starts, which are GC header addresses; rawmalloc records
+    /// payloads because its card prefix makes the allocation start unsuitable.
     #[inline]
     pub fn contains(&self, obj_addr: usize) -> bool {
-        self.ac.contains(obj_addr) || self.rawmalloced_contains(obj_addr)
+        obj_addr
+            .checked_sub(GcHeader::SIZE)
+            .is_some_and(|header| self.ac.contains(header))
+            || self.rawmalloced_contains(obj_addr)
     }
 
     /// Split again inside: the filter test inlines into `contains`, the hashed

--- a/majit/majit-gc/src/rawrefcount.rs
+++ b/majit/majit-gc/src/rawrefcount.rs
@@ -28,33 +28,14 @@ use crate::address_dict::AddressMap;
 /// above it is a reference the C side holds.
 pub const REFCNT_FROM_PYPY: isize = (isize::MAX >> 2) + 1;
 
-/// The count a mirror that must never be freed starts at.
-///
-/// `rawrefcount.py:16-20` has two constants above [`REFCNT_FROM_PYPY`]:
-/// `REFCNT_FROM_PYPY_LIGHT`, for a mirror whose deallocation is a plain free
-/// with no deallocator to run, and `_Py_IMMORTAL_REFCNT`, for one that is never
-/// deallocated at all.  Only the second has a port, and that is not a gap:
-/// nothing creates a light mirror upstream either.  `cpyext` links every
-/// mirror with the plain share (`pypy/module/cpyext/pyobject.py:288`,
-/// `py_obj.c_ob_refcnt += rawrefcount.REFCNT_FROM_PYPY`), and the only
-/// assignments of the light one in the whole tree are in
-/// `rpython/rlib/test/test_rawrefcount.py` and
-/// `rpython/memory/gc/test/test_rawrefcount.py`.
-/// `pypy/doc/discussion/rawrefcount.rst:120-148` proposes the cases that would
-/// use it — "and we can use REFCNT_FROM_PYPY_LIGHT too: 'tp_dealloc' doesn't
-/// need to be called" — in the future tense.  Its three readers in
-/// `incminimark.py` (:3264, :3325, :3361) are therefore branches the
-/// translated interpreter never takes.
-///
-/// The value is chosen for headroom rather than to match either upstream
-/// constant: the asserts below hold it at least `1 << 60` clear of the
-/// threshold at which a mirror is freed, and the same clear of overflow, so no
-/// incref/decref imbalance a running process can produce reaches either end.
-pub const REFCNT_IMMORTAL: isize = REFCNT_FROM_PYPY + (1 << (isize::BITS - 4));
+/// `rawrefcount.py REFCNT_FROM_PYPY_LIGHT`. A dead link carrying this share
+/// needs no type-specific deallocator: `_rrc_free` can release the raw mirror
+/// immediately when no other references remain.
+pub const REFCNT_FROM_PYPY_LIGHT: isize = REFCNT_FROM_PYPY + ((isize::MAX >> 1) + 1);
 
-const IMMORTAL_HEADROOM: isize = 1 << (isize::BITS - 4);
-const _: () = assert!(REFCNT_IMMORTAL - REFCNT_FROM_PYPY >= IMMORTAL_HEADROOM);
-const _: () = assert!(isize::MAX - REFCNT_IMMORTAL >= IMMORTAL_HEADROOM);
+/// Pyre's C-API immortal marker. Keep it above the complete rawrefcount range;
+/// using the LIGHT value for this marker made every LIGHT branch unreachable.
+pub const REFCNT_IMMORTAL: isize = isize::MAX;
 
 /// Scheduled when the dead queue becomes non-empty.
 ///
@@ -62,6 +43,13 @@ const _: () = assert!(isize::MAX - REFCNT_IMMORTAL >= IMMORTAL_HEADROOM);
 /// collection entry point with the collector borrowed, so it may only schedule
 /// work; the drain itself happens later, from the embedder.
 pub type DeallocTriggerFn = fn();
+
+/// Releases a LIGHT mirror through the allocator that created it.
+///
+/// `incminimark.py _rrc_free` calls `lltype.free(..., flavor='raw')` for an
+/// exact LIGHT share.  The collector deliberately knows only the two-word
+/// prefix, so the embedder must supply the matching raw allocator operation.
+pub type LightFreeFn = fn(usize);
 
 /// `incminimark.py:3163-3166 PYOBJ_HDR`: the prefix of a mirror block the
 /// collector reads.  The real block is longer — a type pointer and whatever
@@ -118,6 +106,7 @@ pub(crate) struct RawRefCount {
     /// deallocator the embedder still has to run.
     pub(crate) dealloc_pending: Vec<usize>,
     pub(crate) dealloc_trigger: Option<DeallocTriggerFn>,
+    pub(crate) light_free: Option<LightFreeFn>,
     /// [`FinalizerClaimFn`], and the blocks it has claimed: mirrors kept alive
     /// for one collection so that the drain can run their finalizers.
     pub(crate) finalizer_claim: Option<FinalizerClaimFn>,
@@ -187,6 +176,11 @@ mod tests {
         // rawrefcount.py:15, on a 64-bit host.
         assert_eq!(REFCNT_FROM_PYPY, (isize::MAX / 4) + 1);
         assert_eq!(REFCNT_FROM_PYPY, 1 << (isize::BITS - 3));
+        assert_eq!(
+            REFCNT_FROM_PYPY_LIGHT,
+            REFCNT_FROM_PYPY + (1 << (isize::BITS - 2))
+        );
+        assert!(REFCNT_IMMORTAL > REFCNT_FROM_PYPY_LIGHT);
     }
 
     #[test]

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2864,10 +2864,10 @@ impl GcRewriterImpl {
     /// the actual store address is `obj_ptr + (-HDR_SIZE +
     /// descr.offset())`.  None disables the store (Boehm parity).
     ///
-    /// `fielddescr_tid.field_size` is 4 bytes (descr.rs
-    /// `make_tid_field_descr`): pyre's HDR packs type id into the lower
-    /// 32 bits and gc flags (TRACK_YOUNG_PTRS / VISITED / …) into the
-    /// upper 32 bits, and the slow `dynasm_nursery_slowpath` /
+    /// `fielddescr_tid.field_size` is `WORD / 2` (descr.rs
+    /// `make_tid_field_descr`): pyre's logical HDR word packs the type id
+    /// into its lower half and gc flags (TRACK_YOUNG_PTRS / VISITED / …)
+    /// into its upper half, and the slow `dynasm_nursery_slowpath` /
     /// cranelift-side malloc helpers may promote large or
     /// post-collection allocations to the old gen, where
     /// `collector.rs`'s `alloc_in_oldgen` pre-stamps `TRACK_YOUNG_PTRS`
@@ -2875,7 +2875,7 @@ impl GcRewriterImpl {
     /// wipe that bit and leave a fresh oldgen object invisible to the
     /// remembered-set machinery, dropping any subsequent young pointer
     /// written into it.  Restricting the GC_STORE width to
-    /// `field_size = 4` keeps the upper half intact.
+    /// `field_size = WORD / 2` keeps the flags half intact.
     fn gen_initialize_tid(&self, obj: Operand, tid: u32, st: &mut RewriteState) {
         let Some(tid_fd_ref) = self.fielddescr_tid.as_ref() else {
             return;
@@ -3901,9 +3901,9 @@ mod tests {
             .inline_const_bits()
             .expect("inline ConstInt");
         assert_eq!(tid_val, 7); // type_id = 7
-        // GcHeader packs type id (lower 32 bits) and gc flags (upper 32
-        // bits) into a single u64.  gen_initialize_tid must emit a
-        // 4-byte store so that the runtime-set flags
+        // GcHeader packs the type id and gc flags into the lower and upper
+        // halves of the logical native word. gen_initialize_tid must emit a
+        // HALFWORD store so that the runtime-set flags
         // (collector.rs's alloc_in_oldgen ORs in TRACK_YOUNG_PTRS for
         // oldgen-promoted allocs) survive the type id stamp.
         let store_size = result[1]
@@ -3912,9 +3912,10 @@ mod tests {
             .inline_const_bits()
             .expect("inline ConstInt");
         assert_eq!(
-            store_size, 4,
-            "gen_initialize_tid must emit a 4-byte store (type id half) so \
-             oldgen TRACK_YOUNG_PTRS in the upper 32 bits is preserved"
+            store_size,
+            (std::mem::size_of::<usize>() / 2) as i64,
+            "gen_initialize_tid must emit a HALFWORD store so oldgen \
+             TRACK_YOUNG_PTRS in the flags half is preserved"
         );
 
         for (_key, c) in &constants {

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -4040,7 +4040,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
 
         let malloc = result
             .iter()

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -107,8 +107,18 @@ pub fn remove_ref_constants(ops: &[Op], mut next_pos: u32) -> (Vec<Op>, Vec<GcRe
 /// Alignment for nursery allocations (8 bytes).
 const NURSERY_ALIGN: usize = 8;
 
-/// Align `size` up to `NURSERY_ALIGN`.
+/// `GcRewriterAssembler.round_up_for_allocation` — raise to the nursery's
+/// minimum object size, then align.
+///
+/// A nursery object that moves has its header replaced by the forwarded marker
+/// and the following word by the new address, so a block shorter than
+/// [`GcHeader::MIN_NURSERY_OBJ_SIZE`] would let that second word land in the
+/// next object.  `Nursery::alloc` already raises the runtime bump; the JIT
+/// bumps by whatever this hands `CALL_MALLOC_NURSERY` /
+/// `NURSERY_PTR_INCREMENT`, so it has to raise it too.  Upstream spells the
+/// same floor as `max(size, 2 * WORD)`.
 fn round_up(size: usize) -> usize {
+    let size = size.max(crate::header::GcHeader::MIN_NURSERY_OBJ_SIZE);
     (size + NURSERY_ALIGN - 1) & !(NURSERY_ALIGN - 1)
 }
 
@@ -4009,6 +4019,39 @@ mod tests {
             call.arg(3).to_opref(),
             len_ref,
             "the length operand is threaded through as the helper's num_elem"
+        );
+    }
+
+    /// `GcRewriterAssembler.round_up_for_allocation` raises to
+    /// `minimal_size_in_nursery` before aligning. Without the floor the JIT's inline bump
+    /// and `Nursery::alloc`'s bump disagree for a sub-minimum object, and the
+    /// next allocation lands inside the forwarding word of the previous one.
+    #[test]
+    fn a_headerless_new_below_the_nursery_minimum_bumps_by_the_minimum() {
+        let rw = make_rewriter();
+        let payload_size = std::mem::size_of::<usize>();
+        assert!(payload_size < crate::header::GcHeader::MIN_NURSERY_OBJ_SIZE);
+
+        let ops = vec![Op::with_descr(
+            OpCode::New,
+            &[],
+            headerless_size_descr(payload_size, 78),
+        )];
+
+        let (result, _constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+
+        let malloc = result
+            .iter()
+            .find(|o| o.opcode == OpCode::CallMallocNurseryHeaderless)
+            .expect("a one-word headerless struct fits the nursery");
+        assert_eq!(
+            malloc
+                .arg(0)
+                .to_opref()
+                .inline_const_bits()
+                .expect("inline ConstInt"),
+            crate::header::GcHeader::MIN_NURSERY_OBJ_SIZE as i64
         );
     }
 

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -12,30 +12,39 @@
 use majit_ir::GcRef;
 
 /// One `gctypelayout.GCData.TYPE_INFO` entry of the materialized
-/// type-info group (gc.py:592, x86/assembler.py:1924-1943).
+/// type-info group (`GcLLDescr_framework.get_translated_info_for_typeinfo`,
+/// `Assembler386.genop_guard_guard_is_object`).
 ///
-/// Mirrors the shape of `TYPE_INFO` that `genop_guard_guard_is_object`
-/// reads: `infobits` at offset 0 carries `T_IS_RPYTHON_INSTANCE`.
-///
-/// This row is *smaller* than upstream's, not equal to it. `GCData.TYPE_INFO`
-/// is four words — `infobits`, `customdata`, `fixedsize`, `ofstoptrs` — so 32
-/// bytes on 64-bit, and `VARSIZE_TYPE_INFO` extends it to eight; upstream's
-/// per-entry size is not even uniform, since `get_type_id` allocates the
-/// narrow struct for a fixed-size type and the wide one for a varsize type.
-/// majit consults only `infobits` and keeps the other fields out of this
-/// layout, so the row is one word of content. The reserved word is not there
-/// to match a size: it is there so `TypeEntry`'s stride stays a power of two,
-/// which is what lets the backend address the table by a shift. Deleting it
-/// gives a stride of 24 and the shift no longer applies.
+/// Mirrors `GCData.TYPE_INFO` field-for-field.  The pointer-valued fields are
+/// stored as native addresses so the row remains `Send` while retaining the
+/// C/lltype memory shape consumed by generated code.
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct TypeInfoLayout {
-    pub infobits: u64,
-    /// Reserved for future TYPE_INFO fields (customdata / fixedsize /
-    /// ofstoptrs in the RPython struct, gctypelayout.py:36-42). Kept
-    /// as a raw word so `sizeof_ti` matches the layout the backend
-    /// lowering expects.
-    pub _reserved: u64,
+    pub infobits: usize,
+    pub customdata: usize,
+    pub fixedsize: usize,
+    pub ofstoptrs: usize,
+}
+
+/// `GCData.CUSTOM_DATA_STRUCT` materialized behind
+/// [`TypeInfoLayout::customdata`].
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct CustomDataLayout {
+    pub customfunc: usize,
+    pub memory_pressure_offset: isize,
+}
+
+/// The four fields appended by `GCData.VARSIZE_TYPE_INFO` after its
+/// `TYPE_INFO header`.
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct VarSizeTypeInfoLayout {
+    pub varitemsize: usize,
+    pub ofstovar: usize,
+    pub ofstolength: usize,
+    pub varofstoptrs: usize,
 }
 
 /// One `rclass.CLASSTYPE` entry of the materialized type-info group.
@@ -59,18 +68,36 @@ pub struct ClassTypeLayout {
     pub subclassrange_max: i64,
 }
 
-/// Paired `(TYPE_INFO, CLASSTYPE)` entry in the type-info group.
+/// The bytes following one [`TypeInfoLayout`] row.
 ///
-/// Matches the two-struct pattern RPython's translator emits in the
-/// type_info_group (see `add_vtable_after_typeinfo`
-/// gctypelayout.py:359-374). The fields must stay in this order —
-/// backends walk from `type_info` to `classtype` using
-/// `offset += sizeof_ti`.
+/// `TypeLayoutBuilder.add_vtable_after_typeinfo` asserts that an RPython
+/// instance carrying a `CLASSTYPE` is not varsize.  The same four-word tail can
+/// therefore hold either the varsize extension or the paired class metadata.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union TypeEntryTail {
+    pub varsize: VarSizeTypeInfoLayout,
+    pub classtype: ClassTypeLayout,
+    raw: [usize; 4],
+}
+
+impl Default for TypeEntryTail {
+    fn default() -> Self {
+        Self { raw: [0; 4] }
+    }
+}
+
+/// One materialized type-info group slot.
+///
+/// RPython's heterogeneous group member is either `(TYPE_INFO, CLASSTYPE)` or
+/// `VARSIZE_TYPE_INFO`.  majit's typeids are dense integer indices rather than
+/// pre-scaled `GROUP_MEMBER_OFFSET`s, so every slot has the maximum eight-word
+/// size and generated code can address it with one power-of-two shift.
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct TypeEntry {
     pub type_info: TypeInfoLayout,
-    pub classtype: ClassTypeLayout,
+    pub tail: TypeEntryTail,
 }
 
 impl TypeInfoLayout {
@@ -78,44 +105,44 @@ impl TypeInfoLayout {
     /// `infobits` carry the group member index; majit doesn't use
     /// this field today but reserves the bits to keep the bit layout
     /// compatible with the RPython constants below.
-    pub const T_MEMBER_INDEX: u64 = 0xffff;
+    pub const T_MEMBER_INDEX: usize = 0xffff;
     /// `T_IS_VARSIZE` (gctypelayout.py).
-    pub const T_IS_VARSIZE: u64 = 0x010000;
+    pub const T_IS_VARSIZE: usize = 0x010000;
     /// `T_HAS_GCPTR_IN_VARSIZE` (gctypelayout.py).
-    pub const T_HAS_GCPTR_IN_VARSIZE: u64 = 0x020000;
+    pub const T_HAS_GCPTR_IN_VARSIZE: usize = 0x020000;
     /// `T_IS_GCARRAY_OF_GCPTR` (gctypelayout.py).
-    pub const T_IS_GCARRAY_OF_GCPTR: u64 = 0x040000;
+    pub const T_IS_GCARRAY_OF_GCPTR: usize = 0x040000;
     /// `T_IS_WEAKREF` (gctypelayout.py).
-    pub const T_IS_WEAKREF: u64 = 0x080000;
+    pub const T_IS_WEAKREF: usize = 0x080000;
     /// `T_IS_RPYTHON_INSTANCE` — the type is a subclass of OBJECT
     /// (gctypelayout.py:196). Stored in `infobits` and tested by
     /// `genop_guard_guard_is_object` via the byte mask returned by
     /// `gc_ll_descr.get_translated_info_for_guard_is_object`
     /// (gc.py:603-622).
-    pub const T_IS_RPYTHON_INSTANCE: u64 = 0x100000;
+    pub const T_IS_RPYTHON_INSTANCE: usize = 0x100000;
     /// `T_HAS_CUSTOM_TRACE` (gctypelayout.py).
-    pub const T_HAS_CUSTOM_TRACE: u64 = 0x200000;
+    pub const T_HAS_CUSTOM_TRACE: usize = 0x200000;
     /// `T_HAS_OLDSTYLE_FINALIZER` (gctypelayout.py).
-    pub const T_HAS_OLDSTYLE_FINALIZER: u64 = 0x400000;
+    pub const T_HAS_OLDSTYLE_FINALIZER: usize = 0x400000;
     /// Lightweight-destructor marker (bit 23, the otherwise-unused slot
     /// between `T_HAS_OLDSTYLE_FINALIZER` and `T_HAS_GCPTR`). RPython
     /// folds the lightweight-destructor case into its `q_finalizer`
     /// machinery rather than a distinct infobit; majit models the
     /// `TypeInfo.destructor` half with its own bit so the materialized
     /// table reflects which types carry a destructor.
-    pub const T_HAS_DESTRUCTOR: u64 = 0x800000;
+    pub const T_HAS_DESTRUCTOR: usize = 0x800000;
     /// `T_HAS_GCPTR` (gctypelayout.py).
-    pub const T_HAS_GCPTR: u64 = 0x1000000;
+    pub const T_HAS_GCPTR: usize = 0x1000000;
     /// `T_HAS_MEMORY_PRESSURE` (gctypelayout.py) — first field is
     /// memory pressure field.
-    pub const T_HAS_MEMORY_PRESSURE: u64 = 0x2000000;
+    pub const T_HAS_MEMORY_PRESSURE: usize = 0x2000000;
     /// `T_KEY_MASK` (gctypelayout.py) — bug detection mask.
     /// `_check_valid_type_info` asserts `infobits & T_KEY_MASK ==
     /// T_KEY_VALUE`.
-    pub const T_KEY_MASK: u64 = 0xFC000000;
+    pub const T_KEY_MASK: usize = 0xFC000000;
     /// `T_KEY_VALUE` (gctypelayout.py) — bug detection sentinel
     /// stored in every valid `TYPE_INFO.infobits`.
-    pub const T_KEY_VALUE: u64 = 0x58000000;
+    pub const T_KEY_VALUE: usize = 0x58000000;
 
     pub const INFOBITS_OFFSET: usize = 0;
     /// `rffi.sizeof(GCData.TYPE_INFO)` equivalent. Reported by
@@ -140,7 +167,7 @@ impl TypeEntry {
     /// `get_translated_info_for_typeinfo` docstring.
     pub const STRIDE: usize = std::mem::size_of::<TypeEntry>();
     /// `log2(STRIDE)`. The backend uses this as `shift_by`
-    /// (x86/assembler.py:1934) so the formula
+    /// (`Assembler386.genop_guard_guard_is_object`) so the formula
     /// `base + (typeid << shift_by) + offset` lands on the right
     /// entry. RPython's 64-bit port sets `shift_by = 0` because its
     /// typeid is already pre-scaled to a byte offset
@@ -153,16 +180,38 @@ impl TypeEntry {
         Self::STRIDE.trailing_zeros() as u8
     };
 
-    fn from_type_info(info: &TypeInfo, index: u32) -> Self {
+    fn from_type_info(
+        info: &TypeInfo,
+        index: u32,
+        customdata: usize,
+        fixed_offsets: usize,
+        var_offsets: usize,
+    ) -> Self {
+        let mut tail = TypeEntryTail::default();
+        if info.item_size > 0 {
+            tail.varsize = VarSizeTypeInfoLayout {
+                varitemsize: info.item_size,
+                ofstovar: info.size,
+                ofstolength: info.length_offset,
+                varofstoptrs: var_offsets,
+            };
+        } else {
+            // Start from the all-zero raw tail so the two padding words in
+            // majit's uniform eight-word slot do not contain indeterminate
+            // bytes after writing the narrower CLASSTYPE member.
+            tail.classtype = ClassTypeLayout {
+                subclassrange_min: info.subclassrange_min,
+                subclassrange_max: info.subclassrange_max,
+            };
+        }
         TypeEntry {
             type_info: TypeInfoLayout {
                 infobits: encode_type_shape(info, index),
-                _reserved: 0,
+                customdata,
+                fixedsize: info.size,
+                ofstoptrs: fixed_offsets,
             },
-            classtype: ClassTypeLayout {
-                subclassrange_min: info.subclassrange_min,
-                subclassrange_max: info.subclassrange_max,
-            },
+            tail,
         }
     }
 }
@@ -202,15 +251,15 @@ impl TypeEntry {
 ///   if subclass of OBJECT: infobits |= T_IS_RPYTHON_INSTANCE
 ///   info.infobits = infobits | T_KEY_VALUE
 /// ```
-pub fn encode_type_shape(info: &TypeInfo, index: u32) -> u64 {
+pub fn encode_type_shape(info: &TypeInfo, index: u32) -> usize {
     // gctypelayout.py `infobits = index` — typeid in low 16 bits.
-    let mut infobits: u64 = (index as u64) & TypeInfoLayout::T_MEMBER_INDEX;
+    let mut infobits: usize = (index as usize) & TypeInfoLayout::T_MEMBER_INDEX;
     // gctypelayout.py: T_HAS_GCPTR if there are GC pointer
     // fields in the fixed part.
     if !info.gc_ptr_offsets.is_empty() {
         infobits |= TypeInfoLayout::T_HAS_GCPTR;
     }
-    // gctypelayout.py:245-257 customdata / destructor / oldstyle
+    // `encode_type_shape` customdata / destructor / oldstyle
     // finalizer / memory pressure. majit only models the custom
     // tracer half of this; treat custom_trace.is_some() as the
     // T_HAS_CUSTOM_TRACE bit (info.py:178 `q_has_custom_trace`).
@@ -222,15 +271,15 @@ pub fn encode_type_shape(info: &TypeInfo, index: u32) -> u64 {
         // it (gctypelayout.py:81-83).
         infobits |= TypeInfoLayout::T_HAS_GCPTR;
     }
-    // gctypelayout.py:266-291 varsize encoding.
+    // `encode_type_shape` varsize encoding.
     if info.item_size > 0 {
         infobits |= TypeInfoLayout::T_IS_VARSIZE;
         if info.items_have_gc_ptrs {
-            // gctypelayout.py:288-289: variable-size array carrying
+            // `encode_type_shape`: a variable-size array carrying
             // GC pointers sets both flags.
             infobits |= TypeInfoLayout::T_HAS_GCPTR_IN_VARSIZE;
             infobits |= TypeInfoLayout::T_HAS_GCPTR;
-            // gctypelayout.py:278-280: pure GcArray-of-GcPtr.
+            // `encode_type_shape`: pure GcArray-of-GcPtr.
             if info.gc_ptr_offsets.is_empty() {
                 infobits |= TypeInfoLayout::T_IS_GCARRAY_OF_GCPTR;
             }
@@ -250,7 +299,7 @@ pub fn encode_type_shape(info: &TypeInfo, index: u32) -> u64 {
     if info.destructor.is_some() {
         infobits |= TypeInfoLayout::T_HAS_DESTRUCTOR;
     }
-    // gctypelayout.py:254-257: the translated type's custom data points at
+    // `encode_type_shape`: the translated type's custom data points at
     // its inherited `special_memory_pressure` field.
     if info.memory_pressure_offset.is_some() {
         infobits |= TypeInfoLayout::T_HAS_MEMORY_PRESSURE;
@@ -303,6 +352,11 @@ pub struct TypeRegistry {
     /// guards may embed this slice's base pointer; a boxed slice cannot grow or
     /// reallocate and is reclaimed with the registry.
     frozen_layout_table: Option<Box<[TypeEntry]>>,
+    /// Immortal `OFFSETS_TO_GC_PTR` arrays referenced by materialized rows.
+    /// Word zero is the lltype Array length, followed by Signed offsets.
+    offset_tables: Vec<Box<[usize]>>,
+    /// Immortal `CUSTOM_DATA_STRUCT` objects referenced by materialized rows.
+    custom_data: Vec<Box<CustomDataLayout>>,
     /// `gctypelayout.can_add_new_types` parity. `true` until the
     /// frontend calls `freeze_types`; after that, `register_type`
     /// panics. Mirrors how RPython's translator stops accepting new
@@ -937,6 +991,8 @@ impl TypeRegistry {
             entries: Vec::new(),
             layout_table: Vec::new(),
             frozen_layout_table: None,
+            offset_tables: Vec::new(),
+            custom_data: Vec::new(),
             can_add_new_types: true,
         }
     }
@@ -992,9 +1048,10 @@ impl TypeRegistry {
             info.gc_ptr_offsets = offsets;
             info.has_gc_ptrs = !info.gc_ptr_offsets.is_empty() || info.items_have_gc_ptrs;
         }
-        let entry = TypeEntry::from_type_info(&info, id as u32);
         self.entries.push(info);
-        self.layout_table.push(entry);
+        // No row address is published until `freeze_types`; fill it there once
+        // the pointer-bearing auxiliary tables have stable storage.
+        self.layout_table.push(TypeEntry::default());
         id as u32
     }
 
@@ -1028,13 +1085,51 @@ impl TypeRegistry {
         }
         self.can_add_new_types = false;
         self.assign_inheritance_ids();
-        // Refresh layout_table rows for object types whose
-        // subclassrange_{min,max} just changed.
+        self.offset_tables.reserve(self.entries.len() * 2);
+        self.custom_data.reserve(self.entries.len());
         for (i, info) in self.entries.iter().enumerate() {
-            self.layout_table[i] = TypeEntry::from_type_info(info, i as u32);
+            let fixed_offsets =
+                Self::materialize_offsets(&mut self.offset_tables, &info.gc_ptr_offsets);
+            let var_offsets =
+                Self::materialize_offsets(&mut self.offset_tables, &info.var_gc_ptr_offsets);
+            let customdata = if info.custom_trace.is_some()
+                || info.destructor.is_some()
+                || info.memory_pressure_offset.is_some()
+            {
+                // Pyre permits its Rust-side custom tracer and lightweight
+                // destructor side channels to coexist.  Upstream has one
+                // CUSTOM_FUNC slot; when T_HAS_CUSTOM_TRACE is set, materialize
+                // that function and retain destructor dispatch on TypeInfo.
+                let customfunc = info
+                    .custom_trace
+                    .map(|f| f as usize)
+                    .or_else(|| info.destructor.map(|f| f as usize))
+                    .unwrap_or(0);
+                let data = Box::new(CustomDataLayout {
+                    customfunc,
+                    memory_pressure_offset: info.memory_pressure_offset.unwrap_or(0) as isize,
+                });
+                let address = (&*data) as *const CustomDataLayout as usize;
+                self.custom_data.push(data);
+                address
+            } else {
+                0
+            };
+            self.layout_table[i] =
+                TypeEntry::from_type_info(info, i as u32, customdata, fixed_offsets, var_offsets);
         }
         self.entries.shrink_to_fit();
         self.frozen_layout_table = Some(std::mem::take(&mut self.layout_table).into_boxed_slice());
+    }
+
+    fn materialize_offsets(storage: &mut Vec<Box<[usize]>>, offsets: &[usize]) -> usize {
+        let mut words = Vec::with_capacity(offsets.len() + 1);
+        words.push(offsets.len());
+        words.extend_from_slice(offsets);
+        let table = words.into_boxed_slice();
+        let address = table.as_ptr() as usize;
+        storage.push(table);
+        address
     }
 
     /// `rtyper/normalizecalls.py assign_inheritance_ids` /
@@ -1208,6 +1303,8 @@ impl Default for TypeRegistry {
 mod tests {
     use super::*;
 
+    unsafe fn materialized_destructor(_obj_addr: usize) {}
+
     #[test]
     fn test_type_registry() {
         let mut reg = TypeRegistry::new();
@@ -1219,6 +1316,54 @@ mod tests {
         assert_eq!(reg.get(id0).size, 16);
         assert_eq!(reg.get(id1).size, 32);
         assert!(!reg.get(id0).has_gc_ptrs);
+    }
+
+    #[test]
+    fn test_materialized_type_info_matches_gctypelayout_rows() {
+        let word = std::mem::size_of::<usize>();
+        assert_eq!(std::mem::size_of::<TypeInfoLayout>(), 4 * word);
+        assert_eq!(std::mem::size_of::<VarSizeTypeInfoLayout>(), 4 * word);
+        assert_eq!(std::mem::size_of::<TypeEntry>(), 8 * word);
+
+        let mut reg = TypeRegistry::new();
+        let fixed = reg.register(
+            TypeInfo::with_gc_ptrs(32, vec![0, 24])
+                .with_destructor_fn(materialized_destructor)
+                .with_memory_pressure_offset(16),
+        );
+        let var = reg.register(TypeInfo::varsize_with_gc_ptr_offsets(
+            16,
+            24,
+            8,
+            vec![0, 16],
+            vec![0],
+        ));
+        reg.freeze_types();
+
+        let fixed_row = &reg.type_info_table()[fixed as usize];
+        assert_eq!(fixed_row.type_info.fixedsize, 32);
+        assert_ne!(fixed_row.type_info.customdata, 0);
+        let custom = unsafe { &*(fixed_row.type_info.customdata as *const CustomDataLayout) };
+        assert_eq!(
+            custom.customfunc,
+            materialized_destructor as *const () as usize
+        );
+        assert_eq!(custom.memory_pressure_offset, 16);
+        let fixed_offsets = fixed_row.type_info.ofstoptrs as *const usize;
+        assert_eq!(unsafe { *fixed_offsets }, 2);
+        assert_eq!(unsafe { *fixed_offsets.add(1) }, 0);
+        assert_eq!(unsafe { *fixed_offsets.add(2) }, 24);
+
+        let var_row = &reg.type_info_table()[var as usize];
+        assert_eq!(var_row.type_info.fixedsize, 16);
+        let var_layout = unsafe { var_row.tail.varsize };
+        assert_eq!(var_layout.varitemsize, 24);
+        assert_eq!(var_layout.ofstovar, 16);
+        assert_eq!(var_layout.ofstolength, 8);
+        let var_offsets = var_layout.varofstoptrs as *const usize;
+        assert_eq!(unsafe { *var_offsets }, 2);
+        assert_eq!(unsafe { *var_offsets.add(1) }, 0);
+        assert_eq!(unsafe { *var_offsets.add(2) }, 16);
     }
 
     #[test]

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -259,10 +259,10 @@ pub fn encode_type_shape(info: &TypeInfo, index: u32) -> usize {
     if !info.gc_ptr_offsets.is_empty() {
         infobits |= TypeInfoLayout::T_HAS_GCPTR;
     }
-    // `encode_type_shape` customdata / destructor / oldstyle
-    // finalizer / memory pressure. majit only models the custom
-    // tracer half of this; treat custom_trace.is_some() as the
-    // T_HAS_CUSTOM_TRACE bit (info.py:178 `q_has_custom_trace`).
+    // `encode_type_shape` customdata / destructor / oldstyle finalizer /
+    // memory pressure. `custom_trace` selects T_HAS_CUSTOM_TRACE
+    // (info.py `q_has_custom_trace`); `old_style_finalizer` selects its own
+    // mutually-exclusive bit below.
     if info.custom_trace.is_some() {
         infobits |= TypeInfoLayout::T_HAS_CUSTOM_TRACE;
         // jitframe.py registers JITFRAME via custom_trace and is also
@@ -298,6 +298,9 @@ pub fn encode_type_shape(info: &TypeInfo, index: u32) -> usize {
     // gctypelayout.py:245-257 destructor surface).
     if info.destructor.is_some() {
         infobits |= TypeInfoLayout::T_HAS_DESTRUCTOR;
+    }
+    if info.old_style_finalizer.is_some() {
+        infobits |= TypeInfoLayout::T_HAS_OLDSTYLE_FINALIZER;
     }
     // `encode_type_shape`: the translated type's custom data points at
     // its inherited `special_memory_pressure` field.
@@ -481,6 +484,11 @@ pub struct TypeInfo {
     /// payloads owning non-GC heap memory get their drop glue run. See
     /// [`DestructorFn`].
     pub destructor: Option<DestructorFn>,
+    /// `gctypelayout.py`'s `old_style_finalizer` custom function. Unlike a
+    /// lightweight destructor, this may run arbitrary code and resurrect its
+    /// object. IncrementalMiniMark therefore allocates the object old and
+    /// queues the callback until `GCBase.execute_finalizers`.
+    pub old_style_finalizer: Option<DestructorFn>,
     /// `gctypelayout.get_memory_pressure_ofs(TYPE)` parity. `Some(offset)`
     /// marks a fixed-size type carrying the inherited
     /// `special_memory_pressure` signed field read by
@@ -509,6 +517,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -536,6 +545,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: Some(destructor),
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -547,7 +557,34 @@ impl TypeInfo {
     /// allocation whose drop glue must run when the instance dies — e.g. the
     /// `W_MemoryView` header owning its `*const BufferView` box.
     pub fn with_destructor_fn(mut self, destructor: DestructorFn) -> Self {
+        assert!(
+            self.old_style_finalizer.is_none(),
+            "a type cannot have both a light and an old-style finalizer"
+        );
         self.destructor = Some(destructor);
+        self
+    }
+
+    /// Create a fixed-size type with PyPy's heavyweight, old-style finalizer.
+    /// The collector forces instances out of the nursery and invokes this only
+    /// after finalization ordering has kept the object graph alive.
+    pub fn with_old_style_finalizer(size: usize, finalizer: DestructorFn) -> Self {
+        Self::simple(size).with_old_style_finalizer_fn(finalizer)
+    }
+
+    /// Attach an old-style finalizer to another fixed-size type layout.
+    pub fn with_old_style_finalizer_fn(mut self, finalizer: DestructorFn) -> Self {
+        assert_eq!(self.item_size, 0, "finalizer types must be fixed-size");
+        assert!(!self.is_weakref, "a finalizer type cannot be a weakref");
+        assert!(
+            self.custom_trace.is_none(),
+            "an old-style finalizer cannot share the custom function slot"
+        );
+        assert!(
+            self.destructor.is_none(),
+            "a type cannot have both a light and an old-style finalizer"
+        );
+        self.old_style_finalizer = Some(finalizer);
         self
     }
 
@@ -614,6 +651,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: true,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -647,6 +685,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -679,6 +718,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -709,6 +749,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -748,6 +789,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -777,6 +819,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -803,6 +846,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -868,6 +912,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -894,6 +939,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -936,6 +982,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            old_style_finalizer: None,
             memory_pressure_offset: None,
         }
     }
@@ -1094,6 +1141,7 @@ impl TypeRegistry {
                 Self::materialize_offsets(&mut self.offset_tables, &info.var_gc_ptr_offsets);
             let customdata = if info.custom_trace.is_some()
                 || info.destructor.is_some()
+                || info.old_style_finalizer.is_some()
                 || info.memory_pressure_offset.is_some()
             {
                 // Pyre permits its Rust-side custom tracer and lightweight
@@ -1103,6 +1151,7 @@ impl TypeRegistry {
                 let customfunc = info
                     .custom_trace
                     .map(|f| f as usize)
+                    .or_else(|| info.old_style_finalizer.map(|f| f as usize))
                     .or_else(|| info.destructor.map(|f| f as usize))
                     .unwrap_or(0);
                 let data = Box::new(CustomDataLayout {
@@ -1304,6 +1353,7 @@ mod tests {
     use super::*;
 
     unsafe fn materialized_destructor(_obj_addr: usize) {}
+    unsafe fn materialized_old_style_finalizer(_obj_addr: usize) {}
 
     #[test]
     fn test_type_registry() {
@@ -1364,6 +1414,31 @@ mod tests {
         assert_eq!(unsafe { *var_offsets }, 2);
         assert_eq!(unsafe { *var_offsets.add(1) }, 0);
         assert_eq!(unsafe { *var_offsets.add(2) }, 16);
+    }
+
+    #[test]
+    fn old_style_finalizer_sets_infobit_and_custom_function() {
+        let mut reg = TypeRegistry::new();
+        let type_id = reg.register(TypeInfo::with_old_style_finalizer(
+            16,
+            materialized_old_style_finalizer,
+        ));
+        assert_ne!(
+            encode_type_shape(reg.get(type_id), type_id) & TypeInfoLayout::T_HAS_OLDSTYLE_FINALIZER,
+            0
+        );
+        assert_eq!(
+            encode_type_shape(reg.get(type_id), type_id) & TypeInfoLayout::T_HAS_DESTRUCTOR,
+            0
+        );
+
+        reg.freeze_types();
+        let row = &reg.type_info_table()[type_id as usize];
+        let custom = unsafe { &*(row.type_info.customdata as *const CustomDataLayout) };
+        assert_eq!(
+            custom.customfunc,
+            materialized_old_style_finalizer as *const () as usize
+        );
     }
 
     #[test]

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -352,8 +352,13 @@ pub struct TypeInfo {
     /// For variable-size objects: offset from object start to the length field.
     pub length_offset: usize,
     /// For variable-size objects: whether items contain GC pointers.
-    /// If true, each item is treated as a GcRef.
+    /// Derived from `var_gc_ptr_offsets`; retained as the infobit/card-layout
+    /// predicate used by the JIT-facing interfaces.
     pub items_have_gc_ptrs: bool,
+    /// `VARSIZE_TYPE_INFO.varofstoptrs`: byte offsets of every GC pointer
+    /// inside one variable-size item.  A plain `GcArray(GcRef)` is `[0]`; an
+    /// array of structs may contain several entries at non-zero offsets.
+    pub var_gc_ptr_offsets: Vec<usize>,
     /// RPython `rgc.register_custom_trace_hook` parity.
     /// When set, overrides offset-based tracing entirely.
     pub custom_trace: Option<CustomTraceFn>,
@@ -439,6 +444,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: false,
             has_subclass_range: false,
@@ -465,6 +471,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: false,
             has_subclass_range: false,
@@ -542,6 +549,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: false,
             has_subclass_range: false,
@@ -574,6 +582,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: true,
             has_subclass_range: true,
@@ -605,6 +614,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: true,
             has_subclass_range: true,
@@ -634,6 +644,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: true,
             has_subclass_range: true,
@@ -672,6 +683,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: true,
             has_subclass_range: true,
@@ -700,6 +712,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: Some(trace_fn),
             is_object: true,
             has_subclass_range: true,
@@ -725,6 +738,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: None,
             is_object: false,
             has_subclass_range: false,
@@ -747,6 +761,41 @@ impl TypeInfo {
         items_have_gc_ptrs: bool,
         gc_ptr_offsets: Vec<usize>,
     ) -> Self {
+        let var_gc_ptr_offsets = if items_have_gc_ptrs {
+            vec![0]
+        } else {
+            Vec::new()
+        };
+        Self::varsize_with_gc_ptr_offsets(
+            base_size,
+            item_size,
+            length_offset,
+            var_gc_ptr_offsets,
+            gc_ptr_offsets,
+        )
+    }
+
+    /// Create a variable-size type whose item is itself a structure.
+    ///
+    /// This is `q_varsize_offsets_to_gcpointers_in_var_part`: each offset is
+    /// relative to the start of one item and every item is visited with the
+    /// same offset table.
+    pub fn varsize_with_gc_ptr_offsets(
+        base_size: usize,
+        item_size: usize,
+        length_offset: usize,
+        var_gc_ptr_offsets: Vec<usize>,
+        gc_ptr_offsets: Vec<usize>,
+    ) -> Self {
+        for &offset in &var_gc_ptr_offsets {
+            assert!(
+                offset
+                    .checked_add(std::mem::size_of::<crate::GcRef>())
+                    .is_some_and(|end| end <= item_size),
+                "variable-item GC pointer at offset {offset} exceeds item size {item_size}",
+            );
+        }
+        let items_have_gc_ptrs = !var_gc_ptr_offsets.is_empty();
         TypeInfo {
             size: base_size,
             has_gc_ptrs: !gc_ptr_offsets.is_empty() || items_have_gc_ptrs,
@@ -754,6 +803,7 @@ impl TypeInfo {
             item_size,
             length_offset,
             items_have_gc_ptrs,
+            var_gc_ptr_offsets,
             custom_trace: None,
             is_object: false,
             has_subclass_range: false,
@@ -779,6 +829,7 @@ impl TypeInfo {
             item_size: 0,
             length_offset: 0,
             items_have_gc_ptrs: false,
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: Some(trace_fn),
             is_object: false,
             has_subclass_range: false,
@@ -820,6 +871,7 @@ impl TypeInfo {
             item_size,
             length_offset,
             items_have_gc_ptrs: false, // custom_trace handles ref tracing
+            var_gc_ptr_offsets: Vec::new(),
             custom_trace: Some(trace_fn),
             is_object: false,
             has_subclass_range: false,
@@ -870,7 +922,10 @@ impl TypeInfo {
             let length = unsafe { *((obj_addr + self.length_offset) as *const usize) };
             let items_start = obj_addr + self.size;
             for i in 0..length {
-                f((items_start + i * self.item_size) as *mut GcRef);
+                let item = items_start + i * self.item_size;
+                for &offset in &self.var_gc_ptr_offsets {
+                    f((item + offset) as *mut GcRef);
+                }
             }
         }
     }
@@ -1379,5 +1434,34 @@ mod tests {
         assert_eq!(visited[0], obj_addr + 8);
         assert_eq!(visited[1], obj_addr + 16);
         assert_eq!(visited[2], obj_addr + 24);
+    }
+
+    #[test]
+    fn test_for_each_gc_ptr_varsize_struct_items_uses_varofstoptrs() {
+        let word = std::mem::size_of::<GcRef>();
+        let info = TypeInfo::varsize_with_gc_ptr_offsets(
+            word,
+            3 * word,
+            0,
+            vec![word, 2 * word],
+            Vec::new(),
+        );
+
+        let mut data = vec![0u8; word + 2 * 3 * word];
+        let obj_addr = data.as_mut_ptr() as usize;
+        unsafe { *(obj_addr as *mut usize) = 2 };
+
+        let mut visited = Vec::new();
+        unsafe { info.for_each_gc_ptr(obj_addr, |ptr| visited.push(ptr as usize)) };
+
+        assert_eq!(
+            visited,
+            vec![
+                obj_addr + 2 * word,
+                obj_addr + 3 * word,
+                obj_addr + 5 * word,
+                obj_addr + 6 * word,
+            ]
+        );
     }
 }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -7387,11 +7387,11 @@ pub fn make_vtable_field_descr() -> DescrRef {
 /// framework-GC object's header.  None on Boehm builds (gc.py:157), where
 /// `gen_initialize_tid` is a no-op.
 ///
-/// pyre's `GcHeader` is a single u64 word (`tid_and_flags`) split into a
-/// lower 32-bit type id and an upper 32-bit flags half (header.rs
-/// FLAG_SHIFT = 32).  The descr addresses the *type id* slot only —
-/// `offset = 0`, `field_size = 4 bytes`.  Restricting the store width
-/// to four bytes is what lets `gen_initialize_tid` overwrite the type
+/// pyre's `GcHeader` stores the logical RPython word in `tid_and_flags`, split
+/// into native half-word type-id and flag fields (`FLAG_SHIFT = LONG_BIT/2`).
+/// The descr addresses the *type id* slot only — `offset = 0`,
+/// `field_size = WORD/2`. Restricting the store width to that half-word is
+/// what lets `gen_initialize_tid` overwrite the type
 /// id without disturbing flag bits the runtime may already have set on
 /// the same word: collector.rs's `alloc_in_oldgen` ORs in
 /// `TRACK_YOUNG_PTRS` for any object the malloc-nursery slow path
@@ -7411,16 +7411,15 @@ pub fn make_tid_field_descr() -> DescrRef {
     static TID_FIELD_DESCR: OnceLock<DescrRef> = OnceLock::new();
     TID_FIELD_DESCR
         .get_or_init(|| {
-            // header.rs `GcHeader.tid_and_flags: u64` is split:
-            // bits  0..32 — type id (this descr).
-            // bits 32..64 — gc flags (TRACK_YOUNG_PTRS / VISITED / PINNED /
-            //               HAS_CARDS …).  Owned by the GC, not the JIT.
+            // header.rs splits the logical native word in half: type id
+            // first, then flags (TRACK_YOUNG_PTRS / VISITED / PINNED /
+            // HAS_CARDS …). Owned by the GC, not the JIT.
             // is_immutable=false: incminimark mutates flag bits on mark
             // and rewrites the whole word on forwarding.
             Arc::new(SimpleFieldDescr::new(
                 0x7000_0000,
-                0,                          // offset within HDR
-                std::mem::size_of::<u32>(), // field_size = 4 bytes (lower 32 bits = type id)
+                0,                                // offset within HDR
+                std::mem::size_of::<usize>() / 2, // HALFWORD type-id field
                 crate::Type::Int,
                 false, // is_immutable — flags / forwarding marker mutate
             ))

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -5770,17 +5770,19 @@ fn build_class_inner(
             // Every `__set_name__` runs Python, so the snapshot cannot stay in
             // an untraced Vec across the loop.  `PyDict_Next` walks every
             // entry, so a descriptor stored under a non-string key gets its
-            // `__set_name__` call too.
+            // `__set_name__` call too. Publish every name/value before the
+            // first forwarding query: a per-item `pin_root` is a safepoint
+            // that can move the still-unpinned tail.
             let _entry_roots = pyre_object::gc_roots::push_roots();
-            let entries_root = pyre_object::gc_roots::shadow_stack_len();
-            let mut pinned = 0;
+            let mut flat = Vec::with_capacity(entries.len() * 2);
             for (w_name, value) in entries {
                 if !value.is_null() {
-                    let _ = pyre_object::gc_roots::pin_root(w_name);
-                    let _ = pyre_object::gc_roots::pin_root(value);
-                    pinned += 1;
+                    flat.push(w_name);
+                    flat.push(value);
                 }
             }
+            let entries_root = pyre_object::gc_roots::pin_roots(&flat);
+            let pinned = flat.len() / 2;
             for i in 0..pinned {
                 let w_name = pyre_object::gc_roots::shadow_stack_get(entries_root + i * 2);
                 let value = pyre_object::gc_roots::shadow_stack_get(entries_root + i * 2 + 1);

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -428,10 +428,27 @@ pub fn as_pyobj(w_obj: PyObjectRef) -> *mut CPyObject {
     if w_obj.is_null() {
         return std::ptr::null_mut();
     }
+    // pyobject.py `as_pyobj`: `_cpyext_as_pyobj` first, then `create_ref`
+    // when that lookup is empty. A type's `_cpy_ref` is the direct-storage
+    // spelling of the same miss; returning the null field skipped the
+    // create that every other object still takes.
     if unsafe { pyre_object::is_type(w_obj) } {
-        return unsafe { pyre_object::w_type_get_cpy_ref(w_obj) }.cast();
+        let direct = unsafe { pyre_object::w_type_get_cpy_ref(w_obj) };
+        if !direct.is_null() {
+            return direct.cast();
+        }
     }
-    majit_gc::gc_rawrefcount_from_obj(majit_ir::GcRef(w_obj as usize)) as *mut CPyObject
+    let existing = majit_gc::gc_rawrefcount_from_obj(majit_ir::GcRef(w_obj as usize));
+    if existing != 0 {
+        return existing as *mut CPyObject;
+    }
+    // `create_ref` needs the rawrefcount tables. Before `initialize()` they
+    // do not exist, so a miss stays a miss — the same answer the type
+    // `_cpy_ref` field already gave.
+    if !majit_gc::gc_rawrefcount_enabled() {
+        return std::ptr::null_mut();
+    }
+    ensure_mirror(w_obj)
 }
 
 /// Attach `W_Root`'s weakref lifeline to an already-existing C mirror.

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -1114,8 +1114,15 @@ pub(super) unsafe fn resize_cached_bytes(
 /// right moment.
 pub(super) fn init_rawrefcount() {
     majit_gc::gc_rawrefcount_init(schedule_drain);
+    majit_gc::gc_rawrefcount_set_light_free(free_light_mirror);
     majit_gc::gc_rawrefcount_set_c_edge_census(super::gc::c_edges);
     majit_gc::gc_rawrefcount_set_finalizer_claim(super::gc::claim_finalizer);
+}
+
+/// `incminimark.py _rrc_free`'s raw release for a LIGHT link, routed through
+/// the same allocator and bookkeeping as every other cpyext mirror block.
+fn free_light_mirror(mirror: usize) {
+    unsafe { free_block(mirror as *mut CPyObject) };
 }
 
 /// Fired from inside a collection, so it may only schedule.

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -2,8 +2,10 @@
 //!
 //! A C extension never sees a [`pyre_object::PyObject`].  It sees a mirror at a
 //! fixed address carrying a reference count and an `ob_pyre_link` to the moving
-//! interpreter object, which is the `rawrefcount` P-link
-//! (`rpython/rlib/rawrefcount.py`).
+//! interpreter object. Ordinary objects use rawrefcount's P-link; a
+//! `W_PyCTypeObject` realised from an extension type uses its O-link and keeps
+//! the mirror in `W_TypeObject._cpy_ref` (`rpython/rlib/rawrefcount.py`,
+//! `W_PyCTypeObject._cpyext_attach_pyobj`).
 //!
 //! A mirror's block is as large as its type asks for: `sizeof(PyObject)` for an
 //! ordinary object, `sizeof(PyTypeObject)` for a type, `tp_basicsize` for an
@@ -174,6 +176,12 @@ pub fn type_mirror(w_obj: PyObjectRef) -> *mut CPyTypeObject {
 /// never receive the plain `PyObject`-sized block a non-type receives — a
 /// `PyModule_AddObject` of a class would otherwise decide the shape.
 pub(super) fn ensure_mirror(w_obj: PyObjectRef) -> *mut CPyObject {
+    if unsafe { pyre_object::is_type(w_obj) } {
+        let direct = unsafe { pyre_object::w_type_get_cpy_ref(w_obj) };
+        if !direct.is_null() {
+            return direct as *mut CPyObject;
+        }
+    }
     let existing = majit_gc::gc_rawrefcount_from_obj(majit_ir::GcRef(w_obj as usize));
     if existing != 0 {
         return existing as *mut CPyObject;
@@ -313,6 +321,28 @@ pub(super) fn attach_foreign(w_obj: PyObjectRef, raw: *mut CPyObject) {
     enter(w_obj, raw, 0);
 }
 
+/// `W_PyCTypeObject._cpyext_attach_pyobj` — link an extension's existing
+/// `PyTypeObject` in the O direction and retain its address directly on the
+/// interpreter type.
+///
+/// `pyobject.py:track_reference` adds the link share before dispatching to the
+/// object's attachment method. Unlike a P-link, an O-link has no
+/// `rawrefcount.from_obj` entry: the direct `_cpy_ref` field is the lookup path.
+pub(super) fn attach_foreign_pyobj(w_obj: PyObjectRef, raw: *mut CPyObject) {
+    debug_assert!(unsafe { pyre_object::is_type(w_obj) });
+    debug_assert!(
+        unsafe { (*raw).ob_refcnt } < REFCNT_FROM_PYPY,
+        "track_reference requires the unshared C refcount"
+    );
+    unsafe {
+        (*raw).ob_refcnt += REFCNT_FROM_PYPY;
+        (*raw).ob_pyre_link = w_obj;
+        pyre_object::w_type_set_cpy_ref(w_obj, raw.cast());
+    }
+    record_block(raw as usize, 0);
+    majit_gc::gc_rawrefcount_create_link_pyobj(majit_ir::GcRef(w_obj as usize), raw as usize);
+}
+
 /// Link a block that already exists to a fresh interpreter object.
 ///
 /// `PyObject_Malloc` hands out an unlinked block and `PyObject_Init` is what
@@ -341,6 +371,9 @@ fn enter(w_obj: PyObjectRef, raw: *mut CPyObject, size: usize) {
         unsafe { (*raw).ob_refcnt } >= REFCNT_FROM_PYPY,
         "a linked mirror carries the link share"
     );
+    if unsafe { pyre_object::is_type(w_obj) } {
+        unsafe { pyre_object::w_type_set_cpy_ref(w_obj, raw.cast()) };
+    }
     record_block(raw as usize, size);
     majit_gc::gc_rawrefcount_create_link_pypy(majit_ir::GcRef(w_obj as usize), raw as usize);
 }
@@ -367,7 +400,10 @@ pub fn make_ref(w_obj: PyObjectRef) -> *mut CPyObject {
         return std::ptr::null_mut();
     }
     let raw = ensure_mirror(w_obj);
-    unsafe { (*raw).ob_refcnt += 1 };
+    // Static builtin mirrors use the immortal sentinel.  Go through the same
+    // incref operation the public API does so direct `_cpy_ref` storage does
+    // not try to increment `isize::MAX`.
+    unsafe { incref(raw) };
     raw
 }
 
@@ -391,6 +427,9 @@ pub(super) fn borrow_mirror(w_obj: PyObjectRef) -> *mut CPyObject {
 pub fn as_pyobj(w_obj: PyObjectRef) -> *mut CPyObject {
     if w_obj.is_null() {
         return std::ptr::null_mut();
+    }
+    if unsafe { pyre_object::is_type(w_obj) } {
+        return unsafe { pyre_object::w_type_get_cpy_ref(w_obj) }.cast();
     }
     majit_gc::gc_rawrefcount_from_obj(majit_ir::GcRef(w_obj as usize)) as *mut CPyObject
 }

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -377,12 +377,17 @@ const fn immortal_type() -> CPyTypeObject {
     }
 }
 
-/// The raw block `type_alloc` hands to `type_realize` upstream. It starts
-/// with an ordinary C reference; `track_reference` adds the rawrefcount share
-/// when the `W_PyCTypeObject` is attached.
+/// The raw block `type_alloc` hands to `type_realize` upstream.
+///
+/// PyPy's `PyType_FromModuleAndSpec` returns that already-owned raw block
+/// directly (`result_is_ll=True`).  Pyre's [`from_spec`] instead returns the
+/// attached interpreter object through `object::result`, whose `make_ref`
+/// supplies the one C reference at the API boundary.  Start the wrapper-owned
+/// count at zero so that `attach_foreign_pyobj`'s rawrefcount share followed by
+/// that `make_ref` lands on `REFCNT_FROM_PYPY + 1`, exactly as upstream does.
 const fn allocated_type() -> CPyTypeObject {
     let mut tp = immortal_type();
-    tp.ob_base.ob_base.ob_refcnt = 1;
+    tp.ob_base.ob_base.ob_refcnt = 0;
     tp
 }
 
@@ -7066,6 +7071,16 @@ pub(super) fn ensure_linked() {
 
 #[cfg(test)]
 mod tests {
+    /// `PyType_FromModuleAndSpec` is `result_is_ll=True` upstream: its
+    /// `PyType_GenericAlloc` reference is the one returned to C.  Pyre routes
+    /// the interpreter object through `object::result`, so the corresponding
+    /// reference is added there and must not already be present in the raw
+    /// wrapper block.
+    #[test]
+    fn spec_type_wrapper_starts_without_a_second_c_reference() {
+        assert_eq!(super::allocated_type().ob_base.ob_base.ob_refcnt, 0);
+    }
+
     /// Every thunk in every pool must have an address of its own.
     ///
     /// The address is the only channel telling a thunk which `(owner, method)`

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -377,6 +377,15 @@ const fn immortal_type() -> CPyTypeObject {
     }
 }
 
+/// The raw block `type_alloc` hands to `type_realize` upstream. It starts
+/// with an ordinary C reference; `track_reference` adds the rawrefcount share
+/// when the `W_PyCTypeObject` is attached.
+const fn allocated_type() -> CPyTypeObject {
+    let mut tp = immortal_type();
+    tp.ob_base.ob_base.ob_refcnt = 1;
+    tp
+}
+
 /// Sentinel type for a `PyModuleDef`, which is C static storage rather than a
 /// mirror of an interpreter object: its `ob_pyre_link` stays null and it is
 /// never entered in the census.
@@ -5400,12 +5409,12 @@ fn ready(tp: *mut CPyTypeObject, w_metaclass: PyObjectRef) -> Result<(), crate::
     stamp_tp_dict(tp, pyre_object::gc_roots::shadow_stack_get(type_slot));
     stamp_objclass(pyre_object::gc_roots::shadow_stack_get(type_slot), tp);
 
-    // The extension's own static becomes the type mirror: it is at a fixed
-    // address for the life of the library, which is what `attach_foreign` is
-    // for.
+    // `type_realize` allocates a `W_PyCTypeObject`, then `track_reference`
+    // dispatches to `W_PyCTypeObject._cpyext_attach_pyobj`: unlike ordinary
+    // type mirrors, the extension's existing block is an O-link and its
+    // address lives directly in the interpreter type's `_cpy_ref` field.
     unsafe {
-        (*tp).ob_base.ob_base.ob_refcnt = REFCNT_IMMORTAL;
-        pyobject::attach_foreign(
+        pyobject::attach_foreign_pyobj(
             pyre_object::gc_roots::shadow_stack_get(type_slot),
             &raw mut (*tp).ob_base.ob_base,
         );
@@ -6022,9 +6031,10 @@ fn from_spec(
             "PyType_FromSpec(): NULL spec",
         ));
     }
-    // The type object and its tables outlive the call for good: a type is
-    // immortal here, so the allocation is deliberately leaked.
-    let tp: *mut CPyTypeObject = Box::leak(Box::new(immortal_type()));
+    // The type block is raw storage, like `type_alloc` upstream. This port's
+    // allocator record cannot yet reclaim the leaked Rust box, but its
+    // refcount and rawrefcount ownership remain ordinary rather than immortal.
+    let tp: *mut CPyTypeObject = Box::leak(Box::new(allocated_type()));
     unsafe {
         (*tp).tp_name = (*spec).name;
         (*tp).tp_itemsize = (*spec).itemsize as isize;

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1171,8 +1171,12 @@ pub(super) fn make_subview(
     // dictionary does move, and every store below allocates, so that is pinned
     // and read back at each store.  Each value is built into a local first: call
     // arguments evaluate left to right, so an inline allocating value would
-    // consume a pre-move dictionary word.
+    // consume a pre-move dictionary word.  `parent` is the caller's word for an
+    // object this function does not construct, so it is pinned and read back at
+    // each use for the same reason the dictionary is.
     let _roots = pyre_object::gc_roots::push_roots();
+    let parent_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(parent);
     let inst = pyre_object::w_instance_new(proto);
     let inst = pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
@@ -1182,19 +1186,21 @@ pub(super) fn make_subview(
     let _ = pyre_object::gc_roots::pin_root(d);
     let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
-        if let Some(ba) = cdata_buffer(parent) {
+        if let Some(ba) = cdata_buffer(pyre_object::gc_roots::shadow_stack_get(parent_slot)) {
             pyre_object::w_dict_setitem_str(
                 pyre_object::gc_roots::shadow_stack_get(d_slot),
                 CDATA_BUFFER_KEY,
                 ba,
             );
-            let w_offset = pyre_object::w_int_new((boff(parent) + field_offset) as i64);
+            let w_offset = pyre_object::w_int_new(
+                (boff(pyre_object::gc_roots::shadow_stack_get(parent_slot)) + field_offset) as i64,
+            );
             pyre_object::w_dict_setitem_str(
                 pyre_object::gc_roots::shadow_stack_get(d_slot),
                 BOFF_KEY,
                 w_offset,
             );
-        } else if let Some(addr) = baddr(parent) {
+        } else if let Some(addr) = baddr(pyre_object::gc_roots::shadow_stack_get(parent_slot)) {
             let w_address = pyre_object::w_int_new((addr + field_offset) as i64);
             pyre_object::w_dict_setitem_str(
                 pyre_object::gc_roots::shadow_stack_get(d_slot),
@@ -1211,7 +1217,7 @@ pub(super) fn make_subview(
         pyre_object::w_dict_setitem_str(
             pyre_object::gc_roots::shadow_stack_get(d_slot),
             BBASE_KEY,
-            parent,
+            pyre_object::gc_roots::shadow_stack_get(parent_slot),
         );
     }
     inst
@@ -1256,8 +1262,13 @@ pub(super) fn make_at_address(
     base: PyObjectRef,
 ) -> PyObjectRef {
     // The fresh instance is reachable only from this frame across the lookup and
-    // the stores below; it does not move, so one pin covers it.
+    // the stores below; it does not move, so one pin covers it.  `base` is the
+    // caller's word for an arbitrary object — `in_dll` forwards its library
+    // argument, which can be a bound method — so it is pinned and read back at
+    // the store, past the dictionary the lookup allocates.
     let _roots = pyre_object::gc_roots::push_roots();
+    let base_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(base);
     let inst = pyre_object::w_instance_new(proto);
     let inst = pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
@@ -1277,6 +1288,7 @@ pub(super) fn make_at_address(
                 BSZ_KEY,
                 w_size,
             );
+            let base = pyre_object::gc_roots::shadow_stack_get(base_slot);
             if !base.is_null() && !pyre_object::is_none(base) {
                 pyre_object::w_dict_setitem_str(
                     pyre_object::gc_roots::shadow_stack_get(d_slot),

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -1148,7 +1148,15 @@ fn do_match(
         .copied()
         .ok_or_else(|| crate::PyError::type_error(format!("{name} requires self and string")))?;
     let code = get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
+    // A buffer subject is gathered into fresh bytes nothing else holds
+    // (`readbuf_obj`), and `subj` borrows that payload, so it has to survive the
+    // bound conversions below — `pos` and `endpos` run `__index__`, which is
+    // user code, and a sweep in there would free the gathered bytes underneath
+    // both the slice and the match this returns.
+    let _roots = pyre_object::gc_roots::push_roots();
     let (subj, w_buffer) = make_subject(pat, string)?;
+    let buffer_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_buffer);
 
     let (pos, endpos) = normalize_bounds(
         subj.len(),
@@ -1167,7 +1175,14 @@ fn do_match(
     };
 
     if matched {
-        Ok(make_match(pat, string, w_buffer, &state, pos as i64, endpos as i64))
+        Ok(make_match(
+            pat,
+            string,
+            pyre_object::gc_roots::shadow_stack_get(buffer_slot),
+            &state,
+            pos as i64,
+            endpos as i64,
+        ))
     } else {
         Ok(w_none())
     }
@@ -1356,7 +1371,13 @@ fn sre_pattern_finditer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
     // Validate the compiled code is present (matches do_match's guard).
     get_code(pat).ok_or_else(|| crate::PyError::type_error("no compiled code"))?;
+    // Same window as `do_match`: the gathered bytes are held only here across
+    // the `__index__` calls the bound conversions make, and the scanner keeps
+    // them as its `_buffer`.
+    let _roots = pyre_object::gc_roots::push_roots();
     let (subj, w_buffer) = make_subject(pat, string)?;
+    let buffer_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_buffer);
     let (pos, endpos) = normalize_bounds(
         subj.len(),
         arg_int_kw(args, 2, kwargs, "pos", 0)?,
@@ -1366,7 +1387,7 @@ fn sre_pattern_finditer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let scanner = w_sre_scanner_new(
         pat,
         string,
-        w_buffer,
+        pyre_object::gc_roots::shadow_stack_get(buffer_slot),
         pos as i64,
         endpos as i64,
         export_active,

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -884,6 +884,13 @@ fn wrap_raw_nodes(first: usize, last: usize) -> usize {
     let result_first = pyre_object::gc_roots::shadow_stack_len();
     for slot in first..last {
         let raw = majit_ir::GcRef(pyre_object::gc_roots::shadow_stack_get(slot) as usize);
+        // `inspector.py:get_rpy_roots` returns its non-resizable raw list with
+        // spare NULL entries; `referents.py:get_rpy_roots` removes those at
+        // the Python boundary. `get_rpy_referents` has no NULL padding, so the
+        // same check is harmless for its other caller.
+        if raw.is_null() {
+            continue;
+        }
         let wrapped = if majit_gc::is_app_level_object(raw) {
             // The query enters the collector; the address comes back out of
             // the slot rather than out of the word held across it.
@@ -1555,14 +1562,20 @@ crate::py_module! {
         "enable_finalizers" / 0 = |_| {
             // `interp_gc.py`: unlike gc.enable(), an unmatched public
             // enable is an error rather than a no-op.
-            if let Some(action) = user_del_action() {
-                if action.finalizers_lock_count == 0 {
-                    return Err(crate::PyError::value_error(
-                        "finalizers are already enabled",
-                    ));
-                }
-                enable_finalizers(action);
+            let Some(action) = user_del_action() else {
+                // Before UserDelAction is installed there cannot have been a
+                // matching disable. Treat that as the same zero lock depth,
+                // not as a bootstrap-only silent success.
+                return Err(crate::PyError::value_error(
+                    "finalizers are already enabled",
+                ));
+            };
+            if action.finalizers_lock_count == 0 {
+                return Err(crate::PyError::value_error(
+                    "finalizers are already enabled",
+                ));
             }
+            enable_finalizers(action);
             Ok(w_none())
         },
         "disable"       / 0 = |_| {
@@ -1755,13 +1768,13 @@ crate::py_module! {
         },
         "is_tracked"    / 1 = |args| {
             // CPython 3.14 `PyObject_GC_IsTracked` first requires
-            // `_PyObject_IS_GC`. Pyre's collector does not dynamically
-            // untrack eligible tuples/dicts, so that type-level eligibility
-            // is also its tracked state. Some eligible objects (notably
-            // modules) are rooted outside the moving arena, while scalar Rust
-            // structs may live inside it; arena membership therefore cannot
-            // be used as the app-level answer.
-            Ok(w_bool_from(crate::typedef::cpython_object_is_gc(args[0])))
+            // `_PyObject_IS_GC`, then asks the collector's tracked state. Host
+            // fallback objects are outside MiniMark and retain their type-level
+            // answer; managed objects must not bypass `GCBase.is_tracked`.
+            let eligible = crate::typedef::cpython_object_is_gc(args[0]);
+            let tracked = !majit_gc::gc_owns_object(args[0] as usize)
+                || majit_gc::is_tracked(majit_ir::GcRef(args[0] as usize));
+            Ok(w_bool_from(eligible && tracked))
         },
         "get_rpy_memory_usage" / 1 = |args| {
             // referents.py:97-104 / inspector.py:76-77.  The size is just the

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -685,12 +685,11 @@ pub fn dist(args: &[PyObjectRef]) -> PyResult {
     let collect_coords = |obj: PyObjectRef| -> Result<Vec<f64>, crate::PyError> {
         let items = crate::builtins::collect_iterable(obj)?;
         // Conversion can call an element's `__float__`, so publish the whole
-        // materialized sequence before converting any member.
+        // materialized sequence before converting any member. `pin_roots`
+        // writes every pointer before the first forwarding query; a
+        // per-item `pin_root` would let that query collect the rest.
         let _roots = pyre_object::gc_roots::push_roots();
-        let items_base = pyre_object::gc_roots::shadow_stack_len();
-        for &item in &items {
-            let _ = pyre_object::gc_roots::pin_root(item);
-        }
+        let items_base = pyre_object::gc_roots::pin_roots(&items);
         (0..items.len())
             .map(|index| {
                 try_get_double(pyre_object::gc_roots::shadow_stack_get(items_base + index))
@@ -1596,10 +1595,10 @@ pub fn prod(args: &[PyObjectRef]) -> PyResult {
     let acc_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(start);
     let items = crate::builtins::collect_iterable(positional[0])?;
-    let items_base = pyre_object::gc_roots::shadow_stack_len();
-    for &item in &items {
-        let _ = pyre_object::gc_roots::pin_root(item);
-    }
+    // `collect_iterable` returns unrooted pointers. Publish the whole
+    // slice before any forwarding query; a per-item `pin_root` is a
+    // safepoint that can move the still-unpinned tail.
+    let items_base = pyre_object::gc_roots::pin_roots(&items);
     // Multiplication can call `__mul__`; reload both operands after every
     // collection and keep the running product in its rooted slot.
     for index in 0..items.len() {
@@ -1624,21 +1623,16 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
     }
     let p = crate::builtins::collect_iterable(args[0])?;
     // Collecting the second input runs its iterator, so publish the first
-    // materialized sequence before that call.
+    // materialized sequence before that call. `pin_roots` writes every
+    // pointer before the first forwarding query.
     let _roots = pyre_object::gc_roots::push_roots();
-    let p_base = pyre_object::gc_roots::shadow_stack_len();
-    for &item in &p {
-        let _ = pyre_object::gc_roots::pin_root(item);
-    }
+    let p_base = pyre_object::gc_roots::pin_roots(&p);
     let q = crate::builtins::collect_iterable(args[1])?;
     // `mul` and `add` dispatch to the operands' `__mul__` / `__add__`, so a
     // Decimal or Fraction element makes every turn a collection point.  Both
     // collected sequences and the running total are native locals no root
     // walker updates, so publish them and read each operand back per turn.
-    let q_base = pyre_object::gc_roots::shadow_stack_len();
-    for &item in &q {
-        let _ = pyre_object::gc_roots::pin_root(item);
-    }
+    let q_base = pyre_object::gc_roots::pin_roots(&q);
     if p.len() != q.len() {
         return Err(crate::PyError::value_error(
             "Inputs are not the same length",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -32867,6 +32867,19 @@ fn init_chain_type(ns: PyObjectRef) {
 
 // ── __dict__ / __weakref__ descriptors ───────────────────────────────
 
+/// Hold `obj` in a process-lifetime slot the collector can rewrite.
+///
+/// `dict_descr` / `weakref_descr` exist only in a `OnceLock`; without this
+/// they are invisible to a major collection and the recycled address is
+/// later installed as `__dict__` / `__weakref__`. Same idiom as
+/// `intern_exact_str`.
+fn root_cached_object(obj: pyre_object::PyObjectRef) -> Box<usize> {
+    let mut slot = Box::new(obj as usize);
+    let root_slot = (&mut *slot) as *mut usize as *mut *mut u8;
+    unsafe { pyre_object::gc_hook::try_gc_add_root(root_slot) };
+    slot
+}
+
 /// typedef.py dict_descr.
 ///
 /// ```python
@@ -32876,8 +32889,12 @@ fn init_chain_type(ns: PyObjectRef) {
 /// ```
 pub fn dict_descr() -> pyre_object::PyObjectRef {
     use std::sync::OnceLock;
-    static CACHED: OnceLock<usize> = OnceLock::new();
-    let addr = *CACHED.get_or_init(|| {
+    // The template lives only in this cache. A moving or sweeping collection
+    // would recycle the address, and `copy_for_type` would then hand the
+    // recycled block out as `__dict__`. Keep one rooted slot for the
+    // collector, the `intern_exact_str` idiom.
+    static CACHED: OnceLock<Box<usize>> = OnceLock::new();
+    let slot = CACHED.get_or_init(|| {
         let fget = make_builtin_function_with_arity("descr_get_dict", descr_get_dict, 2);
         let fset = make_builtin_function_with_arity("descr_set_dict", descr_set_dict, 3);
         let fdel = make_builtin_function_with_arity("descr_del_dict", descr_del_dict, 2);
@@ -32887,15 +32904,15 @@ pub fn dict_descr() -> pyre_object::PyObjectRef {
         // `"__dict__"` instead of the `"<generic property>"` sentinel.
         // The earlier setattr fix-up was masked by the new read-only
         // `__name__` getset and silently failed.
-        make_getset_property_named_doc(
+        root_cached_object(make_getset_property_named_doc(
             fget,
             fset,
             fdel,
             "dictionary for instance variables",
             "__dict__",
-        ) as usize
+        ))
     });
-    addr as pyre_object::PyObjectRef
+    **slot as pyre_object::PyObjectRef
 }
 
 /// typedef.py weakref_descr.
@@ -32907,20 +32924,20 @@ pub fn dict_descr() -> pyre_object::PyObjectRef {
 /// ```
 pub fn weakref_descr() -> pyre_object::PyObjectRef {
     use std::sync::OnceLock;
-    static CACHED: OnceLock<usize> = OnceLock::new();
-    let addr = *CACHED.get_or_init(|| {
+    static CACHED: OnceLock<Box<usize>> = OnceLock::new();
+    let slot = CACHED.get_or_init(|| {
         let fget = make_builtin_function_with_arity("descr_get_weakref", descr_get_weakref, 2);
         // typedef.py `weakref_descr.name = '__weakref__'` —
         // see `dict_descr` for the parity rationale.
-        make_getset_property_named_doc(
+        root_cached_object(make_getset_property_named_doc(
             fget,
             pyre_object::PY_NULL,
             pyre_object::PY_NULL,
             "list of weak references to the object",
             "__weakref__",
-        ) as usize
+        ))
     });
-    addr as pyre_object::PyObjectRef
+    **slot as pyre_object::PyObjectRef
 }
 
 /// PyPy stores `fget/fset/fdel/doc/reqcls/use_closure/name` directly on

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1452,10 +1452,20 @@ fn expand_pyre_class(
                 }
             }
 
-            /// Allocate a fresh instance via `lltype::malloc_typed`,
-            /// stamping the PyObject header so the GC and dispatcher
-            /// can identify it.  `payload` carries the user-defined
-            /// fields; the `ob` header is filled in by this fn.
+            /// Allocate a fresh instance via `lltype::malloc_typed_stable`,
+            /// stamping the PyObject header so the collector and dispatcher
+            /// can identify it. `payload` carries the user-defined fields;
+            /// the `ob` header is filled in by this fn.
+            ///
+            /// PyPy's translated `gct_fv_gc_malloc` may use the nursery because
+            /// the framework GC transform roots every live GC pointer around a
+            /// collecting operation.  Pyre's Rust interpreter has not yet
+            /// completed that transform for arbitrary Rust locals, so a
+            /// `#[pyre_class]` value can outlive this call in an unrewritable
+            /// raw local (a range iterator held by a compiled loop is the
+            /// smallest example).  Keep these payloads collector-owned but
+            /// non-moving until that transform exists; the old host allocation
+            /// was not collector-owned at all and leaked permanently.
             #[allow(dead_code)]
             pub fn allocate(payload: Self) -> ::pyre_object::PyObjectRef {
                 let _roots = ::pyre_object::gc_roots::push_roots();
@@ -1466,7 +1476,7 @@ fn expand_pyre_class(
                     },
                     ..payload
                 };
-                ::pyre_object::lltype::malloc_typed(full) as ::pyre_object::PyObjectRef
+                ::pyre_object::lltype::malloc_typed_stable(full) as ::pyre_object::PyObjectRef
             }
 
             /// Stable-address variant of [`Self::allocate`]: allocates via

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -234,6 +234,14 @@ impl Layout {
 #[repr(C)]
 pub struct W_TypeObject {
     pub ob_header: PyObject,
+    /// `W_TypeObject._cpy_ref` (`cpyext/pyobject.py:add_direct_pyobj_storage`).
+    ///
+    /// Types keep their C mirror directly on the interpreter object. Most
+    /// type mirrors are ordinary rawrefcount P-links too, but a type realised
+    /// from an extension's `PyTypeObject` is a `W_PyCTypeObject`: its mirror
+    /// owns the interpreter object and is therefore an O-link, for which
+    /// `rawrefcount.from_obj` deliberately has no identity-table entry.
+    pub cpy_ref: *mut u8,
     /// Class name (heap-allocated, leaked).
     pub name: *mut String,
     /// App-level `__name__` object.  CPython preserves this object's identity
@@ -592,6 +600,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
             ob_type: &TYPE_TYPE as *const PyType,
             w_class: std::ptr::null_mut(),
         },
+        cpy_ref: std::ptr::null_mut(),
         mro_w: std::ptr::null_mut(),
         name,
         w_name: PY_NULL,
@@ -721,6 +730,7 @@ pub fn w_type_new_builtin(
             ob_type: &TYPE_TYPE as *const PyType,
             w_class: std::ptr::null_mut(),
         },
+        cpy_ref: std::ptr::null_mut(),
         mro_w: std::ptr::null_mut(),
         name,
         w_name: PY_NULL,
@@ -1602,6 +1612,26 @@ pub unsafe fn is_mro_purely_of_types(mro_w: &[PyObjectRef]) -> bool {
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn is_type(obj: PyObjectRef) -> bool {
     py_type_check(obj, &TYPE_TYPE)
+}
+
+/// `W_TypeObject._cpyext_as_pyobj` from
+/// `cpyext/pyobject.py:add_direct_pyobj_storage`.
+///
+/// # Safety
+/// `obj` must be null or a valid type object.
+pub unsafe fn w_type_get_cpy_ref(obj: PyObjectRef) -> *mut u8 {
+    if obj.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe { (*(obj as *const W_TypeObject)).cpy_ref }
+}
+
+/// `W_TypeObject._cpyext_attach_pyobj`'s direct-storage half.
+///
+/// # Safety
+/// `obj` must be a valid type object and `raw` its live C mirror.
+pub unsafe fn w_type_set_cpy_ref(obj: PyObjectRef, raw: *mut u8) {
+    unsafe { (*(obj as *mut W_TypeObject)).cpy_ref = raw };
 }
 
 /// typeobject.py `is_heaptype(self)`.


### PR DESCRIPTION
Follow-on to #1677, which merged while this was in flight.

## `_ctypes`, `_sre` rooting

`make_at_address` stored its `base` parameter under `_b_base_` after
`getdict_native` had allocated the instance dictionary and two
`w_dict_setitem_str` calls had run, with the parameter never published.
`in_dll` forwards its library argument there, and that argument only has to
answer `_handle` with an int — a bound method does, and `w_method_new`
allocates through `try_gc_alloc_nursery_raw`. Reachable from Python:

```python
ctypes.c_void_p.in_dll(C().m, "_PyImport_FrozenBootstrap")  # _b_base_ is that bound method
```

`make_subview` carries `parent` the same way; its current callers all pass
cdata instances, which are born old, so that half is hardening.

`do_match` and `sre_pattern_finditer` took the subject from `make_subject`,
which gathers a `memoryview` or other buffer exporter into fresh bytes held
nowhere else, then ran `pos`/`endpos` through `arg_int_kw` — `__index__` is
user code — before `drive_match` read the borrowed payload and before the
match or scanner captured the buffer. Reported on #1677 by codex (P1) and
coderabbit independently. `bytes` is born old, so this is a sweep hazard
rather than a relocation one, which is why the movable-filtered column in
the analysis did not name it.

No deterministic fixture for either: the only collection point in the
`make_at_address` window is an internal dictionary allocation with no user
hook, and 3000 iterations across several nursery sizes never caught it.

## Baselines

`linux` recorded from the CI gate log at `de7e1a7` (it was still at
`903151e`: tier15 0/0, tier1 9/7). `darwin` refitted onto the new base:
tier15 102/56 → 101/55, unbracketed 2064/835 → 2057/832, invariants at zero.

## Checks

Gated snippets 183/183 on all three runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP