### PR TITLE
majit: complete Rust lowering support needed by Rhai

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -19264,6 +19264,15 @@ impl majit_backend::Backend for CraneliftBackend {
         fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> majit_ir::GcRef {
         let offset = fielddescr.as_offset();
+        if matches!(
+            fielddescr,
+            majit_translate::jitcode::BhDescr::Field {
+                field_flag: majit_ir::descr::ArrayFlag::Struct,
+                ..
+            }
+        ) {
+            return majit_ir::GcRef((struct_ptr as usize).wrapping_add(offset));
+        }
         majit_ir::GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }
 

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -19264,15 +19264,9 @@ impl majit_backend::Backend for CraneliftBackend {
         fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> majit_ir::GcRef {
         let offset = fielddescr.as_offset();
-        if matches!(
-            fielddescr,
-            majit_translate::jitcode::BhDescr::Field {
-                field_flag: majit_ir::descr::ArrayFlag::Struct,
-                ..
-            }
-        ) {
-            return majit_ir::GcRef((struct_ptr as usize).wrapping_add(offset));
-        }
+        // `llmodel.py bh_getfield_gc_r` loads a value, including a by-value
+        // transparent newtype. Address projections are lowered separately by
+        // `jtransform.py rewrite_op_getsubstruct`.
         majit_ir::GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }
 
@@ -19509,6 +19503,32 @@ impl majit_backend::Backend for CraneliftBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn reference_value_read_does_not_become_a_substructure_address() {
+        let referent = 123usize;
+        let field_words = [0usize, &referent as *const usize as usize];
+        let backend = CraneliftBackend::new();
+        for flag in [
+            majit_ir::descr::ArrayFlag::Pointer,
+            majit_ir::descr::ArrayFlag::Struct,
+        ] {
+            let fd = majit_ir::descr::SimpleFieldDescr::new_with_name(
+                0,
+                std::mem::size_of::<usize>(),
+                std::mem::size_of::<usize>(),
+                majit_ir::Type::Ref,
+                false,
+                flag,
+                "Node.value".into(),
+                "value".into(),
+            );
+            let bh = majit_translate::jitcode::BhDescr::from_field_descr(&fd);
+            assert_eq!(
+                backend.bh_getfield_gc_r(field_words.as_ptr() as i64, &bh),
+                majit_ir::GcRef(field_words[1])
+            );
+        }
+    }
     use majit_backend::Backend;
     use majit_gc::GcFlags;
     use majit_gc::collector::{GcConfig, MiniMarkGC};

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -4062,6 +4062,32 @@ impl Backend for DynasmBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn reference_value_read_does_not_become_a_substructure_address() {
+        let referent = 123usize;
+        let field_words = [0usize, &referent as *const usize as usize];
+        let backend = DynasmBackend::new();
+        for flag in [
+            majit_ir::descr::ArrayFlag::Pointer,
+            majit_ir::descr::ArrayFlag::Struct,
+        ] {
+            let fd = majit_ir::descr::SimpleFieldDescr::new_with_name(
+                0,
+                std::mem::size_of::<usize>(),
+                std::mem::size_of::<usize>(),
+                majit_ir::Type::Ref,
+                false,
+                flag,
+                "Node.value".into(),
+                "value".into(),
+            );
+            let bh = majit_translate::jitcode::BhDescr::from_field_descr(&fd);
+            assert_eq!(
+                backend.bh_getfield_gc_r(field_words.as_ptr() as i64, &bh),
+                majit_ir::GcRef(field_words[1])
+            );
+        }
+    }
     use majit_backend::Backend;
     use majit_backend::jitframe::{
         FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_INFO_OFS,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3681,24 +3681,6 @@ impl Backend for DynasmBackend {
         self.read_int_at_mem(struct_ptr, offset as i64, size, sign)
     }
 
-    fn bh_getfield_gc_r(
-        &self,
-        struct_ptr: i64,
-        fielddescr: &majit_translate::jitcode::BhDescr,
-    ) -> GcRef {
-        let offset = fielddescr.as_offset();
-        if matches!(
-            fielddescr,
-            majit_translate::jitcode::BhDescr::Field {
-                field_flag: majit_ir::descr::ArrayFlag::Struct,
-                ..
-            }
-        ) {
-            return GcRef((struct_ptr as usize).wrapping_add(offset));
-        }
-        GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
-    }
-
     /// `llmodel.py bh_setfield_gc_i` →
     /// `write_int_at_mem(struct, ofs, size, value)`.  Sign discarded by
     /// `unpack_fielddescr_size` consumer (`llmodel.py`); only

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3687,6 +3687,15 @@ impl Backend for DynasmBackend {
         fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> GcRef {
         let offset = fielddescr.as_offset();
+        if matches!(
+            fielddescr,
+            majit_translate::jitcode::BhDescr::Field {
+                field_flag: majit_ir::descr::ArrayFlag::Struct,
+                ..
+            }
+        ) {
+            return GcRef((struct_ptr as usize).wrapping_add(offset));
+        }
         GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -3231,15 +3231,9 @@ pub trait Backend: Send {
         fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> GcRef {
         let offset = fielddescr.as_offset();
-        if matches!(
-            fielddescr,
-            majit_translate::jitcode::BhDescr::Field {
-                field_flag: majit_ir::descr::ArrayFlag::Struct,
-                ..
-            }
-        ) {
-            return GcRef((struct_ptr as usize).wrapping_add(offset));
-        }
+        // `llmodel.py bh_getfield_gc_r` always loads the value. Address
+        // projections belong to `jtransform.py rewrite_op_getsubstruct`;
+        // the layout flag alone cannot turn an ordinary read into one.
         // SAFETY: see `bh_getfield_gc_i`.
         GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -3231,6 +3231,15 @@ pub trait Backend: Send {
         fielddescr: &majit_translate::jitcode::BhDescr,
     ) -> GcRef {
         let offset = fielddescr.as_offset();
+        if matches!(
+            fielddescr,
+            majit_translate::jitcode::BhDescr::Field {
+                field_flag: majit_ir::descr::ArrayFlag::Struct,
+                ..
+            }
+        ) {
+            return GcRef((struct_ptr as usize).wrapping_add(offset));
+        }
         // SAFETY: see `bh_getfield_gc_i`.
         GcRef(unsafe { *((struct_ptr as *const u8).add(offset) as *const usize) })
     }

--- a/majit/majit-backend/src/model.rs
+++ b/majit/majit-backend/src/model.rs
@@ -408,15 +408,9 @@ impl Cpu for DefaultCpu {
 
     fn bh_getfield_gc_r(&self, struct_ptr: usize, fd: &dyn FieldDescr) -> GcRef {
         let addr = struct_ptr + fd.offset();
-        // `descr.py FLAG_STRUCT`: the field IS a substructure, laid out inline
-        // at `offset`, so what a reference to it names is that address.
-        // `rtyper` hands such a projection to `getsubstruct`, never to
-        // `getfield`, and reading a word there would return the substructure's
-        // first bytes as if they were its address.
-        if fd.field_flag() == majit_ir::descr::ArrayFlag::Struct {
-            return GcRef(addr);
-        }
-        // llmodel.py read_ref_at_mem — pointer width.
+        // `llmodel.py bh_getfield_gc_r` / `read_ref_at_mem`: pointer-width
+        // value load. `rewrite_op_getsubstruct` handles address projections
+        // before execution; an inline layout alone does not request one.
         GcRef(unsafe { *(addr as *const usize) })
     }
 
@@ -471,4 +465,34 @@ pub fn cpu_from_cls_of_box_fn(f: fn(i64) -> i64) -> Arc<dyn Cpu> {
 /// + tests that want the model.py typeptr-at-offset-0 read.
 pub fn default_cpu() -> Arc<dyn Cpu> {
     Arc::new(DefaultCpu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_value_read_does_not_become_a_substructure_address() {
+        let referent = 123usize;
+        let field_words = [0usize, &referent as *const usize as usize];
+        for flag in [
+            majit_ir::descr::ArrayFlag::Pointer,
+            majit_ir::descr::ArrayFlag::Struct,
+        ] {
+            let fd = majit_ir::descr::SimpleFieldDescr::new_with_name(
+                0,
+                std::mem::size_of::<usize>(),
+                std::mem::size_of::<usize>(),
+                majit_ir::Type::Ref,
+                false,
+                flag,
+                "Node.value".into(),
+                "value".into(),
+            );
+            assert_eq!(
+                DefaultCpu.bh_getfield_gc_r(field_words.as_ptr() as usize, &fd),
+                GcRef(field_words[1])
+            );
+        }
+    }
 }

--- a/majit/majit-backend/src/model.rs
+++ b/majit/majit-backend/src/model.rs
@@ -407,8 +407,16 @@ impl Cpu for DefaultCpu {
     }
 
     fn bh_getfield_gc_r(&self, struct_ptr: usize, fd: &dyn FieldDescr) -> GcRef {
-        // llmodel.py read_ref_at_mem — pointer width.
         let addr = struct_ptr + fd.offset();
+        // `descr.py FLAG_STRUCT`: the field IS a substructure, laid out inline
+        // at `offset`, so what a reference to it names is that address.
+        // `rtyper` hands such a projection to `getsubstruct`, never to
+        // `getfield`, and reading a word there would return the substructure's
+        // first bytes as if they were its address.
+        if fd.field_flag() == majit_ir::descr::ArrayFlag::Struct {
+            return GcRef(addr);
+        }
+        // llmodel.py read_ref_at_mem — pointer width.
         GcRef(unsafe { *(addr as *const usize) })
     }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -380,6 +380,16 @@ impl StructId {
         StructId(path_hash(canonical_path))
     }
 
+    /// Mint the concrete identity named by an already-canonical spelling.
+    /// Generic enum variants carry their arguments before the variant tail
+    /// (`Result<T, E>::Ok`); use the same template + instantiation split as
+    /// [`struct_id_for_name`] without consulting its optional alias table.
+    pub fn from_canonical_spelling(canonical_path: &str) -> Self {
+        let template = strip_generic_args(canonical_path);
+        let id = Self::from_canonical(template.as_ref());
+        generic_args_span(canonical_path).map_or(id, |args| id.instantiate(args))
+    }
+
     /// Derive the identity of one concrete generic instantiation from the
     /// defining type's identity and its balanced `<...>` argument spelling.
     ///

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2807,20 +2807,39 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
     // sums, for every other enum.  Restricted to the tag: it is the only row
     // the base carries, so a payload row reaching here under a base spelling
     // would be naming a field the base does not have.
-    fn variant_inherits_enum_tag(slot_owner: &str, field_owner: &str, field_key: &str) -> bool {
-        if field_key != "__discriminant" {
+    fn variant_inherits_enum_tag(
+        slot_owner: &str,
+        field_owner: &str,
+        field_name: &str,
+        parent_keys: Option<(u64, u64)>,
+    ) -> bool {
+        if field_name != "__discriminant" {
             return false;
         }
         let slot = majit_ir::descr::strip_generic_args(slot_owner);
         let Some((base, _variant)) = slot.rsplit_once("::") else {
             return false;
         };
-        base == majit_ir::descr::strip_generic_args(field_owner).as_ref()
+        if base != majit_ir::descr::strip_generic_args(field_owner).as_ref() {
+            return false;
+        }
+        // Unlike the two explicitly-declared Result/Option shells above, an
+        // arbitrary textual `Enum::Variant -> Enum` shape is not itself proof
+        // of inheritance: two crates can publish the same stripped spelling.
+        // Require both parent cache keys to be the identities derived from the
+        // producer-canonical names. This admits the distinct variant/base
+        // StructIds of the real superclass edge and rejects an alias whose
+        // spelling happens to collide with either identity.
+        parent_keys.is_some_and(|(slot_key, field_key)| {
+            majit_ir::descr::StructId::from_canonical_spelling(slot_owner).as_u64() == slot_key
+                && majit_ir::descr::StructId::from_canonical_spelling(field_owner).as_u64()
+                    == field_key
+        })
     }
 
-    let owners_agree = |slot_owner: &str, field_owner: &str| {
+    let owners_agree = |slot_owner: &str, field_owner: &str, parent_keys: Option<(u64, u64)>| {
         explicit_sum_inherits(slot_owner, field_owner)
-            || variant_inherits_enum_tag(slot_owner, field_owner, field.field_key())
+            || variant_inherits_enum_tag(slot_owner, field_owner, field.field_key(), parent_keys)
     };
 
     let names_name_same_owner = || match (display_owner(slot), display_owner(field)) {
@@ -2830,9 +2849,9 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
                 majit_ir::descr::struct_id_for_name(field_owner),
             ) {
                 (Some(slot_id), Some(field_id)) => {
-                    slot_id == field_id || owners_agree(slot_owner, field_owner)
+                    slot_id == field_id || owners_agree(slot_owner, field_owner, None)
                 }
-                _ => slot_owner == field_owner || owners_agree(slot_owner, field_owner),
+                _ => slot_owner == field_owner || owners_agree(slot_owner, field_owner, None),
             }
         }
         // Neither descriptor contains an owner spelling.  This is the
@@ -2858,7 +2877,7 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
                     slot_key == field_key
                         || match (display_owner(slot), display_owner(field)) {
                             (Some(slot_owner), Some(field_owner)) => {
-                                owners_agree(slot_owner, field_owner)
+                                owners_agree(slot_owner, field_owner, Some((slot_key, field_key)))
                             }
                             _ => false,
                         }
@@ -3851,10 +3870,80 @@ mod tests {
             "a::E::V.__discriminant".to_string(),
             "__discriminant".to_string(),
         )
-        .with_parent_descr(variant_parent, 0);
+        .with_parent_descr(variant_parent.clone(), 0);
         assert!(
             !slot_holds_field(&collision_slot, &suffix_collision),
             "a suffix-related path does not prove an enum inheritance edge"
+        );
+    }
+
+    #[test]
+    fn native_enum_tag_inheritance_requires_matching_parent_identities() {
+        let variant_owner = "types::dynamic::Union::Int";
+        let base_owner = "types::dynamic::Union";
+        let mut variant_size = majit_ir::descr::SimpleSizeDescr::new(0, 16, 1);
+        variant_size.set_cache_key(
+            majit_ir::descr::StructId::from_canonical_spelling(variant_owner).as_u64(),
+        );
+        let variant_parent = Arc::new(variant_size) as DescrRef;
+        let mut base_size = majit_ir::descr::SimpleSizeDescr::new(1, 16, 2);
+        base_size
+            .set_cache_key(majit_ir::descr::StructId::from_canonical_spelling(base_owner).as_u64());
+        let base_parent = Arc::new(base_size) as DescrRef;
+        let slot = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            1,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Unsigned,
+            format!("{variant_owner}.__discriminant"),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(variant_parent.clone(), 0);
+        let field = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            1,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Unsigned,
+            format!("{base_owner}.__discriminant"),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(base_parent.clone(), 0);
+        assert!(
+            slot_holds_field(&slot, &field),
+            "slot={:?} key={:?} parent={:?}; field={:?} key={:?} parent={:?}",
+            slot.field_name(),
+            slot.field_key(),
+            slot.get_parent_descr()
+                .and_then(|p| p.as_size_descr().map(|s| s.cache_key())),
+            field.field_name(),
+            field.field_key(),
+            field
+                .get_parent_descr()
+                .and_then(|p| p.as_size_descr().map(|s| s.cache_key())),
+        );
+
+        let mut foreign_size = majit_ir::descr::SimpleSizeDescr::new(2, 16, 3);
+        foreign_size
+            .set_cache_key(majit_ir::descr::StructId::from_canonical("other::Union::Int").as_u64());
+        let foreign_parent = Arc::new(foreign_size) as DescrRef;
+        let foreign = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            1,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Unsigned,
+            format!("{variant_owner}.__discriminant"),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(foreign_parent.clone(), 0);
+        assert!(
+            !slot_holds_field(&foreign, &field),
+            "a colliding owner spelling must not override a distinct parent identity"
         );
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2799,23 +2799,6 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
                 || field_variant.is_empty())
     }
 
-    /// Whether two module paths name one item, one of them possibly having had
-    /// its crate root stripped.  Charon spells the same declaration both ways
-    /// and the front end registers both as aliases of one `StructId`, but that
-    /// build-time registry is not serialized into the generated runtime, so
-    /// compare the paths segment-wise from the leaf: `grain::vm::Vm` and
-    /// `rhai::grain::vm::Vm` agree, `a::Vm` and `b::Vm` do not.
-    fn path_alias(left: &str, right: &str) -> bool {
-        let left: Vec<&str> = left.split("::").collect();
-        let right: Vec<&str> = right.split("::").collect();
-        let (long, short) = if left.len() >= right.len() {
-            (left, right)
-        } else {
-            (right, left)
-        };
-        short.as_slice() == &long[long.len() - short.len()..]
-    }
-
     // `rclass.InstanceRepr._setup_repr` gives a sum-type variant subclass the
     // base's fields before its own, and pyre's payload enums carry the tag on
     // that base alone (`front/mir.rs`), so a variant's flattened field list
@@ -2832,10 +2815,7 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
         let Some((base, _variant)) = slot.rsplit_once("::") else {
             return false;
         };
-        path_alias(
-            base,
-            majit_ir::descr::strip_generic_args(field_owner).as_ref(),
-        )
+        base == majit_ir::descr::strip_generic_args(field_owner).as_ref()
     }
 
     let owners_agree = |slot_owner: &str, field_owner: &str| {
@@ -3848,6 +3828,34 @@ mod tests {
         )
         .with_parent_descr(base_parent, 0);
         assert!(!slot_holds_field(&slot, &unrelated));
+
+        let suffix_parent = majit_ir::descr::make_size_descr(8);
+        let suffix_collision = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "b::a::E.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(suffix_parent, 0);
+        let collision_slot = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "a::E::V.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(variant_parent, 0);
+        assert!(
+            !slot_holds_field(&collision_slot, &suffix_collision),
+            "a suffix-related path does not prove an enum inheritance edge"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2786,6 +2786,32 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
     // from the qualified owners.  Two *different* variants of one enum are not
     // that edge -- their payloads are different fields sharing an address --
     // and neither is a same-name/same-offset field from an arbitrary struct.
+    fn is_registered_std_shell(owner: &str) -> bool {
+        // Same anchors `codewriter/assembler.rs is_explicit_shell_variant_owner`
+        // uses, plus the enum roots the inherited-tag edge names. A name
+        // registered to any other StructId is a lookalike and must not ride
+        // the shell inheritance exception.
+        const ANCHORS: [&str; 10] = [
+            "core::result::Result::Ok",
+            "std::result::Result::Ok",
+            "core::result::Result::Err",
+            "std::result::Result::Err",
+            "core::option::Option::Some",
+            "std::option::Option::Some",
+            "core::result::Result",
+            "std::result::Result",
+            "core::option::Option",
+            "std::option::Option",
+        ];
+        let Some(owner_id) = majit_ir::descr::struct_template_id_for_name(owner) else {
+            return false;
+        };
+        ANCHORS.iter().any(|anchor| {
+            majit_ir::descr::struct_template_id_for_name(anchor) == Some(owner_id)
+                || majit_ir::descr::StructId::from_canonical(anchor) == owner_id
+        })
+    }
+
     fn explicit_sum_inherits(slot_owner: &str, field_owner: &str) -> bool {
         let (Some((slot_enum, slot_variant)), Some((field_enum, field_variant))) = (
             shelled_sum_owner(slot_owner),
@@ -2793,10 +2819,31 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
         ) else {
             return false;
         };
-        slot_enum == field_enum
-            && (slot_variant == field_variant
+        if slot_enum != field_enum
+            || !(slot_variant == field_variant
                 || slot_variant.is_empty()
                 || field_variant.is_empty())
+        {
+            return false;
+        }
+        // Spelling is not identity. When the StructId table is populated,
+        // both owners must resolve to a core/std shell; a user type that
+        // collapses to `result::Result` keeps its own StructId and must
+        // not inherit a standard-library tag or payload slot.
+        //
+        // An empty table is the pre-registry test shape: nothing has been
+        // published, so there is no lookalike to distinguish and the
+        // textual edge stands.
+        match (
+            majit_ir::descr::struct_template_id_for_name(slot_owner),
+            majit_ir::descr::struct_template_id_for_name(field_owner),
+        ) {
+            (None, None) => true,
+            (slot_id, field_id) => {
+                slot_id.is_none_or(|_| is_registered_std_shell(slot_owner))
+                    && field_id.is_none_or(|_| is_registered_std_shell(field_owner))
+            }
+        }
     }
 
     // `rclass.InstanceRepr._setup_repr` gives a sum-type variant subclass the
@@ -4007,6 +4054,60 @@ mod tests {
         )
         .with_parent_descr(template_parent, 1);
         assert!(!slot_holds_field(&ok, &err));
+    }
+
+    #[test]
+    fn explicit_sum_inheritance_rejects_a_registered_lookalike() {
+        static REGISTRY: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+        let _registry = REGISTRY.lock();
+        let core_some = majit_ir::descr::StructId::from_canonical("core::option::Option::Some");
+        let user_some =
+            majit_ir::descr::StructId::from_canonical("user_crate::option::Option::Some");
+        let mut ids = std::collections::HashMap::new();
+        for name in [
+            "Option::Some",
+            "core::option::Option::Some",
+            "std::option::Option::Some",
+        ] {
+            ids.insert(name.to_string(), Some(core_some));
+        }
+        ids.insert("option::Option::Some".to_string(), Some(user_some));
+        majit_ir::descr::register_struct_ids(ids);
+
+        let mut user_size = majit_ir::descr::SimpleSizeDescr::new(0, 8, 1);
+        user_size.set_cache_key(user_some.as_u64());
+        let user_parent = Arc::new(user_size) as DescrRef;
+        let mut core_size = majit_ir::descr::SimpleSizeDescr::new(1, 16, 2);
+        core_size.set_cache_key(core_some.as_u64());
+        let core_parent = Arc::new(core_size) as DescrRef;
+
+        let lookalike = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "option::Option::Some.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(user_parent, 0);
+        let shell = majit_ir::SimpleFieldDescr::new_with_name(
+            1,
+            8,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "Option::Some.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(core_parent, 1);
+        assert!(
+            !slot_holds_field(&lookalike, &shell),
+            "a user type registered under option::Option::Some must not inherit the std shell"
+        );
+        majit_ir::descr::register_struct_ids(std::collections::HashMap::new());
     }
 
     fn assign_positions(ops: &mut [Op]) {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2725,60 +2725,123 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
         name.strip_suffix(key)?.strip_suffix('.')
     }
 
+    /// The shelled sum `(enum, variant)` an owner spelling names, with its
+    /// qualification and its instantiation erased.  The variant is empty when
+    /// the spelling names the enum itself; `None` when the owner is not a
+    /// shelled sum at all.
+    ///
+    /// `front/mir` gives `Option::Some`, `Result::Ok` and `Result::Err` an
+    /// explicit `[tag@0 | payload@8]` shell, and admits every spelling from
+    /// the bare `Result::Ok` up to the fully qualified
+    /// `std::result::Result::Ok`.  The two producers of one shelled field
+    /// therefore reach here disagreeing on both halves of the spelling at
+    /// once: the allocation carries the instantiated owner
+    /// (`core::option::Option<Dynamic>::Some`) while the read carries the
+    /// erased template (`Option::Some`).  The shell's layout is the same for
+    /// every instantiation -- that is what makes it a shell -- so erasing the
+    /// argument list here loses nothing the field identity needs.
+    ///
+    /// The segments are matched as a suffix of a `core`/`std`-rooted path, so
+    /// a user enum declared at `mycrate::option::Option::Some` stays out:
+    /// `front::option_ctor` writes no tag for that one, so its payload sits at
+    /// its own registered layout rather than behind an injected discriminant.
+    /// `codewriter/assembler.rs is_explicit_shell_variant_owner` anchors the
+    /// producer side the same way and for the same reason, and likewise takes
+    /// a lone leaf (`Ok`) as too little evidence.
+    fn shelled_sum_owner(owner: &str) -> Option<(&'static str, &'static str)> {
+        const SHELLED: [&[&str]; 6] = [
+            &["core", "result", "Result", "Ok"],
+            &["std", "result", "Result", "Ok"],
+            &["core", "result", "Result", "Err"],
+            &["std", "result", "Result", "Err"],
+            &["core", "option", "Option", "Some"],
+            &["std", "option", "Option", "Some"],
+        ];
+        let owner = majit_ir::descr::strip_generic_args(owner);
+        let segments: Vec<&str> = owner.split("::").collect();
+        if segments.len() < 2 {
+            return None;
+        }
+        for path in SHELLED {
+            if segments.len() <= path.len() && segments == path[path.len() - segments.len()..] {
+                return Some((path[path.len() - 2], path[path.len() - 1]));
+            }
+            let enum_path = &path[..path.len() - 1];
+            if segments.len() <= enum_path.len()
+                && segments == enum_path[enum_path.len() - segments.len()..]
+            {
+                return Some((path[path.len() - 2], ""));
+            }
+        }
+        None
+    }
+
     // `heaptracker.all_fielddescrs(gccache, STRUCT)` walks an embedded base
     // before the subclass's own fields.  Consequently a subclass SizeDescr
     // legitimately contains the base's FieldDescr at the same slot even
     // though their parent STRUCT keys differ (`rclass.InstanceRepr._setup_repr`
     // creates exactly this `super` edge).  Pyre's explicit Result/Option shell
-    // serializes the flattened row under the variant parent, so recover that
-    // one proven inheritance edge from the qualified owners.  Do not accept a
-    // same-name/same-offset field from an arbitrary different struct.
+    // serializes the flattened row under the variant parent while a read of
+    // that row can name the enum, so recover that one proven inheritance edge
+    // from the qualified owners.  Two *different* variants of one enum are not
+    // that edge -- their payloads are different fields sharing an address --
+    // and neither is a same-name/same-offset field from an arbitrary struct.
     fn explicit_sum_inherits(slot_owner: &str, field_owner: &str) -> bool {
-        fn same_owner(left: &str, right: &str) -> bool {
-            let left = majit_ir::descr::strip_generic_args(left);
-            let right = majit_ir::descr::strip_generic_args(right);
-            // The translated explicit sum shell is deliberately accepted
-            // under both the full standard-library spelling and Charon's
-            // crate-stripped spelling (`core::option::Option` /
-            // `option::Option`, likewise `Result`).  The translator-side
-            // StructId registry proves those aliases while building the
-            // JitCode, but that build-only registry is not serialized into
-            // the generated runtime.  Recover only these two already-gated
-            // shell identities here; a general suffix comparison would merge
-            // an unrelated `mycrate::option::Option` and violate
-            // `descr.py`'s `(STRUCT, fieldname)` identity.
-            fn explicit_sum_template(name: &str) -> Option<&'static str> {
-                let segments: Vec<&str> = name.split("::").collect();
-                match segments.as_slice() {
-                    ["option", "Option"] | ["core" | "std", "option", "Option"] => Some("Option"),
-                    ["result", "Result"] | ["core" | "std", "result", "Result"] => Some("Result"),
-                    _ => None,
-                }
-            }
-            if let (Some(left), Some(right)) = (
-                explicit_sum_template(left.as_ref()),
-                explicit_sum_template(right.as_ref()),
-            ) {
-                return left == right;
-            }
-            match (
-                majit_ir::descr::struct_template_id_for_name(left.as_ref()),
-                majit_ir::descr::struct_template_id_for_name(right.as_ref()),
-            ) {
-                (Some(left), Some(right)) => left == right,
-                _ => {
-                    majit_ir::descr::canonical_struct_name(left.as_ref())
-                        == majit_ir::descr::canonical_struct_name(right.as_ref())
-                }
-            }
-        }
-
-        let slot = majit_ir::descr::strip_generic_args(slot_owner);
-        let Some((base, variant)) = slot.rsplit_once("::") else {
+        let (Some((slot_enum, slot_variant)), Some((field_enum, field_variant))) = (
+            shelled_sum_owner(slot_owner),
+            shelled_sum_owner(field_owner),
+        ) else {
             return false;
         };
-        matches!(variant, "Some" | "Ok" | "Err") && same_owner(base, field_owner)
+        slot_enum == field_enum
+            && (slot_variant == field_variant
+                || slot_variant.is_empty()
+                || field_variant.is_empty())
     }
+
+    /// Whether two module paths name one item, one of them possibly having had
+    /// its crate root stripped.  Charon spells the same declaration both ways
+    /// and the front end registers both as aliases of one `StructId`, but that
+    /// build-time registry is not serialized into the generated runtime, so
+    /// compare the paths segment-wise from the leaf: `grain::vm::Vm` and
+    /// `rhai::grain::vm::Vm` agree, `a::Vm` and `b::Vm` do not.
+    fn path_alias(left: &str, right: &str) -> bool {
+        let left: Vec<&str> = left.split("::").collect();
+        let right: Vec<&str> = right.split("::").collect();
+        let (long, short) = if left.len() >= right.len() {
+            (left, right)
+        } else {
+            (right, left)
+        };
+        short.as_slice() == &long[long.len() - short.len()..]
+    }
+
+    // `rclass.InstanceRepr._setup_repr` gives a sum-type variant subclass the
+    // base's fields before its own, and pyre's payload enums carry the tag on
+    // that base alone (`front/mir.rs`), so a variant's flattened field list
+    // legitimately holds a row whose own parent descr is the base.  That is
+    // the same super edge `explicit_sum_inherits` recovers for the two shelled
+    // sums, for every other enum.  Restricted to the tag: it is the only row
+    // the base carries, so a payload row reaching here under a base spelling
+    // would be naming a field the base does not have.
+    fn variant_inherits_enum_tag(slot_owner: &str, field_owner: &str, field_key: &str) -> bool {
+        if field_key != "__discriminant" {
+            return false;
+        }
+        let slot = majit_ir::descr::strip_generic_args(slot_owner);
+        let Some((base, _variant)) = slot.rsplit_once("::") else {
+            return false;
+        };
+        path_alias(
+            base,
+            majit_ir::descr::strip_generic_args(field_owner).as_ref(),
+        )
+    }
+
+    let owners_agree = |slot_owner: &str, field_owner: &str| {
+        explicit_sum_inherits(slot_owner, field_owner)
+            || variant_inherits_enum_tag(slot_owner, field_owner, field.field_key())
+    };
 
     let names_name_same_owner = || match (display_owner(slot), display_owner(field)) {
         (Some(slot_owner), Some(field_owner)) => {
@@ -2786,8 +2849,10 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
                 majit_ir::descr::struct_id_for_name(slot_owner),
                 majit_ir::descr::struct_id_for_name(field_owner),
             ) {
-                (Some(slot_id), Some(field_id)) => slot_id == field_id,
-                _ => slot_owner == field_owner,
+                (Some(slot_id), Some(field_id)) => {
+                    slot_id == field_id || owners_agree(slot_owner, field_owner)
+                }
+                _ => slot_owner == field_owner || owners_agree(slot_owner, field_owner),
             }
         }
         // Neither descriptor contains an owner spelling.  This is the
@@ -2813,7 +2878,7 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
                     slot_key == field_key
                         || match (display_owner(slot), display_owner(field)) {
                             (Some(slot_owner), Some(field_owner)) => {
-                                explicit_sum_inherits(slot_owner, field_owner)
+                                owners_agree(slot_owner, field_owner)
                             }
                             _ => false,
                         }
@@ -3783,6 +3848,68 @@ mod tests {
         )
         .with_parent_descr(base_parent, 0);
         assert!(!slot_holds_field(&slot, &unrelated));
+    }
+
+    #[test]
+    fn slot_identity_accepts_the_shell_template_spelling_of_a_variant_payload() {
+        let mut variant_size = majit_ir::descr::SimpleSizeDescr::new(0, 16, 1);
+        variant_size.set_cache_key(0x61);
+        let variant_parent = Arc::new(variant_size) as DescrRef;
+        let mut template_size = majit_ir::descr::SimpleSizeDescr::new(1, 16, 2);
+        template_size.set_cache_key(0x62);
+        let template_parent = Arc::new(template_size) as DescrRef;
+
+        // The allocation names the instantiation it allocated; the read names
+        // the shell template, whose declared payload width is the erased one.
+        let slot = majit_ir::SimpleFieldDescr::new_with_name(
+            1,
+            8,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "core::option::Option<Dynamic>::Some.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(variant_parent.clone(), 1);
+        let template = majit_ir::SimpleFieldDescr::new_with_name(
+            1,
+            8,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "Option::Some.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(template_parent.clone(), 1);
+        assert!(slot_holds_field(&slot, &template));
+
+        // Two variants of one shelled enum put different fields at one
+        // address, so the shell template does not merge them.
+        let ok = majit_ir::SimpleFieldDescr::new_with_name(
+            1,
+            8,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "core::result::Result<Dynamic,str>::Ok.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(variant_parent, 1);
+        let err = majit_ir::SimpleFieldDescr::new_with_name(
+            1,
+            8,
+            8,
+            Type::Ref,
+            false,
+            majit_ir::ArrayFlag::Pointer,
+            "Result::Err.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        )
+        .with_parent_descr(template_parent, 1);
+        assert!(!slot_holds_field(&ok, &err));
     }
 
     fn assign_positions(ops: &mut [Op]) {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4512,11 +4512,7 @@ where
                 // folded into one op because no `getfield` an optimizer or a
                 // backend sees would then mean a load.
                 if is_ref && is_substruct {
-                    let addr = if struct_ptr == 0 {
-                        0
-                    } else {
-                        struct_ptr.wrapping_add(offset as i64)
-                    };
+                    let addr = struct_ptr.wrapping_add(offset as i64);
                     let base_int = ctx.execute_and_record(
                         Some(self.cpu.as_ref()),
                         OpCode::CastPtrToInt,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4474,73 +4474,26 @@ where
                     let frame = self.frames.current_mut();
                     frame.read_getfield_gc()
                 };
-                let (offset, field_size, is_field_signed, is_substruct, fielddescr) = {
+                let (offset, field_size, is_field_signed, fielddescr) = {
                     let frame = self.frames.current_mut();
                     let bh = frame.runtime_bh_descr(descr_idx).unwrap_or_else(|| {
                         panic!("BC_GETFIELD_GC: descrs[{descr_idx}] is not a BhDescr entry")
                     });
-                    let (field_size, is_field_signed, is_substruct) = match bh {
+                    let (field_size, is_field_signed) = match bh {
                         crate::blackhole::BhDescr::Field {
                             field_size,
                             is_field_signed,
-                            field_flag,
                             ..
-                        } => (
-                            *field_size,
-                            *is_field_signed,
-                            *field_flag == majit_ir::descr::ArrayFlag::Struct,
-                        ),
-                        _ => (8, false, false),
+                        } => (*field_size, *is_field_signed),
+                        _ => (8, false),
                     };
                     let offset = field_offset_from_bh(bh, "BC_GETFIELD_GC");
                     let fielddescr = frame
                         .runtime_optimizer_descr(descr_idx)
                         .unwrap_or_else(|| field_descr_ref_from_bh(bh).1);
-                    (
-                        offset,
-                        field_size,
-                        is_field_signed,
-                        is_substruct,
-                        fielddescr,
-                    )
+                    (offset, field_size, is_field_signed, fielddescr)
                 };
                 let (struct_opref, struct_ptr) = self.read_ref_reg(struct_reg);
-                // `descr.py FLAG_STRUCT`: the field IS a substructure laid out
-                // inline at `offset`, so a reference to it is that address and
-                // not the word stored there. `CpuModel::bh_getfield_gc_r`
-                // answers the same way; the arithmetic is recorded rather than
-                // folded into one op because no `getfield` an optimizer or a
-                // backend sees would then mean a load.
-                if is_ref && is_substruct {
-                    let addr = struct_ptr.wrapping_add(offset as i64);
-                    let base_int = ctx.execute_and_record(
-                        Some(self.cpu.as_ref()),
-                        OpCode::CastPtrToInt,
-                        None,
-                        &[struct_opref],
-                        Some(Value::Int(struct_ptr)),
-                        self.last_exception_value,
-                    );
-                    let offset_const = ctx.const_int(offset as i64);
-                    let sum = ctx.execute_and_record(
-                        Some(self.cpu.as_ref()),
-                        OpCode::IntAdd,
-                        None,
-                        &[base_int, offset_const],
-                        Some(Value::Int(addr)),
-                        self.last_exception_value,
-                    );
-                    let op = ctx.execute_and_record(
-                        Some(self.cpu.as_ref()),
-                        OpCode::CastIntToPtr,
-                        None,
-                        &[sum],
-                        Some(Value::Ref(majit_ir::GcRef(addr as usize))),
-                        self.last_exception_value,
-                    );
-                    self.set_ref_reg(dest, Some(op), Some(addr));
-                    return TraceAction::Continue;
-                }
                 // blackhole.py:1432-1443 reads the field through the fielddescr,
                 // which carries the field's byte width; a sub-word integer field
                 // (`Char`/`Bool`/`INT` narrower than a word) must be read at that

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4474,26 +4474,77 @@ where
                     let frame = self.frames.current_mut();
                     frame.read_getfield_gc()
                 };
-                let (offset, field_size, is_field_signed, fielddescr) = {
+                let (offset, field_size, is_field_signed, is_substruct, fielddescr) = {
                     let frame = self.frames.current_mut();
                     let bh = frame.runtime_bh_descr(descr_idx).unwrap_or_else(|| {
                         panic!("BC_GETFIELD_GC: descrs[{descr_idx}] is not a BhDescr entry")
                     });
-                    let (field_size, is_field_signed) = match bh {
+                    let (field_size, is_field_signed, is_substruct) = match bh {
                         crate::blackhole::BhDescr::Field {
                             field_size,
                             is_field_signed,
+                            field_flag,
                             ..
-                        } => (*field_size, *is_field_signed),
-                        _ => (8, false),
+                        } => (
+                            *field_size,
+                            *is_field_signed,
+                            *field_flag == majit_ir::descr::ArrayFlag::Struct,
+                        ),
+                        _ => (8, false, false),
                     };
                     let offset = field_offset_from_bh(bh, "BC_GETFIELD_GC");
                     let fielddescr = frame
                         .runtime_optimizer_descr(descr_idx)
                         .unwrap_or_else(|| field_descr_ref_from_bh(bh).1);
-                    (offset, field_size, is_field_signed, fielddescr)
+                    (
+                        offset,
+                        field_size,
+                        is_field_signed,
+                        is_substruct,
+                        fielddescr,
+                    )
                 };
                 let (struct_opref, struct_ptr) = self.read_ref_reg(struct_reg);
+                // `descr.py FLAG_STRUCT`: the field IS a substructure laid out
+                // inline at `offset`, so a reference to it is that address and
+                // not the word stored there. `CpuModel::bh_getfield_gc_r`
+                // answers the same way; the arithmetic is recorded rather than
+                // folded into one op because no `getfield` an optimizer or a
+                // backend sees would then mean a load.
+                if is_ref && is_substruct {
+                    let addr = if struct_ptr == 0 {
+                        0
+                    } else {
+                        struct_ptr.wrapping_add(offset as i64)
+                    };
+                    let base_int = ctx.execute_and_record(
+                        Some(self.cpu.as_ref()),
+                        OpCode::CastPtrToInt,
+                        None,
+                        &[struct_opref],
+                        Some(Value::Int(struct_ptr)),
+                        self.last_exception_value,
+                    );
+                    let offset_const = ctx.const_int(offset as i64);
+                    let sum = ctx.execute_and_record(
+                        Some(self.cpu.as_ref()),
+                        OpCode::IntAdd,
+                        None,
+                        &[base_int, offset_const],
+                        Some(Value::Int(addr)),
+                        self.last_exception_value,
+                    );
+                    let op = ctx.execute_and_record(
+                        Some(self.cpu.as_ref()),
+                        OpCode::CastIntToPtr,
+                        None,
+                        &[sum],
+                        Some(Value::Ref(majit_ir::GcRef(addr as usize))),
+                        self.last_exception_value,
+                    );
+                    self.set_ref_reg(dest, Some(op), Some(addr));
+                    return TraceAction::Continue;
+                }
                 // blackhole.py:1432-1443 reads the field through the fielddescr,
                 // which carries the field's byte width; a sub-word integer field
                 // (`Char`/`Bool`/`INT` narrower than a word) must be read at that

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -5209,7 +5209,7 @@ mod tests {
         );
         bk.set_struct_fields(Rc::new(reg));
         // The origin `front::mir` now registers for an enum leaf.
-        majit_ir::descr::register_struct_origins(
+        let _registry = crate::test_support::register_struct_origins_serialized(
             [("Newt".to_string(), "probemod".to_string())].into(),
         );
 

--- a/majit/majit-translate/src/codewriter/annotation_state.rs
+++ b/majit/majit-translate/src/codewriter/annotation_state.rs
@@ -46,6 +46,13 @@ pub fn valuetype_to_someshell(vt: &ValueType) -> Option<SomeValue> {
         // codewriter / regalloc share register classes via Int|Unsigned
         // arms downstream.
         ValueType::Int => Some(SomeValue::Integer(SomeInteger::default())),
+        // `SomeSingleFloat`, agreeing with the bookkeeper, which already
+        // shells a Rust `f32` field this way (`bookkeeper.rs`'s `"f32"`
+        // arm).  Shelling it as `SomeInteger` made the two disagree
+        // about the same type.
+        ValueType::SingleFloat => Some(SomeValue::SingleFloat(
+            crate::annotator::model::SomeSingleFloat::new(),
+        )),
         ValueType::Unsigned => Some(SomeValue::Integer(SomeInteger::new(false, true))),
         ValueType::Int128 => Some(SomeValue::Integer(SomeInteger::new_with_knowntype(
             false,

--- a/majit/majit-translate/src/codewriter/annotation_state.rs
+++ b/majit/majit-translate/src/codewriter/annotation_state.rs
@@ -159,9 +159,11 @@ pub fn somevalue_to_valuetype(s: &SomeValue) -> ValueType {
         },
         SomeValue::Bool(_) => ValueType::Bool,
         SomeValue::Float(_) | SomeValue::LongFloat(_) => ValueType::Float,
-        // `getkind(SingleFloat) == 'int'` (history.py): singlefloats
-        // are stored in an int register, not the float bank.
-        SomeValue::SingleFloat(_) => ValueType::Int,
+        // Preserve the annotation-level type across fixpoint rounds.  The
+        // later codewriter kind projection banks SingleFloat as an integer;
+        // collapsing it here would instead union Int with SingleFloat on the
+        // next annotator pass and erase the binding as Unknown.
+        SomeValue::SingleFloat(_) => ValueType::SingleFloat,
         SomeValue::Instance(_) | SomeValue::Ptr(_) | SomeValue::PBC(_) => ValueType::Ref(None),
         // Keep the `StringBuilder` shell distinct across the roundtrip so
         // the rtyper picks `StringBuilderRepr` rather than the generic
@@ -214,6 +216,14 @@ mod tests {
             "StringBuilder must project to SomeStringBuilder, got {shell:?}"
         );
         assert_eq!(somevalue_to_valuetype(&shell), ValueType::StringBuilder);
+    }
+
+    #[test]
+    fn singlefloat_roundtrips_through_shell() {
+        let shell = valuetype_to_someshell(&ValueType::SingleFloat)
+            .expect("SingleFloat projects to an annotation shell");
+        assert!(matches!(shell, SomeValue::SingleFloat(_)));
+        assert_eq!(somevalue_to_valuetype(&shell), ValueType::SingleFloat);
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3856,35 +3856,29 @@ impl crate::translator::rtyper::lltypesystem::llmemory::OffsetLayout for NoStruc
 /// Whether `owner` names one of the three enum variants `front/mir` gives an
 /// explicit `[tag@0 | payload@8]` shell to.
 ///
-/// `front/mir` admits every spelling from the bare `Result::Ok` up to the fully
-/// qualified `std::result::Result::Ok`, and `canonical_struct_name` keeps
-/// whichever the call site used, so this accepts each of them -- but as a
-/// *suffix of the whole path*, matched segment by segment against a `core` or
-/// `std` root.  A plain `ends_with` also admits a user enum declared at
-/// `mycrate::option::Option::Some`, which `front::option_ctor` never gives a
-/// shell to; its payload would then be described at offset 8 behind an injected
-/// discriminant rather than at its registered native layout.  Anchoring at the
-/// root rejects that while keeping every real spelling, the same reason
-/// [`crate::front::option_ctor::option_variant_ctor_tag`] anchors its own head.
+/// `front/mir` admits aliases from the bare `Result::Ok` up to the fully
+/// qualified standard-library spelling. The spelling alone is insufficient:
+/// a crate root named `option` can define `option::Option::Some` too. Resolve
+/// the candidate and the fully-qualified `core`/`std` anchors through the
+/// StructId registry and require their defining identities to agree.
 ///
 /// A lone leaf (`Ok`) is not enough: the shortest form `front/mir` produces
 /// names the enum as well as the variant.
 fn is_explicit_shell_variant_owner(owner: &str) -> bool {
-    const SHELLED: [&[&str]; 6] = [
-        &["core", "result", "Result", "Ok"],
-        &["std", "result", "Result", "Ok"],
-        &["core", "result", "Result", "Err"],
-        &["std", "result", "Result", "Err"],
-        &["core", "option", "Option", "Some"],
-        &["std", "option", "Option", "Some"],
+    const SHELLED: [&str; 6] = [
+        "core::result::Result::Ok",
+        "std::result::Result::Ok",
+        "core::result::Result::Err",
+        "std::result::Result::Err",
+        "core::option::Option::Some",
+        "std::option::Option::Some",
     ];
-    let segments: Vec<&str> = owner.split("::").collect();
-    if segments.len() < 2 {
+    let Some(owner_id) = majit_ir::descr::struct_template_id_for_name(owner) else {
         return false;
-    }
+    };
     SHELLED
-        .iter()
-        .any(|path| segments.len() <= path.len() && segments == path[path.len() - segments.len()..])
+        .into_iter()
+        .any(|anchor| majit_ir::descr::struct_template_id_for_name(anchor) == Some(owner_id))
 }
 
 pub(crate) fn bh_size_spec_from_callcontrol(
@@ -6077,6 +6071,46 @@ mod tests {
 
     use crate::test_support::register_struct_ids_serialized;
 
+    fn standard_shell_struct_ids() -> HashMap<String, Option<majit_ir::descr::StructId>> {
+        let option_some = majit_ir::descr::StructId::from_canonical("core::option::Option::Some");
+        let result_ok = majit_ir::descr::StructId::from_canonical("core::result::Result::Ok");
+        let result_err = majit_ir::descr::StructId::from_canonical("core::result::Result::Err");
+        let mut ids = HashMap::new();
+        for name in [
+            "Option::Some",
+            "option::Option::Some",
+            "std::option::Option::Some",
+            "core::option::Option::Some",
+        ] {
+            ids.insert(name.to_string(), Some(option_some));
+        }
+        for (identity, names) in [
+            (
+                result_ok,
+                [
+                    "Result::Ok",
+                    "result::Result::Ok",
+                    "std::result::Result::Ok",
+                    "core::result::Result::Ok",
+                ],
+            ),
+            (
+                result_err,
+                [
+                    "Result::Err",
+                    "result::Result::Err",
+                    "std::result::Result::Err",
+                    "core::result::Result::Err",
+                ],
+            ),
+        ] {
+            for name in names {
+                ids.insert(name.to_string(), Some(identity));
+            }
+        }
+        ids
+    }
+
     #[test]
     fn fielddescrof_resolves_the_slot_when_the_offset_comes_from_the_layout_registry() {
         use crate::call::{CallControl, StructFieldLayout, StructLayout};
@@ -6273,6 +6307,7 @@ mod tests {
     fn explicit_result_variant_size_inherits_discriminant_slot() {
         use crate::call::CallControl;
 
+        let _registry = register_struct_ids_serialized(standard_shell_struct_ids());
         let mut cc = CallControl::new();
         let mut struct_fields = crate::front::StructFieldRegistry::default();
         struct_fields.fields.insert(
@@ -6296,6 +6331,7 @@ mod tests {
     fn instantiated_result_payload_follows_template_discriminant_slot() {
         use crate::call::CallControl;
 
+        let _registry = register_struct_ids_serialized(standard_shell_struct_ids());
         let owner = "core::result::Result<*mut PyObject,PyError>::Ok";
         let mut cc = CallControl::new();
         let mut struct_fields = crate::front::StructFieldRegistry::default();
@@ -6336,10 +6372,7 @@ mod tests {
         let template_name = "core::option::Option::Some";
         let template_id = majit_ir::descr::StructId::from_canonical(template_name);
         let concrete_id = template_id.instantiate("<i64>");
-        let _registry = register_struct_ids_serialized(HashMap::from([(
-            template_name.to_string(),
-            Some(template_id),
-        )]));
+        let _registry = register_struct_ids_serialized(standard_shell_struct_ids());
         let mut cc = CallControl::new();
         let mut struct_fields = crate::front::StructFieldRegistry::default();
         struct_fields.fields.insert(
@@ -6404,11 +6437,19 @@ mod tests {
     fn a_lookalike_variant_owner_keeps_its_native_layout() {
         use crate::call::CallControl;
 
-        let owner = "mycrate::option::Option<*mut PyObject>::Some";
+        let owner = "option::Option<*mut PyObject>::Some";
+        let mut ids = standard_shell_struct_ids();
+        ids.insert(
+            "option::Option::Some".to_string(),
+            Some(majit_ir::descr::StructId::from_canonical(
+                "user_crate::option::Option::Some",
+            )),
+        );
+        let _registry = register_struct_ids_serialized(ids);
         let mut cc = CallControl::new();
         let mut struct_fields = crate::front::StructFieldRegistry::default();
         struct_fields.fields.insert(
-            "mycrate::option::Option::Some".to_string(),
+            "option::Option::Some".to_string(),
             vec![("__pos_0".to_string(), "*mut PyObject".to_string())],
         );
         cc.set_struct_fields(struct_fields);
@@ -6427,6 +6468,7 @@ mod tests {
     /// pins the same list on the producer side.
     #[test]
     fn the_shelled_variant_owners_are_every_rooted_spelling() {
+        let _registry = register_struct_ids_serialized(standard_shell_struct_ids());
         for owner in [
             "Result::Ok",
             "result::Result::Ok",
@@ -6453,6 +6495,22 @@ mod tests {
         ] {
             assert!(!is_explicit_shell_variant_owner(owner), "{owner}");
         }
+    }
+
+    #[test]
+    fn a_short_standard_library_lookalike_is_not_a_shell_by_spelling() {
+        let mut ids = standard_shell_struct_ids();
+        ids.insert(
+            "option::Option::Some".to_string(),
+            Some(majit_ir::descr::StructId::from_canonical(
+                "user_crate::option::Option::Some",
+            )),
+        );
+        let _registry = register_struct_ids_serialized(ids);
+        assert!(!is_explicit_shell_variant_owner("option::Option::Some"));
+        assert!(is_explicit_shell_variant_owner(
+            "core::option::Option::Some"
+        ));
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -4101,12 +4101,15 @@ pub(crate) fn bh_size_spec_from_callcontrol(
 ///
 /// The row is named under the *variant*, the way the explicit shell's own tag
 /// row is: it is the variant's slot 0, and what identifies it as the base's
-/// field is the inheritance edge the read side resolves, not the spelling.
+/// field is the inheritance edge the read side resolves. Charon can spell the
+/// variant with a crate prefix or only the enum leaf while the discriminant
+/// read uses the crate-stripped canonical base. Rebuild the variant owner from
+/// that leaf's registered origin so both spell the same inheritance edge.
 fn inherited_enum_tag_spec(
     cc: &CallControl,
     variant_owner: &str,
 ) -> Option<crate::jitcode::BhFieldSpec> {
-    let (base_owner, _variant) = variant_owner.rsplit_once("::")?;
+    let (base_owner, variant) = variant_owner.rsplit_once("::")?;
     let entries = cc.struct_field_entries(base_owner)?;
     if entries.len() != 1 || entries[0].0 != "__discriminant" {
         return None;
@@ -4114,9 +4117,14 @@ fn inherited_enum_tag_spec(
     let tag = bh_all_field_specs_for_struct(cc, base_owner)
         .into_iter()
         .find(|spec| spec.field_key() == "__discriminant")?;
+    let base_leaf = base_owner.rsplit("::").next().unwrap_or(base_owner);
+    let canonical_variant_owner = format!(
+        "{}::{variant}",
+        majit_ir::descr::canonical_struct_name(base_leaf)
+    );
     Some(bh_field_spec_from_parts(
         0,
-        variant_owner,
+        &canonical_variant_owner,
         "__discriminant",
         tag.offset,
         tag.field_size,
@@ -6344,6 +6352,49 @@ mod tests {
             bh_size_spec_from_callcontrol(&cc, owner).expect("instantiated Option variant size");
         assert_eq!(spec.type_id, concrete_id.as_u64());
         assert_eq!(spec.all_fielddescrs.len(), 2);
+    }
+
+    #[test]
+    fn native_enum_variant_inherited_tag_uses_the_canonical_base_path() {
+        use crate::call::CallControl;
+
+        let _registry = crate::test_support::register_struct_origins_serialized(HashMap::from([
+            ("BinOperand".to_string(), "grain::bytecode::op".to_string()),
+            ("Union".to_string(), "types::dynamic".to_string()),
+        ]));
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        for (base, variant) in [
+            (
+                "rhai::grain::bytecode::op::BinOperand",
+                "rhai::grain::bytecode::op::BinOperand::Local",
+            ),
+            ("Union", "Union::Int"),
+        ] {
+            struct_fields.fields.insert(
+                base.to_string(),
+                vec![("__discriminant".to_string(), "u8".to_string())],
+            );
+            struct_fields.fields.insert(
+                variant.to_string(),
+                vec![("__pos_0".to_string(), "i64".to_string())],
+            );
+        }
+        cc.set_struct_fields(struct_fields);
+
+        let bin_operand =
+            bh_size_spec_from_callcontrol(&cc, "rhai::grain::bytecode::op::BinOperand::Local")
+                .expect("BinOperand variant size");
+        assert_eq!(
+            bin_operand.all_fielddescrs[0].name,
+            "grain::bytecode::op::BinOperand::Local.__discriminant"
+        );
+
+        let union = bh_size_spec_from_callcontrol(&cc, "Union::Int").expect("Union variant size");
+        assert_eq!(
+            union.all_fielddescrs[0].name,
+            "types::dynamic::Union::Int.__discriminant"
+        );
     }
 
     /// A user enum whose path merely ends in `option::Option::Some` gets no

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3572,6 +3572,12 @@ fn value_type_to_kind(ty: &crate::model::ValueType) -> char {
         ValueType::Int128 | ValueType::UInt128 => {
             panic!("getkind: 128-bit integer type is too large (history.py:62)")
         }
+        ValueType::SingleFloat => panic!(
+            "getkind: SingleFloat is not supported (history.py:61) — majit is \
+             the `supports_singlefloats = False` CPU (backend/model.py:20), so \
+             the codewriter policy refuses a graph carrying one; reaching here \
+             means a carrier escaped `collect_declared_value_types`"
+        ),
     }
 }
 

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -6391,10 +6391,13 @@ mod tests {
     fn native_enum_variant_inherited_tag_uses_the_canonical_base_path() {
         use crate::call::CallControl;
 
-        let _registry = crate::test_support::register_struct_origins_serialized(HashMap::from([
-            ("BinOperand".to_string(), "grain::bytecode::op".to_string()),
-            ("Union".to_string(), "types::dynamic".to_string()),
-        ]));
+        let _registry = crate::test_support::register_struct_registries_serialized(
+            HashMap::new(),
+            HashMap::from([
+                ("BinOperand".to_string(), "grain::bytecode::op".to_string()),
+                ("Union".to_string(), "types::dynamic".to_string()),
+            ]),
+        );
         let mut cc = CallControl::new();
         let mut struct_fields = crate::front::StructFieldRegistry::default();
         for (base, variant) in [

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3993,6 +3993,31 @@ pub(crate) fn bh_size_spec_from_callcontrol(
             field.index_in_parent = index;
         }
     }
+    // `rclass.py InstanceRepr._setup_repr` seats a sum-type variant subclass's
+    // own fields after the base's, and pyre registers that base carrying the
+    // enum's synthetic `__discriminant` row alone (`front/mir.rs`).
+    // `Rvalue::Discriminant`
+    // reads the tag through the base identity while the allocation is the
+    // variant, and `PtrInfo` indexes a virtual's fields by `index_in_parent`,
+    // so a variant list without the inherited row gives the tag and the first
+    // payload slot 0 alike: the payload store replaces the tag, and every
+    // later read of either resolves to a slot holding the other.  The explicit
+    // shell reconstructs that row above; a native enum's variant inherits the
+    // same row, at the tag's own recorded offset and width rather than the
+    // shell's word, and keeps it first the way the walk that counts through
+    // the embedded base does.
+    if !result_variant
+        && !all_fielddescrs
+            .iter()
+            .any(|field| field.field_key() == "__discriminant")
+        && let Some(tag) = inherited_enum_tag_spec(cc, template_owner)
+    {
+        for (index, field) in all_fielddescrs.iter_mut().enumerate() {
+            field.index = (index + 1) as u32;
+            field.index_in_parent = index + 1;
+        }
+        all_fielddescrs.insert(0, tag);
+    }
     let violating_fields = all_fielddescrs
         .iter()
         .filter(|field| field.offset + field.field_size > size)
@@ -4062,6 +4087,45 @@ pub(crate) fn bh_size_spec_from_callcontrol(
         vtable: 0,
         all_fielddescrs,
     })
+}
+
+/// The enum base's `__discriminant` row that `variant_owner` inherits, or
+/// `None` when `variant_owner` does not name a variant of a tag-carrying enum.
+///
+/// The evidence is the `__discriminant`-only base registration `front/mir.rs`
+/// writes for every payload enum whose tag width Charon spelled -- a plain
+/// struct whose path merely contains `::` registers its own rows under that
+/// key and fails the shape test, and an enum whose tag width was recorded but
+/// is unspellable registers no base at all, which is the state that wants a
+/// declining read rather than a reconstructed slot.
+///
+/// The row is named under the *variant*, the way the explicit shell's own tag
+/// row is: it is the variant's slot 0, and what identifies it as the base's
+/// field is the inheritance edge the read side resolves, not the spelling.
+fn inherited_enum_tag_spec(
+    cc: &CallControl,
+    variant_owner: &str,
+) -> Option<crate::jitcode::BhFieldSpec> {
+    let (base_owner, _variant) = variant_owner.rsplit_once("::")?;
+    let entries = cc.struct_field_entries(base_owner)?;
+    if entries.len() != 1 || entries[0].0 != "__discriminant" {
+        return None;
+    }
+    let tag = bh_all_field_specs_for_struct(cc, base_owner)
+        .into_iter()
+        .find(|spec| spec.field_key() == "__discriminant")?;
+    Some(bh_field_spec_from_parts(
+        0,
+        variant_owner,
+        "__discriminant",
+        tag.offset,
+        tag.field_size,
+        tag.field_type,
+        tag.field_flag,
+        tag.is_immutable,
+        tag.is_quasi_immutable,
+        0,
+    ))
 }
 
 fn bh_all_field_specs_for_struct(

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3046,6 +3046,7 @@ impl Assembler {
                 OpKind::ConstUInt(_) => "ConstUInt",
                 OpKind::ConstInt128(_) => "ConstInt128",
                 OpKind::ConstUInt128(_) => "ConstUInt128",
+                OpKind::ConstSingleFloat(_) => "ConstSingleFloat",
                 OpKind::ConstBool(_) => "ConstBool",
                 OpKind::ConstSymbolic { .. } => "ConstSymbolic",
                 OpKind::ConstFloat(_) => "ConstFloat",
@@ -5026,6 +5027,12 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::ConstInt(_) | OpKind::ConstUInt(_) => "int_copy".into(),
         OpKind::ConstInt128(_) | OpKind::ConstUInt128(_) => {
             panic!("getkind: 128-bit integer constant is too large (history.py:62)")
+        }
+        OpKind::ConstSingleFloat(_) => {
+            panic!(
+                "getkind: SingleFloat constant is not supported (history.py:61) — \
+                 the codewriter policy refuses a graph carrying one"
+            )
         }
         // RPython folds `lltype.Bool` into kind `'int'`
         // (`flatten.py:getkind`), so the bool constant materialises

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -9004,6 +9004,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstSingleFloat(_)
         | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8133,6 +8133,11 @@ fn collect_readwrite_effects(
                             | crate::model::ValueType::Unknown => majit_ir::value::Type::Ref,
                             crate::model::ValueType::Float => majit_ir::value::Type::Float,
                             crate::model::ValueType::Void => majit_ir::value::Type::Void,
+                            crate::model::ValueType::SingleFloat => panic!(
+                                "getkind: SingleFloat is not supported \
+                                 (history.py:61) — the codewriter policy \
+                                 refuses a graph carrying one"
+                            ),
                             crate::model::ValueType::Int128 | crate::model::ValueType::UInt128 => {
                                 panic!(
                                     "getkind: 128-bit array item type is too large \
@@ -8186,6 +8191,11 @@ fn collect_readwrite_effects(
                             | crate::model::ValueType::Unknown => majit_ir::value::Type::Ref,
                             crate::model::ValueType::Float => majit_ir::value::Type::Float,
                             crate::model::ValueType::Void => majit_ir::value::Type::Void,
+                            crate::model::ValueType::SingleFloat => panic!(
+                                "getkind: SingleFloat is not supported \
+                                 (history.py:61) — the codewriter policy \
+                                 refuses a graph carrying one"
+                            ),
                             crate::model::ValueType::Int128 | crate::model::ValueType::UInt128 => {
                                 panic!(
                                     "getkind: 128-bit array item type is too large \
@@ -9149,6 +9159,7 @@ fn value_type_discriminant(ty: &crate::model::ValueType) -> u8 {
         ValueType::Unknown => 5,
         ValueType::Int128 => 6,
         ValueType::UInt128 => 7,
+        ValueType::SingleFloat => 8,
     }
 }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -1499,7 +1499,10 @@ impl<'a> Transformer<'a> {
             }
             ValueType::Float => crate::codewriter::type_state::ConcreteType::Float,
             ValueType::Void => crate::codewriter::type_state::ConcreteType::Void,
-            ValueType::Unknown | ValueType::Int128 | ValueType::UInt128 => return,
+            ValueType::Unknown
+            | ValueType::Int128
+            | ValueType::UInt128
+            | ValueType::SingleFloat => return,
         };
         self.stamp_value_kind(graph, value, ty);
     }
@@ -7719,6 +7722,12 @@ fn value_type_to_kind(ty: &ValueType) -> char {
         ValueType::Int128 | ValueType::UInt128 => {
             panic!("getkind: 128-bit integer type is too large (history.py:62)")
         }
+        ValueType::SingleFloat => panic!(
+            "getkind: SingleFloat is not supported (history.py:61) — majit is \
+             the `supports_singlefloats = False` CPU (backend/model.py:20), so \
+             the codewriter policy refuses a graph carrying one; reaching here \
+             means a carrier escaped `collect_declared_value_types`"
+        ),
     }
 }
 
@@ -7790,6 +7799,12 @@ fn value_type_to_ir_type(ty: &ValueType) -> majit_ir::value::Type {
         ValueType::Int128 | ValueType::UInt128 => {
             panic!("getkind: 128-bit integer type is too large (history.py:62)")
         }
+        ValueType::SingleFloat => panic!(
+            "getkind: SingleFloat is not supported (history.py:61) — majit is \
+             the `supports_singlefloats = False` CPU (backend/model.py:20), so \
+             the codewriter policy refuses a graph carrying one; reaching here \
+             means a carrier escaped `collect_declared_value_types`"
+        ),
     }
 }
 
@@ -15317,6 +15332,7 @@ mod tests {
                 "String"
             }
             ValueType::Float => "f64",
+            ValueType::SingleFloat => "f32",
             ValueType::Void => "",
             ValueType::Bool => "bool",
             ValueType::Int128 => "i128",
@@ -15571,6 +15587,7 @@ mod tests {
                 "String"
             }
             ValueType::Float => "f64",
+            ValueType::SingleFloat => "f32",
             ValueType::Void => "",
             ValueType::Bool => "bool",
             ValueType::Int128 => "i128",

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -462,9 +462,6 @@ pub struct Transformer<'a> {
     /// RPython: DependencyTracker — caches transitive analysis results.
     /// Shared across all getcalldescr() calls within this transform pass.
     analysis_cache: crate::call::AnalysisCache,
-    /// Results consumed as explicit arguments by a direct or indirect call in
-    /// the graph before call lowering rewrites those operations.
-    call_argument_vars: Vec<crate::flowspace::model::Variable>,
 }
 
 /// RPython: jtransform.py vable_flags values
@@ -969,7 +966,6 @@ impl<'a> Transformer<'a> {
             vable_rewrites: 0,
             calls_classified: 0,
             analysis_cache: crate::call::AnalysisCache::default(),
-            call_argument_vars: Vec::new(),
         }
     }
 
@@ -1059,18 +1055,6 @@ impl<'a> Transformer<'a> {
         // this spine keeps them to the codewriter, where each is a
         // symbolic residual no host symbol backs.
         crate::codewriter::iter_lower::lower_iterators(&mut rewritten);
-
-        self.call_argument_vars = rewritten
-            .blocks
-            .iter()
-            .flat_map(|block| &block.operations)
-            .filter_map(|op| match &op.kind {
-                OpKind::Call { args, .. } | OpKind::IndirectCall { args, .. } => Some(args),
-                _ => None,
-            })
-            .flatten()
-            .cloned()
-            .collect();
 
         let exceptblock = rewritten.exceptblock;
         let graph_name = rewritten.name.clone();
@@ -3441,16 +3425,14 @@ impl<'a> Transformer<'a> {
             };
             return RewriteResult::Identity(base.clone());
         }
-        if inline_substruct_offset.is_some()
-            && op
-                .result
-                .as_ref()
-                .is_some_and(|result| self.call_argument_vars.contains(result))
-        {
+        if inline_substruct_offset.is_some() {
             // `jtransform.py rewrite_op_getsubstruct` refuses GC
-            // substructures during translation. Pyre must still resolve the
-            // portal graph, so defer the same refusal to a result-less runtime
-            // abort; the enclosing call then remains residual.
+            // substructures during translation.  A nonzero-offset interior
+            // address cannot enter the Ref bank even when it is only carried
+            // across blocks: the GC map would treat it as an independently
+            // movable object and lose the owning allocation. Pyre must still
+            // resolve the portal graph, so defer the same refusal to a
+            // result-less runtime abort; the enclosing call remains residual.
             return RewriteResult::Replace(vec![
                 SpaceOperation {
                     result: None,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -8059,6 +8059,7 @@ fn remap_op(
         | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
+        | OpKind::ConstSingleFloat(_)
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -40,7 +40,7 @@
 use std::collections::HashSet;
 
 use crate::front::semantic::SemanticFunction;
-use crate::model::FunctionGraph;
+use crate::model::{Block, BlockId, FunctionGraph, OpKind, ValueType};
 
 /// policy.py: shared mutable state and the default classifier.
 ///
@@ -327,24 +327,234 @@ fn jit_look_inside_hint(hints: &[String]) -> Option<bool> {
     None
 }
 
-/// policy.py `contains_unsupported_variable_type(graph, ...)`.
+/// `policy.py:88-108 contains_unsupported_variable_type(graph, ...)`.
 ///
-/// TODO: pyre's value-id table does not yet carry the
-/// per-value lltype information that RPython walks here.  Since pyre
-/// always supports floats and the codewriter never produces longlong /
-/// singlefloat values, the upstream check would never reject a graph in
-/// the current state.  We keep the function signature (and behaviour
-/// "everything is supported") so that `look_inside_graph` matches the
-/// upstream control flow.  When the IR gains per-value lltype metadata
-/// the body must walk every `Block.inputargs` / `SpaceOperation.kind`
-/// arg and result identical to `policy.py:90-104`.
+/// ```python
+/// def contains_unsupported_variable_type(graph, supports_floats,
+///                                               supports_longlong,
+///                                               supports_singlefloats):
+///     getkind = history.getkind
+///     try:
+///         for block in graph.iterblocks():
+///             for v in block.inputargs:
+///                 getkind(v.concretetype, ...)
+///             for op in block.operations:
+///                 for v in op.args:
+///                     getkind(v.concretetype, ...)
+///                 v = op.result
+///                 getkind(v.concretetype, ...)
+///     except NotImplementedError as e:
+///         log.WARNING('%s, ignoring graph' % (e,))
+///         log.WARNING('  %s' % (graph,))
+///         return True
+///     return False
+/// ```
+///
+/// Upstream reaches every value's type through `v.concretetype`, so it
+/// can call `getkind` on `block.inputargs`, `op.args` and `op.result`
+/// alike.  Pyre's per-`Variable` type is
+/// [`crate::codewriter::type_state::ConcreteType`], a four-way
+/// `Signed / GcRef / Float / Void` projection with no width axis: a
+/// 128-bit value is indistinguishable from a word-sized one there, and
+/// walking `inputargs` would answer `Signed` for both.  The width
+/// survives only on the [`ValueType`] an [`OpKind`] declares, which is
+/// the same field the two `value_type_to_kind` copies
+/// (`codewriter/jtransform.rs`, `codewriter/assembler.rs`) later read to
+/// form an opname, and which the sibling `value_type_to_ir_type` /
+/// `constvalue_kind` / array-descr arms panic on in the same shape.  So
+/// this walks that field set — see [`collect_declared_value_types`] —
+/// over the same startblock-reachable block closure
+/// `graph.iterblocks()` yields.
+///
+/// The three `supports_*` flags are upstream's signature and stay on
+/// pyre's, but nothing here consults them: the two families they gate
+/// (`Float` under a CPU without float registers, `SingleFloat`) are not
+/// refusable in pyre's `ValueType` domain.  See [`value_type_has_kind`].
+///
+/// `look_inside_graph` turns a `true` here into a refusal, which makes
+/// the call residual; the census records it under the
+/// `"unsupported-variable-type"` reason, standing in for upstream's
+/// `log.WARNING('%s, ignoring graph')`.
 pub fn contains_unsupported_variable_type(
-    _graph: &FunctionGraph,
+    graph: &FunctionGraph,
     _supports_floats: bool,
     _supports_longlong: bool,
     _supports_singlefloats: bool,
 ) -> bool {
+    // `iterblocks()` parity (`rpython/flowspace/model.py:66`): the
+    // startblock-reachable closure over `Block.exits`, id-keyed because
+    // block ids need not be index-aligned with `blocks` storage order.
+    let by_id: std::collections::HashMap<BlockId, &Block> =
+        graph.blocks.iter().map(|b| (b.id, b)).collect();
+    let mut block_seen: HashSet<BlockId> = HashSet::new();
+    let mut stack = vec![graph.startblock];
+    let mut declared: Vec<&ValueType> = Vec::new();
+    while let Some(bid) = stack.pop() {
+        if !block_seen.insert(bid) {
+            continue;
+        }
+        let Some(block) = by_id.get(&bid) else {
+            continue;
+        };
+        for op in &block.operations {
+            declared.clear();
+            collect_declared_value_types(&op.kind, &mut declared);
+            if declared.iter().any(|ty| !value_type_has_kind(ty)) {
+                return true;
+            }
+        }
+        stack.extend(block.exits.iter().rev().map(|e| e.target));
+    }
     false
+}
+
+/// Whether `history.py:56-69 getkind(TYPE, ...)` has a register kind for
+/// `ty`, or raises `NotImplementedError` on it.
+///
+/// `getkind` refuses three families.  Two of them have no [`ValueType`]
+/// spelling to refuse:
+///
+///   - `SingleFloat` (`history.py:59`, refused when the CPU has no
+///     single-float support) has no variant in this enum at all.
+///   - `Float` is refused by the same line when `supports_floats` is
+///     false, but pyre's kind projection does not model a float-less
+///     CPU: both `value_type_to_kind` copies map `Float` to `'f'`
+///     unconditionally, so refusing a graph for a float here would
+///     refuse one the codewriter goes on to lower.
+///
+/// The third is `history.py:60-63`, `"type %s is too large"`, for a
+/// primitive wider than `Signed`.  [`ValueType::Int128`] /
+/// [`ValueType::UInt128`] (RPython `SignedLongLongLong` /
+/// `UnsignedLongLongLong`) are 16 bytes, twice a word; upstream's
+/// `supports_longlong` arm asserts a width of exactly 8 before handing
+/// the value the `'float'` slot, so no flag setting rescues a 16-byte
+/// type from the raise.  That arm is the one every downstream kind
+/// projection panics on rather than declines — both `value_type_to_kind`
+/// copies, `jtransform`'s `value_type_to_ir_type`, `flatten`'s
+/// `constvalue_kind`, and `call`'s array-descr item projection — and the
+/// one this refuses.
+fn value_type_has_kind(ty: &ValueType) -> bool {
+    match ty {
+        // `raise NotImplementedError("type %s is too large" % TYPE)`
+        ValueType::Int128 | ValueType::UInt128 => false,
+        ValueType::Int
+        | ValueType::Unsigned
+        | ValueType::Bool
+        | ValueType::State
+        | ValueType::Ref(_)
+        | ValueType::Str
+        | ValueType::StringBuilder
+        | ValueType::Unknown
+        | ValueType::Float
+        | ValueType::Void => true,
+    }
+}
+
+/// Append the [`ValueType`]s one operation declares to `out`.
+///
+/// Two surfaces declare one.  Most variants carry it in a `ty` /
+/// `item_ty` / `result_ty` field, which is what the `value_type_to_kind`
+/// copies read.  The `ConstInt128` / `ConstUInt128` variants carry no
+/// such field — the width is in the variant name and the payload is a
+/// Rust literal — but they are the op form of upstream's
+/// `Constant(value, SignedLongLongLong)` operand, which `policy.py:96-98`
+/// reaches through `op.args` and refuses like any other value.  They
+/// report the type they materialise, so a graph holding a 128-bit
+/// literal is refused here instead of panicking later in
+/// `assembler.rs`'s opname formation.
+///
+/// The match is exhaustive and deliberately carries no wildcard arm: an
+/// `OpKind` variant added with a `ValueType` field has to be classified
+/// here, and until it is the crate does not compile.  A wildcard would
+/// let a new carrier of a 128-bit type pass the policy gate and reach
+/// `value_type_to_kind`, which panics rather than declining.
+pub fn collect_declared_value_types<'a>(kind: &'a OpKind, out: &mut Vec<&'a ValueType>) {
+    // The 128-bit constant variants have no `ValueType` field to borrow
+    // from, and `ValueType` owns a `String` so it cannot be promoted to a
+    // `&'static` from a `const`.  Name the two shapes once instead.
+    static INT128: ValueType = ValueType::Int128;
+    static UINT128: ValueType = ValueType::UInt128;
+
+    match kind {
+        // The type of the value the op reads or writes.
+        OpKind::Input { ty, .. }
+        | OpKind::ConstSymbolic { ty, .. }
+        | OpKind::FieldRead { ty, .. }
+        | OpKind::FieldWrite { ty, .. }
+        | OpKind::VableFieldRead { ty, .. }
+        | OpKind::VableFieldWrite { ty, .. }
+        | OpKind::LoadStatic { ty, .. } => out.push(ty),
+
+        // The element type of the array or interior field addressed.
+        OpKind::NewArrayClear { item_ty, .. }
+        | OpKind::NewListClear { item_ty, .. }
+        | OpKind::ArrayRead { item_ty, .. }
+        | OpKind::ArrayWrite { item_ty, .. }
+        | OpKind::RawLoad { item_ty, .. }
+        | OpKind::RawStore { item_ty, .. }
+        | OpKind::InteriorFieldRead { item_ty, .. }
+        | OpKind::InteriorFieldWrite { item_ty, .. }
+        | OpKind::VableArrayRead { item_ty, .. }
+        | OpKind::VableArrayWrite { item_ty, .. }
+        | OpKind::VableArrayLen { item_ty, .. } => out.push(item_ty),
+
+        // The declared type of the op's result.
+        OpKind::Call { result_ty, .. }
+        | OpKind::IndirectCall { result_ty, .. }
+        | OpKind::BinOp { result_ty, .. }
+        | OpKind::UnaryOp { result_ty, .. }
+        | OpKind::IsInstance { result_ty, .. } => out.push(result_ty),
+
+        // `policy.py:96-98`'s `for v in op.args: getkind(v.concretetype)`
+        // over a `Constant` of the 16-byte primitive.
+        OpKind::ConstInt128(_) => out.push(&INT128),
+        OpKind::ConstUInt128(_) => out.push(&UINT128),
+
+        // No value type declared.  The remaining constant variants carry
+        // a Rust literal whose kind is fixed by the variant name, and the
+        // call variants downstream of `jtransform` carry a `result_kind`
+        // char that `value_type_to_kind` already produced.
+        OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
+        | OpKind::ConstBool(_)
+        | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
+        | OpKind::ConstRef(_)
+        | OpKind::ConstRefNull
+        | OpKind::ConstNone
+        | OpKind::ConstRefAddr(_)
+        | OpKind::New { .. }
+        | OpKind::NewWithVtable { .. }
+        | OpKind::ArrayLen { .. }
+        | OpKind::GuardTrue { .. }
+        | OpKind::GuardFalse { .. }
+        | OpKind::GuardValue { .. }
+        | OpKind::VtableMethodPtr { .. }
+        | OpKind::VableForce { .. }
+        | OpKind::Hint { .. }
+        | OpKind::CallElidable { .. }
+        | OpKind::CallResidual { .. }
+        | OpKind::CallMayForce { .. }
+        | OpKind::InlineCall { .. }
+        | OpKind::RecursiveCall { .. }
+        | OpKind::JitDebug { .. }
+        | OpKind::AssertGreen { .. }
+        | OpKind::CurrentTraceLength
+        | OpKind::IsConstant { .. }
+        | OpKind::IsVirtual { .. }
+        | OpKind::ConditionalCall { .. }
+        | OpKind::ConditionalCallValue { .. }
+        | OpKind::RecordKnownResult { .. }
+        | OpKind::RecordQuasiImmutField { .. }
+        | OpKind::Live
+        | OpKind::JitMergePoint { .. }
+        | OpKind::LoopHeader { .. }
+        | OpKind::Abort { .. }
+        | OpKind::NewTuple { .. }
+        | OpKind::NewList { .. }
+        | OpKind::GetSlice { .. }
+        | OpKind::LoweredBlackholeOp { .. } => {}
+    }
 }
 
 /// `rpython.translator.backendopt.support.find_backedges(graph)`.
@@ -484,6 +694,98 @@ mod tests {
         g.set_goto(entry, entry, Vec::new());
         assert!(!policy.look_inside_graph(&SemanticFunction {
             name: "loopy".into(),
+            graph: g,
+            return_type: None,
+            self_ty_root: None,
+            trait_impl_id: None,
+            hints: vec![],
+            module_path: String::new(),
+            trait_root: None,
+            trait_qualified: None,
+            returns_objectptr: false,
+        }));
+    }
+
+    /// `policy.py:88-108`: a graph holding a value `history.getkind`
+    /// refuses is refused here, not carried to the codewriter — where
+    /// `value_type_to_kind` panics rather than declining.
+    #[test]
+    fn a_128_bit_result_type_is_unsupported() {
+        let mut g = FunctionGraph::new("wide");
+        let entry = g.startblock;
+        g.push_op_var(
+            entry,
+            OpKind::Input {
+                name: "x".into(),
+                ty: ValueType::Int128,
+                class_root: None,
+            },
+            true,
+        );
+        assert!(contains_unsupported_variable_type(&g, true, true, true));
+    }
+
+    /// The 128-bit constants declare their width through the variant
+    /// name rather than a `ValueType` field, and are refused all the
+    /// same — `policy.py:96-98` reaches upstream's equivalent
+    /// `Constant(value, SignedLongLongLong)` through `op.args`.
+    #[test]
+    fn a_128_bit_constant_is_unsupported() {
+        let mut g = FunctionGraph::new("wide_const");
+        let entry = g.startblock;
+        g.push_op_var(entry, OpKind::ConstUInt128(1), true);
+        assert!(contains_unsupported_variable_type(&g, true, true, true));
+    }
+
+    /// Word-sized and float values keep their kinds, so an ordinary
+    /// graph is not refused.  The `supports_*` flags do not enter into
+    /// it: `false` for all three answers the same as `true`, because
+    /// pyre's kind projection models no float-less CPU.
+    #[test]
+    fn ordinary_value_types_are_supported() {
+        let mut g = FunctionGraph::new("narrow");
+        let entry = g.startblock;
+        for ty in [
+            ValueType::Int,
+            ValueType::Unsigned,
+            ValueType::Bool,
+            ValueType::Float,
+            ValueType::Void,
+            ValueType::Ref(None),
+        ] {
+            g.push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "x".into(),
+                    ty,
+                    class_root: None,
+                },
+                true,
+            );
+        }
+        assert!(!contains_unsupported_variable_type(&g, true, true, true));
+        assert!(!contains_unsupported_variable_type(&g, false, false, false));
+    }
+
+    /// The gate that consumes it: a graph the codewriter cannot give a
+    /// register kind is declined rather than reaching
+    /// `value_type_to_kind`.
+    #[test]
+    fn look_inside_graph_declines_a_128_bit_graph() {
+        let mut policy = DefaultJitPolicy::new();
+        let mut g = FunctionGraph::new("wide");
+        let entry = g.startblock;
+        g.push_op_var(
+            entry,
+            OpKind::Input {
+                name: "x".into(),
+                ty: ValueType::UInt128,
+                class_root: None,
+            },
+            true,
+        );
+        assert!(!policy.look_inside_graph(&SemanticFunction {
+            name: "wide".into(),
             graph: g,
             return_type: None,
             self_ty_root: None,

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -39,8 +39,9 @@
 
 use std::collections::HashSet;
 
+use crate::flowspace::model::ConstValue;
 use crate::front::semantic::SemanticFunction;
-use crate::model::{Block, BlockId, FunctionGraph, OpKind, ValueType};
+use crate::model::{Block, BlockId, FunctionGraph, LinkArg, OpKind, ValueType};
 
 /// policy.py: shared mutable state and the default classifier.
 ///
@@ -406,6 +407,15 @@ pub fn contains_unsupported_variable_type(
                 return true;
             }
         }
+        if block.exits.iter().flat_map(|link| &link.args).any(|arg| {
+            matches!(
+                arg,
+                LinkArg::Const(constant)
+                    if matches!(constant.value, ConstValue::Int128(_) | ConstValue::UInt128(_))
+            )
+        }) {
+            return true;
+        }
         stack.extend(block.exits.iter().rev().map(|e| e.target));
     }
     false
@@ -762,6 +772,24 @@ mod tests {
         let mut g = FunctionGraph::new("wide_const");
         let entry = g.startblock;
         g.push_op_var(entry, OpKind::ConstUInt128(1), true);
+        assert!(contains_unsupported_variable_type(&g, true, true, true));
+    }
+
+    #[test]
+    fn a_128_bit_link_constant_is_unsupported() {
+        let mut g = FunctionGraph::new("wide_link_const");
+        let entry = g.startblock;
+        let (target, _) = g.create_block_with_arg_vars(1);
+        g.block_mut(entry).exits = vec![
+            crate::model::Link::new_mixed(
+                vec![LinkArg::Const(crate::flowspace::model::Constant::new(
+                    ConstValue::UInt128(1),
+                ))],
+                target,
+                None,
+            )
+            .with_prevblock(entry),
+        ];
         assert!(contains_unsupported_variable_type(&g, true, true, true));
     }
 

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -366,9 +366,9 @@ fn jit_look_inside_hint(hints: &[String]) -> Option<bool> {
 /// over the same startblock-reachable block closure
 /// `graph.iterblocks()` yields.
 ///
-/// The three `supports_*` flags are upstream's signature and stay on
-/// pyre's, but nothing here consults them: the two families they gate
-/// (`Float` under a CPU without float registers, `SingleFloat`) are not
+/// `supports_singlefloats` reaches [`value_type_has_kind`], which is the
+/// flag's whole purpose upstream.  `supports_floats` and
+/// `supports_longlong` stay unconsulted: neither family they gate is
 /// refusable in pyre's `ValueType` domain.  See [`value_type_has_kind`].
 ///
 /// `look_inside_graph` turns a `true` here into a refusal, which makes
@@ -379,7 +379,7 @@ pub fn contains_unsupported_variable_type(
     graph: &FunctionGraph,
     _supports_floats: bool,
     _supports_longlong: bool,
-    _supports_singlefloats: bool,
+    supports_singlefloats: bool,
 ) -> bool {
     // `iterblocks()` parity (`rpython/flowspace/model.py:66`): the
     // startblock-reachable closure over `Block.exits`, id-keyed because
@@ -399,7 +399,10 @@ pub fn contains_unsupported_variable_type(
         for op in &block.operations {
             declared.clear();
             collect_declared_value_types(&op.kind, &mut declared);
-            if declared.iter().any(|ty| !value_type_has_kind(ty)) {
+            if declared
+                .iter()
+                .any(|ty| !value_type_has_kind(ty, supports_singlefloats))
+            {
                 return true;
             }
         }
@@ -411,16 +414,31 @@ pub fn contains_unsupported_variable_type(
 /// Whether `history.py:56-69 getkind(TYPE, ...)` has a register kind for
 /// `ty`, or raises `NotImplementedError` on it.
 ///
-/// `getkind` refuses three families.  Two of them have no [`ValueType`]
-/// spelling to refuse:
+/// `getkind` refuses three families.
 ///
-///   - `SingleFloat` (`history.py:59`, refused when the CPU has no
-///     single-float support) has no variant in this enum at all.
-///   - `Float` is refused by the same line when `supports_floats` is
-///     false, but pyre's kind projection does not model a float-less
-///     CPU: both `value_type_to_kind` copies map `Float` to `'f'`
-///     unconditionally, so refusing a graph for a float here would
-///     refuse one the codewriter goes on to lower.
+/// `history.py:58-61` refuses `SingleFloat` unless the CPU supports
+/// single floats, which is what `supports_singlefloats` carries.  Pyre's
+/// effective value is `false`: `warmspot.py:250`
+/// (`policy.set_supports_singlefloats(cpu.supports_singlefloats)`) has no
+/// port, so the flag keeps the base backend's answer
+/// (`backend/model.py:20`).
+///
+/// It must stay false for a reason upstream does not have to state.
+/// Upstream's "singlefloats are stored in an int" holds because RPython
+/// gives `SingleFloat` no arithmetic at all — `rffi` converts to `Float`,
+/// computes, and converts back, so the rtyper never emits a float-kind
+/// operation over a SingleFloat operand.  Rust source does contain native
+/// `f32` arithmetic, and pyre has no `cast_singlefloat_to_float` to
+/// bracket it with, so an accepted `f32` graph lowers that arithmetic
+/// over the float's bit pattern in the integer bank.  Flipping this flag
+/// is sound only once those casts exist and `f32` arithmetic lowers
+/// through them.
+///
+/// `Float` is refused by the same line when `supports_floats` is false,
+/// but pyre's kind projection does not model a float-less CPU: both
+/// `value_type_to_kind` copies map `Float` to `'f'` unconditionally, so
+/// refusing a graph for a float here would refuse one the codewriter goes
+/// on to lower.
 ///
 /// The third is `history.py:60-63`, `"type %s is too large"`, for a
 /// primitive wider than `Signed`.  [`ValueType::Int128`] /
@@ -433,10 +451,14 @@ pub fn contains_unsupported_variable_type(
 /// copies, `jtransform`'s `value_type_to_ir_type`, `flatten`'s
 /// `constvalue_kind`, and `call`'s array-descr item projection — and the
 /// one this refuses.
-fn value_type_has_kind(ty: &ValueType) -> bool {
+fn value_type_has_kind(ty: &ValueType, supports_singlefloats: bool) -> bool {
     match ty {
         // `raise NotImplementedError("type %s is too large" % TYPE)`
         ValueType::Int128 | ValueType::UInt128 => false,
+        // `if TYPE is lltype.SingleFloat and supports_singlefloats`,
+        // falling through to `raise NotImplementedError("type %s not
+        // supported" % TYPE)` when it does not.
+        ValueType::SingleFloat => supports_singlefloats,
         ValueType::Int
         | ValueType::Unsigned
         | ValueType::Bool
@@ -735,6 +757,30 @@ mod tests {
         let entry = g.startblock;
         g.push_op_var(entry, OpKind::ConstUInt128(1), true);
         assert!(contains_unsupported_variable_type(&g, true, true, true));
+    }
+
+    /// `history.py:58-61`: a singlefloat is refused unless the CPU
+    /// supports one, and pyre's effective answer is the base backend's
+    /// `False` (`backend/model.py:20`) because `warmspot.py:250` has no
+    /// port. The flag is honoured rather than hardcoded, so both answers
+    /// are asserted here — the `true` leg is what upstream's x86 gets
+    /// (`backend/x86/runner.py:21`), and reaching it in pyre would need
+    /// the singlefloat casts first.
+    #[test]
+    fn a_singlefloat_is_unsupported_unless_the_cpu_supports_one() {
+        let mut g = FunctionGraph::new("narrow_float");
+        let entry = g.startblock;
+        g.push_op_var(
+            entry,
+            OpKind::Input {
+                name: "x".into(),
+                ty: ValueType::SingleFloat,
+                class_root: None,
+            },
+            true,
+        );
+        assert!(contains_unsupported_variable_type(&g, true, true, false));
+        assert!(!contains_unsupported_variable_type(&g, true, true, true));
     }
 
     /// Word-sized and float values keep their kinds, so an ordinary

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -496,6 +496,7 @@ pub fn collect_declared_value_types<'a>(kind: &'a OpKind, out: &mut Vec<&'a Valu
     // `&'static` from a `const`.  Name the two shapes once instead.
     static INT128: ValueType = ValueType::Int128;
     static UINT128: ValueType = ValueType::UInt128;
+    static SINGLEFLOAT: ValueType = ValueType::SingleFloat;
 
     match kind {
         // The type of the value the op reads or writes.
@@ -531,6 +532,11 @@ pub fn collect_declared_value_types<'a>(kind: &'a OpKind, out: &mut Vec<&'a Valu
         // over a `Constant` of the 16-byte primitive.
         OpKind::ConstInt128(_) => out.push(&INT128),
         OpKind::ConstUInt128(_) => out.push(&UINT128),
+        // Likewise `Constant(value, SingleFloat)`.  This is the only way
+        // the walk sees an `f32` literal: the variant declares no
+        // `ValueType` field, and the literal's own type channel is not
+        // one this walk reads.
+        OpKind::ConstSingleFloat(_) => out.push(&SINGLEFLOAT),
 
         // No value type declared.  The remaining constant variants carry
         // a Rust literal whose kind is fixed by the variant name, and the
@@ -781,6 +787,19 @@ mod tests {
         );
         assert!(contains_unsupported_variable_type(&g, true, true, false));
         assert!(!contains_unsupported_variable_type(&g, true, true, true));
+    }
+
+    /// The `f32` literal is the carrier with no `ValueType` field
+    /// anywhere on its path — it declares none, and nothing else in a
+    /// literal-only graph declares one either. `policy.py:96-98` reaches
+    /// upstream's `Constant(value, SingleFloat)` through `op.args`, and
+    /// this is how the walk reaches its op form.
+    #[test]
+    fn a_singlefloat_constant_is_unsupported() {
+        let mut g = FunctionGraph::new("narrow_float_const");
+        let entry = g.startblock;
+        g.push_op_var(entry, OpKind::ConstSingleFloat(1.0f32.to_bits()), true);
+        assert!(contains_unsupported_variable_type(&g, true, true, false));
     }
 
     /// Word-sized and float values keep their kinds, so an ordinary

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -81,9 +81,11 @@ pub(crate) fn valuetype_to_concrete(vt: &ValueType) -> ConcreteType {
         ValueType::Ref(_) | ValueType::Str | ValueType::StringBuilder => ConcreteType::GcRef,
         ValueType::Float => ConcreteType::Float,
         ValueType::Void => ConcreteType::Void,
-        ValueType::State | ValueType::Unknown | ValueType::Int128 | ValueType::UInt128 => {
-            ConcreteType::Unknown
-        }
+        ValueType::State
+        | ValueType::Unknown
+        | ValueType::Int128
+        | ValueType::UInt128
+        | ValueType::SingleFloat => ConcreteType::Unknown,
     }
 }
 

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -347,13 +347,27 @@ pub(crate) fn emit_option_variant(
     disc: i64,
     payload: Option<(&str, Variable, ValueType)>,
 ) -> Variable {
-    let res = graph.alloc_value_var();
     let variant = match disc {
         0 => "None",
         1 => "Some",
         other => panic!("emit_option_variant: Option discriminant must be 0 or 1, got {other}"),
     };
-    push_option_variant_ctor(graph, block, res.clone(), option_owner, variant);
+    emit_sum_variant(graph, block, option_owner, variant, disc, payload)
+}
+
+/// Build one statically selected two-variant enum shell.  This is the common
+/// aggregate shape used by `Option` and `Result`: a variant constructor, the
+/// enum-root discriminant row, and an optional variant-owned payload row.
+pub(crate) fn emit_sum_variant(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    enum_owner: &str,
+    variant: &str,
+    disc: i64,
+    payload: Option<(&str, Variable, ValueType)>,
+) -> Variable {
+    let res = graph.alloc_value_var();
+    push_option_variant_ctor(graph, block, res.clone(), enum_owner, variant);
     // `__discriminant` keys the enum root (tag offset 0 of every variant);
     // materialize the tag as a `ConstInt` value, matching the aggregate
     // path's `FieldWrite { value: Value(..) }` shape.
@@ -362,7 +376,7 @@ pub(crate) fn emit_option_variant(
         result: Some(disc_var.clone()),
         kind: OpKind::ConstInt(disc),
     });
-    write_option_fields(graph, block, &res, option_owner, disc_var, payload);
+    write_option_fields(graph, block, &res, enum_owner, disc_var, payload);
     res
 }
 

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -180,15 +180,24 @@ fn var_read_in_reachable(
 /// left as the residual call (Skip), so a mismatch never regresses a graph
 /// the legacy walker already handled.  Returns the number of sites
 /// rewritten.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct CheckedArithRewriteCount {
+    pub(crate) total: usize,
+    pub(crate) result_shells: usize,
+}
+
 pub(crate) fn rewire_checked_arith_call_sites(
     graph: &mut FunctionGraph,
     sites: &[Variable],
     ok_or_else_sites: &[CheckedArithOkOrElseSite],
-) -> usize {
-    let mut rewritten = 0;
+) -> CheckedArithRewriteCount {
+    let mut rewritten = CheckedArithRewriteCount::default();
     for opt in sites {
         match rewire_one_checked_arith_site(graph, opt, ok_or_else_sites) {
-            Ok(()) => rewritten += 1,
+            Ok(created_result_shell) => {
+                rewritten.total += 1;
+                rewritten.result_shells += usize::from(created_result_shell);
+            }
             Err(_decline) => {
                 if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
@@ -209,7 +218,7 @@ fn rewire_one_checked_arith_site(
     graph: &mut FunctionGraph,
     opt: &Variable,
     ok_or_else_sites: &[CheckedArithOkOrElseSite],
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let name = graph.name.clone();
     // Block A: the `checked_*()` residual call producing `opt`, closed by
     // lower_call with a single forwarding exit.
@@ -287,6 +296,7 @@ fn rewire_one_checked_arith_site(
             ovf_opname,
             ok_or_else_sites,
         )
+        .map(|()| true)
         .map_err(|reason| {
             format!("{name}: block {c} lacks the Option __discriminant read; {reason}")
         });
@@ -430,7 +440,7 @@ fn rewire_one_checked_arith_site(
         Link::new_mixed(normal_args, some_target, None),
         overflow_link,
     ];
-    Ok(())
+    Ok(false)
 }
 
 /// Rewrite the signed-arithmetic `checked_*(lhs, rhs).ok_or_else(env)` shape.
@@ -787,7 +797,8 @@ mod tests {
         ];
 
         let rewritten = rewire_checked_arith_call_sites(&mut g, std::slice::from_ref(&opt), &[]);
-        assert_eq!(rewritten, 1, "the checked_add site must be rewritten");
+        assert_eq!(rewritten.total, 1, "the checked_add site must be rewritten");
+        assert_eq!(rewritten.result_shells, 0);
 
         // Block A's last op is now `add_ovf(va, vb)`, reusing `opt`.
         let last = g.blocks[a.0].operations.last().unwrap();
@@ -890,7 +901,8 @@ mod tests {
         };
         let rewritten =
             rewire_checked_arith_call_sites(&mut g, std::slice::from_ref(&opt), &[paired]);
-        assert_eq!(rewritten, 1);
+        assert_eq!(rewritten.total, 1);
+        assert_eq!(rewritten.result_shells, 1);
         assert!(matches!(
             &g.blocks[a.0].operations.last().unwrap().kind,
             OpKind::BinOp { op, .. } if op == "add_ovf"
@@ -1016,7 +1028,8 @@ mod tests {
         ];
 
         let rewritten = rewire_checked_arith_call_sites(&mut g, std::slice::from_ref(&opt), &[]);
-        assert_eq!(rewritten, 0, "a None arm that reads opt must decline");
+        assert_eq!(rewritten.total, 0, "a None arm that reads opt must decline");
+        assert_eq!(rewritten.result_shells, 0);
         // The residual call survives untouched.
         let last = g.blocks[a.0].operations.last().unwrap();
         assert!(matches!(

--- a/majit/majit-translate/src/front/checked_arith_uint.rs
+++ b/majit/majit-translate/src/front/checked_arith_uint.rs
@@ -1,9 +1,10 @@
-//! `usize::checked_{add,mul}()` → native unsigned-overflow ops + a
+//! `usize::checked_{add,sub,mul}()` → native unsigned-overflow ops + a
 //! virtualized `Option`.
 //!
 //! ## Positioning
 //!
-//! `core::num::<Impl>::checked_add` / `checked_mul` on **unsigned** operands
+//! `core::num::<Impl>::checked_add` / `checked_sub` / `checked_mul` on
+//! **unsigned** operands
 //! are Opaque core bodies (Charon cannot extract `core`), so the caller
 //! carries a residual `checked_*` call the rtyper census cannot type.
 //! [`crate::front::checked_arith`] lowers the **signed** match-shape into a
@@ -16,6 +17,8 @@
 //!     product is non-zero: `uint_mul_high(x, y) != 0`.
 //!   - `checked_add(x, y)` overflows iff the sum wrapped below an addend
 //!     (carry): `uint_lt(x + y, x)`.
+//!   - `checked_sub(x, y)` underflows iff the subtrahend is above the
+//!     minuend (borrow): `uint_lt(x, y)`.
 //!
 //! ## The rewrite (`rewire_one_checked_arith_uint_site`)
 //!
@@ -26,6 +29,8 @@
 //!     `disc = eq(hi, 0)`, value = `lo`.
 //!   - `checked_add`: `sum = add(x, y)`, `ovf = uint_lt(sum, x)`,
 //!     `disc = eq(ovf, 0)`, value = `sum`.
+//!   - `checked_sub`: `diff = sub(x, y)`, `ovf = uint_lt(x, y)`,
+//!     `disc = eq(ovf, 0)`, value = `diff`.
 //!   - `opt = Some/None` aggregate with `__discriminant = disc` (dynamic,
 //!     `1` = `Some` when no overflow, `0` = `None` on overflow) and
 //!     `__pos_0 = value`.
@@ -37,7 +42,7 @@
 //!
 //! It is **fail-safe**: any structural mismatch returns `Err`, the caller
 //! leaves the residual call untouched, and the census Skip / legacy-walker
-//! fallback is unchanged.  Gating (an unsigned `checked_{add,mul}` producer
+//! fallback is unchanged.  Gating (an unsigned `checked_{add,sub,mul}` producer
 //! still present as its `Call`) is applied both at the recording site (only
 //! unsigned operands are recorded) and here (the producer must still be the
 //! `Call`, so a site [`crate::front::checked_arith`] already rewrote is
@@ -47,7 +52,7 @@ use crate::flowspace::model::Variable;
 use crate::front::bool_then::emit_option_variant_dynamic;
 use crate::model::{CallTarget, FunctionGraph, OpKind, SpaceOperation, ValueType};
 
-/// A recorded unsigned `checked_{add,mul}` call whose result is an
+/// A recorded unsigned `checked_{add,sub,mul}` call whose result is an
 /// `Option<T>`, captured during body lowering with the `Option`/`Some` owners
 /// and payload type resolved from the destination type.
 #[derive(Clone)]
@@ -64,7 +69,7 @@ pub(crate) struct CheckedArithUintSite {
     pub payload_ty: ValueType,
 }
 
-/// Rewrite every recorded unsigned `checked_{add,mul}` site into the native
+/// Rewrite every recorded unsigned `checked_{add,sub,mul}` site into the native
 /// overflow-test + virtualized `Option` shape.  Returns the number of sites
 /// rewritten; declined sites keep their residual call (census Skip).
 pub(crate) fn rewire_checked_arith_uint_sites(
@@ -90,13 +95,11 @@ pub(crate) fn rewire_checked_arith_uint_sites(
     rewritten
 }
 
-/// The unsigned `checked_*` operators this pass lowers.  `checked_sub` is
-/// intentionally absent: unsigned subtraction underflow is a `uint_lt(x, y)`
-/// guard, but no census site spells it in the `?`-shape, so it stays a
-/// residual.
+/// The unsigned `checked_*` operators this pass lowers.
 #[derive(Clone, Copy)]
 enum UintArith {
     Add,
+    Sub,
     Mul,
 }
 
@@ -104,6 +107,7 @@ impl UintArith {
     fn from_leaf(leaf: &str) -> Option<Self> {
         match leaf {
             "checked_add" => Some(UintArith::Add),
+            "checked_sub" => Some(UintArith::Sub),
             "checked_mul" => Some(UintArith::Mul),
             _ => None,
         }
@@ -129,7 +133,8 @@ fn rewire_one_checked_arith_uint_site(
         })
         .ok_or_else(|| format!("{name}: checked_* result var has no producer block"))?;
 
-    // The call must still be A's last op (a `[..]::checked_add/checked_mul`
+    // The call must still be A's last op (a
+    // `[..]::checked_add/checked_sub/checked_mul`
     // 2-arg FunctionPath call); a site `checked_arith`'s first pass already
     // rewrote is now a `*_ovf` BinOp producer — skip it.  The overflow op is
     // resolved here (before any mutation) so an unsupported leaf declines
@@ -198,6 +203,22 @@ fn rewire_one_checked_arith_uint_site(
             let ovf = push_binop(graph, a_id, "uint_lt", sum.clone(), lhs, ValueType::Int);
             let disc = push_no_overflow_disc(graph, a_id, ovf);
             (sum, disc)
+        }
+        UintArith::Sub => {
+            let diff = push_binop(
+                graph,
+                a_id,
+                "sub",
+                lhs.clone(),
+                rhs.clone(),
+                ValueType::Unsigned,
+            );
+            // Unsigned borrow: the subtrahend is strictly above the minuend.
+            // The difference is emitted either way and read only when the
+            // discriminant says `Some`, as the wrapped sum above is.
+            let ovf = push_binop(graph, a_id, "uint_lt", lhs, rhs, ValueType::Int);
+            let disc = push_no_overflow_disc(graph, a_id, ovf);
+            (diff, disc)
         }
     };
 
@@ -278,6 +299,22 @@ mod tests {
             some_owner: "core::option::Option::Some".to_string(),
             payload_ty: ValueType::Unsigned,
         }
+    }
+
+    /// The two operands [`build_checked_site`] fed the `checked_*` call.
+    ///
+    /// Matched by their literal values rather than by position: the rewrite
+    /// appends a `0` of its own for the discriminant test, so a positional
+    /// read would pick that up once the pass has run.
+    fn const_operand_vars(graph: &FunctionGraph, a: usize) -> (Variable, Variable) {
+        let mut operands = graph.blocks[a]
+            .operations
+            .iter()
+            .filter(|op| matches!(op.kind, OpKind::ConstInt(3) | OpKind::ConstInt(8)))
+            .filter_map(|op| op.result.clone());
+        let x = operands.next().expect("the first operand");
+        let y = operands.next().expect("the second operand");
+        (x, y)
     }
 
     /// The op names / owners the virtualized `Option` tail carries, in order.
@@ -374,6 +411,32 @@ mod tests {
         assert_eq!(rewritten, 1, "the unsigned checked_add site must rewrite");
         // Carry test: `add` (wrapping sum) + `uint_lt(sum, x)` + `eq`.
         assert_eq!(tail_binops(&g, a), vec!["add", "uint_lt", "eq"]);
+    }
+
+    #[test]
+    fn checked_sub_lowers_to_uint_lt_borrow_test() {
+        let (mut g, opt, a) = build_checked_site("checked_sub");
+        let rewritten = rewire_checked_arith_uint_sites(&mut g, &[site_for(&opt)]);
+        assert_eq!(rewritten, 1, "the unsigned checked_sub site must rewrite");
+        // Borrow test: `sub` (wrapping difference) + `uint_lt(x, y)` + `eq`.
+        assert_eq!(tail_binops(&g, a), vec!["sub", "uint_lt", "eq"]);
+
+        // Which operand order makes the test a borrow is the whole of this
+        // arm's correctness: `x < y` underflows, while the carry arm's
+        // `sum < x` is a different question about different values. Reversed,
+        // the tag would answer `Some` on exactly the inputs that underflow.
+        let (x, y) = const_operand_vars(&g, a);
+        let borrow = g.blocks[a]
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::BinOp {
+                    op: name, lhs, rhs, ..
+                } if name == "uint_lt" => Some((lhs.clone(), rhs.clone())),
+                _ => None,
+            })
+            .expect("the borrow test must be present");
+        assert_eq!(borrow, (x, y));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2593,8 +2593,9 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 static_addrs.error_carrier,
             )
         };
+        let mut result_exc_rewritten = 0usize;
         if result_exc_callee {
-            crate::front::result_exc::lower_result_exc_returns(
+            result_exc_rewritten = crate::front::result_exc::lower_result_exc_returns(
                 &mut lo.graph,
                 tail_forwarded_returns,
                 static_addrs.error_carrier,
@@ -2694,6 +2695,24 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &lo.checked_arith_uint_sites,
             )
         };
+        // `rewire_checked_arith_ok_or_else` rebuilds `Result::Ok(sum)` /
+        // `Result::Err(closure())` shells on the two edges it fuses, and it
+        // runs after the callee rule above.  A scoped callee whose return WAS
+        // that `checked_*(..).ok_or_else(..)` pair therefore had nothing for
+        // the callee rule to rewrite when it ran, and carries the fold's fresh
+        // shells into its returnblock afterwards — while
+        // `rewire_result_exc_call_sites` has already rewired this callee's
+        // call sites to receive the unwrapped value.  Lower what the fold
+        // produced, so the two halves of the one decision agree again.
+        if result_exc_callee && (checked_arith_rewritten > 0 || checked_arith_uint_rewritten > 0) {
+            crate::front::result_exc::lower_result_exc_returns(
+                &mut lo.graph,
+                tail_forwarded_returns + result_exc_rewritten,
+                static_addrs.error_carrier,
+            )
+            .map_err(LowerError::Unsupported)?;
+            crate::front::result_exc::fuse_kind_ctor_raise(&mut lo.graph);
+        }
         // The `Layout::from_size_align(..).ok()` rewrite
         // (`front::from_size_align`) collapses the `from_size_align` + `ok`
         // residual pair into a native `uint_lt` bound test + a virtualized
@@ -8668,6 +8687,31 @@ impl<'a> Lowering<'a> {
                 // the conversion as identity too (Rust `String` and
                 // `&str` both lower to the immutable rpy_string), so
                 // it takes the same alias path.
+                // `core::mem::forget(x)` and `core::mem::drop(x)` leave
+                // nothing behind to record.  `forget` runs nothing by
+                // definition, and `drop` runs a destructor the trace model
+                // does not run either: `TermKind::Drop` above forwards
+                // unconditionally, so a value falling out of scope in traced
+                // code already leaves its destructor unrun, and spelling that
+                // same release as a call does not change what the model does.
+                //
+                // Their `FOREIGN_STDLIB_EXTERNALS` entries type the callsite
+                // but still leave a residual naming a `core` body the build
+                // has no address for, and one residual target a portal can
+                // reach whose address the build left unbound refuses every
+                // trace, arm taken or not.  Binding one instead is not open:
+                // the path key collapses every `T`, so a single address would
+                // serve monomorphisations that do not share a destructor.
+                if args.len() == 1 && self.is_mem_release(&reg) {
+                    let void = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Void);
+                    self.local_var[dest_local] = Some(void);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 if args.len() == 1
                     && (matches!(self.blanket_into_devirt(&reg), Some(IntoDevirt::Identity))
                         || self.is_reflexive_from(&reg)
@@ -11856,28 +11900,34 @@ impl<'a> Lowering<'a> {
         {
             self.checked_arith_ok_or_else_sites.push(site);
         }
-        // Capture UNSIGNED `usize::checked_{add,mul}()` results
+        // Capture UNSIGNED `usize::checked_{add,sub,mul}()` results
         // (`Option<usize>`) for the native-overflow rewiring pass
         // (`front::checked_arith_uint`).  Signed arithmetic stays on
         // `front::checked_arith` (→ `*_ovf` + OverflowError); unsigned has no
         // signed-overflow op, so it lowers to `uint_mul_high` / `uint_lt`
         // overflow tests + a virtualized `Option`.  The operand-signedness
         // gate lives here because the operand types are only in hand at the
-        // call site; `checked_sub` is excluded (no `?`-shape census site).
+        // call site.
+        //
+        // Either operand answers for both: these are
+        // `fn(self, rhs: Self) -> Option<Self>`, so the two are one type.  A
+        // literal operand carries no `Place` to read a type from, which is
+        // what `n.checked_sub(1)` spells, so demanding that both resolve would
+        // leave the constant-operand form on the residual path for want of a
+        // type the callee's signature already fixes.
         if let OpKind::Call { target, .. } = &op_kind
             && let CallTarget::FunctionPath { segments } = target
             && matches!(
                 segments.last().map(String::as_str),
-                Some("checked_add" | "checked_mul")
+                Some("checked_add" | "checked_sub" | "checked_mul")
             )
             && crate::front::checked_arith::is_checked_arith_target(target)
             && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
-            && first_arg_ty
+            && let Some(operand_ty) = first_arg_ty
                 .as_ref()
-                .is_some_and(|t| tyref_to_value_type(t, self.llbc) == ValueType::Unsigned)
-            && second_arg_ty
-                .as_ref()
-                .is_some_and(|t| tyref_to_value_type(t, self.llbc) == ValueType::Unsigned)
+                .or(second_arg_ty.as_ref())
+                .map(|t| tyref_to_value_type(t, self.llbc))
+            && operand_ty == ValueType::Unsigned
             && let Some(site) = self.recognize_checked_arith_uint_site(&call.dest.ty, &result_var)
         {
             self.checked_arith_uint_sites.push(site);
@@ -13896,6 +13946,22 @@ impl<'a> Lowering<'a> {
     /// returns its argument unchanged and `core` has no graph body for it
     /// (an unregistered callee), so the callsite aliases its argument
     /// instead of calling the missing identity body.
+    /// `core::mem::forget(value)` / `core::mem::drop(value)` — the two ways
+    /// to spell "this value is released here".  `core` has no graph body for
+    /// either, so a callsite that keeps the call carries a residual whose
+    /// target the build cannot address.
+    fn is_mem_release(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::mem::forget" | "core::mem::drop"
+            )
+        })
+    }
+
     fn is_hint_must_use(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6373,6 +6373,7 @@ impl<'a> Lowering<'a> {
             DecodedConst::UInt128(n) => OpKind::ConstUInt128(n),
             DecodedConst::Bool(b) => OpKind::ConstBool(b),
             DecodedConst::Float(bits) => OpKind::ConstFloat(bits),
+            DecodedConst::SingleFloat(bits) => OpKind::ConstSingleFloat(bits),
             // String / char / byte-string constants — no
             // ConstStr opkind exists; synthesise a 0-arg `Call` whose
             // path encodes the literal text so the IR stays stable.
@@ -24550,6 +24551,10 @@ enum DecodedConst {
     UInt128(u128),
     Bool(bool),
     Float(u64),
+    /// An `f32` literal, as its f32 bit pattern.  Charon records the
+    /// width on the constant (`{"Float": {"value": "...", "ty": "F32"}}`),
+    /// and parsing both widths into an f64 bit pattern is what erased it.
+    SingleFloat(u32),
     /// String / char / byte-string literals. The IR has no dedicated
     /// string constant opkind; the codewriter treats these as opaque
     /// pointer-typed values. We carry the textual representation as a
@@ -24566,6 +24571,8 @@ enum DecodedConst {
 #[derive(Clone, Copy)]
 enum ConstLit {
     Int(i64),
+    /// See [`DecodedConst::SingleFloat`].
+    SingleFloat(u32),
     /// Unsigned integer bits.  Keeping this distinct is required while
     /// evaluating const initializers: `(1_u64 << 63) - 1` cannot be
     /// evaluated correctly after prematurely reinterpreting the first
@@ -24725,13 +24732,21 @@ fn decode_const_lit(value: &serde_json::Value) -> Option<ConstLit> {
     if let Some(value) = literal.get("Bool").and_then(serde_json::Value::as_bool) {
         return Some(ConstLit::Bool(value));
     }
-    if let Some(value) = literal
-        .get("Float")
-        .and_then(|float| float.get("value"))
-        .and_then(serde_json::Value::as_str)
-        .and_then(|text| text.parse::<f64>().ok())
+    if let Some(float) = literal.get("Float")
+        && let Some(value) = float
+            .get("value")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|text| text.parse::<f64>().ok())
     {
-        return Some(ConstLit::Float(value.to_bits()));
+        // See [`decode_literal_constant`]: the width rides beside the
+        // value, and an `f32` keeps its own carrier.
+        return Some(
+            if float.get("ty").and_then(serde_json::Value::as_str) == Some("F32") {
+                ConstLit::SingleFloat((value as f32).to_bits())
+            } else {
+                ConstLit::Float(value.to_bits())
+            },
+        );
     }
     None
 }
@@ -24807,6 +24822,7 @@ fn const_lit_to_op(value: ConstLit) -> Option<OpKind> {
         ConstLit::UInt(n) => Some(OpKind::ConstUInt(n)),
         ConstLit::Bool(b) => Some(OpKind::ConstBool(b)),
         ConstLit::Float(bits) => Some(OpKind::ConstFloat(bits)),
+        ConstLit::SingleFloat(bits) => Some(OpKind::ConstSingleFloat(bits)),
         ConstLit::Checked(..) | ConstLit::CheckedUInt(..) => None,
     }
 }
@@ -25232,13 +25248,19 @@ fn decode_literal(lit: &serde_json::Value) -> Result<DecodedConst, LowerError> {
         return Ok(DecodedConst::Bool(b));
     }
     if let Some(f) = lit_obj.get("Float") {
-        if let Some(s) = f
-            .as_object()
-            .and_then(|m| m.get("value"))
-            .and_then(Value::as_str)
+        if let Some(obj) = f.as_object()
+            && let Some(s) = obj.get("value").and_then(Value::as_str)
             && let Ok(v) = s.parse::<f64>()
         {
-            return Ok(DecodedConst::Float(v.to_bits()));
+            // The width is carried beside the value, and an `f32` keeps
+            // its own carrier: narrowing to `f32` here is the conversion
+            // rustc already applied to the literal, and the f64 bit
+            // pattern of the same number is a different value.
+            return Ok(if obj.get("ty").and_then(Value::as_str) == Some("F32") {
+                DecodedConst::SingleFloat((v as f32).to_bits())
+            } else {
+                DecodedConst::Float(v.to_bits())
+            });
         }
         return Err(LowerError::Schema(format!("Float shape: {f}")));
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2607,6 +2607,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         let result_map_err_rewritten = crate::front::result_map_err::rewire_result_map_err_sites(
             &mut lo.graph,
             &lo.result_map_err_sites,
+            static_addrs.error_carrier,
         );
         if result_exc_callee {
             crate::front::result_exc::lower_result_exc_returns(

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12323,6 +12323,9 @@ impl<'a> Lowering<'a> {
         } = &op_kind
             && args.len() == 2
             && name == "map_err"
+            && callee_name_path
+                .as_deref()
+                .is_some_and(is_core_result_map_err_path)
             && let Some(site) = self.recognize_result_map_err_site(
                 first_arg_ty.as_ref(),
                 second_arg_ty.as_ref(),
@@ -26020,6 +26023,18 @@ fn fmt_path_ends_with(segments: &[String], tail: &[&str]) -> bool {
             .all(|(s, t)| s.as_str() == *t)
 }
 
+/// `core::result::<Impl>::map_err` / `std::result::Result::map_err`.
+///
+/// The leaf name `map_err` is not enough: an extension trait can publish
+/// the same method on `Result` and Charon still emits `CallTarget::Method`.
+/// Gate on the resolved callee path so a foreign `map_err` stays residual.
+fn is_core_result_map_err_path(path: &str) -> bool {
+    matches!(
+        path.split("::").collect::<Vec<_>>().as_slice(),
+        ["core" | "std", "result", "<Impl>" | "Result", "map_err"]
+    )
+}
+
 /// `<[T]>::to_vec` — Rust MIR `alloc::slice::<Impl>::to_vec`, a slice→owned-Vec
 /// copy. Retargeted to the `list` builtin (`rtype_bltn_list` -> `ll_copy`).
 fn is_slice_to_vec(segments: &[String]) -> bool {
@@ -28229,12 +28244,33 @@ mod tests {
         DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
-        json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
-        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
-        tyref_is_raw_byte_ptr, tyref_to_value_type,
+        is_core_result_map_err_path, json_ty_is_thin_pointer_element,
+        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
+        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
+
+    #[test]
+    fn map_err_capture_requires_the_core_result_callee() {
+        for path in [
+            "core::result::<Impl>::map_err",
+            "std::result::<Impl>::map_err",
+            "core::result::Result::map_err",
+            "std::result::Result::map_err",
+        ] {
+            assert!(is_core_result_map_err_path(path), "{path}");
+        }
+        for path in [
+            "map_err",
+            "Result::map_err",
+            "mycrate::result::<Impl>::map_err",
+            "core::result::ResultExt::<Impl>::map_err",
+            "foo::bar::map_err",
+        ] {
+            assert!(!is_core_result_map_err_path(path), "{path}");
+        }
+    }
 
     #[test]
     fn checked_unsigned_capture_rejects_narrow_integer_atoms() {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2536,6 +2536,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
         if !lo.result_exc_call_results.is_empty()
             || !lo.option_ok_or_else_try_sites.is_empty()
+            || !lo.result_map_err_sites.is_empty()
             || result_exc_callee
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
@@ -2593,9 +2594,12 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 static_addrs.error_carrier,
             )
         };
-        let mut result_exc_rewritten = 0usize;
+        let result_map_err_rewritten = crate::front::result_map_err::rewire_result_map_err_sites(
+            &mut lo.graph,
+            &lo.result_map_err_sites,
+        );
         if result_exc_callee {
-            result_exc_rewritten = crate::front::result_exc::lower_result_exc_returns(
+            crate::front::result_exc::lower_result_exc_returns(
                 &mut lo.graph,
                 tail_forwarded_returns,
                 static_addrs.error_carrier,
@@ -2705,9 +2709,14 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // call sites to receive the unwrapped value.  Lower what the fold
         // produced, so the two halves of the one decision agree again.
         if result_exc_callee && (checked_arith_rewritten > 0 || checked_arith_uint_rewritten > 0) {
+            // This is a new validation pass over the shells the checked-arith
+            // rewrites just created.  Earlier tail-forwards and rewritten
+            // returns cannot certify these new returns: if none of them has a
+            // supported shape, the callee must decline instead of exposing a
+            // mixture of unwrapped values and Result shells to its callers.
             crate::front::result_exc::lower_result_exc_returns(
                 &mut lo.graph,
-                tail_forwarded_returns + result_exc_rewritten,
+                0,
                 static_addrs.error_carrier,
             )
             .map_err(LowerError::Unsupported)?;
@@ -2926,6 +2935,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || option_ok_or_else_try_rewritten > 0
+            || result_map_err_rewritten > 0
             || next_rewritten > 0
             || checked_arith_rewritten > 0
             || checked_arith_uint_rewritten > 0
@@ -3533,6 +3543,10 @@ struct Lowering<'a> {
     /// not itself a translated scoped callee, so its `Result` shell must be
     /// removed together with the Option select.
     option_ok_or_else_try_sites: Vec<crate::front::result_exc::OptionOkOrElseTrySite>,
+    /// `Result::map_err(result, closure)` sites lowered to an explicit
+    /// Ok/Err closure-select before the exception-link pass consumes the
+    /// newly built result shells.
+    result_map_err_sites: Vec<crate::front::result_map_err::ResultMapErrSite>,
     /// `Iterator::next()` call results (`Option<T>`-typed) recorded for
     /// the `next`-diamond rewiring pass (`front::iter_next`) that runs
     /// after the body lowering completes.  The paired [`ValueType`] is the
@@ -3889,6 +3903,7 @@ impl<'a> Lowering<'a> {
             string_array_view_locals: Vec::new(),
             result_exc_call_results: Vec::new(),
             option_ok_or_else_try_sites: Vec::new(),
+            result_map_err_sites: Vec::new(),
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
             checked_arith_ok_or_else_sites: Vec::new(),
@@ -12288,6 +12303,26 @@ impl<'a> Lowering<'a> {
         {
             self.is_none_sites.push(site);
         }
+        // `Result::map_err(result, closure)` is a foreign core combinator.
+        // Record the concrete receiver/result instantiations while their MIR
+        // types are available; the post-pass restores the ordinary Ok/Err
+        // diamond before exceptiontransform-style Result lowering runs.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && name == "map_err"
+            && let Some(site) = self.recognize_result_map_err_site(
+                first_arg_ty.as_ref(),
+                second_arg_ty.as_ref(),
+                &call.dest.ty,
+                &result_var,
+            )
+        {
+            self.result_map_err_sites.push(site);
+        }
         // Capture `Option::map`/`and_then`/`unwrap_or_else(opt, closure)` sites
         // for the discriminant closure-select `front::option_closure_select`
         // synthesizes.  All three are Opaque (foreign `core`) with the `Option`
@@ -15518,6 +15553,58 @@ impl<'a> Lowering<'a> {
             payload_ty,
             error_ty,
             niche: self.tyref_is_niche_option_ptr(recv_ty),
+        })
+    }
+
+    /// Resolve `Result<T, E>::map_err(result, closure) -> Result<T, F>` into
+    /// the owners and payload types needed by `front::result_map_err`.
+    fn recognize_result_map_err_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        env_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::result_map_err::ResultMapErrSite> {
+        let recv_ty = recv_ty?;
+        let recv_ok = crate::front::result_exc::tyref_result_ok(recv_ty, self.llbc)?;
+        let recv_err = crate::front::result_exc::tyref_result_err(recv_ty, self.llbc)?;
+        let dest_ok = crate::front::result_exc::tyref_result_ok(dest_ty, self.llbc)?;
+        let dest_err = crate::front::result_exc::tyref_result_err(dest_ty, self.llbc)?;
+
+        let recv_decl = self.llbc.type_by_id(self.tyref_adt_def_id(recv_ty)?)?;
+        let dest_decl = self.llbc.type_by_id(self.tyref_adt_def_id(dest_ty)?)?;
+        let receiver_owner = format!(
+            "{}{}",
+            recv_decl.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(recv_ty, self.llbc)
+        );
+        let result_owner = format!(
+            "{}{}",
+            dest_decl.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
+        let receiver_ok_owner = Self::tagged_pair_payload_owner(recv_decl, &receiver_owner, 0)?;
+        let receiver_err_owner = Self::tagged_pair_payload_owner(recv_decl, &receiver_owner, 1)?;
+        let result_ok_owner = Self::tagged_pair_payload_owner(dest_decl, &result_owner, 0)?;
+        let result_err_owner = Self::tagged_pair_payload_owner(dest_decl, &result_owner, 1)?;
+        let env_decl = self.llbc.type_by_id(self.tyref_ref_adt_def_id(env_ty?)?)?;
+
+        Some(crate::front::result_map_err::ResultMapErrSite {
+            result_var: result_var.clone(),
+            receiver_owner,
+            receiver_ok_owner,
+            receiver_err_owner,
+            result_owner,
+            result_ok_owner,
+            result_err_owner,
+            call_once_owner: env_decl.item_meta.name_path(),
+            ok_ty: tyref_enum_payload_value_type(&recv_ok, self.llbc),
+            ok_class_root: enum_payload_instance_class_root(&dest_ok, self.llbc),
+            err_ty: tyref_enum_payload_value_type(&recv_err, self.llbc),
+            err_class_root: enum_payload_instance_class_root(&recv_err, self.llbc),
+            mapped_err_ty: tyref_enum_payload_value_type(&dest_err, self.llbc),
+            mapped_err_class_root: enum_payload_instance_class_root(&dest_err, self.llbc),
+            args_tuple_suffix: payload_tuple_suffix(&recv_err, self.llbc),
         })
     }
 
@@ -23937,6 +24024,44 @@ fn option_payload_tuple_suffix(recv_ty: &TyRef, llbc: &Llbc) -> String {
     // 3. return tyref_tuple_suffix of the wrapper — the same renderer the read
     //    side routes through, so the `&`-stripped leaf matches by construction.
     tyref_tuple_suffix(&TyRef::Other(wrapper), llbc)
+}
+
+/// The closure-argument tuple spelling for an already projected enum payload.
+/// Both the synthesized writer and Charon's closure `call_once` reader use
+/// `tyref_tuple_suffix`, so reference erasure and generic rendering stay
+/// identical on the two sides.
+fn payload_tuple_suffix(payload: &TyRef, llbc: &Llbc) -> String {
+    let node = match payload {
+        TyRef::Inline { value: (_, value) } | TyRef::Other(value) => value.clone(),
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(value) => value.clone(),
+            None => return String::new(),
+        },
+    };
+    let wrapper = serde_json::json!({
+        "Adt": {
+            "id": "Tuple",
+            "generics": { "types": [node] }
+        }
+    });
+    tyref_tuple_suffix(&TyRef::Other(wrapper), llbc)
+}
+
+/// Preserve a reference payload's concrete class across a synthesized enum
+/// and closure-tuple field write.  RPython derives the field repr from that
+/// class annotation (`rclass.py:InstanceRepr._setup_repr`); the register-bank
+/// [`ValueType`] alone cannot distinguish two reference classes.
+fn enum_payload_instance_class_root(payload: &TyRef, llbc: &Llbc) -> Option<String> {
+    let payload = strip_ty_indirections(tyref_node(payload, llbc)?, llbc)?;
+    if let Some(root) = raw_ptr_pointee_class_root(payload, llbc) {
+        return Some(root);
+    }
+    if let Some(root) = adt_node_class_root(payload, llbc) {
+        return Some(root);
+    }
+    let pointee = payload.as_object()?.get("Ref")?.as_array()?.get(1)?;
+    let pointee = strip_ty_wrappers(pointee, llbc)?;
+    raw_ptr_pointee_class_root(pointee, llbc).or_else(|| adt_node_class_root(pointee, llbc))
 }
 
 /// A type-argument drives a per-instantiation variant-class split unless

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2675,7 +2675,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // actual rewrite detaches the discriminant switch's block, so the
         // unreachable-block sweep is gated on that count.
         let checked_arith_rewritten = if lo.checked_arith_call_results.is_empty() {
-            0
+            crate::front::checked_arith::CheckedArithRewriteCount::default()
         } else {
             crate::front::checked_arith::rewire_checked_arith_call_sites(
                 &mut lo.graph,
@@ -2708,7 +2708,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // `rewire_result_exc_call_sites` has already rewired this callee's
         // call sites to receive the unwrapped value.  Lower what the fold
         // produced, so the two halves of the one decision agree again.
-        if result_exc_callee && (checked_arith_rewritten > 0 || checked_arith_uint_rewritten > 0) {
+        if result_exc_callee && checked_arith_rewritten.result_shells > 0 {
             // This is a new validation pass over the shells the checked-arith
             // rewrites just created.  Earlier tail-forwards and rewritten
             // returns cannot certify these new returns: if none of them has a
@@ -2937,7 +2937,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || option_ok_or_else_try_rewritten > 0
             || result_map_err_rewritten > 0
             || next_rewritten > 0
-            || checked_arith_rewritten > 0
+            || checked_arith_rewritten.total > 0
             || checked_arith_uint_rewritten > 0
             || from_size_align_rewritten > 0
             || from_size_align_expect_rewritten > 0
@@ -8702,22 +8702,20 @@ impl<'a> Lowering<'a> {
                 // the conversion as identity too (Rust `String` and
                 // `&str` both lower to the immutable rpy_string), so
                 // it takes the same alias path.
-                // `core::mem::forget(x)` and `core::mem::drop(x)` leave
-                // nothing behind to record.  `forget` runs nothing by
-                // definition, and `drop` runs a destructor the trace model
-                // does not run either: `TermKind::Drop` above forwards
-                // unconditionally, so a value falling out of scope in traced
-                // code already leaves its destructor unrun, and spelling that
-                // same release as a call does not change what the model does.
+                // `core::mem::forget(x)` leaves nothing behind to record: it
+                // deliberately suppresses the destructor.  `core::mem::drop`
+                // is different — it must run destructor glue immediately —
+                // so it stays a residual call until Drop lowering preserves
+                // that observable effect.
                 //
-                // Their `FOREIGN_STDLIB_EXTERNALS` entries type the callsite
+                // Its `FOREIGN_STDLIB_EXTERNALS` entry types the callsite
                 // but still leave a residual naming a `core` body the build
                 // has no address for, and one residual target a portal can
                 // reach whose address the build left unbound refuses every
                 // trace, arm taken or not.  Binding one instead is not open:
                 // the path key collapses every `T`, so a single address would
                 // serve monomorphisations that do not share a destructor.
-                if args.len() == 1 && self.is_mem_release(&reg) {
+                if args.len() == 1 && self.is_mem_forget(&reg) {
                     let void = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Void);
@@ -13981,20 +13979,17 @@ impl<'a> Lowering<'a> {
     /// returns its argument unchanged and `core` has no graph body for it
     /// (an unregistered callee), so the callsite aliases its argument
     /// instead of calling the missing identity body.
-    /// `core::mem::forget(value)` / `core::mem::drop(value)` — the two ways
-    /// to spell "this value is released here".  `core` has no graph body for
-    /// either, so a callsite that keeps the call carries a residual whose
-    /// target the build cannot address.
-    fn is_mem_release(&self, reg: &RegularCall) -> bool {
+    /// `core::mem::forget(value)` deliberately suppresses destructor glue.
+    /// `core::mem::drop(value)` is not included: erasing that call would erase
+    /// an observable destructor, so it remains residual until Drop lowering
+    /// can preserve the effect.
+    fn is_mem_forget(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
-        self.llbc.fn_by_id(*id).is_some_and(|fd| {
-            matches!(
-                fd.item_meta.name_path().as_str(),
-                "core::mem::forget" | "core::mem::drop"
-            )
-        })
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::mem::forget")
     }
 
     fn is_hint_must_use(&self, reg: &RegularCall) -> bool {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11947,11 +11947,11 @@ impl<'a> Lowering<'a> {
             )
             && crate::front::checked_arith::is_checked_arith_target(target)
             && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
-            && let Some(operand_ty) = first_arg_ty
+            && let Some(operand_atom) = first_arg_ty
                 .as_ref()
                 .or(second_arg_ty.as_ref())
-                .map(|t| tyref_to_value_type(t, self.llbc))
-            && operand_ty == ValueType::Unsigned
+                .and_then(|t| self.tyref_literal_uint_atom(t))
+            && checked_arith_uint_atom_is_word_sized(operand_atom)
             && let Some(site) = self.recognize_checked_arith_uint_site(&call.dest.ty, &result_var)
         {
             self.checked_arith_uint_sites.push(site);
@@ -18031,6 +18031,14 @@ impl<'a> Lowering<'a> {
             self.block_entry_positional_aggregate_locals[target_bb].remove(&local_idx);
         }
     }
+}
+
+/// The unsigned checked-arithmetic pass uses one machine-word operation and
+/// its carry/borrow test.  Charon's flattened [`ValueType::Unsigned`] erases
+/// the source width, so retain the literal atom at the capture gate: a narrow
+/// `u8`/`u16`/`u32` overflow is not necessarily a word overflow.
+fn checked_arith_uint_atom_is_word_sized(atom: &str) -> bool {
+    matches!(atom, "U64") || (atom == "Usize" && crate::layout::target_word_size() == 8)
 }
 
 /// Which PBC family an `OpKind::IndirectCall` through a bare function
@@ -28220,12 +28228,25 @@ mod tests {
     use super::{
         DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
-        decode_literal, fn_ptr_family_for, json_ty_is_thin_pointer_element,
-        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
-        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr, tyref_to_value_type,
+        checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
+        json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
+        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
+        tyref_is_raw_byte_ptr, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
+
+    #[test]
+    fn checked_unsigned_capture_rejects_narrow_integer_atoms() {
+        for atom in ["U8", "U16", "U32", "U128"] {
+            assert!(!checked_arith_uint_atom_is_word_sized(atom));
+        }
+        assert!(checked_arith_uint_atom_is_word_sized("U64"));
+        assert_eq!(
+            checked_arith_uint_atom_is_word_sized("Usize"),
+            crate::layout::target_word_size() == 8
+        );
+    }
 
     #[test]
     fn numeric_bank_crossing_casts_preserve_the_builtin_owner() {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1479,7 +1479,8 @@ fn tuple_field_value_type(type_name: &str) -> ValueType {
         // kind rather than collapsing into `Int` like the word-sized integers.
         "i128" => ValueType::Int128,
         "u128" => ValueType::UInt128,
-        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "isize" => ValueType::Int,
+        "f32" => ValueType::SingleFloat,
+        "bool" | "char" | "i8" | "i16" | "i32" | "i64" | "isize" => ValueType::Int,
         // A `u*` element shells to an unsigned `SomeInteger`
         // (`valuetype_to_someshell(Unsigned)`), so an `r_uint` tuple element
         // reconciles with the FORCE_ATTRIBUTES seed instead of walling
@@ -20664,6 +20665,11 @@ fn value_type_bank(ty: &ValueType) -> u8 {
         ValueType::Unknown => 5,
         ValueType::Int128 => 6,
         ValueType::UInt128 => 7,
+        // Its own bank, not the integer one `getkind` would give it: a
+        // same-bank pair is aliased without an op, and an `f32` that
+        // aliased an `i64` is what let Rust's native `f32` arithmetic
+        // lower to integer arithmetic over the float's bit pattern.
+        ValueType::SingleFloat => 8,
     }
 }
 
@@ -20901,11 +20907,13 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
                 return ValueType::Bool;
             }
             if let Some(f) = lit_obj.get("Float").and_then(serde_json::Value::as_str) {
-                // `getkind(SingleFloat) == 'int'` (history.py): single
-                // floats live in the int register bank; only `f64`
-                // (`lltype.Float`) keeps the float kind.
+                // A singlefloat is neither `Int` nor `Float`: `getkind`
+                // banks it as `'int'`, but only where the CPU supports
+                // singlefloats, and RPython gives it no arithmetic to
+                // bank in the first place.  Spelling it apart is what
+                // lets the codewriter policy refuse the graph.
                 return if f == "F32" {
-                    ValueType::Int
+                    ValueType::SingleFloat
                 } else {
                     ValueType::Float
                 };
@@ -21440,6 +21448,7 @@ fn dont_look_inside_return_token(
         ValueType::Int128 => "i128",
         ValueType::UInt128 => "u128",
         ValueType::Float => "f64",
+        ValueType::SingleFloat => "f32",
         // A `*mut PyObject` result keeps its typed `OBJECTPTR` lowering, so a
         // caller reading the returned object's fields rtypes against the real
         // struct; the generic `GCREF` `ref` token would erase that and stub
@@ -21574,10 +21583,10 @@ fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
                 return ValueType::Bool;
             }
             if let Some(f) = lit_obj.get("Float").and_then(serde_json::Value::as_str) {
-                // `getkind(SingleFloat) == 'int'`: single floats are
-                // int-banked; only `f64` keeps the float kind.
+                // See [`tyref_to_value_type`]: a singlefloat is spelled
+                // apart from both banks so the policy can refuse it.
                 return if f == "F32" {
-                    ValueType::Int
+                    ValueType::SingleFloat
                 } else {
                     ValueType::Float
                 };

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -15667,23 +15667,22 @@ impl<'a> Lowering<'a> {
             let Some(impl_trait) = impl_row.get("impl_trait") else {
                 return false;
             };
-            let Some(trait_id) = impl_trait.get("id").and_then(serde_json::Value::as_u64) else {
-                return false;
-            };
-            if self
-                .llbc
-                .trait_by_id(trait_id)
-                .is_none_or(|decl| decl.item_meta.name_path() != "core::ops::drop::Drop")
-            {
-                return false;
-            }
-            impl_trait
+            let owner = impl_trait
                 .get("generics")
                 .and_then(|generics| generics.get("types"))
                 .and_then(serde_json::Value::as_array)
                 .and_then(|types| types.first())
-                .and_then(|owner| resolve_tyexpr_to_adt_def_id_free(self.llbc, owner))
-                == Some(def_id)
+                .and_then(|owner| resolve_tyexpr_to_adt_def_id_free(self.llbc, owner));
+            if owner != Some(def_id) {
+                return false;
+            }
+            // Missing trait metadata cannot prove this capture dropless.
+            // Keep the call residual until its destructor contract is known.
+            impl_trait
+                .get("id")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|trait_id| self.llbc.trait_by_id(trait_id))
+                .is_none_or(|decl| decl.item_meta.name_path() == "core::ops::drop::Drop")
         })
     }
 
@@ -31550,6 +31549,67 @@ mod tests {
             }
         });
         Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses")
+    }
+
+    #[test]
+    fn map_err_drop_detection_requires_resolved_trait_metadata() {
+        use super::{Lowering, Unstructured};
+        let span = serde_json::json!({"data": {
+            "file_id": 0, "beg": {"line": 1, "col": 0}, "end": {"line": 1, "col": 1}
+        }});
+        let meta = |path: &[&str]| {
+            serde_json::json!({
+                "name": path.iter().map(|s| serde_json::json!({"Ident": [s, 0]})).collect::<Vec<_>>(),
+                "span": span.clone(), "source_text": null,
+                "attr_info": {"attributes": [], "inline": null, "rename": null, "public": true},
+                "is_local": true
+            })
+        };
+        for (trait_name, dropless) in [(Some("Drop"), false), (None, false), (Some("Copy"), true)] {
+            let traits = trait_name
+                .map(|name| {
+                    vec![serde_json::json!({
+                        "def_id": 0, "item_meta": meta(&["core", "ops", "drop", name])
+                    })]
+                })
+                .unwrap_or_default();
+            let file = serde_json::json!({
+                "charon_version": "0.1.201", "has_errors": false,
+                "translated": {
+                    "crate_name": "fixture",
+                    "type_decls": [{"def_id": 0, "item_meta": meta(&["fixture", "Capture"]), "kind": {"Struct": []}}],
+                    "fun_decls": [], "global_decls": [], "trait_decls": traits,
+                    "trait_impls": [{"impl_trait": {"id": 0, "generics": {"types": [
+                        {"HashConsedValue": [1, {"Adt": {"id": {"Adt": 0}, "generics": {"regions": [], "types": [], "const_generics": [], "trait_refs": []}}}]}
+                    ]}}}]
+                }
+            });
+            let llbc = Llbc::from_slice(file.to_string().as_bytes()).unwrap();
+            let body: Unstructured = serde_json::from_value(serde_json::json!({
+                "locals": {"arg_count": 0, "locals": []}, "body": [], "span": span.clone()
+            }))
+            .unwrap();
+            let dont_look_inside = std::collections::HashSet::new();
+            let lowering = Lowering::new(
+                &llbc,
+                "fixture".into(),
+                &body,
+                crate::HostStaticAddrs::default(),
+                &[],
+                None,
+                &dont_look_inside,
+            )
+            .unwrap();
+            assert_eq!(
+                lowering.type_decl_is_trivially_dropless(llbc.type_by_id(0).unwrap(), 0),
+                dropless,
+                "{trait_name:?}"
+            );
+            assert!(
+                !lowering.type_decl_has_explicit_drop(99),
+                "an unrelated owner must not be rejected"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2534,6 +2534,16 @@ fn lower_unstructured_with_static_addrs_and_attrs(
     let result_exc_ok_is_unit = result_exc_callee
         && crate::front::result_exc::tyref_result_ok_is_unit(&fd.signature.output, llbc);
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
+        if let Some(site) = lo
+            .result_map_err_sites
+            .iter()
+            .find(|site| !site.closure_env_is_trivially_dropless)
+        {
+            return Err(LowerError::Unsupported(format!(
+                "{}: Result::map_err closure {} captures values, but the Ok-arm destructor glue is not lowered",
+                lo.graph.name, site.call_once_owner
+            )));
+        }
         if !lo.result_exc_call_results.is_empty()
             || !lo.option_ok_or_else_try_sites.is_empty()
             || !lo.result_map_err_sites.is_empty()
@@ -15583,6 +15593,7 @@ impl<'a> Lowering<'a> {
         let result_ok_owner = Self::tagged_pair_payload_owner(dest_decl, &result_owner, 0)?;
         let result_err_owner = Self::tagged_pair_payload_owner(dest_decl, &result_owner, 1)?;
         let env_decl = self.llbc.type_by_id(self.tyref_ref_adt_def_id(env_ty?)?)?;
+        let closure_env_is_trivially_dropless = self.type_decl_is_trivially_dropless(env_decl, 0);
 
         Some(crate::front::result_map_err::ResultMapErrSite {
             result_var: result_var.clone(),
@@ -15600,6 +15611,75 @@ impl<'a> Lowering<'a> {
             mapped_err_ty: tyref_enum_payload_value_type(&dest_err, self.llbc),
             mapped_err_class_root: enum_payload_instance_class_root(&dest_err, self.llbc),
             args_tuple_suffix: payload_tuple_suffix(&recv_err, self.llbc),
+            closure_env_is_trivially_dropless,
+        })
+    }
+
+    /// Conservative `needs_drop::<ClosureEnv>() == false` projection for the
+    /// compiler-generated closure types consumed by `Result::map_err`.
+    fn type_decl_is_trivially_dropless(&self, decl: &TypeDecl, depth: usize) -> bool {
+        if depth > 16 || self.type_decl_has_explicit_drop(decl.def_id) {
+            return false;
+        }
+        match &decl.kind {
+            TypeDeclKind::Struct(fields) | TypeDeclKind::Union(fields) => fields
+                .iter()
+                .all(|field| self.tyref_is_trivially_dropless(&field.ty, depth + 1)),
+            TypeDeclKind::Enum(variants) => variants.iter().all(|variant| {
+                variant
+                    .fields
+                    .iter()
+                    .all(|field| self.tyref_is_trivially_dropless(&field.ty, depth + 1))
+            }),
+            TypeDeclKind::Alias(_) | TypeDeclKind::Opaque | TypeDeclKind::Unknown => false,
+        }
+    }
+
+    fn tyref_is_trivially_dropless(&self, ty: &TyRef, depth: usize) -> bool {
+        if depth > 16 {
+            return false;
+        }
+        let Some(node) = tyref_node(ty, self.llbc) else {
+            return false;
+        };
+        if node.get("Literal").is_some()
+            || node.get("Ref").is_some()
+            || node.get("RawPtr").is_some()
+            || node.get("FnDef").is_some()
+            || node.get("FnPtr").is_some()
+        {
+            return true;
+        }
+        let Some(def_id) = strip_ty_wrappers(node, self.llbc).and_then(adt_node_def_id) else {
+            return false;
+        };
+        self.llbc
+            .type_by_id(def_id)
+            .is_some_and(|decl| self.type_decl_is_trivially_dropless(decl, depth + 1))
+    }
+
+    fn type_decl_has_explicit_drop(&self, def_id: u64) -> bool {
+        self.llbc.trait_impls_raw().iter().any(|impl_row| {
+            let Some(impl_trait) = impl_row.get("impl_trait") else {
+                return false;
+            };
+            let Some(trait_id) = impl_trait.get("id").and_then(serde_json::Value::as_u64) else {
+                return false;
+            };
+            if self
+                .llbc
+                .trait_by_id(trait_id)
+                .is_none_or(|decl| decl.item_meta.name_path() != "core::ops::drop::Drop")
+            {
+                return false;
+            }
+            impl_trait
+                .get("generics")
+                .and_then(|generics| generics.get("types"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|types| types.first())
+                .and_then(|owner| resolve_tyexpr_to_adt_def_id_free(self.llbc, owner))
+                == Some(def_id)
         })
     }
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -86,6 +86,7 @@ pub(crate) mod range_contains;
 pub(crate) mod range_iter;
 pub(crate) mod rbigint_call;
 pub(crate) mod result_exc;
+pub(crate) mod result_map_err;
 pub(crate) mod rfloat_call;
 pub(crate) mod saturating_sub;
 pub mod semantic;

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -834,6 +834,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::ConstInt(_)
         | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
+        | OpKind::ConstSingleFloat(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -438,13 +438,26 @@ pub(crate) fn lower_result_exc_returns(
     // is the same here — this only records the reason before it is
     // discarded, so the refusal stays countable.
     let outcome = lower_result_exc_returns_inner(graph, tail_forwarded_returns, spec);
-    if let Err(msg) = &outcome {
-        crate::decline::record_reason(
+    match &outcome {
+        Err(msg) => crate::decline::record_reason(
             RESULT_EXC_CALLEE_GATE,
             "callee-declined-to-residual",
             msg,
             &graph.name,
-        );
+        ),
+        // An accept that rewrote nothing is the third outcome, and the one a
+        // decline census cannot show: the callee keeps returning its shell
+        // while `rewire_result_exc_call_sites` has already rewired its call
+        // sites to the unwrapped value, so the two halves of the one decision
+        // disagree without either half saying so.
+        Ok(0) => crate::decline::observe_accept(
+            RESULT_EXC_CALLEE_GATE,
+            "callee-accepted-without-rewriting",
+            &graph.name,
+        ),
+        Ok(_) => {
+            crate::decline::observe_accept(RESULT_EXC_CALLEE_GATE, "callee-rewritten", &graph.name);
+        }
     }
     outcome
 }
@@ -600,6 +613,19 @@ fn lower_result_exc_returns_inner(
                     graph.name
                 ));
             }
+            crate::decline::record_reason(
+                RESULT_EXC_CALLEE_GATE,
+                "site-skipped-consumed-intermediate",
+                &format!(
+                    "{}: block {bi} conditional {} shell left materialised \
+                     (op_uses={}, link_uses={})",
+                    graph.name,
+                    if is_err { "Err" } else { "Ok" },
+                    consumers.op_uses,
+                    consumers.link_uses,
+                ),
+                &graph.name,
+            );
             continue;
         }
         // A ctor is one of this graph's return values only if its value
@@ -668,6 +694,23 @@ fn lower_result_exc_returns_inner(
                     graph.name
                 ));
             }
+            crate::decline::record_reason(
+                RESULT_EXC_CALLEE_GATE,
+                "site-skipped-consumed-intermediate",
+                &format!(
+                    "{}: block {bi} {} shell left materialised (op_uses={}, \
+                     link_uses={}{})",
+                    graph.name,
+                    if is_err { "Err" } else { "Ok" },
+                    consumers.op_uses,
+                    consumers.link_uses,
+                    forward_err
+                        .as_deref()
+                        .map(|e| format!("; {e}"))
+                        .unwrap_or_default(),
+                ),
+                &graph.name,
+            );
             continue;
         }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -816,7 +816,7 @@ fn lower_result_exc_returns_inner(
 /// allocation/rooting implementation out of the caller JitCode.  A consumer
 /// whose carrier already is the exception value declares no helper and gets
 /// the identity path.
-fn materialize_error_to_exc_object(
+pub(crate) fn materialize_error_to_exc_object(
     graph: &mut FunctionGraph,
     block: BlockId,
     payload: Variable,

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -515,6 +515,7 @@ fn lower_result_exc_returns_inner(
         // returns a payload-carrying Result (unit payloads would lower
         // with no FieldWrite and need a Void widening).
         let mut fieldwrite_idx: Option<(usize, Variable)> = None;
+        let mut discriminant_write_idx: Option<usize> = None;
         for (i, op) in graph.blocks[bi]
             .operations
             .iter()
@@ -526,10 +527,30 @@ fn lower_result_exc_returns_inner(
             } = &op.kind
                 && *base == ctor_var
             {
+                if field.name == "__discriminant" {
+                    if discriminant_write_idx.is_some() {
+                        return Err(format!(
+                            "{}: block {bi} Result ctor has two __discriminant writes",
+                            graph.name
+                        ));
+                    }
+                    let expected = i64::from(is_err);
+                    if link_arg_const_int_in_block(graph, bi, value) != Some(expected) {
+                        return Err(format!(
+                            "{}: block {bi} Result {} ctor has a non-matching \
+                             __discriminant write (expected {expected})",
+                            graph.name,
+                            if is_err { "Err" } else { "Ok" },
+                        ));
+                    }
+                    discriminant_write_idx = Some(i);
+                    continue;
+                }
                 if field.name != "__pos_0" || fieldwrite_idx.is_some() {
                     return Err(format!(
                         "{}: block {bi} Result ctor with unexpected FieldWrite \
-                         {} — only a single __pos_0 payload is supported",
+                         {} — only __discriminant and a single __pos_0 payload \
+                         are supported",
                         graph.name, field.name
                     ));
                 }
@@ -569,7 +590,8 @@ fn lower_result_exc_returns_inner(
         // the `Err` rewrite discards the exit wholesale (`set_raise_values`
         // → `set_goto`), so multiple forwarding slots lower soundly.
         let consumers = count_var_uses(graph, &ctor_var);
-        let well_formed_return = consumers.op_uses == 1 && consumers.link_uses >= 1;
+        let expected_op_uses = 1 + usize::from(discriminant_write_idx.is_some());
+        let well_formed_return = consumers.op_uses == expected_op_uses && consumers.link_uses >= 1;
         // The shell must flow out through this block's single
         // unconditional exit.  A conditional exit is acceptable only when
         // the ctor is a consumed intermediate, not a return value: the
@@ -714,12 +736,21 @@ fn lower_result_exc_returns_inner(
             continue;
         }
 
-        // Drop the ctor + FieldWrite (higher index first).
+        // Drop the ctor + payload and optional static discriminant writes
+        // (higher index first).  A dead `ConstInt` producer for the tag is
+        // removed by the ordinary dead-op sweep.
         {
             let ops = &mut graph.blocks[bi].operations;
             debug_assert!(fw_idx > ctor_idx);
-            ops.remove(fw_idx);
-            ops.remove(ctor_idx);
+            let mut remove = vec![ctor_idx, fw_idx];
+            if let Some(disc_idx) = discriminant_write_idx {
+                remove.push(disc_idx);
+            }
+            remove.sort_unstable();
+            remove.dedup();
+            for idx in remove.into_iter().rev() {
+                ops.remove(idx);
+            }
         }
         if is_err {
             // `return Err(e)` → materialise the runtime exception
@@ -832,6 +863,26 @@ fn has_tail_forwarded_call_result(graph: &FunctionGraph) -> bool {
 struct UseCounts {
     op_uses: usize,
     link_uses: usize,
+}
+
+/// Resolve the literal tag written beside a statically selected `Result`
+/// variant.  `front::mir` and the combinator adapters both materialise the
+/// discriminant in the constructor block, while later widening may inline it
+/// into the `FieldWrite` as a flowspace constant.
+fn link_arg_const_int_in_block(graph: &FunctionGraph, block: usize, arg: &LinkArg) -> Option<i64> {
+    match arg {
+        LinkArg::Const(c) => match &c.value {
+            crate::flowspace::model::ConstValue::Int(value) => Some(*value),
+            _ => None,
+        },
+        LinkArg::Value(var) => graph.blocks[block].operations.iter().find_map(|op| {
+            (op.result.as_ref() == Some(var)).then_some(match &op.kind {
+                OpKind::ConstInt(value) => Some(*value),
+                OpKind::ConstUInt(value) => i64::try_from(*value).ok(),
+                _ => None,
+            })?
+        }),
+    }
 }
 
 /// Count uses of `var` as an op operand and as a link arg across the
@@ -3706,6 +3757,92 @@ fn message_is_str_literal(
         }
     }
     true
+}
+
+#[cfg(test)]
+mod static_result_shell_tests {
+    use super::*;
+    use crate::model::SpaceOperation;
+
+    fn ok_shell_with_tag(tag: i64) -> (FunctionGraph, Variable, Variable) {
+        let mut graph = FunctionGraph::new("static_result_shell");
+        let entry = graph.startblock;
+        let payload = graph
+            .push_op_var(entry, OpKind::ConstInt(41), true)
+            .expect("payload");
+        let shell = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor_with_owner(
+                        vec!["core".into(), "result".into(), "Result<i64,E>".into()],
+                        "Ok",
+                    ),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::result::Result<i64,E>::Ok".into())),
+                },
+                true,
+            )
+            .expect("shell");
+        let disc = graph
+            .push_op_var(entry, OpKind::ConstInt(tag), true)
+            .expect("tag");
+        for (name, owner, value) in [
+            ("__discriminant", "core::result::Result<i64,E>", disc),
+            (
+                "__pos_0",
+                "core::result::Result<i64,E>::Ok",
+                payload.clone(),
+            ),
+        ] {
+            graph.block_mut(entry).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: shell.clone(),
+                    field: crate::model::FieldDescriptor {
+                        name: name.into(),
+                        owner_root: Some(owner.into()),
+                        owner_id: None,
+                        base_is_deref: None,
+                        taken_by_address: false,
+                    },
+                    value: LinkArg::Value(value),
+                    ty: ValueType::Int,
+                },
+            });
+        }
+        let returnblock = graph.returnblock;
+        graph.set_goto(entry, returnblock, vec![shell.clone()]);
+        (graph, shell, payload)
+    }
+
+    #[test]
+    fn static_ok_tag_write_is_removed_with_the_result_shell() {
+        let (mut graph, shell, payload) = ok_shell_with_tag(0);
+        assert_eq!(
+            lower_result_exc_returns(&mut graph, 0, crate::ErrorCarrierSpec::default())
+                .expect("matching static tag lowers"),
+            1
+        );
+        assert!(graph.blocks.iter().flat_map(|b| &b.operations).all(|op| {
+            !matches!(&op.kind, OpKind::FieldWrite { base, .. } if *base == shell)
+                && !matches!(&op.kind, OpKind::Call { target, .. } if result_ctor_kind(target).is_some())
+        }));
+        assert!(
+            graph.blocks[graph.startblock.0].exits[0]
+                .args
+                .iter()
+                .any(|arg| matches!(arg, LinkArg::Value(value) if *value == payload))
+        );
+    }
+
+    #[test]
+    fn static_ok_with_err_tag_is_rejected() {
+        let (mut graph, _, _) = ok_shell_with_tag(1);
+        let err = lower_result_exc_returns(&mut graph, 0, crate::ErrorCarrierSpec::default())
+            .expect_err("mismatched variant tag must fail closed");
+        assert!(err.contains("non-matching __discriminant write"));
+    }
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -218,29 +218,58 @@ fn rewire_one(
         // result_exc has already made the map_err call a can-raise site. Keep
         // that exact exceptional destination: a `?` site targets exceptblock,
         // while catch_and_rewrap targets its local Err-shell rebuilding arm.
-        // In both cases the edge carries a trace-level exception object, not
-        // the interpreter-specific error carrier returned by the mapper.
-        let exc = crate::front::result_exc::materialize_error_to_exc_object(
-            graph, err_block, mapped, spec,
-        );
         let exceptional = saved_exception_exit
             .as_ref()
             .expect("LastException form captured its exceptional edge");
-        let last_exception = exceptional
-            .last_exception
-            .as_ref()
-            .and_then(LinkArg::as_variable)
-            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exception"))?;
-        let last_exc_value = exceptional
-            .last_exc_value
-            .as_ref()
-            .and_then(LinkArg::as_variable)
-            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exc_value"))?;
-        let args = exceptional
-            .args
-            .iter()
-            .map(|arg| -> Result<LinkArg, String> {
-                Ok(match arg {
+        if exceptional.target != graph.exceptblock {
+            // `catch_and_rewrap` only converted the old call into an exception
+            // edge so its local handler could recreate the value-encoded
+            // Result.  The mapper has already produced the carrier that handler
+            // would reconstruct; build the Err shell here and bypass the
+            // carrier -> exception object -> carrier round trip.  Besides an
+            // avoidable allocation, PyError::from_exc_object cannot preserve
+            // carrier-only state such as attach_tb or reraise_lasti.
+            let err_result = emit_sum_variant(
+                graph,
+                err_block,
+                &site.result_owner,
+                "Err",
+                1,
+                Some((&site.result_err_owner, mapped, site.mapped_err_ty.clone())),
+            );
+            let (rewrap_target, rewrap_args) = bypass_rewrap_handler_args(
+                graph,
+                exceptional,
+                &err_result,
+                &err_sources,
+                &err_inputs,
+                &site.result_err_owner,
+                &name,
+            )?;
+            close_goto_mixed(graph, err_block, rewrap_target, rewrap_args);
+        } else {
+            // An actual propagation edge carries a trace-level exception
+            // object, not the interpreter-specific carrier returned by the
+            // mapper.
+            let exc = crate::front::result_exc::materialize_error_to_exc_object(
+                graph, err_block, mapped, spec,
+            );
+            let last_exception = exceptional
+                .last_exception
+                .as_ref()
+                .and_then(LinkArg::as_variable)
+                .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exception"))?;
+            let last_exc_value = exceptional
+                .last_exc_value
+                .as_ref()
+                .and_then(LinkArg::as_variable)
+                .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exc_value"))?;
+            let args =
+                exceptional
+                    .args
+                    .iter()
+                    .map(|arg| -> Result<LinkArg, String> {
+                        Ok(match arg {
                     LinkArg::Value(value) if value == last_exception || value == last_exc_value => {
                         LinkArg::Value(exc.clone())
                     }
@@ -251,9 +280,10 @@ fn rewire_one(
                     ),
                     LinkArg::Const(value) => LinkArg::Const(value.clone()),
                 })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        close_goto_mixed(graph, err_block, exceptional.target, args);
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+            close_goto_mixed(graph, err_block, exceptional.target, args);
+        }
     } else {
         let err_result = emit_sum_variant(
             graph,
@@ -294,6 +324,93 @@ fn rewire_one(
     });
     graph.set_branch(a_id, disc, err_block, err_sources, ok_block, ok_sources);
     Ok(())
+}
+
+/// Bypass the local handler installed by `result_exc::catch_and_rewrap`.
+///
+/// That handler receives the original non-result live values followed by the
+/// exception pair, converts `last_exc_value` back into the error carrier, and
+/// builds the Err shell consumed by the untouched custom match.  A lowered
+/// `map_err` Err arm already owns the mapped carrier, so route a shell built
+/// from that exact value to the handler's successor and remap the other live
+/// values through this arm's inputargs.
+fn bypass_rewrap_handler_args(
+    graph: &FunctionGraph,
+    exceptional: &crate::model::Link,
+    err_result: &Variable,
+    err_sources: &[Variable],
+    err_inputs: &[Variable],
+    result_err_owner: &str,
+    name: &str,
+) -> Result<(crate::model::BlockId, Vec<LinkArg>), String> {
+    let handler = &graph.blocks[exceptional.target.0];
+    if handler.exitswitch.is_some() || handler.exits.len() != 1 {
+        return Err(format!(
+            "{name}: map_err rewrap handler is not a single plain forwarding block"
+        ));
+    }
+    let exit = &handler.exits[0];
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: map_err rewrap handler exit is not a plain goto"
+        ));
+    }
+    let shell = handler
+        .operations
+        .iter()
+        .find_map(|op| match &op.kind {
+            OpKind::Call { target, .. }
+                if crate::front::result_exc::result_ctor_kind(target) == Some(true)
+                    && op.result.as_ref().is_some_and(|result| {
+                        handler.operations.iter().any(|write| {
+                            matches!(
+                                &write.kind,
+                                OpKind::FieldWrite { base, field, .. }
+                                    if base == result
+                                        && field.name == "__pos_0"
+                                        && field.owner_root.as_deref() == Some(result_err_owner)
+                            )
+                        })
+                    }) =>
+            {
+                op.result.clone()
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: map_err rewrap handler lacks its Err shell"))?;
+    if exceptional.args.len() != handler.inputargs.len() {
+        return Err(format!(
+            "{name}: map_err rewrap handler input arity does not match its exceptional edge"
+        ));
+    }
+    let mut args = Vec::with_capacity(exit.args.len());
+    for arg in &exit.args {
+        match arg {
+            LinkArg::Const(value) => args.push(LinkArg::Const(value.clone())),
+            LinkArg::Value(value) if *value == shell => {
+                args.push(LinkArg::Value(err_result.clone()))
+            }
+            LinkArg::Value(value) => {
+                let pos = handler
+                    .inputargs
+                    .iter()
+                    .position(|input| input == value)
+                    .ok_or_else(|| {
+                        format!("{name}: map_err rewrap handler forwards an unknown value")
+                    })?;
+                let LinkArg::Value(source) = &exceptional.args[pos] else {
+                    return Err(format!(
+                        "{name}: map_err rewrap handler input is sourced from a constant"
+                    ));
+                };
+                let remapped = map_source(err_sources, err_inputs, source).ok_or_else(|| {
+                    format!("{name}: map_err rewrap handler carries an unthreaded value")
+                })?;
+                args.push(LinkArg::Value(remapped));
+            }
+        }
+    }
+    Ok((exit.target, args))
 }
 
 fn read_payload(
@@ -421,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn exception_lowered_map_err_materializes_and_keeps_the_catch_target() {
+    fn exception_lowered_map_err_bypasses_rewrap_without_carrier_round_trip() {
         let mut graph = FunctionGraph::new("map_err_catch_fixture");
         let entry = graph.startblock;
         let receiver = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
@@ -440,8 +557,29 @@ mod tests {
             .unwrap();
         let (normal, _) = graph.create_block_with_arg_vars(2);
         graph.set_return(normal, None);
-        let (catch, _) = graph.create_block_with_arg_vars(3);
-        graph.set_return(catch, None);
+        let (catch, catch_inputs) = graph.create_block_with_arg_vars(3);
+        let reconstructed = graph
+            .push_op_var(
+                catch,
+                OpKind::Call {
+                    target: CallTarget::method("from_exc_object", Some("Error".into())),
+                    args: vec![catch_inputs[2].clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let old_shell = crate::front::result_exc::build_shell(
+            &mut graph,
+            catch,
+            "Err",
+            reconstructed,
+            ValueType::Ref(None),
+            "<i64,Error>",
+        );
+        let (downstream, _) = graph.create_block_with_arg_vars(2);
+        graph.set_return(downstream, None);
+        graph.set_goto(catch, downstream, vec![catch_inputs[0].clone(), old_shell]);
         let etype = graph.alloc_value_var();
         let evalue = graph.alloc_value_var();
         let mut exceptional = crate::model::Link::new_mixed(
@@ -479,32 +617,114 @@ mod tests {
         };
         assert_eq!(rewire_result_map_err_sites(&mut graph, &[site], spec), 1);
 
-        let materializer_block = graph
+        let err_arm = graph
             .blocks
             .iter()
             .find(|block| {
                 block.operations.iter().any(|op| {
                     matches!(
                         &op.kind,
-                        OpKind::Call {
-                            target: CallTarget::FunctionPath { segments },
-                            ..
-                        } if segments == &["fixture".to_string(), "to_exc_object".to_string()]
+                        OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                            if name == "call_once"
                     )
                 })
             })
-            .expect("Err arm must materialize the mapped carrier");
-        assert_eq!(materializer_block.exits.len(), 1);
-        assert_eq!(materializer_block.exits[0].target, catch);
-        assert_ne!(materializer_block.exits[0].target, graph.exceptblock);
-        assert_eq!(materializer_block.exits[0].args.len(), 3);
-        let carried_alias = materializer_block.exits[0].args[0]
+            .expect("Err arm must call the mapper");
+        assert!(!err_arm.operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["fixture".to_string(), "to_exc_object".to_string()]
+            )
+        }));
+        assert_eq!(err_arm.exits.len(), 1);
+        assert_eq!(err_arm.exits[0].target, downstream);
+        assert_ne!(err_arm.exits[0].target, catch);
+        assert_eq!(err_arm.exits[0].args.len(), 2);
+        let carried_alias = err_arm.exits[0].args[0]
             .as_variable()
             .expect("carried value stays a Variable");
-        assert!(materializer_block.inputargs.contains(carried_alias));
-        assert_eq!(
-            materializer_block.exits[0].args[1],
-            materializer_block.exits[0].args[2]
+        assert!(err_arm.inputargs.contains(carried_alias));
+        assert!(err_arm.operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::FieldWrite { field, value: LinkArg::Value(_), .. }
+                    if field.owner_root.as_deref()
+                        == Some("core::result::Result<i64,Error>::Err")
+            )
+        }));
+    }
+
+    #[test]
+    fn exception_lowered_map_err_materializes_an_actual_propagation() {
+        let mut graph = FunctionGraph::new("map_err_propagate_fixture");
+        let entry = graph.startblock;
+        let receiver = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
+        let env = graph.push_op_var(entry, OpKind::ConstInt(2), true).unwrap();
+        let result = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::method("map_err", Some("Result".into())),
+                    args: vec![receiver, env],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (normal, _) = graph.create_block_with_arg_vars(1);
+        graph.set_return(normal, None);
+        let etype = graph.alloc_value_var();
+        let evalue = graph.alloc_value_var();
+        let mut exceptional = crate::model::Link::new_mixed(
+            vec![
+                LinkArg::Value(etype.clone()),
+                LinkArg::Value(evalue.clone()),
+            ],
+            graph.exceptblock,
+            Some(crate::model::exception_exitcase()),
         );
+        exceptional.last_exception = Some(LinkArg::Value(etype));
+        exceptional.last_exc_value = Some(LinkArg::Value(evalue));
+        graph.set_control_flow_metadata(
+            entry,
+            Some(crate::model::ExitSwitch::LastException),
+            vec![
+                crate::model::Link::new_mixed(vec![LinkArg::Value(result.clone())], normal, None),
+                exceptional,
+            ],
+        );
+
+        let mut site = fixture_site(result);
+        site.closure_env_is_trivially_dropless = true;
+        let spec = crate::ErrorCarrierSpec {
+            to_exc_object: Some(&["fixture", "to_exc_object"]),
+            ..crate::ErrorCarrierSpec::default()
+        };
+        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site], spec), 1);
+
+        let err_arm = graph
+            .blocks
+            .iter()
+            .find(|block| {
+                block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                            if name == "call_once"
+                    )
+                })
+            })
+            .expect("Err arm must call the mapper");
+        assert!(err_arm.operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["fixture".to_string(), "to_exc_object".to_string()]
+            )
+        }));
+        assert_eq!(err_arm.exits.len(), 1);
+        assert_eq!(err_arm.exits[0].target, graph.exceptblock);
+        assert_eq!(err_arm.exits[0].args[0], err_arm.exits[0].args[1]);
     }
 }

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -35,6 +35,10 @@ pub(crate) struct ResultMapErrSite {
     pub mapped_err_ty: ValueType,
     pub mapped_err_class_root: Option<String>,
     pub args_tuple_suffix: String,
+    /// True only when every captured field recursively needs no destructor.
+    /// Other closure environments stay on the fail-closed path until MIR Drop
+    /// lowering can preserve their conditional destruction on the Ok arm.
+    pub closure_env_is_trivially_dropless: bool,
 }
 
 pub(crate) fn rewire_result_map_err_sites(
@@ -49,6 +53,11 @@ pub(crate) fn rewire_result_map_err_sites(
 
 fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), String> {
     let name = graph.name.clone();
+    if !site.closure_env_is_trivially_dropless {
+        return Err(format!(
+            "{name}: Result::map_err closure captures values whose Ok-arm destruction is not lowered"
+        ));
+    }
     let a = graph
         .blocks
         .iter()
@@ -77,19 +86,42 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
         } if name == "map_err" && args.len() == 2 => (args[0].clone(), args[1].clone()),
         other => return Err(format!("{name}: recorded map_err site changed: {other:?}")),
     };
-    let [exit] = graph.blocks[a].exits.as_slice() else {
-        return Err(format!("{name}: Result::map_err block has multiple exits"));
+    // When the mapped Result is consumed by `?`, result_exc runs first and
+    // changes this call block to LastException exits.  The map_err rewrite
+    // then completes that same decision: receiver Ok forwards its payload to
+    // the normal edge, receiver Err calls the mapper and raises the mapped
+    // value.  A plain map_err consumer keeps the value-encoded Result arms.
+    let exception_lowered = matches!(
+        graph.blocks[a].exitswitch,
+        Some(crate::model::ExitSwitch::LastException)
+    );
+    let saved_exit = if exception_lowered {
+        if graph.blocks[a].exits.len() != 2 {
+            return Err(format!(
+                "{name}: Result::map_err LastException block does not have two exits"
+            ));
+        }
+        graph.blocks[a]
+            .exits
+            .iter()
+            .find(|exit| exit.exitcase.is_none())
+            .cloned()
+            .ok_or_else(|| format!("{name}: Result::map_err has no normal exception edge"))?
+    } else {
+        let [exit] = graph.blocks[a].exits.as_slice() else {
+            return Err(format!("{name}: Result::map_err block has multiple exits"));
+        };
+        if graph.blocks[a].exitswitch.is_some()
+            || exit.exitcase.is_some()
+            || exit.last_exception.is_some()
+            || exit.last_exc_value.is_some()
+        {
+            return Err(format!(
+                "{name}: Result::map_err block exit is not a plain goto"
+            ));
+        }
+        exit.clone()
     };
-    if graph.blocks[a].exitswitch.is_some()
-        || exit.exitcase.is_some()
-        || exit.last_exception.is_some()
-        || exit.last_exc_value.is_some()
-    {
-        return Err(format!(
-            "{name}: Result::map_err block exit is not a plain goto"
-        ));
-    }
-    let saved_exit = exit.clone();
     let target = saved_exit.target;
     let mut carried = Vec::new();
     for arg in &saved_exit.args {
@@ -122,14 +154,18 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
         site.ok_ty.clone(),
     );
     let ok_payload = emit_narrow(graph, ok_block, ok_payload, &site.ok_class_root);
-    let ok_result = emit_sum_variant(
-        graph,
-        ok_block,
-        &site.result_owner,
-        "Ok",
-        0,
-        Some((&site.result_ok_owner, ok_payload, site.ok_ty.clone())),
-    );
+    let ok_result = if exception_lowered {
+        ok_payload
+    } else {
+        emit_sum_variant(
+            graph,
+            ok_block,
+            &site.result_owner,
+            "Ok",
+            0,
+            Some((&site.result_ok_owner, ok_payload, site.ok_ty.clone())),
+        )
+    };
     let ok_args = reproduce_exit_args(
         &saved_exit,
         &site.result_var,
@@ -166,23 +202,27 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
         &site.args_tuple_suffix,
     );
     let mapped = emit_narrow(graph, err_block, mapped, &site.mapped_err_class_root);
-    let err_result = emit_sum_variant(
-        graph,
-        err_block,
-        &site.result_owner,
-        "Err",
-        1,
-        Some((&site.result_err_owner, mapped, site.mapped_err_ty.clone())),
-    );
-    let err_args = reproduce_exit_args(
-        &saved_exit,
-        &site.result_var,
-        &err_result,
-        &err_sources,
-        &err_inputs,
-        &name,
-    )?;
-    close_goto_mixed(graph, err_block, target, err_args);
+    if exception_lowered {
+        graph.set_raise_values(err_block, mapped.clone(), mapped);
+    } else {
+        let err_result = emit_sum_variant(
+            graph,
+            err_block,
+            &site.result_owner,
+            "Err",
+            1,
+            Some((&site.result_err_owner, mapped, site.mapped_err_ty.clone())),
+        );
+        let err_args = reproduce_exit_args(
+            &saved_exit,
+            &site.result_var,
+            &err_result,
+            &err_sources,
+            &err_inputs,
+            &name,
+        )?;
+        close_goto_mixed(graph, err_block, target, err_args);
+    }
 
     let a_id = graph.blocks[a].id;
     graph.blocks[a].operations.truncate(call_idx);
@@ -257,7 +297,7 @@ mod tests {
         graph.set_return(join, None);
         graph.set_goto(entry, join, vec![result.clone()]);
 
-        let site = ResultMapErrSite {
+        let mut site = ResultMapErrSite {
             result_var: result,
             receiver_owner: "core::result::Result<i64,str>".into(),
             receiver_ok_owner: "core::result::Result<i64,str>::Ok".into(),
@@ -273,7 +313,18 @@ mod tests {
             mapped_err_ty: ValueType::Ref(Some("Error".into())),
             mapped_err_class_root: Some("Error".into()),
             args_tuple_suffix: "<str>".into(),
+            closure_env_is_trivially_dropless: false,
         };
+        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site.clone()]), 0);
+        assert!(graph.blocks[entry.0].operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                    if name == "map_err"
+            )
+        }));
+
+        site.closure_env_is_trivially_dropless = true;
         assert_eq!(rewire_result_map_err_sites(&mut graph, &[site]), 1);
 
         let calls: Vec<&CallTarget> = graph

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -1,0 +1,307 @@
+//! `Result::map_err(result, closure)` → discriminant closure-select.
+//!
+//! Rust's foreign `core::result` body is opaque in LLBC.  Leaving the method
+//! call residual is not executable for an embedded interpreter because there
+//! is no monomorphisation-independent host address for its closure type.  The
+//! equivalent RPython graph already has the ordinary two exception/value
+//! branches (`translator/exceptiontransform.py`); this adapter restores that
+//! shape before `result_exc` converts an exception-carrying result to native
+//! graph exception edges.
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{
+    close_goto_mixed, emit_sum_variant, map_source, reproduce_exit_args,
+};
+use crate::front::option_closure_select::emit_call_once;
+use crate::front::option_map_or::emit_narrow;
+use crate::model::{
+    CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+#[derive(Clone)]
+pub(crate) struct ResultMapErrSite {
+    pub result_var: Variable,
+    pub receiver_owner: String,
+    pub receiver_ok_owner: String,
+    pub receiver_err_owner: String,
+    pub result_owner: String,
+    pub result_ok_owner: String,
+    pub result_err_owner: String,
+    pub call_once_owner: String,
+    pub ok_ty: ValueType,
+    pub ok_class_root: Option<String>,
+    pub err_ty: ValueType,
+    pub err_class_root: Option<String>,
+    pub mapped_err_ty: ValueType,
+    pub mapped_err_class_root: Option<String>,
+    pub args_tuple_suffix: String,
+}
+
+pub(crate) fn rewire_result_map_err_sites(
+    graph: &mut FunctionGraph,
+    sites: &[ResultMapErrSite],
+) -> usize {
+    sites
+        .iter()
+        .filter(|site| rewire_one(graph, site).is_ok())
+        .count()
+}
+
+fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    let a = graph
+        .blocks
+        .iter()
+        .position(|block| {
+            block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: Result::map_err result has no producer block"))?;
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: Result::map_err producer vanished"))?;
+    if call_idx + 1 != graph.blocks[a].operations.len() {
+        return Err(format!(
+            "{name}: Result::map_err is not the block's last op"
+        ));
+    }
+    let (receiver, env) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } if name == "map_err" && args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => return Err(format!("{name}: recorded map_err site changed: {other:?}")),
+    };
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!("{name}: Result::map_err block has multiple exits"));
+    };
+    if graph.blocks[a].exitswitch.is_some()
+        || exit.exitcase.is_some()
+        || exit.last_exception.is_some()
+        || exit.last_exc_value.is_some()
+    {
+        return Err(format!(
+            "{name}: Result::map_err block exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let target = saved_exit.target;
+    let mut carried = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(value) = arg
+            && *value != site.result_var
+            && !carried.contains(value)
+        {
+            carried.push(value.clone());
+        }
+    }
+
+    let mut ok_sources = carried.clone();
+    if !ok_sources.contains(&receiver) {
+        ok_sources.push(receiver.clone());
+    }
+    let mut err_sources = ok_sources.clone();
+    if !err_sources.contains(&env) {
+        err_sources.push(env.clone());
+    }
+    let (ok_block, ok_inputs) = graph.create_block_with_arg_vars(ok_sources.len());
+    let (err_block, err_inputs) = graph.create_block_with_arg_vars(err_sources.len());
+
+    let receiver_ok = map_source(&ok_sources, &ok_inputs, &receiver)
+        .ok_or_else(|| format!("{name}: Result receiver not threaded into Ok arm"))?;
+    let ok_payload = read_payload(
+        graph,
+        ok_block,
+        receiver_ok,
+        &site.receiver_ok_owner,
+        site.ok_ty.clone(),
+    );
+    let ok_payload = emit_narrow(graph, ok_block, ok_payload, &site.ok_class_root);
+    let ok_result = emit_sum_variant(
+        graph,
+        ok_block,
+        &site.result_owner,
+        "Ok",
+        0,
+        Some((&site.result_ok_owner, ok_payload, site.ok_ty.clone())),
+    );
+    let ok_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &ok_result,
+        &ok_sources,
+        &ok_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, ok_block, target, ok_args);
+
+    let receiver_err = map_source(&err_sources, &err_inputs, &receiver)
+        .ok_or_else(|| format!("{name}: Result receiver not threaded into Err arm"))?;
+    let err_payload = read_payload(
+        graph,
+        err_block,
+        receiver_err,
+        &site.receiver_err_owner,
+        site.err_ty.clone(),
+    );
+    let err_payload = emit_narrow(graph, err_block, err_payload, &site.err_class_root);
+    let env_err = map_source(&err_sources, &err_inputs, &env)
+        .ok_or_else(|| format!("{name}: closure env not threaded into Err arm"))?;
+    let mapped = emit_call_once(
+        graph,
+        err_block,
+        env_err,
+        Some((
+            err_payload,
+            site.err_ty.clone(),
+            site.err_class_root.clone(),
+        )),
+        &site.call_once_owner,
+        site.mapped_err_ty.clone(),
+        &site.args_tuple_suffix,
+    );
+    let mapped = emit_narrow(graph, err_block, mapped, &site.mapped_err_class_root);
+    let err_result = emit_sum_variant(
+        graph,
+        err_block,
+        &site.result_owner,
+        "Err",
+        1,
+        Some((&site.result_err_owner, mapped, site.mapped_err_ty.clone())),
+    );
+    let err_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &err_result,
+        &err_sources,
+        &err_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, err_block, target, err_args);
+
+    let a_id = graph.blocks[a].id;
+    graph.blocks[a].operations.truncate(call_idx);
+    let disc = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(disc.clone()),
+        kind: OpKind::FieldRead {
+            base: receiver,
+            field: FieldDescriptor {
+                name: "__discriminant".to_string(),
+                owner_root: Some(site.receiver_owner.clone()),
+                owner_id: None,
+                base_is_deref: None,
+                taken_by_address: false,
+            },
+            ty: ValueType::Int,
+            pure: true,
+        },
+    });
+    graph.set_branch(a_id, disc, err_block, err_sources, ok_block, ok_sources);
+    Ok(())
+}
+
+fn read_payload(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    receiver: Variable,
+    owner: &str,
+    ty: ValueType,
+) -> Variable {
+    let payload = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(payload.clone()),
+        kind: OpKind::FieldRead {
+            base: receiver,
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some(owner.to_string()),
+                owner_id: None,
+                base_is_deref: None,
+                taken_by_address: false,
+            },
+            ty,
+            pure: true,
+        },
+    });
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_err_becomes_ok_passthrough_and_err_closure_arms() {
+        let mut graph = FunctionGraph::new("map_err_fixture");
+        let entry = graph.startblock;
+        let receiver = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
+        let env = graph.push_op_var(entry, OpKind::ConstInt(2), true).unwrap();
+        let result = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::method("map_err", Some("Result".into())),
+                    args: vec![receiver, env],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (join, _inputs) = graph.create_block_with_arg_vars(1);
+        graph.set_return(join, None);
+        graph.set_goto(entry, join, vec![result.clone()]);
+
+        let site = ResultMapErrSite {
+            result_var: result,
+            receiver_owner: "core::result::Result<i64,str>".into(),
+            receiver_ok_owner: "core::result::Result<i64,str>::Ok".into(),
+            receiver_err_owner: "core::result::Result<i64,str>::Err".into(),
+            result_owner: "core::result::Result<i64,Error>".into(),
+            result_ok_owner: "core::result::Result<i64,Error>::Ok".into(),
+            result_err_owner: "core::result::Result<i64,Error>::Err".into(),
+            call_once_owner: "fixture::closure".into(),
+            ok_ty: ValueType::Int,
+            ok_class_root: None,
+            err_ty: ValueType::Str,
+            err_class_root: None,
+            mapped_err_ty: ValueType::Ref(Some("Error".into())),
+            mapped_err_class_root: Some("Error".into()),
+            args_tuple_suffix: "<str>".into(),
+        };
+        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site]), 1);
+
+        let calls: Vec<&CallTarget> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call { target, .. } => Some(target),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !calls.iter().any(
+                |target| matches!(target, CallTarget::Method { name, .. } if name == "map_err")
+            )
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|target| matches!(target, CallTarget::Method { name, .. } if name == "call_once"))
+                .count(),
+            1,
+            "only the Err arm invokes the mapper"
+        );
+        for variant in ["Ok", "Err"] {
+            assert!(calls.iter().any(|target| {
+                matches!(target, CallTarget::SyntheticTransparentCtor { name, .. } if name == variant)
+            }));
+        }
+    }
+}

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -4,7 +4,8 @@
 //! call residual is not executable for an embedded interpreter because there
 //! is no monomorphisation-independent host address for its closure type.  The
 //! equivalent RPython graph already has the ordinary two exception/value
-//! branches (`translator/exceptiontransform.py`); this adapter restores that
+//! branches (`translator/exceptiontransform.py::ExceptionTransformer.transform_block`);
+//! this adapter restores that
 //! shape before `result_exc` converts an exception-carrying result to native
 //! graph exception edges.
 
@@ -152,6 +153,45 @@ fn rewire_one(
     let mut err_sources = ok_sources.clone();
     if !err_sources.contains(&env) {
         err_sources.push(env.clone());
+    }
+    // Validate the complete exception destination before adding any blocks.
+    // Like ExceptionTransformer.transform_block / insert_matching, a rejected
+    // transformation must leave the original exception graph intact. Identity
+    // inputs let the rewrap validator check the same mappings without issuing
+    // fresh SSA variables or populating orphan call_once operations.
+    if let Some(exceptional) = &saved_exception_exit {
+        let last_exception = exceptional
+            .last_exception
+            .as_ref()
+            .and_then(LinkArg::as_variable)
+            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exception"))?;
+        let last_exc_value = exceptional
+            .last_exc_value
+            .as_ref()
+            .and_then(LinkArg::as_variable)
+            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exc_value"))?;
+        for arg in &exceptional.args {
+            if let LinkArg::Value(value) = arg
+                && value != last_exception
+                && value != last_exc_value
+                && !err_sources.contains(value)
+            {
+                return Err(format!(
+                    "{name}: exceptional map_err edge carries an unthreaded value"
+                ));
+            }
+        }
+        if exceptional.target != graph.exceptblock {
+            bypass_rewrap_handler_args(
+                graph,
+                exceptional,
+                &site.result_var,
+                &err_sources,
+                &err_sources,
+                &site.result_err_owner,
+                &name,
+            )?;
+        }
     }
     let (ok_block, ok_inputs) = graph.create_block_with_arg_vars(ok_sources.len());
     let (err_block, err_inputs) = graph.create_block_with_arg_vars(err_sources.len());
@@ -442,6 +482,75 @@ fn read_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn malformed_exception_edges_leave_the_graph_unchanged() {
+        for defect in ["last_exception", "last_exc_value", "unthreaded", "rewrap"] {
+            let mut graph = FunctionGraph::new("map_err_invalid_exception");
+            let entry = graph.startblock;
+            let receiver = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
+            let env = graph.push_op_var(entry, OpKind::ConstInt(2), true).unwrap();
+            let result = graph
+                .push_op_var(
+                    entry,
+                    OpKind::Call {
+                        target: CallTarget::method("map_err", Some("Result".into())),
+                        args: vec![receiver, env],
+                        result_ty: ValueType::Ref(None),
+                    },
+                    true,
+                )
+                .unwrap();
+            let (normal, _) = graph.create_block_with_arg_vars(1);
+            graph.set_return(normal, None);
+            let etype = graph.alloc_value_var();
+            let evalue = graph.alloc_value_var();
+            let mut exceptional = crate::model::Link::new_mixed(
+                vec![
+                    LinkArg::Value(etype.clone()),
+                    LinkArg::Value(evalue.clone()),
+                ],
+                graph.exceptblock,
+                Some(crate::model::exception_exitcase()),
+            );
+            exceptional.last_exception = Some(LinkArg::Value(etype));
+            exceptional.last_exc_value = Some(LinkArg::Value(evalue));
+            match defect {
+                "last_exception" => exceptional.last_exception = None,
+                "last_exc_value" => exceptional.last_exc_value = None,
+                "unthreaded" => exceptional
+                    .args
+                    .push(LinkArg::Value(graph.alloc_value_var())),
+                "rewrap" => exceptional.target = normal,
+                _ => unreachable!(),
+            }
+            graph.set_control_flow_metadata(
+                entry,
+                Some(crate::model::ExitSwitch::LastException),
+                vec![
+                    crate::model::Link::new_mixed(
+                        vec![LinkArg::Value(result.clone())],
+                        normal,
+                        None,
+                    ),
+                    exceptional,
+                ],
+            );
+            let mut site = fixture_site(result);
+            site.closure_env_is_trivially_dropless = true;
+            let before = format!("{graph:?}");
+            assert_eq!(
+                rewire_result_map_err_sites(
+                    &mut graph,
+                    &[site],
+                    crate::ErrorCarrierSpec::default()
+                ),
+                0,
+                "{defect}"
+            );
+            assert_eq!(format!("{graph:?}"), before, "{defect} mutated the graph");
+        }
+    }
 
     fn fixture_site(result_var: Variable) -> ResultMapErrSite {
         ResultMapErrSite {

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -44,14 +44,19 @@ pub(crate) struct ResultMapErrSite {
 pub(crate) fn rewire_result_map_err_sites(
     graph: &mut FunctionGraph,
     sites: &[ResultMapErrSite],
+    spec: crate::ErrorCarrierSpec<'_>,
 ) -> usize {
     sites
         .iter()
-        .filter(|site| rewire_one(graph, site).is_ok())
+        .filter(|site| rewire_one(graph, site, spec).is_ok())
         .count()
 }
 
-fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), String> {
+fn rewire_one(
+    graph: &mut FunctionGraph,
+    site: &ResultMapErrSite,
+    spec: crate::ErrorCarrierSpec<'_>,
+) -> Result<(), String> {
     let name = graph.name.clone();
     if !site.closure_env_is_trivially_dropless {
         return Err(format!(
@@ -95,18 +100,25 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
         graph.blocks[a].exitswitch,
         Some(crate::model::ExitSwitch::LastException)
     );
-    let saved_exit = if exception_lowered {
+    let (saved_exit, saved_exception_exit) = if exception_lowered {
         if graph.blocks[a].exits.len() != 2 {
             return Err(format!(
                 "{name}: Result::map_err LastException block does not have two exits"
             ));
         }
-        graph.blocks[a]
+        let normal = graph.blocks[a]
             .exits
             .iter()
             .find(|exit| exit.exitcase.is_none())
             .cloned()
-            .ok_or_else(|| format!("{name}: Result::map_err has no normal exception edge"))?
+            .ok_or_else(|| format!("{name}: Result::map_err has no normal exception edge"))?;
+        let exceptional = graph.blocks[a]
+            .exits
+            .iter()
+            .find(|exit| exit.exitcase.is_some())
+            .cloned()
+            .ok_or_else(|| format!("{name}: Result::map_err has no exceptional edge"))?;
+        (normal, Some(exceptional))
     } else {
         let [exit] = graph.blocks[a].exits.as_slice() else {
             return Err(format!("{name}: Result::map_err block has multiple exits"));
@@ -120,7 +132,7 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
                 "{name}: Result::map_err block exit is not a plain goto"
             ));
         }
-        exit.clone()
+        (exit.clone(), None)
     };
     let target = saved_exit.target;
     let mut carried = Vec::new();
@@ -203,7 +215,45 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultMapErrSite) -> Result<(), 
     );
     let mapped = emit_narrow(graph, err_block, mapped, &site.mapped_err_class_root);
     if exception_lowered {
-        graph.set_raise_values(err_block, mapped.clone(), mapped);
+        // result_exc has already made the map_err call a can-raise site. Keep
+        // that exact exceptional destination: a `?` site targets exceptblock,
+        // while catch_and_rewrap targets its local Err-shell rebuilding arm.
+        // In both cases the edge carries a trace-level exception object, not
+        // the interpreter-specific error carrier returned by the mapper.
+        let exc = crate::front::result_exc::materialize_error_to_exc_object(
+            graph, err_block, mapped, spec,
+        );
+        let exceptional = saved_exception_exit
+            .as_ref()
+            .expect("LastException form captured its exceptional edge");
+        let last_exception = exceptional
+            .last_exception
+            .as_ref()
+            .and_then(LinkArg::as_variable)
+            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exception"))?;
+        let last_exc_value = exceptional
+            .last_exc_value
+            .as_ref()
+            .and_then(LinkArg::as_variable)
+            .ok_or_else(|| format!("{name}: exceptional map_err edge lacks last_exc_value"))?;
+        let args = exceptional
+            .args
+            .iter()
+            .map(|arg| -> Result<LinkArg, String> {
+                Ok(match arg {
+                    LinkArg::Value(value) if value == last_exception || value == last_exc_value => {
+                        LinkArg::Value(exc.clone())
+                    }
+                    LinkArg::Value(value) => LinkArg::Value(
+                        map_source(&err_sources, &err_inputs, value).ok_or_else(|| {
+                            format!("{name}: exceptional map_err edge carries an unthreaded value")
+                        })?,
+                    ),
+                    LinkArg::Const(value) => LinkArg::Const(value.clone()),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        close_goto_mixed(graph, err_block, exceptional.target, args);
     } else {
         let err_result = emit_sum_variant(
             graph,
@@ -276,6 +326,27 @@ fn read_payload(
 mod tests {
     use super::*;
 
+    fn fixture_site(result_var: Variable) -> ResultMapErrSite {
+        ResultMapErrSite {
+            result_var,
+            receiver_owner: "core::result::Result<i64,str>".into(),
+            receiver_ok_owner: "core::result::Result<i64,str>::Ok".into(),
+            receiver_err_owner: "core::result::Result<i64,str>::Err".into(),
+            result_owner: "core::result::Result<i64,Error>".into(),
+            result_ok_owner: "core::result::Result<i64,Error>::Ok".into(),
+            result_err_owner: "core::result::Result<i64,Error>::Err".into(),
+            call_once_owner: "fixture::closure".into(),
+            ok_ty: ValueType::Int,
+            ok_class_root: None,
+            err_ty: ValueType::Str,
+            err_class_root: None,
+            mapped_err_ty: ValueType::Ref(Some("Error".into())),
+            mapped_err_class_root: Some("Error".into()),
+            args_tuple_suffix: "<str>".into(),
+            closure_env_is_trivially_dropless: false,
+        }
+    }
+
     #[test]
     fn map_err_becomes_ok_passthrough_and_err_closure_arms() {
         let mut graph = FunctionGraph::new("map_err_fixture");
@@ -297,25 +368,15 @@ mod tests {
         graph.set_return(join, None);
         graph.set_goto(entry, join, vec![result.clone()]);
 
-        let mut site = ResultMapErrSite {
-            result_var: result,
-            receiver_owner: "core::result::Result<i64,str>".into(),
-            receiver_ok_owner: "core::result::Result<i64,str>::Ok".into(),
-            receiver_err_owner: "core::result::Result<i64,str>::Err".into(),
-            result_owner: "core::result::Result<i64,Error>".into(),
-            result_ok_owner: "core::result::Result<i64,Error>::Ok".into(),
-            result_err_owner: "core::result::Result<i64,Error>::Err".into(),
-            call_once_owner: "fixture::closure".into(),
-            ok_ty: ValueType::Int,
-            ok_class_root: None,
-            err_ty: ValueType::Str,
-            err_class_root: None,
-            mapped_err_ty: ValueType::Ref(Some("Error".into())),
-            mapped_err_class_root: Some("Error".into()),
-            args_tuple_suffix: "<str>".into(),
-            closure_env_is_trivially_dropless: false,
-        };
-        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site.clone()]), 0);
+        let mut site = fixture_site(result);
+        assert_eq!(
+            rewire_result_map_err_sites(
+                &mut graph,
+                &[site.clone()],
+                crate::ErrorCarrierSpec::default()
+            ),
+            0
+        );
         assert!(graph.blocks[entry.0].operations.iter().any(|op| {
             matches!(
                 &op.kind,
@@ -325,7 +386,10 @@ mod tests {
         }));
 
         site.closure_env_is_trivially_dropless = true;
-        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site]), 1);
+        assert_eq!(
+            rewire_result_map_err_sites(&mut graph, &[site], crate::ErrorCarrierSpec::default()),
+            1
+        );
 
         let calls: Vec<&CallTarget> = graph
             .blocks
@@ -354,5 +418,93 @@ mod tests {
                 matches!(target, CallTarget::SyntheticTransparentCtor { name, .. } if name == variant)
             }));
         }
+    }
+
+    #[test]
+    fn exception_lowered_map_err_materializes_and_keeps_the_catch_target() {
+        let mut graph = FunctionGraph::new("map_err_catch_fixture");
+        let entry = graph.startblock;
+        let receiver = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
+        let env = graph.push_op_var(entry, OpKind::ConstInt(2), true).unwrap();
+        let carried = graph.push_op_var(entry, OpKind::ConstInt(3), true).unwrap();
+        let result = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::method("map_err", Some("Result".into())),
+                    args: vec![receiver, env],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (normal, _) = graph.create_block_with_arg_vars(2);
+        graph.set_return(normal, None);
+        let (catch, _) = graph.create_block_with_arg_vars(3);
+        graph.set_return(catch, None);
+        let etype = graph.alloc_value_var();
+        let evalue = graph.alloc_value_var();
+        let mut exceptional = crate::model::Link::new_mixed(
+            vec![
+                LinkArg::Value(carried.clone()),
+                LinkArg::Value(etype.clone()),
+                LinkArg::Value(evalue.clone()),
+            ],
+            catch,
+            Some(crate::model::exception_exitcase()),
+        );
+        exceptional.last_exception = Some(LinkArg::Value(etype));
+        exceptional.last_exc_value = Some(LinkArg::Value(evalue));
+        graph.set_control_flow_metadata(
+            entry,
+            Some(crate::model::ExitSwitch::LastException),
+            vec![
+                crate::model::Link::new_mixed(
+                    vec![
+                        LinkArg::Value(result.clone()),
+                        LinkArg::Value(carried.clone()),
+                    ],
+                    normal,
+                    None,
+                ),
+                exceptional,
+            ],
+        );
+
+        let mut site = fixture_site(result);
+        site.closure_env_is_trivially_dropless = true;
+        let spec = crate::ErrorCarrierSpec {
+            to_exc_object: Some(&["fixture", "to_exc_object"]),
+            ..crate::ErrorCarrierSpec::default()
+        };
+        assert_eq!(rewire_result_map_err_sites(&mut graph, &[site], spec), 1);
+
+        let materializer_block = graph
+            .blocks
+            .iter()
+            .find(|block| {
+                block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments == &["fixture".to_string(), "to_exc_object".to_string()]
+                    )
+                })
+            })
+            .expect("Err arm must materialize the mapped carrier");
+        assert_eq!(materializer_block.exits.len(), 1);
+        assert_eq!(materializer_block.exits[0].target, catch);
+        assert_ne!(materializer_block.exits[0].target, graph.exceptblock);
+        assert_eq!(materializer_block.exits[0].args.len(), 3);
+        let carried_alias = materializer_block.exits[0].args[0]
+            .as_variable()
+            .expect("carried value stays a Variable");
+        assert!(materializer_block.inputargs.contains(carried_alias));
+        assert_eq!(
+            materializer_block.exits[0].args[1],
+            materializer_block.exits[0].args[2]
+        );
     }
 }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -461,6 +461,7 @@ pub(crate) fn remap_op_kind(
         },
         OpKind::ConstUInt(v) => OpKind::ConstUInt(*v),
         OpKind::ConstInt128(v) => OpKind::ConstInt128(*v),
+        OpKind::ConstSingleFloat(v) => OpKind::ConstSingleFloat(*v),
         OpKind::ConstUInt128(v) => OpKind::ConstUInt128(*v),
         OpKind::ConstBool(v) => OpKind::ConstBool(*v),
         OpKind::ConstSymbolic { tag, ty } => OpKind::ConstSymbolic {
@@ -954,6 +955,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         | OpKind::ConstInt(_)
         | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
+        | OpKind::ConstSingleFloat(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
@@ -1232,6 +1234,7 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::ConstInt(_)
         | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
+        | OpKind::ConstSingleFloat(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)
         // `_we_are_jitted` symbolic const — a pure `Constant`, removable

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -32,13 +32,6 @@ pub enum ValueType {
     /// `rbuiltin.py:178-189` / `rbuiltin.py:220-225` /
     /// `rarithmetic.py:600`.
     Unsigned,
-    /// RPython `r_longlonglong` / `lltype.SignedLongLongLong`.
-    ///
-    /// This is a translation-level 128-bit primitive used by
-    /// `rbigint` when `SHIFT == 63`. It deliberately remains distinct
-    /// from the word-sized `Int`: PyPy's source translator and rtyper
-    /// preserve it, while `history.getkind` rejects it at the JIT
-    /// codewriter boundary because it occupies 16 bytes.
     /// RPython `lltype.SingleFloat` — `rffi.r_singlefloat`, a Rust `f32`.
     ///
     /// Distinct from both [`ValueType::Int`] and [`ValueType::Float`].
@@ -54,6 +47,13 @@ pub enum ValueType {
     /// native `f32` arithmetic lower to an integer operation over the
     /// float's bit pattern.
     SingleFloat,
+    /// RPython `r_longlonglong` / `lltype.SignedLongLongLong`.
+    ///
+    /// This is a translation-level 128-bit primitive used by
+    /// `rbigint` when `SHIFT == 63`. It deliberately remains distinct
+    /// from the word-sized `Int`: PyPy's source translator and rtyper
+    /// preserve it, while `history.getkind` rejects it at the JIT
+    /// codewriter boundary because it occupies 16 bytes.
     Int128,
     /// RPython `r_ulonglonglong` / `lltype.UnsignedLongLongLong`.
     UInt128,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -39,6 +39,21 @@ pub enum ValueType {
     /// from the word-sized `Int`: PyPy's source translator and rtyper
     /// preserve it, while `history.getkind` rejects it at the JIT
     /// codewriter boundary because it occupies 16 bytes.
+    /// RPython `lltype.SingleFloat` — `rffi.r_singlefloat`, a Rust `f32`.
+    ///
+    /// Distinct from both [`ValueType::Int`] and [`ValueType::Float`].
+    /// `history.getkind` banks it as `'int'` ("singlefloats are stored in
+    /// an int") but only when the CPU supports singlefloats; the base
+    /// backend does not (`backend/model.py:20`), and RPython gives it no
+    /// arithmetic at all — `rffi` converts through `cast_singlefloat_to_float`
+    /// before computing and back afterwards, so the rtyper never emits a
+    /// float-kind operation over a SingleFloat operand.
+    ///
+    /// It is spelled here so the codewriter policy can refuse a graph that
+    /// carries one, rather than collapsing into `Int` and letting Rust's
+    /// native `f32` arithmetic lower to an integer operation over the
+    /// float's bit pattern.
+    SingleFloat,
     Int128,
     /// RPython `r_ulonglonglong` / `lltype.UnsignedLongLongLong`.
     UInt128,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -787,6 +787,19 @@ pub enum OpKind {
     /// existing `constants_f` pool with a `float_copy` op, mirroring
     /// the `ConstInt` → `int_copy` lowering.
     ConstFloat(u64),
+    /// RPython `flowmodel.py:Constant(value)` whose `concretetype` is
+    /// `lltype.SingleFloat` — a Rust `f32` literal.  Stored as the f32
+    /// bit pattern, which is what distinguishes it from [`OpKind::ConstFloat`]:
+    /// a Charon float constant records its width (`{"Float": {"value":
+    /// "...", "ty": "F32"}}`), and parsing both widths into an f64 bit
+    /// pattern is what erased it.
+    ///
+    /// It carries no [`ValueType`] field, for the same reason
+    /// [`OpKind::ConstInt128`] carries none: the width is in the variant
+    /// name.  The codewriter policy reaches it the way `policy.py:96-98`
+    /// reaches upstream's `Constant(value, SingleFloat)` through
+    /// `op.args`, and refuses the graph.
+    ConstSingleFloat(u32),
     /// RPython `flowmodel.py:Constant(str_value)` after
     /// `StringRepr.convert_const` resolves the host string to a
     /// prebuilt `Ptr(STR)`. The pre-jtransform string-constant fold

--- a/majit/majit-translate/src/test_support.rs
+++ b/majit/majit-translate/src/test_support.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashMap;
 
+static STRUCT_REGISTRY_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
 /// Publish `table` into the process-global name → `StructId` map and hold
 /// every other registering test out until the returned guard drops.
 ///
@@ -39,8 +41,20 @@ use std::collections::HashMap;
 pub(crate) fn register_struct_ids_serialized(
     table: HashMap<String, Option<majit_ir::descr::StructId>>,
 ) -> parking_lot::MutexGuard<'static, ()> {
-    static LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
-    let guard = LOCK.lock();
+    let guard = STRUCT_REGISTRY_TEST_LOCK.lock();
     majit_ir::descr::register_struct_ids(table);
+    guard
+}
+
+/// Publish an origin table while excluding tests that replace either global
+/// struct-name registry. Production publishes both together for one program;
+/// tests must likewise prevent one table from changing under another test's
+/// descriptor construction.
+#[must_use = "the returned guard holds the registry lock for the rest of the test"]
+pub(crate) fn register_struct_origins_serialized(
+    table: HashMap<String, String>,
+) -> parking_lot::MutexGuard<'static, ()> {
+    let guard = STRUCT_REGISTRY_TEST_LOCK.lock();
+    majit_ir::descr::register_struct_origins(table);
     guard
 }

--- a/majit/majit-translate/src/test_support.rs
+++ b/majit/majit-translate/src/test_support.rs
@@ -38,6 +38,9 @@ static STRUCT_REGISTRY_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::n
 /// remove — while still compiling, and still passing in isolation.
 #[must_use = "the returned guard holds the registry lock for the rest of \
               the test; dropping it immediately re-opens the race"]
+/// Do not hold this guard while calling another registrar: the lock is not
+/// reentrant. A test that must publish both tables should use
+/// [`register_struct_registries_serialized`].
 pub(crate) fn register_struct_ids_serialized(
     table: HashMap<String, Option<majit_ir::descr::StructId>>,
 ) -> parking_lot::MutexGuard<'static, ()> {
@@ -56,5 +59,19 @@ pub(crate) fn register_struct_origins_serialized(
 ) -> parking_lot::MutexGuard<'static, ()> {
     let guard = STRUCT_REGISTRY_TEST_LOCK.lock();
     majit_ir::descr::register_struct_origins(table);
+    guard
+}
+
+/// Publish both global struct-name registries under one acquisition of their
+/// non-reentrant test lock. A test that needs both tables must use this helper
+/// instead of retaining one single-table guard while requesting the other.
+#[must_use = "the returned guard holds the registry lock for the rest of the test"]
+pub(crate) fn register_struct_registries_serialized(
+    ids: HashMap<String, Option<majit_ir::descr::StructId>>,
+    origins: HashMap<String, String>,
+) -> parking_lot::MutexGuard<'static, ()> {
+    let guard = STRUCT_REGISTRY_TEST_LOCK.lock();
+    majit_ir::descr::register_struct_ids(ids);
+    majit_ir::descr::register_struct_origins(origins);
     guard
 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2661,6 +2661,7 @@ fn valuetype_to_lltype(vt: &crate::model::ValueType) -> Option<LowLevelType> {
         ValueType::UInt128 => LowLevelType::UnsignedLongLongLong,
         ValueType::Bool => LowLevelType::Bool,
         ValueType::Float => LowLevelType::Float,
+        ValueType::SingleFloat => LowLevelType::SingleFloat,
         ValueType::Str => crate::translator::rtyper::lltypesystem::rstr::STRPTR.clone(),
         ValueType::StringBuilder => {
             crate::translator::rtyper::lltypesystem::rbuilder::STRINGBUILDERPTR.clone()

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -267,6 +267,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         OpKind::ConstInt(_) => ValueType::Int,
         OpKind::ConstUInt(_) => ValueType::Unsigned,
         OpKind::ConstInt128(_) => ValueType::Int128,
+        OpKind::ConstSingleFloat(_) => ValueType::SingleFloat,
         OpKind::ConstUInt128(_) => ValueType::UInt128,
         OpKind::ConstBool(_) => ValueType::Bool,
         // `_we_are_jitted` symbolic carries its own concretetype

--- a/pyre/pyre-object/src/rordereddict.rs
+++ b/pyre/pyre-object/src/rordereddict.rs
@@ -403,6 +403,30 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
         }
     }
 
+    /// Whether the index table already names `slot`, walking the same probe
+    /// `delete_by_entry_index` uses. A collection that rebuilt the table
+    /// during `entries.push` will have placed the new slot already.
+    fn slot_is_indexed(&self, hash: u64, slot: usize) -> bool {
+        if self.indexes.is_empty() {
+            return false;
+        }
+        let mask = self.indexes.len() - 1;
+        let target = slot as u32 + VALID_OFFSET;
+        let mut i = (hash as usize) & mask;
+        let mut perturb = hash;
+        for _ in 0..=self.indexes.len() {
+            if self.indexes[i] == target {
+                return true;
+            }
+            if self.indexes[i] == FREE {
+                return false;
+            }
+            i = Self::probe_next(i, perturb, mask);
+            perturb >>= PERTURB_SHIFT;
+        }
+        false
+    }
+
     /// `ll_dict_store_clean` (rordereddict.py:1128) — probe for a [`FREE`]
     /// slot only, valid when no key can already be present.
     fn insert_clean(&mut self, hash: u64, slot: u32) {
@@ -565,30 +589,34 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
             reindexed = true;
             rc = self.resize_counter - 3;
         }
-        // A reindex rebuilt the whole table, so the probe's slot names nothing.
-        match index_slot.filter(|_| !reindexed) {
-            Some(index_slot) => self.indexes[index_slot] = self.next_slot() + VALID_OFFSET,
-            None => {
-                let slot = self.next_slot();
-                self.insert_clean(hash, slot);
-            }
-        }
+        // Upstream writes the index first because `d.entries` is a
+        // preallocated array (`_ll_dict_setitem_lookup_done`); the slot
+        // already exists, so the index cannot dangle. This port grows
+        // `entries` with `Vec::push`, which allocates. Writing the index
+        // before that push leaves a name for a slot that is not there yet
+        // (`_ll_dict_rescue` exists for exactly that window). Push first,
+        // then name the slot that now exists. If a collection rebuilt the
+        // table during the push, the rebuilt index already names it.
+        let slot = self.next_slot();
         self.resize_counter = rc;
-        // `ll_dict_grow` replaces `d.entries` outright when the array is full,
-        // so a growth here is the same event `entries != d.entries` reports.
-        //
-        // !! Read the *capacity*, not the data pointer: a `Vec` growth goes
-        // through `realloc`, and an allocator that extends the block in place
-        // hands back the address it already had — measured, this passed on
-        // dynasm and cranelift and left wasm answering a mutating `__eq__`
-        // without its restart.  Capacity changes on every growth whatever the
-        // allocator does.
         let entries_capacity = self.entries.capacity();
         self.entries.push(Some(Entry { hash, key, value }));
         if self.entries.capacity() != entries_capacity {
             self.generation = self.generation.wrapping_add(1);
         }
         self.num_live_items += 1;
+        if !self.slot_is_indexed(hash, slot as usize) {
+            match index_slot.filter(|_| !reindexed) {
+                Some(index_slot)
+                    if index_slot < self.indexes.len()
+                        && (self.indexes[index_slot] == FREE
+                            || self.indexes[index_slot] == DELETED) =>
+                {
+                    self.indexes[index_slot] = slot + VALID_OFFSET;
+                }
+                _ => self.insert_clean(hash, slot),
+            }
+        }
     }
 
     /// `ll_call_delete_by_entry_index` (rordereddict.py:1157) — re-probe from
@@ -931,6 +959,24 @@ mod tests {
         check_invariants(&d);
         let got: Vec<u64> = d.keys().copied().collect();
         assert_eq!(got, (0..100).filter(|i| i % 2 == 1).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn insert_after_reindex_still_names_the_new_slot() {
+        let mut d: RDict<u64, u64> = RDict::new();
+        for i in 0..32 {
+            d.insert(i, i);
+        }
+        for i in 0..24 {
+            d.remove(&i);
+        }
+        for i in 100..116 {
+            d.insert(i, i);
+        }
+        check_invariants(&d);
+        assert_eq!(d.get(&115), Some(&115));
+        assert_eq!(d.remove(&115), Some(115));
+        check_invariants(&d);
     }
 
     #[test]

--- a/pyre/pyre-object/src/rordereddict.rs
+++ b/pyre/pyre-object/src/rordereddict.rs
@@ -403,42 +403,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
         }
     }
 
-    /// Whether the index table already names `slot`, walking the same probe
-    /// `delete_by_entry_index` uses. A collection that rebuilt the table
-    /// during `entries.push` will have placed the new slot already.
-    fn slot_is_indexed(&self, hash: u64, slot: usize) -> bool {
-        if self.indexes.is_empty() {
-            return false;
-        }
-        let mask = self.indexes.len() - 1;
-        let target = slot as u32 + VALID_OFFSET;
-        let mut i = (hash as usize) & mask;
-        let mut perturb = hash;
-        for _ in 0..=self.indexes.len() {
-            if self.indexes[i] == target {
-                return true;
-            }
-            if self.indexes[i] == FREE {
-                return false;
-            }
-            i = Self::probe_next(i, perturb, mask);
-            perturb >>= PERTURB_SHIFT;
-        }
-        false
-    }
-
     /// `ll_dict_store_clean` (rordereddict.py:1128) — probe for a [`FREE`]
     /// slot only, valid when no key can already be present.
     fn insert_clean(&mut self, hash: u64, slot: u32) {
         let mask = self.indexes.len() - 1;
         let mut i = (hash as usize) & mask;
         let mut perturb = hash;
-        let mut probes = 0;
         while self.indexes[i] != FREE {
             i = Self::probe_next(i, perturb, mask);
             perturb >>= PERTURB_SHIFT;
-            probes += 1;
-            debug_assert!(probes <= self.indexes.len(), "no FREE slot to insert into");
         }
         self.indexes[i] = slot + VALID_OFFSET;
     }
@@ -577,11 +550,16 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
         // `if len(d.entries) == d.num_ever_used_items: ll_dict_grow(d)` — the
         // entries array is full, and `ll_dict_grow` (755) compacts instead of
         // growing when over half of it is dead.
-        if self.entries.len() == self.entries.capacity()
-            && self.num_live_items < self.entries.len() / 2
-        {
-            self.remove_deleted_items();
-            reindexed = true;
+        if self.entries.len() == self.entries.capacity() {
+            if self.num_live_items < self.entries.len() / 2 {
+                self.remove_deleted_items();
+                reindexed = true;
+            } else {
+                // `ll_dict_grow` prepares the entries array before the index
+                // is published. Reserve here so the final push cannot allocate.
+                self.entries.reserve(1);
+                self.generation = self.generation.wrapping_add(1);
+            }
         }
         let mut rc = self.resize_counter - 3;
         if rc <= 0 {
@@ -589,34 +567,19 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
             reindexed = true;
             rc = self.resize_counter - 3;
         }
-        // Upstream writes the index first because `d.entries` is a
-        // preallocated array (`_ll_dict_setitem_lookup_done`); the slot
-        // already exists, so the index cannot dangle. This port grows
-        // `entries` with `Vec::push`, which allocates. Writing the index
-        // before that push leaves a name for a slot that is not there yet
-        // (`_ll_dict_rescue` exists for exactly that window). Push first,
-        // then name the slot that now exists. If a collection rebuilt the
-        // table during the push, the rebuilt index already names it.
-        let slot = self.next_slot();
-        self.resize_counter = rc;
-        let entries_capacity = self.entries.capacity();
-        self.entries.push(Some(Entry { hash, key, value }));
-        if self.entries.capacity() != entries_capacity {
-            self.generation = self.generation.wrapping_add(1);
-        }
-        self.num_live_items += 1;
-        if !self.slot_is_indexed(hash, slot as usize) {
-            match index_slot.filter(|_| !reindexed) {
-                Some(index_slot)
-                    if index_slot < self.indexes.len()
-                        && (self.indexes[index_slot] == FREE
-                            || self.indexes[index_slot] == DELETED) =>
-                {
-                    self.indexes[index_slot] = slot + VALID_OFFSET;
-                }
-                _ => self.insert_clean(hash, slot),
+        // `_ll_dict_setitem_lookup_done`: after growth/resize, publish the
+        // index and then initialize the preallocated entry, with no allocation
+        // between them. Only a reindex invalidates the original probe's slot.
+        match index_slot.filter(|_| !reindexed) {
+            Some(index_slot) => self.indexes[index_slot] = self.next_slot() + VALID_OFFSET,
+            None => {
+                let slot = self.next_slot();
+                self.insert_clean(hash, slot);
             }
         }
+        self.resize_counter = rc;
+        self.entries.push(Some(Entry { hash, key, value }));
+        self.num_live_items += 1;
     }
 
     /// `ll_call_delete_by_entry_index` (rordereddict.py:1157) — re-probe from
@@ -626,15 +589,13 @@ impl<K: Hash + Eq, V, S: BuildHasher> RDict<K, V, S> {
         let target = slot as u32 + VALID_OFFSET;
         let mut i = (hash as usize) & mask;
         let mut perturb = hash;
-        let mut probes = 0;
         while self.indexes[i] != target {
+            // `ll_dict_delete_by_entry_index` checks for FREE, not a probe
+            // count: the perturb prefix may revisit slots before becoming a
+            // full-period walk, so a valid search can exceed indexes.len().
+            debug_assert_ne!(self.indexes[i], FREE, "no index slot names entry {slot}");
             i = Self::probe_next(i, perturb, mask);
             perturb >>= PERTURB_SHIFT;
-            probes += 1;
-            debug_assert!(
-                probes <= self.indexes.len(),
-                "no index slot names entry {slot}"
-            );
         }
         self.indexes[i] = DELETED;
     }
@@ -845,6 +806,33 @@ impl<K, V, S> IntoIterator for RDict<K, V, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn perturb_probes_can_revisit_slots_before_covering_the_table() {
+        #[derive(Default)]
+        struct CollisionHasher;
+        impl Hasher for CollisionHasher {
+            fn finish(&self) -> u64 {
+                0x3a18_dd5a_e3c4_5eb9
+            }
+            fn write(&mut self, _: &[u8]) {}
+        }
+        let mut d: RDict<u64, u64, std::hash::BuildHasherDefault<CollisionHasher>> = RDict::new();
+        for key in 0..10 {
+            d.insert(key, key);
+        }
+        assert_eq!(d.indexes.len(), 16);
+        check_invariants(&d);
+        // The tenth distinct slot is reached after 20 probes, despite the
+        // index table having only 16 slots. The perturb prefix revisits slots.
+        assert_eq!(d.remove(&9), Some(9));
+        d.reindex(16);
+        check_invariants(&d);
+        for key in 0..9 {
+            assert_eq!(d.remove(&key), Some(key));
+        }
+        check_invariants(&d);
+    }
 
     // ---- a reference model: insertion-ordered Vec + linear lookup ----
     #[derive(Default)]


### PR DESCRIPTION
## Summary

- carry declared value types and distinct `f32` constants through the codewriter pipeline
- preserve enum discriminant and substructure layout when virtualizing Rust sum types
- lower unsigned `checked_sub`, `mem::drop`/`mem::forget`, and reconstructed Result exception paths

## Validation

- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py`
  - dynasm: 543/543
  - cranelift: 543/543
  - wasm: 536/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for translating `Result::map_err` flows, including exception-handling paths.
  * Added checked unsigned subtraction rewriting.
  * Improved handling of enum variants, option/result shells, and discriminant tags.

* **Bug Fixes**
  * Corrected inline struct-field address handling across supported backends.
  * Preserved single-precision float type information and rejected unsupported graphs cleanly.
  * Improved validation for unsupported values, including 128-bit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->