### PR TITLE
majit: record compiled opcodes and narrow entry JITFRAME clearing

### DIFF
--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use majit_backend::deadframe::{ExitDescr, JitFrameDeadFrame};
 use majit_backend::jitframe::{
     HostHeapGc, check_jitframe_descr, jitframe_is_gc_object, jitframe_write_barrier,
-    malloc_jitframe, malloc_jitframe_no_collect,
+    malloc_entry_jitframe, malloc_jitframe, malloc_jitframe_no_collect,
 };
 use majit_backend::libc_deadframe::LibcJitFrameDeadFrame;
 use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, JitCellToken};
@@ -333,7 +333,7 @@ fn alloc_entry_jitframe(size_bytes: usize, args: &[Value]) -> (*mut JitFrame, bo
         } else {
             EntryArgRoots::new()
         };
-        (malloc_jitframe(gc, size_bytes), gc_object, roots)
+        (malloc_entry_jitframe(gc, size_bytes), gc_object, roots)
     })
 }
 

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -284,10 +284,11 @@ pub(crate) unsafe fn dealloc_off_gc_block(base: *mut u8, total: usize) {
 
 /// Zero-fill a frame the collector handed back.
 ///
-/// RPython's nursery is zeroed once per reset, so `lltype.malloc(JITFRAME)`
-/// returns cleared memory and `GuardNotForced` can read `jf_descr != 0`.
-/// Ours is not, so a fresh frame is cleared here. Old-gen arenas recycle
-/// bytes the same way.
+/// RPython's `gen_malloc_frame` initializes the fixed fields itself; its
+/// native nursery reset uses `arena_reset(..., 0)` and does not clear recycled
+/// bytes. This conservative allocator remains for callers whose initialization
+/// contract has not yet been narrowed to those fields. Old-gen arenas recycle
+/// bytes too.
 fn zeroed_gc_frame(gcref: majit_ir::GcRef, size_bytes: usize) -> *mut JitFrame {
     assert!(!gcref.is_null(), "JITFRAME allocation failed");
     unsafe { std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes) };
@@ -314,6 +315,35 @@ fn alloc_gc_jitframe(
         gc.alloc_nursery_no_collect_typed(type_id, size_bytes)
     };
     zeroed_gc_frame(gcref, size_bytes)
+}
+
+fn entry_gc_frame(gcref: majit_ir::GcRef) -> *mut JitFrame {
+    assert!(!gcref.is_null(), "JITFRAME allocation failed");
+    let frame = gcref.0 as *mut JitFrame;
+    unsafe { std::ptr::write_bytes(frame, 0, 1) };
+    frame
+}
+
+/// Allocate a compiled-entry frame without clearing its trailing spill slots.
+///
+/// Entry code writes every live slot before reading it or publishing it through
+/// a GC map. [`JitFrame::init`] supplies the fixed-field initialization that
+/// RPython emits in `rewrite.py`'s `gen_malloc_frame`.
+pub fn malloc_entry_jitframe(
+    gc: &mut dyn majit_gc::GcAllocator,
+    size_bytes: usize,
+) -> *mut JitFrame {
+    match gc.jitframe_type_id() {
+        Some(type_id) => {
+            let gcref = if jitframe_prefer_oldgen() {
+                gc.alloc_oldgen_typed(type_id, size_bytes)
+            } else {
+                gc.alloc_nursery_typed(type_id, size_bytes)
+            };
+            entry_gc_frame(gcref)
+        }
+        None => malloc_host_jitframe(size_bytes),
+    }
 }
 
 /// `llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`,
@@ -518,15 +548,14 @@ impl JitFrame {
 
     /// jitframe.py — jitframe_allocate.
     ///
-    /// Initialize a freshly-allocated (zero-filled) JitFrame at `ptr`.
+    /// Initialize a freshly-allocated JitFrame at `ptr`.
     /// Caller is responsible for allocation (nursery or malloc).
     ///
     /// # Safety
-    /// `ptr` must point to at least `alloc_size(depth)` zero-filled bytes.
+    /// `ptr` must point to at least `alloc_size(depth)` writable bytes with a
+    /// zero-filled fixed header. Trailing slots need not be initialized yet.
     pub unsafe fn init(ptr: *mut JitFrame, info: *const JitFrameInfo, depth: usize) {
         unsafe {
-            // RPython: frame.jf_frame_info = frame_info
-            // (other fields are zero from malloc)
             (*ptr).jf_frame_info = info;
             // Write the jf_frame array length
             let len_ptr = (ptr as *mut u8).add(JF_FRAME_OFS) as *mut isize;
@@ -806,6 +835,33 @@ where
 mod tests {
     use super::*;
     use majit_gc::GcAllocator;
+
+    #[test]
+    fn entry_init_clears_the_header_without_touching_frame_slots() {
+        let depth = 4;
+        let words = JitFrame::alloc_size(depth) / std::mem::size_of::<usize>();
+        let mut storage = vec![usize::MAX; words];
+        let frame = entry_gc_frame(majit_ir::GcRef(storage.as_mut_ptr() as usize));
+        let info = JitFrameInfo::default();
+
+        unsafe { JitFrame::init(frame, &info, depth) };
+
+        unsafe {
+            assert_eq!((*frame).jf_frame_info, &info);
+            assert_eq!((*frame).jf_descr, 0);
+            assert_eq!((*frame).jf_force_descr, 0);
+            assert!((*frame).jf_gcmap.is_null());
+            assert_eq!((*frame).jf_savedata, 0);
+            assert_eq!((*frame).jf_guard_exc, 0);
+            assert!((*frame).jf_forward.is_null());
+            assert_eq!(JitFrame::frame_length(frame), depth as isize);
+            assert!(
+                JitFrame::frame_slots(frame, depth)
+                    .iter()
+                    .all(|&slot| slot == -1)
+            );
+        }
+    }
 
     /// The emitted write-barrier fast path loads one byte at
     /// `jit_wb_if_flag_byteofs` from the frame pointer, and that offset is

--- a/majit/majit-metainterp/src/embed.rs
+++ b/majit/majit-metainterp/src/embed.rs
@@ -80,6 +80,11 @@ static LAST_ALWAYS_FAILS: AtomicBool = AtomicBool::new(false);
 /// threads at once.
 static WINDOW_LOCK: Mutex<()> = Mutex::new(());
 
+/// The opcode list of every loop compiled since the last [`Census::begin`] or
+/// [`Census::reset`], in compile order. An RCA instrument: the counters above
+/// say HOW MANY ops a trace kept, this says WHICH.
+static COMPILED_OPCODE_LOG: Mutex<Vec<Vec<majit_ir::OpCode>>> = Mutex::new(Vec::new());
+
 /// One reading of what the JIT did.
 ///
 /// Every field except the two `last_*` ones is a count over the window it was
@@ -213,6 +218,7 @@ impl Census {
             TRACE_OPS_BEFORE.fetch_add(ops_before, Ordering::Relaxed);
             TRACE_OPS_AFTER.fetch_add(ops_after, Ordering::Relaxed);
             LAST_OPS_AFTER.store(ops_after, Ordering::Relaxed);
+            COMPILED_OPCODE_LOG.lock().push(opcodes.to_vec());
             let shape = LoopBodyShape::of(opcodes);
             LAST_HAS_JUMP.store(shape.has_jump, Ordering::Relaxed);
             LAST_ALWAYS_FAILS.store(shape.has_always_fails, Ordering::Relaxed);
@@ -245,6 +251,7 @@ impl Census {
         LAST_OPS_AFTER.store(0, Ordering::Relaxed);
         LAST_HAS_JUMP.store(false, Ordering::Relaxed);
         LAST_ALWAYS_FAILS.store(false, Ordering::Relaxed);
+        COMPILED_OPCODE_LOG.lock().clear();
         Self {
             base: RawCounts::read(),
             aborts_before: abort_reasons(),
@@ -328,6 +335,12 @@ impl Census {
         }
         LAST_HAS_JUMP.store(false, Ordering::Relaxed);
         LAST_ALWAYS_FAILS.store(false, Ordering::Relaxed);
+        COMPILED_OPCODE_LOG.lock().clear();
+    }
+
+    /// A copy of the opcode log -- see [`COMPILED_OPCODE_LOG`].
+    pub fn compiled_opcode_log() -> Vec<Vec<majit_ir::OpCode>> {
+        COMPILED_OPCODE_LOG.lock().clone()
     }
 }
 


### PR DESCRIPTION
## Summary

- record each compiled loop's opcode list in the embed census so tests can assert trace shape directly
- add a compiled-entry JITFRAME allocator that clears only the fixed header, leaving spill slots for entry code to initialize
- preserve the current `jitframe_prefer_oldgen` placement policy for the specialized entry allocator

## Verification

- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py`
  - dynasm: 543/543
  - cranelift: 543/543
  - wasm: 536/536