### PR TITLE
majit-macros: terminate empty dispatch-arm JitCodes

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -3002,11 +3002,17 @@ pub(super) fn lower_dispatch_chain(
                 // none of them records a degraded arm.  Recording them would
                 // make the channel fire on every `_ => break` and
                 // `_ => panic!` in the corpus and stop discriminating.
+                // Both stubs still end in `void_return`: every jitcode the
+                // codewriter builds terminates in a return opcode (an empty
+                // graph keeps its return block), and `dispatch_loop` reads
+                // past the end otherwise — the blackhole treats that as a
+                // frame that never produced a result and panics.
                 crate::jit_interp::classify::ArmPattern::Nop => (
                     quote::quote! {
                         {
                             let mut __sub_builder = majit_metainterp::JitCodeBuilder::new();
                             __sub_builder.set_name(#sub_jitcode_name);
+                            __sub_builder.void_return();
                             __sub_builder.finish()
                         }
                     },
@@ -3017,6 +3023,7 @@ pub(super) fn lower_dispatch_chain(
                         {
                             let mut __sub_builder = majit_metainterp::JitCodeBuilder::new();
                             __sub_builder.set_name(#sub_jitcode_name);
+                            __sub_builder.void_return();
                             __sub_builder.finish()
                         }
                     },


### PR DESCRIPTION
## Summary

- end `Nop` dispatch-arm sub-JitCodes with `void_return`
- end `Halt` dispatch-arm sub-JitCodes with `void_return`
- preserve the parent dispatch CFG distinction: Nop returns to the loop head, while Halt continues to the function's typed return

## PyPy parity

RPython's `FlattenSSA.make_bytecode_block` retains an empty return block and `FlattenSSA.make_return` emits `void_return` for it. Its blackhole `dispatch_loop` has no successful end-of-bytecode exit; normal completion is raised by a typed return handler as `LeaveFrame`.

Previously these two proc-macro arm patterns produced zero-instruction sub-JitCodes. A blackhole resume through `handler_inline_call_nested_ext` therefore reached pyre's non-upstream `BhRunOutcome::EndOfCode` without producing a callee result and panicked.

## Verification

- `cargo test -p majit-macros --lib --features dynasm` — 162 passed
- Aheui corpus gates recorded in the commit: logo, aa+quine, aa+99bottles, and aa+40col remained byte-identical with unchanged guard-failure counters
