### PR TITLE
codewriter: make BoolRepr identity representation-wide

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -2747,13 +2747,18 @@ pub(super) fn lower_dispatch_chain(
             None
         };
         let inline_outcome = if pc_return_increment.is_none()
-            && pc_is_green(config)
             && matches!(
                 arm.pattern,
                 crate::jit_interp::classify::ArmPattern::Lowerable
             )
             && !has_infer_call
         {
+            // Red `pc` still lives in the merge-point register file. A
+            // sub-JitCode `pc += N` never writes that slot back
+            // (`BC_INLINE_CALL` is caller→callee only), so the next
+            // merge point rereads a stale pc. Inline with `pc_pinned`
+            // is the same Variable-in-place write RPython's flatten
+            // keeps for `next_instr`.
             lowerer.try_inline_dispatch_arm(&arm.original_body)
         } else {
             InlineArmOutcome::Rejected
@@ -3350,7 +3355,22 @@ pub(super) fn resolve_reds(
 
     let owned_red_names: Vec<String>;
     let reds_names: Vec<&str> = if !explicit_red_names.is_empty() {
-        owned_red_names = explicit_red_names;
+        // `promote_greens` only walks `jitdriver.greens`. A name that is
+        // also listed in `reds` would be both guarded and passed as a
+        // red — `handle_jit_marker__jit_merge_point` keeps the two lists
+        // disjoint (`args[2:2+num_green]` vs the tail).
+        let green_names: HashSet<String> = config
+            .greens
+            .iter()
+            .filter_map(|expr| match expr {
+                syn::Expr::Path(p) => p.path.get_ident().map(|i| i.to_string()),
+                _ => None,
+            })
+            .collect();
+        owned_red_names = explicit_red_names
+            .into_iter()
+            .filter(|name| !green_names.contains(name))
+            .collect();
         owned_red_names.iter().map(|s| s.as_str()).collect()
     } else {
         // Issue 2.2 (support.py:121 _kind2count = {'int':1,'ref':2,'float':3}):
@@ -3851,8 +3871,15 @@ pub(crate) fn lower_dispatch_body(
     let reds_i_lit: Vec<_> = reds_i.iter().map(|b| quote::quote!(#b)).collect();
     let reds_r_lit: Vec<_> = reds_r.iter().map(|b| quote::quote!(#b)).collect();
     let reds_f_lit: Vec<_> = reds_f.iter().map(|b| quote::quote!(#b)).collect();
+    let mut merge_reads: Vec<Register> = Vec::new();
+    merge_reads.extend(greens_i.iter().map(|&b| Register::int(u16::from(b))));
+    merge_reads.extend(greens_r.iter().map(|&b| Register::ref_(u16::from(b))));
+    merge_reads.extend(greens_f.iter().map(|&b| Register::float(u16::from(b))));
+    merge_reads.extend(reds_i.iter().map(|&b| Register::int(u16::from(b))));
+    merge_reads.extend(reds_r.iter().map(|&b| Register::ref_(u16::from(b))));
+    merge_reads.extend(reds_f.iter().map(|&b| Register::float(u16::from(b))));
     lowerer.emit_op(
-        OpMeta::linear(OpKind::JitMergePoint, vec![], vec![]),
+        OpMeta::linear(OpKind::JitMergePoint, merge_reads, vec![]),
         quote::quote! {
             // __jdindex: jtransform.py:1704 portal_jd.index threaded as runtime param.
             __builder.jit_merge_point(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -2247,24 +2247,28 @@ impl<'c> Lowerer<'c> {
     /// caller by the split path below.
     pub(super) fn arm_body_has_infer_call(&self, body: &Expr) -> bool {
         use syn::visit::Visit;
-        struct InferCallProbe<'a, 'c> {
+        struct LateRejectCallProbe<'a, 'c> {
             lowerer: &'a Lowerer<'c>,
             hit: bool,
         }
-        impl<'ast, 'a, 'c> Visit<'ast> for InferCallProbe<'a, 'c> {
+        impl<'ast, 'a, 'c> Visit<'ast> for LateRejectCallProbe<'a, 'c> {
             fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
-                if !self.hit
-                    && matches!(
-                        self.lowerer.resolve_call_policy(&call.func),
-                        Some(CallPolicySpec::Infer)
-                    )
-                {
-                    self.hit = true;
+                if !self.hit {
+                    match self.lowerer.resolve_call_policy(&call.func) {
+                        Some(CallPolicySpec::Infer) => self.hit = true,
+                        Some(CallPolicySpec::Explicit(
+                            crate::jit_interp::CallPolicyKind::InlinePipelineInt
+                            | crate::jit_interp::CallPolicyKind::InlinePipelineRef
+                            | crate::jit_interp::CallPolicyKind::InlinePipelineFloat
+                            | crate::jit_interp::CallPolicyKind::InlinePipelineVoid,
+                        )) => self.hit = true,
+                        _ => {}
+                    }
                 }
                 syn::visit::visit_expr_call(self, call);
             }
         }
-        let mut probe = InferCallProbe {
+        let mut probe = LateRejectCallProbe {
             lowerer: self,
             hit: false,
         };
@@ -2732,9 +2736,14 @@ pub(super) fn lower_dispatch_chain(
         // transactional sub-lowerer returns an abort stub; if it can, dropping
         // the green return would resume at the old opcode. RPython keeps `pc`
         // in the caller frame across either call shape.
-        // Inferred residual calls also use this split even without the size
-        // opt-in: their resume guards belong to the callee frame, while the
-        // caller still owns green `pc`.
+        // Infer and `inline_pipeline_*` calls stay on the sub-JitCode path
+        // even without the size opt-in. Infer resume guards belong to the
+        // callee frame while the caller still owns green `pc`. Pipeline
+        // callees are resolved at install (`trailing_return_info`); a
+        // missing typed return emits `return None` via
+        // `inference_failure_tokens`, and that `None` must stay inside the
+        // per-arm IIFE so only that arm degrades. Force-inlining would
+        // make the same `return None` abort the whole dispatch JitCode.
         let has_infer_call = lowerer.arm_body_has_infer_call(&arm.original_body);
         let pc_return_increment = if (config.split_dispatch || has_infer_call)
             && pc_is_green(config)

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -430,6 +430,32 @@ pub(super) fn is_word_width_int(ty: &Type) -> bool {
     }
 }
 
+pub(super) fn type_is_unsigned_int(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            type_path.path.is_ident("u8")
+                || type_path.path.is_ident("u16")
+                || type_path.path.is_ident("u32")
+                || type_path.path.is_ident("u64")
+                || type_path.path.is_ident("usize")
+        }
+        _ => false,
+    }
+}
+
+/// Whether a source expression is already an unsigned integer value.
+/// Covers `x as u64` / `(x as u32)` so `as f64` can pick
+/// `cast_uint_to_float` the way `rewrite_op_force_cast` uses
+/// `rffi.size_and_sign`.
+pub(super) fn expr_is_unsigned_int(expr: &Expr) -> bool {
+    match expr {
+        Expr::Paren(paren) => expr_is_unsigned_int(&paren.expr),
+        Expr::Group(group) => expr_is_unsigned_int(&group.expr),
+        Expr::Cast(cast) => type_is_unsigned_int(&cast.ty),
+        _ => false,
+    }
+}
+
 pub(super) fn is_supported_float_type(ty: &Type) -> bool {
     match ty {
         Type::Path(type_path) => type_path.path.is_ident("f64"),
@@ -551,11 +577,11 @@ pub(crate) fn helper_policy_path(expr: &Expr) -> Option<Path> {
 
 /// Emit the int-binop recording call for `dst = lhs <op> rhs`.
 ///
-/// `jtransform.py` rewrites `int_floordiv` / `int_mod` to the
-/// `int.py_div` / `int.py_mod` oopspec builtin call (no `bhimpl_int_*`
-/// primitive exists), so those route to `record_int_py_div` /
-/// `record_int_py_mod` (residual call to `ll_int_py_div` / `ll_int_py_mod`);
-/// every other int binop keeps the bare-primitive `record_binop_i`.
+/// `jtransform.py` `rewrite_op_int_floordiv` / `rewrite_op_int_mod` are
+/// `_do_builtin_call`, which residual-calls `support.py`
+/// `_ll_2_int_floordiv` / `_ll_2_int_mod` (C-truncating). Rust `/` and
+/// `%` are the same truncation. `int.py_div` / `int.py_mod` are a
+/// different rewrite (`_handle_int_special`) for Python-floor `//`.
 pub(super) fn binop_i_emit_tokens(
     dst: u16,
     opcode: &Ident,
@@ -563,8 +589,8 @@ pub(super) fn binop_i_emit_tokens(
     rhs: u16,
 ) -> proc_macro2::TokenStream {
     match opcode.to_string().as_str() {
-        "IntFloorDiv" => quote! { __builder.record_int_py_div(#dst, #lhs, #rhs); },
-        "IntMod" => quote! { __builder.record_int_py_mod(#dst, #lhs, #rhs); },
+        "IntFloorDiv" => quote! { __builder.record_int_floordiv(#dst, #lhs, #rhs); },
+        "IntMod" => quote! { __builder.record_int_mod(#dst, #lhs, #rhs); },
         _ => quote! { __builder.record_binop_i(#dst, majit_ir::OpCode::#opcode, #lhs, #rhs); },
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -71,6 +71,22 @@ impl<'c> Lowerer<'c> {
                 {
                     return None;
                 }
+                // `_rewrite_equality` then `optimize_goto_if_not`:
+                // `int_eq(x, 0)` → `int_is_zero` → `goto_if_not_int_is_zero`.
+                if matches!(lhs.kind, BindingKind::Int)
+                    && matches!(binary.op, BinOp::Eq(_) | BinOp::Ne(_))
+                {
+                    let left_zero = int_literal_value(&binary.left) == Some(0);
+                    let right_zero = int_literal_value(&binary.right) == Some(0);
+                    if left_zero || right_zero {
+                        let value = if right_zero { lhs } else { rhs };
+                        let negated = matches!(binary.op, BinOp::Eq(_));
+                        return Some(LoweredCondition::Value {
+                            binding: value,
+                            negated,
+                        });
+                    }
+                }
                 let prefix = match lhs.kind {
                     BindingKind::Int => "goto_if_not_int_",
                     BindingKind::Float => "goto_if_not_float_",
@@ -548,7 +564,10 @@ impl<'c> Lowerer<'c> {
                 self.emit_jump(break_label);
                 Some(())
             }
-            Stmt::Expr(Expr::Continue(_), _) => {
+            Stmt::Expr(Expr::Continue(cont), _) => {
+                if cont.label.is_some() {
+                    return None;
+                }
                 self.emit_jump(continue_label);
                 Some(())
             }
@@ -799,25 +818,17 @@ impl<'c> Lowerer<'c> {
         &mut self,
         expr_match: &syn::ExprMatch,
     ) -> Option<Option<Binding>> {
-        let (builder_method, recv, arg, none_body) = parse_checked_ovf_match(expr_match)?;
-        Some(self.emit_checked_ovf_match(builder_method, recv, arg, none_body))
+        let parsed = parse_checked_ovf_match(expr_match)?;
+        Some(self.emit_checked_ovf_match(parsed))
     }
 
-    fn emit_checked_ovf_match(
-        &mut self,
-        builder_method: &str,
-        recv: &Expr,
-        arg: &Expr,
-        none_body: &Expr,
-    ) -> Option<Binding> {
-        let lhs = self.lower_value_expr(recv)?;
-        let rhs = self.lower_value_expr(arg)?;
+    fn emit_checked_ovf_match(&mut self, parsed: CheckedOvfMatch<'_>) -> Option<Binding> {
+        let lhs = self.lower_value_expr(parsed.recv)?;
+        let rhs = self.lower_value_expr(parsed.arg)?;
         if !matches!(lhs.kind, BindingKind::Int) || !matches!(rhs.kind, BindingKind::Int) {
             return None;
         }
-        // Lower the overflow (None) arm into a deferred sequence up front so its
-        // result register is known for the convergence move.
-        let (none_seq, none_binding) = self.lower_branch_value_expr(none_body)?;
+        let (none_seq, none_binding) = self.lower_branch_value_expr(parsed.none_body)?;
         if !matches!(none_binding.kind, BindingKind::Int) {
             return None;
         }
@@ -825,15 +836,13 @@ impl<'c> Lowerer<'c> {
         let dst = self.alloc_reg();
         let ovf_label = self.alloc_label();
         let end_label = self.alloc_label();
-        let builder_ident = format_ident!("{builder_method}");
+        let builder_ident = format_ident!("{}", parsed.builder_method);
         let lhs_reg = lhs.reg;
         let rhs_reg = rhs.reg;
         let none_reg = none_binding.reg;
 
         self.emit_aux(quote! { let #ovf_label = __builder.new_label(); });
         self.emit_aux(quote! { let #end_label = __builder.new_label(); });
-        // `-live-` precedes the fused guard so blackhole liveness decodes at the
-        // op's resume position (see `lower_if_stmt`).
         self.emit_op(
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
@@ -847,9 +856,39 @@ impl<'c> Lowerer<'c> {
             ),
             quote! { __builder.#builder_ident(#dst, #lhs_reg, #rhs_reg, #ovf_label); },
         );
-        // No-overflow path: `dst` holds the result; skip the overflow arm.
+        if !some_arm_is_identity(parsed.some_pat, parsed.some_body) {
+            let saved = self.bindings.clone();
+            if let Some(name) = some_pat_bound_name(parsed.some_pat) {
+                self.bindings.insert(
+                    name,
+                    Binding {
+                        reg: dst,
+                        kind: BindingKind::Int,
+                        depends_on_stack: false,
+                        struct_type: None,
+                    },
+                );
+            }
+            let lowered = self.lower_branch_value_expr(parsed.some_body);
+            self.bindings = saved;
+            let (seq, binding) = lowered?;
+            if !matches!(binding.kind, BindingKind::Int) {
+                return None;
+            }
+            self.append_lowered_sequence(seq);
+            if binding.reg != dst {
+                let some_reg = binding.reg;
+                self.emit_op(
+                    OpMeta::linear(
+                        OpKind::MoveI,
+                        vec![Register::int(some_reg)],
+                        vec![Register::int(dst)],
+                    ),
+                    quote! { __builder.move_i(#dst, #some_reg); },
+                );
+            }
+        }
         self.emit_jump(&end_label);
-        // Overflow path: run the None arm and converge its result into `dst`.
         self.emit_label_def(&ovf_label);
         self.append_lowered_sequence(none_seq);
         self.emit_op(
@@ -893,13 +932,53 @@ fn option_variant_of_pat(pat: &Pat) -> Option<OptionPatVariant> {
     }
 }
 
-/// Recognize the orthodox `ovfcheck` idiom
-/// `match recv.checked_{add,sub,mul}(arg) { Some(_) => _, None => <handler> }`.
-/// Returns the fused builder method name, the two operand expressions, and the
-/// overflow (`None`) arm body; `None` when `expr_match` is not this shape.
-fn parse_checked_ovf_match(
-    expr_match: &syn::ExprMatch,
-) -> Option<(&'static str, &Expr, &Expr, &Expr)> {
+struct CheckedOvfMatch<'a> {
+    builder_method: &'static str,
+    recv: &'a Expr,
+    arg: &'a Expr,
+    none_body: &'a Expr,
+    some_pat: &'a Pat,
+    some_body: &'a Expr,
+}
+
+fn some_pat_bound_name(pat: &Pat) -> Option<String> {
+    let Pat::TupleStruct(ts) = pat else {
+        return None;
+    };
+    if ts.elems.len() != 1 {
+        return None;
+    }
+    match &ts.elems[0] {
+        Pat::Ident(pi) if pi.subpat.is_none() => Some(pi.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// `Some(v) => v` is RPython `ovfcheck`'s success edge: the residual is
+/// the overflow-checked add itself. Any other success body must be
+/// lowered; treating it as identity miscompiles.
+fn some_arm_is_identity(pat: &Pat, body: &Expr) -> bool {
+    let Some(name) = some_pat_bound_name(pat) else {
+        return false;
+    };
+    match body {
+        Expr::Path(p) => p
+            .path
+            .get_ident()
+            .is_some_and(|ident| ident == name.as_str()),
+        Expr::Block(block) if block.block.stmts.len() == 1 => match &block.block.stmts[0] {
+            Stmt::Expr(Expr::Path(p), None) => p
+                .path
+                .get_ident()
+                .is_some_and(|ident| ident == name.as_str()),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Recognize `match recv.checked_{add,sub,mul}(arg) { Some(..) => .., None => .. }`.
+fn parse_checked_ovf_match(expr_match: &syn::ExprMatch) -> Option<CheckedOvfMatch<'_>> {
     let call = match &*expr_match.expr {
         Expr::MethodCall(call) => call,
         _ => return None,
@@ -915,25 +994,29 @@ fn parse_checked_ovf_match(
     }
     let recv = &*call.receiver;
     let arg = call.args.first()?;
-    // Exactly two guard-less arms: `Some(_) => _` and `None => <handler>`.
     if expr_match.arms.len() != 2 {
         return None;
     }
-    let mut some_seen = false;
-    let mut none_body: Option<&Expr> = None;
+    let mut some_arm = None;
+    let mut none_body = None;
     for arm in &expr_match.arms {
         if arm.guard.is_some() {
             return None;
         }
         match option_variant_of_pat(&arm.pat)? {
-            OptionPatVariant::Some => some_seen = true,
+            OptionPatVariant::Some => some_arm = Some((&arm.pat, &*arm.body)),
             OptionPatVariant::None => none_body = Some(&*arm.body),
         }
     }
-    if !some_seen {
-        return None;
-    }
-    Some((builder_method, recv, arg, none_body?))
+    let (some_pat, some_body) = some_arm?;
+    Some(CheckedOvfMatch {
+        builder_method,
+        recv,
+        arg,
+        none_body: none_body?,
+        some_pat,
+        some_body,
+    })
 }
 
 #[cfg(test)]
@@ -1163,5 +1246,106 @@ mod unroll_binding_tests {
             .get("value")
             .expect("the typed local must create its identifier binding");
         assert!(matches!(binding.kind, BindingKind::Int));
+    }
+
+    #[test]
+    fn a_labelled_continue_in_a_loop_refuses() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "flag".to_string(),
+            Binding {
+                reg: 0,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr: syn::ExprWhile = syn::parse_quote! {
+            'outer: while flag {
+                continue 'outer;
+            }
+        };
+        assert!(
+            lowerer.lower_while_loop(&expr).is_none(),
+            "a labelled continue must not retarget the innermost header"
+        );
+    }
+
+    #[test]
+    fn if_eq_zero_fuses_to_goto_if_not_int_is_zero() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "n".to_string(),
+            Binding {
+                reg: 4,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr_if: syn::ExprIf = syn::parse_quote! { if n == 0 { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            emitted.contains("goto_if_not_int_is_zero"),
+            "`if n == 0` must fuse to int_is_zero, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("goto_if_not_int_eq"),
+            "must not keep the binary compare:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn checked_add_some_body_is_lowered() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "a".to_string(),
+            Binding {
+                reg: 1,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        lowerer.bindings.insert(
+            "b".to_string(),
+            Binding {
+                reg: 2,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr: syn::ExprMatch = syn::parse_quote! {
+            match a.checked_add(b) {
+                Some(v) => v + 1,
+                None => 0,
+            }
+        };
+        let binding = lowerer
+            .lower_checked_ovf_match(&expr)
+            .expect("recognized")
+            .expect("lowered");
+        assert!(matches!(binding.kind, BindingKind::Int));
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            emitted.contains("int_add_jump_if_ovf"),
+            "expected ovf jump, got:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("IntAdd") || emitted.contains("int_add"),
+            "Some(v) => v + 1 must emit the increment, got:\n{emitted}"
+        );
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -84,6 +84,7 @@ impl<'c> Lowerer<'c> {
                         return Some(LoweredCondition::Value {
                             binding: value,
                             negated,
+                            int_is_true: true,
                         });
                     }
                 }
@@ -109,7 +110,11 @@ impl<'c> Lowerer<'c> {
         if negated && !matches!(binding.kind, BindingKind::Int) {
             return None;
         }
-        Some(LoweredCondition::Value { binding, negated })
+        Some(LoweredCondition::Value {
+            binding,
+            negated,
+            int_is_true: false,
+        })
     }
 
     pub(super) fn lower_if_stmt(&mut self, expr_if: &ExprIf) -> Option<()> {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -282,11 +282,16 @@ impl<'c> Lowerer<'c> {
                 })
             }
             Expr::Cast(ExprCast { expr, ty, .. }) if is_supported_float_type(ty) => {
+                let unsigned = expr_is_unsigned_int(expr);
                 let binding = self.lower_value_expr(expr)?;
-                if !matches!(binding.kind, BindingKind::Int) {
-                    return None;
+                match binding.kind {
+                    // Same-type force_cast is a no-op (`rewrite_op_force_cast`
+                    // when `v_arg.concretetype == v_result.concretetype`).
+                    BindingKind::Float => Some(binding),
+                    BindingKind::Int if unsigned => self.lower_uint_to_float_cast(binding),
+                    BindingKind::Int => self.lower_int_to_float_cast(binding),
+                    BindingKind::Ref => None,
                 }
-                self.lower_int_to_float_cast(binding)
             }
             Expr::Cast(ExprCast { expr, ty, .. }) if is_supported_int_cast(ty) => {
                 let binding = self.lower_value_expr(expr)?;
@@ -298,7 +303,11 @@ impl<'c> Lowerer<'c> {
                     // is `127`, which a float->i64 followed by an int narrowing
                     // (`44`) would not reproduce.
                     BindingKind::Float if is_word_width_int(ty) => {
-                        self.lower_float_to_int_cast(binding)
+                        if type_is_unsigned_int(ty) {
+                            self.lower_float_to_uint_cast(binding)
+                        } else {
+                            self.lower_float_to_int_cast(binding)
+                        }
                     }
                     _ => None,
                 }
@@ -603,6 +612,9 @@ impl<'c> Lowerer<'c> {
         }
         let base = self.lower_value_expr(&call.args[0])?;
         let ea = self.lower_value_expr(&call.args[1])?;
+        if !matches!(base.kind, BindingKind::Int) || !matches!(ea.kind, BindingKind::Int) {
+            return None;
+        }
         let (base_reg, ea_reg) = (base.reg, ea.reg);
         let dst = self.alloc_reg();
         self.emit_op(
@@ -785,6 +797,9 @@ impl<'c> Lowerer<'c> {
         if !self.bindings.contains_key(&lhs_ident) {
             return None;
         }
+        if lhs_ident == "pc" && !self.pc_pinned {
+            return None;
+        }
         let binding = self.lower_value_expr(&assign.right)?;
         self.bindings.insert(lhs_ident, binding);
         Some(())
@@ -807,6 +822,14 @@ impl<'c> Lowerer<'c> {
             return None;
         };
         let lhs_ident = lhs_path.path.get_ident()?.to_string();
+        // An unpinned `pc` write in a sub-JitCode updates the callee copy
+        // and never reaches the merge-point register (`BC_INLINE_CALL`
+        // copies caller→callee only). Refuse so the arm degrades instead
+        // of compiling a stale-pc loop. `pc_pinned` (inline dispatch)
+        // intercepts these writes first.
+        if lhs_ident == "pc" && !self.pc_pinned {
+            return None;
+        }
         // `lower_expr_stmt` reaches this before `lower_stmt_fallback`, so the
         // green-write refusal there never sees the statement.  A green is a
         // caller local threaded through the merge point: writing it into this
@@ -2384,6 +2407,27 @@ impl<'c> Lowerer<'c> {
         })
     }
 
+    /// `rewrite_op_force_cast` when the source is unsigned and the
+    /// destination is float: residual `cast_uint_to_float`.
+    fn lower_uint_to_float_cast(&mut self, binding: Binding) -> Option<Binding> {
+        let src_reg = binding.reg;
+        let reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::UnaryI,
+                Register::ints(&[src_reg]),
+                vec![Register::float(reg)],
+            ),
+            quote! { __builder.record_cast_uint_to_float(#reg, #src_reg); },
+        );
+        Some(Binding {
+            reg,
+            kind: BindingKind::Float,
+            depends_on_stack: binding.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
     /// Lower a `<float> as i64` cast to RPython's `cast_float_to_int`
     /// (`bhimpl_cast_float_to_int`), the inverse of
     /// [`Self::lower_int_to_float_cast`]. The operand is read from the float
@@ -2402,6 +2446,27 @@ impl<'c> Lowerer<'c> {
                 vec![Register::int(reg)],
             ),
             quote! { __builder.record_cast_float_to_int(#reg, #src_reg); },
+        );
+        Some(Binding {
+            reg,
+            kind: BindingKind::Int,
+            depends_on_stack: binding.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
+    /// `rewrite_op_force_cast` float → unsigned word: residual
+    /// `cast_float_to_uint`.
+    fn lower_float_to_uint_cast(&mut self, binding: Binding) -> Option<Binding> {
+        let src_reg = binding.reg;
+        let reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::UnaryI,
+                vec![Register::float(src_reg)],
+                vec![Register::int(reg)],
+            ),
+            quote! { __builder.record_cast_float_to_uint(#reg, #src_reg); },
         );
         Some(Binding {
             reg,
@@ -2434,18 +2499,51 @@ impl<'c> Lowerer<'c> {
             "u8" => (false, 8),
             "u16" => (false, 16),
             "u32" => (false, 32),
-            // 64-bit / pointer-width targets keep the full machine word.
-            "i64" | "u64" | "isize" | "usize" => return Some(binding),
+            // `_int_to_int_cast` to Bool is `int_is_true`.
+            "bool" => {
+                let src_reg = binding.reg;
+                let reg = self.alloc_reg();
+                self.emit_op(
+                    OpMeta::linear(
+                        OpKind::UnaryI,
+                        Register::ints(&[src_reg]),
+                        vec![Register::int(reg)],
+                    ),
+                    quote! { __builder.record_unary_i(#reg, majit_ir::OpCode::IntIsTrue, #src_reg); },
+                );
+                return Some(Binding {
+                    reg,
+                    kind: BindingKind::Int,
+                    depends_on_stack: binding.depends_on_stack,
+                    struct_type: None,
+                });
+            }
+            // 64-bit targets keep the full machine word. Pointer-width
+            // targets are the host crate's `usize`, which is 32 bits on
+            // wasm32 — emit a shift/mask whose count is computed there.
+            "i64" | "u64" => return Some(binding),
+            "isize" => (true, 0),
+            "usize" => (false, 0),
             _ => return None,
         };
         let depends_on_stack = binding.depends_on_stack;
         let x_reg = binding.reg;
         let result_reg = if signed {
-            let shift = (64 - bits) as i64;
             let shift_reg = self.alloc_reg();
+            let shift_tokens = if bits == 0 {
+                quote! {
+                    __builder.load_const_i_value(
+                        #shift_reg,
+                        (64 - ::core::mem::size_of::<usize>() * 8) as i64,
+                    );
+                }
+            } else {
+                let shift = (64 - bits) as i64;
+                quote! { __builder.load_const_i_value(#shift_reg, #shift); }
+            };
             self.emit_op(
                 OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(shift_reg)]),
-                quote! { __builder.load_const_i_value(#shift_reg, #shift); },
+                shift_tokens,
             );
             let shl_reg = self.alloc_reg();
             let lshift = syn::Ident::new("IntLshift", proc_macro2::Span::call_site());
@@ -2469,11 +2567,28 @@ impl<'c> Lowerer<'c> {
             );
             res_reg
         } else {
-            let mask = ((1u64 << bits) - 1) as i64;
             let mask_reg = self.alloc_reg();
+            let mask_tokens = if bits == 0 {
+                quote! {
+                    __builder.load_const_i_value(
+                        #mask_reg,
+                        {
+                            let bits = ::core::mem::size_of::<usize>() * 8;
+                            if bits >= 64 {
+                                -1i64
+                            } else {
+                                ((1u64 << bits) - 1) as i64
+                            }
+                        },
+                    );
+                }
+            } else {
+                let mask = ((1u64 << bits) - 1) as i64;
+                quote! { __builder.load_const_i_value(#mask_reg, #mask); }
+            };
             self.emit_op(
                 OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(mask_reg)]),
-                quote! { __builder.load_const_i_value(#mask_reg, #mask); },
+                mask_tokens,
             );
             let res_reg = self.alloc_reg();
             let and = syn::Ident::new("IntAnd", proc_macro2::Span::call_site());
@@ -3097,6 +3212,24 @@ mod tests {
             assert!(
                 emitted(&lowerer).contains("IntIsZero"),
                 "`0 == n` is `_rewrite_symmetric` then the same fold"
+            );
+        }
+
+        #[test]
+        fn rust_div_records_c_truncating_floordiv() {
+            let (lowerer, out) = lower("a / b", |l| {
+                l.bindings.insert("a".into(), binding(1, BindingKind::Int));
+                l.bindings.insert("b".into(), binding(2, BindingKind::Int));
+            });
+            assert!(out.is_some());
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("record_int_floordiv"),
+                "Rust `/` is `_ll_2_int_floordiv`, got:\n{text}"
+            );
+            assert!(
+                !text.contains("record_int_py_div"),
+                "must not emit Python-floor `ll_int_py_div`:\n{text}"
             );
         }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -405,7 +405,7 @@ impl<'c> Lowerer<'c> {
     }
 
     pub(super) fn emit_conditional_guard(&mut self, cond_reg: u16, target: &Ident) {
-        self.emit_conditional_guard_negatable(cond_reg, target, false);
+        self.emit_conditional_guard_negatable(cond_reg, target, false, false);
     }
 
     /// The branch RPython writes as `goto_if_not_<opname>`: fall through
@@ -416,16 +416,22 @@ impl<'c> Lowerer<'c> {
     /// `int_is_zero`, and `optimize_goto_if_not` folds that operation into
     /// the block's exitswitch rather than materialising its result, so the
     /// negation costs a different branch opname and nothing else.
+    ///
+    /// `int_is_true` is the integer `!= 0` rewrite. A Rust `if`/`while`
+    /// condition is otherwise `bool`, so flatten emits plain `goto_if_not`.
     pub(super) fn emit_conditional_guard_negatable(
         &mut self,
         cond_reg: u16,
         target: &Ident,
         negated: bool,
+        int_is_true: bool,
     ) {
         let branch = if negated {
             format_ident!("goto_if_not_int_is_zero")
-        } else {
+        } else if int_is_true {
             format_ident!("goto_if_not_int_is_true")
+        } else {
+            format_ident!("goto_if_not")
         };
         // Both forms read an int-banked register: `assembler.py write_insn`
         // takes a `Register` operand's argcode from `x.kind[0]`, which is
@@ -445,8 +451,12 @@ impl<'c> Lowerer<'c> {
         target: &Ident,
     ) {
         match condition {
-            LoweredCondition::Value { binding, negated } => {
-                self.emit_conditional_guard_negatable(binding.reg, target, *negated);
+            LoweredCondition::Value {
+                binding,
+                negated,
+                int_is_true,
+            } => {
+                self.emit_conditional_guard_negatable(binding.reg, target, *negated, *int_is_true);
             }
             LoweredCondition::Compare { lhs, rhs, branch } => {
                 let lhs_reg = Register::new(lhs.kind, lhs.reg);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -37,16 +37,17 @@ mod reexports {
     };
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_f_emit_tokens, binop_i_emit_tokens,
-        binop_is_symmetric, block_has_loop_control, expr_has_loop_control, extract_block_tail_int,
-        extract_bool_branch_values, extract_branch_int, extract_pat_switch_case_tokens,
-        extract_pat_value_tokens, extract_stmts, inline_call_tokens, inline_call_tokens_void,
-        inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
-        inline_ref_arg_tokens, inline_shared_path, int_arg_regs, int_literal_value,
-        is_lowercase_binding_pat, is_supported_float_type, is_supported_int_cast,
-        is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens, mirrored_compare_binop,
-        opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f,
-        opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
-        word_result_addr_for_kind, word_result_addr_tokens, word_void_addr_tokens,
+        binop_is_symmetric, block_has_loop_control, expr_has_loop_control, expr_is_unsigned_int,
+        extract_block_tail_int, extract_bool_branch_values, extract_branch_int,
+        extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
+        inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
+        inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, inline_shared_path,
+        int_arg_regs, int_literal_value, is_lowercase_binding_pat, is_supported_float_type,
+        is_supported_int_cast, is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens,
+        mirrored_compare_binop, opcode_for_assign_binop, opcode_for_assign_binop_f,
+        opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control,
+        type_is_unsigned_int, typed_call_arg_tokens, word_result_addr_for_kind,
+        word_result_addr_tokens, word_void_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -1655,6 +1655,10 @@ pub(super) enum LoweredCondition {
     Value {
         binding: Binding,
         negated: bool,
+        /// `true` when this value is an integer `== 0` / `!= 0` compare
+        /// rewritten as a truth test. Rust `if`/`while` conditions are
+        /// otherwise `bool`, which flatten emits as `goto_if_not`.
+        int_is_true: bool,
     },
     Compare {
         lhs: Binding,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -6408,6 +6408,19 @@ pub fn cast_uint_to_float(x: i64) -> f64 {
     (x as u64) as f64
 }
 
+/// Residual-call ABI for [`cast_uint_to_float`]. `jtransform.py`
+/// `rewrite_op_cast_uint_to_float = _do_builtin_call` residual-calls
+/// `support.py _ll_1_cast_uint_to_float`.
+pub extern "C" fn _ll_1_cast_uint_to_float(x: i64) -> f64 {
+    cast_uint_to_float(x)
+}
+
+/// Residual-call ABI for [`cast_float_to_uint`]. `jtransform.py`
+/// `rewrite_op_cast_float_to_uint = _do_builtin_call`.
+pub extern "C" fn _ll_1_cast_float_to_uint(f: f64) -> i64 {
+    cast_float_to_uint(f)
+}
+
 /// RPython `support.py:274 _ll_1_cast_float_to_uint(f)` —
 /// `r_uint(long(f))` mod 2^64 wrap (matching
 /// `op_cast_float_to_uint` at `opimpl.py`).  Plain

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2756,21 +2756,22 @@ impl JitCodeBuilder {
     }
 
     /// RPython `flatten.py` emits a plain `Bool` exitswitch as opname
-    /// `goto_if_not`, which is what this writes.
-    ///
-    /// `goto_if_not_int_is_true` is a real second opname upstream —
-    /// `jtransform.py optimize_goto_if_not` admits `int_is_true` into the set
-    /// of operations it folds into the exitswitch tuple, and `flatten.py` then
-    /// spells the opname `'goto_if_not_' + exitswitch[0]`. It reaches
-    /// `MIFrame.opimpl_goto_if_not_int_is_true`, which re-executes the folded
-    /// `INT_IS_TRUE` before branching. Nothing here performs that fold: every
-    /// caller's condition is a Rust `bool`, already the `0|1` the canonical
-    /// opname wants, so there is no `int_is_true` to fold away and no
-    /// operation to re-materialise. The Rust method keeps the longer name for
-    /// readability at the call site.
-    pub fn goto_if_not_int_is_true(&mut self, reg: u16, label: u16) {
+    /// `goto_if_not`. The operand is already 0 or 1; the tracer may rebind
+    /// it to `CONST_1`.
+    pub fn goto_if_not(&mut self, reg: u16, label: u16) {
         self.touch_reg(reg);
         self.write_insn("goto_if_not/iL");
+        self.push_u8(reg as u8);
+        self.push_label_ref(label);
+    }
+
+    /// `jtransform.py optimize_goto_if_not` folds `int_is_true` into the
+    /// exitswitch; `flatten.py` then emits `goto_if_not_int_is_true`.
+    /// The tracer re-executes `INT_IS_TRUE` and branches with `replace=False`,
+    /// so a general integer (`if n != 0`) must not go through `goto_if_not`.
+    pub fn goto_if_not_int_is_true(&mut self, reg: u16, label: u16) {
+        self.touch_reg(reg);
+        self.write_insn("goto_if_not_int_is_true/iL");
         self.push_u8(reg as u8);
         self.push_label_ref(label);
     }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2571,16 +2571,37 @@ impl JitCodeBuilder {
         self.push_u8(dst as u8);
     }
 
-    /// `jtransform.py` `rewrite_op_int_floordiv = _do_builtin_call`
-    /// / `rewrite_op_int_mod = _do_builtin_call`: `int_floordiv` / `int_mod`
-    /// have no `bhimpl_int_*` primitive (`record_binop_i` rejects them), so
-    /// RPython rewrites them to the `int.py_div` / `int.py_mod` oopspec
-    /// residual call (`rint.py ll_int_py_div` / `ll_int_py_mod`,
-    /// `EF_ELIDABLE_CANNOT_RAISE`). Mirrors the trace-path redirect at
-    /// `pyre-jit-trace/src/jitcode_dispatch/specialize.rs::walker_emit_int_py_div_or_mod`.  The
-    /// `_ovf_zer` zero/overflow guards the trace path inlines have no
-    /// jitcode `guard_false` analog here, so the helper carries the same
-    /// precondition (`rhs != 0`, not `INT_MIN / -1`) as any non-traced caller.
+    /// `jtransform.py` `rewrite_op_int_floordiv = _do_builtin_call`:
+    /// residual `_ll_2_int_floordiv` (C-truncating). Rust `/` is the same
+    /// truncation. This is **not** `int.py_div` (`ll_int_py_div`, Python
+    /// floor) — that oopspec is `_handle_int_special` for `//`.
+    /// `lloperation.py` marks `int_floordiv` `canfold=True`; zero is a
+    /// caller precondition, matching `emit_int_mod_or_floordiv_residual`.
+    pub fn record_int_floordiv(&mut self, dst: u16, lhs: u16, rhs: u16) {
+        self.record_int_py_helper(
+            dst,
+            lhs,
+            rhs,
+            crate::blackhole::_ll_2_int_floordiv as *const (),
+            crate::call_descr::cannot_raise_effect_info(),
+        );
+    }
+
+    /// `jtransform.py` `rewrite_op_int_mod = _do_builtin_call`: residual
+    /// `_ll_2_int_mod` (C-truncating remainder). See [`Self::record_int_floordiv`].
+    pub fn record_int_mod(&mut self, dst: u16, lhs: u16, rhs: u16) {
+        self.record_int_py_helper(
+            dst,
+            lhs,
+            rhs,
+            crate::blackhole::_ll_2_int_mod as *const (),
+            crate::call_descr::cannot_raise_effect_info(),
+        );
+    }
+
+    /// `jtransform.py` `_handle_int_special` `int.py_div` → residual
+    /// `ll_int_py_div` (`EF_ELIDABLE_CANNOT_RAISE`). Python-floor `//`,
+    /// not Rust `/`.
     pub fn record_int_py_div(&mut self, dst: u16, lhs: u16, rhs: u16) {
         self.record_int_py_helper(
             dst,
@@ -5388,6 +5409,34 @@ impl JitCodeBuilder {
         self.write_insn("cast_float_to_int/f>i");
         self.push_u8(src as u8);
         self.push_u8(dst as u8);
+    }
+
+    /// `jtransform.py` `rewrite_op_cast_uint_to_float = _do_builtin_call`.
+    pub fn record_cast_uint_to_float(&mut self, dst: u16, src: u16) {
+        let fn_ptr_idx = self.add_call_target(
+            crate::blackhole::_ll_1_cast_uint_to_float as *const (),
+            crate::blackhole::_ll_1_cast_uint_to_float as *const (),
+        );
+        self.residual_call_float_canonical_via_target_with_effect_info(
+            fn_ptr_idx,
+            &[JitCallArg::int(src)],
+            dst,
+            crate::call_descr::cannot_raise_effect_info(),
+        );
+    }
+
+    /// `jtransform.py` `rewrite_op_cast_float_to_uint = _do_builtin_call`.
+    pub fn record_cast_float_to_uint(&mut self, dst: u16, src: u16) {
+        let fn_ptr_idx = self.add_call_target(
+            crate::blackhole::_ll_1_cast_float_to_uint as *const (),
+            crate::blackhole::_ll_1_cast_float_to_uint as *const (),
+        );
+        self.residual_call_int_canonical_via_target_with_effect_info(
+            fn_ptr_idx,
+            &[JitCallArg::float(src)],
+            dst,
+            crate::call_descr::cannot_raise_effect_info(),
+        );
     }
 
     /// Reinterpret a float's 64-bit pattern as an int — RPython

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -13915,7 +13915,7 @@ mod tests {
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
         builder.load_const_i_value(0, 0);
-        builder.goto_if_not_int_is_true(0, target);
+        builder.goto_if_not(0, target);
         builder.load_const_i_value(1, 10);
         builder.int_return(1);
         builder.mark_label(target);
@@ -14489,7 +14489,7 @@ mod tests {
         // again after the branch is what shows the rebind.
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
-        builder.goto_if_not_int_is_true(0, target);
+        builder.goto_if_not(0, target);
         builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
         builder.mark_label(target);
         let jitcode = builder.finish();
@@ -14508,9 +14508,7 @@ mod tests {
 
     /// `MIFrame.opimpl_goto_if_not_int_is_true` re-executes the `INT_IS_TRUE`
     /// that `jtransform.py optimize_goto_if_not` folded into the exitswitch,
-    /// then branches with `replace=False`. No majit front end emits this byte
-    /// today — every condition it lowers is already a Rust `bool` — so the
-    /// jitcode is patched to it directly.
+    /// then branches with `replace=False`.
     #[test]
     fn goto_if_not_int_is_true_records_the_folded_int_is_true() {
         let mut builder = JitCodeBuilder::new();
@@ -14518,13 +14516,7 @@ mod tests {
         builder.goto_if_not_int_is_true(0, target);
         builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
         builder.mark_label(target);
-        let mut jitcode = builder.finish();
-        let code = &mut jitcode.core_mut().body_mut().code;
-        let at = code
-            .iter()
-            .position(|&b| b == jitcode::insns::BC_GOTO_IF_NOT)
-            .expect("the builder writes the canonical goto_if_not byte");
-        code[at] = jitcode::insns::BC_GOTO_IF_NOT_INT_IS_TRUE;
+        let jitcode = builder.finish();
 
         let recorded = traced_opcodes(
             &[majit_ir::Type::Int],

--- a/majit/majit-metainterp/tests/jit_interp_degraded_arm_accumulates_refusals.rs
+++ b/majit/majit-metainterp/tests/jit_interp_degraded_arm_accumulates_refusals.rs
@@ -67,6 +67,8 @@ fn dispatch_accum(program: &Bytecode, threshold: u32) -> i64 {
                 if state.regs[0] == 0 {
                     break;
                 }
+                // Blocker 3 — `pc` is green; a mid-arm write cannot be
+                // carried back out of this lowering path.
                 pc = pc + 1;
             }
             _ => break,
@@ -112,11 +114,12 @@ fn both_blockers_are_reported() {
         vec![
             RefusalKind::UnlowerableStmt,
             RefusalKind::EnclosedBreakContinue,
+            RefusalKind::GreenWriteback,
             RefusalKind::EnclosedBreakContinue
         ],
         "the arm's blockers must all be reported, reallocation first \
-         (statement order), then the enclosing `if` and the `break` inside it; \
-         reason={reason:?}"
+         (statement order), then the enclosing `if`, the green `pc` write, \
+         and the `break` inside the `if`; reason={reason:?}"
     );
     assert!(
         reason.contains("state.regs = vec!") && reason.contains("break"),

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -3,8 +3,9 @@
 //! Verifies the singleton dispatch JitCode emitted by `__dispatch_jitcode_*`
 //! contains the expected portal IR (BC_JIT_MERGE_POINT, BC_LOOP_HEADER) +
 //! pre-dispatch ops in source order + opcode fetch + dispatch chain
-//! (BC_GOTO_IF_NOT_INT_EQ_CONST chain) + arm BC_INLINE_CALL emissions +
-//! loop close.
+//! (BC_GOTO_IF_NOT_INT_EQ_CONST chain) + Lowerable arm bodies force-inlined
+//! into the dispatch JitCode (`try_inline_dispatch_arm`) + residual
+//! `BC_INLINE_CALL` only for Nop/Halt/abort stubs + loop close.
 
 use majit_metainterp::jitcode::insns::{
     BC_ABORT, BC_GETARRAYITEM_GC_I_PURE, BC_GOTO_IF_NOT_INT_EQ, BC_INLINE_CALL, BC_INT_ADD,
@@ -75,6 +76,25 @@ fn build_dispatch_minimal() -> JitCode {
         .expect("dispatch lower must succeed for fixture")
 }
 
+/// Dispatch JitCode plus every registered arm sub-JitCode. Lowerable red-pc
+/// arms land in the dispatch body (`try_inline_dispatch_arm`); Nop/Halt/abort
+/// stubs stay as `BC_INLINE_CALL` targets. Shape assertions that only care
+/// that an op was emitted must scan both.
+fn dispatch_tree(jc: &JitCode) -> impl Iterator<Item = &JitCode> {
+    std::iter::once(jc).chain(
+        jc.exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode().map(|sub| sub.as_ref())),
+    )
+}
+
+fn count_op_in_dispatch_tree(jc: &JitCode, op: u8) -> usize {
+    dispatch_tree(jc)
+        .map(|code| code.code.iter().filter(|&&b| b == op).count())
+        .sum()
+}
+
 #[test]
 fn dispatch_jitcode_emits_portal_markers() {
     let dispatch_jc = build_dispatch_minimal();
@@ -101,9 +121,11 @@ fn dispatch_jitcode_contains_inline_call_per_arm() {
     let dispatch_jc = build_dispatch_minimal();
     let code = &dispatch_jc.code;
     let inline_call_count = code.iter().filter(|&&b| b == BC_INLINE_CALL).count();
+    // OP_NOP is ArmPattern::Nop and stays a residual empty INLINE_CALL.
+    // OP_INC_A is Lowerable and is force-inlined into the dispatch body.
     assert_eq!(
-        inline_call_count, 2,
-        "dispatch JitCode must emit one BC_INLINE_CALL per non-default arm; got {}",
+        inline_call_count, 1,
+        "dispatch JitCode must emit one BC_INLINE_CALL for the residual Nop arm; got {}",
         inline_call_count
     );
 }
@@ -120,18 +142,13 @@ fn dispatch_arm_subjitcode_lowers_state_field_write() {
 
     assert_eq!(
         sub_jitcodes.len(),
-        2,
-        "dispatch JitCode must register one sub-JitCode per non-default arm"
+        1,
+        "only the residual Nop arm registers a sub-JitCode; Lowerable OP_INC_A is inlined"
     );
     assert!(
-        sub_jitcodes
-            .iter()
-            .any(|sub| sub.code.contains(&BC_STORE_STATE_FIELD)),
-        "state.a += 1 arm must lower to store_state_field in the dispatch inline-call target; sub codes: {:?}",
-        sub_jitcodes
-            .iter()
-            .map(|sub| sub.code.clone())
-            .collect::<Vec<_>>()
+        dispatch_jc.code.contains(&BC_STORE_STATE_FIELD),
+        "state.a += 1 arm must lower to store_state_field in the dispatch body; dispatch={:?}",
+        dispatch_jc.code
     );
     assert!(
         sub_jitcodes.iter().all(|sub| !sub.code.contains(&BC_ABORT)),
@@ -195,29 +212,11 @@ mod literal_for_unroll {
     #[test]
     fn dispatch_arm_unrolls_literal_range_for_loop() {
         let dispatch_jc = build_literal_for_unroll();
-        let sub_jitcodes = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            sub_jitcodes.len(),
-            1,
-            "fixture must register exactly one non-default arm sub-JitCode"
-        );
-
-        let body = sub_jitcodes[0];
-        let store_count = body
-            .code
-            .iter()
-            .filter(|&&b| b == BC_STORE_STATE_FIELD)
-            .count();
+        let store_count = super::count_op_in_dispatch_tree(&dispatch_jc, BC_STORE_STATE_FIELD);
         assert_eq!(
             store_count, 4,
-            "for k in 0..4 body must be unrolled to four straight-line state writes; bytes: {:?}",
-            body.code
+            "for k in 0..4 body must be unrolled to four straight-line state writes; dispatch={:?}",
+            dispatch_jc.code
         );
     }
 }
@@ -270,28 +269,17 @@ mod float_state_field_shape {
         let _ = asm.ensure_canonical_liveness_offset();
         let dispatch_jc = __dispatch_jitcode_dispatch_float_field(&mut asm, 0i64)
             .expect("float dispatch lower must succeed");
-        let sub_jitcodes = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .collect::<Vec<_>>();
         assert!(
-            sub_jitcodes
-                .iter()
-                .any(|sub| sub.code.contains(&BC_STORE_STATE_FIELD_FLOAT)),
-            "state.f update must lower to store_state_field_float; sub codes: {:?}",
-            sub_jitcodes
-                .iter()
-                .map(|sub| sub.code.clone())
-                .collect::<Vec<_>>()
+            super::count_op_in_dispatch_tree(&dispatch_jc, BC_STORE_STATE_FIELD_FLOAT) >= 1,
+            "state.f update must lower to store_state_field_float; dispatch={:?}",
+            dispatch_jc.code
         );
     }
 }
 
 mod or_pattern {
     use super::{Bytecode, OP_INC_A, OP_NOP};
-    use majit_metainterp::jitcode::insns::BC_INLINE_CALL;
+    use majit_metainterp::jitcode::insns::BC_STORE_STATE_FIELD;
     use majit_metainterp::{Assembler, BC_GOTO, JitDriver};
 
     struct OrDispatchState {
@@ -336,19 +324,19 @@ mod or_pattern {
         let dispatch_jc = __dispatch_jitcode_dispatch_or_pattern(&mut asm, 0i64)
             .expect("dispatch lower must succeed for fixture");
         let code = &dispatch_jc.code;
-        let first_inline = code
+        let first_body = code
             .iter()
-            .position(|&b| b == BC_INLINE_CALL)
-            .expect("missing inline_call for OR-pattern arm");
+            .position(|&b| b == BC_STORE_STATE_FIELD)
+            .expect("missing inlined store for OR-pattern arm");
         let first_goto = code
             .iter()
             .position(|&b| b == BC_GOTO)
             .expect("missing successful-alternative jump for OR pattern");
 
         assert!(
-            first_goto < first_inline,
+            first_goto < first_body,
             "OR-pattern dispatch must jump from a successful early alternative \
-             to the shared matched body before inline_call; otherwise A | B is \
+             to the shared matched body before the inlined arm; otherwise A | B is \
              lowered as an accidental conjunction"
         );
     }
@@ -948,26 +936,27 @@ mod oparg_minimal {
             .expect("missing JIT_MERGE_POINT");
         let post_mp = &code[mp_idx..];
 
-        let store_count = post_mp
+        let first_getarr = post_mp
+            .iter()
+            .position(|&b| b == BC_GETARRAYITEM_GC_I_PURE)
+            .expect("BC_GETARRAYITEM_GC_I_PURE missing");
+        let prelude_store_count = post_mp[..first_getarr]
             .iter()
             .filter(|&&b| b == BC_STORE_STATE_FIELD)
             .count();
         assert_eq!(
-            store_count, 1,
-            "A.2.4: dispatch JitCode body must emit exactly one \
+            prelude_store_count, 1,
+            "A.2.4: prelude before opcode fetch must emit exactly one \
              BC_STORE_STATE_FIELD for `state.last_instr = pc as i64` \
-             (pyopcode.py:172); got {}",
-            store_count
+             (pyopcode.py:172); later stores belong to inlined Lowerable \
+             arms. got {}",
+            prelude_store_count
         );
 
         let store_pos = post_mp
             .iter()
             .position(|&b| b == BC_STORE_STATE_FIELD)
             .expect("BC_STORE_STATE_FIELD missing");
-        let first_getarr = post_mp
-            .iter()
-            .position(|&b| b == BC_GETARRAYITEM_GC_I_PURE)
-            .expect("BC_GETARRAYITEM_GC_I_PURE missing");
         assert!(
             store_pos < first_getarr,
             "A.2.4: last_instr store must precede opcode fetch \
@@ -1149,8 +1138,8 @@ mod oparg_minimal {
         );
     }
 
-    /// A.3.4: `BC_LOOP_HEADER` jdindex wire — call-site emission inside
-    /// the OP_JUMP_BACK arm sub-JitCode.
+    /// A.3.4: `BC_LOOP_HEADER` jdindex wire — call-site emission for the
+    /// force-inlined OP_JUMP_BACK arm.
     ///
     /// `jtransform.py` `handle_jit_marker__loop_header` emits
     /// `SpaceOperation('loop_header', [c_index], None)` with `c_index =
@@ -1160,62 +1149,54 @@ mod oparg_minimal {
     /// path early-returns at `interp_jit.py:104 if jumpto >= next_instr:
     /// return jumpto`).  Pyre's parity is achieved by recognising
     /// `can_enter_jit!(...)` as a `Stmt::Macro` inside `Lowerer::lower_stmt`
-    /// (`jitcode_lower/lower_stmt.rs`) and emitting the LH op INSIDE the
-    /// arm body sub-JitCode at that exact stmt position.  No post-INLINE_CALL
-    /// emission appears at the dispatch-JitCode level — that would over-emit
-    /// on every arm execution including forward-progress arms.
+    /// (`jitcode_lower/lower_stmt.rs`) and emitting the LH op at that exact
+    /// stmt position. The OP_JUMP_BACK arm is Lowerable, so
+    /// `try_inline_dispatch_arm` places that call-site LH in the dispatch
+    /// JitCode rather than a sub-JitCode. Forward-progress arms still must
+    /// not emit their own LH.
     ///
     /// The test pins:
-    ///   1. `BC_LOOP_HEADER` appears in the OP_JUMP_BACK arm sub-JitCode
-    ///      (the one whose body contains `can_enter_jit!()`); OP_NOP and
-    ///      OP_ADD_I arms must NOT emit it.
+    ///   1. Exactly one const-pool-anchored `BC_LOOP_HEADER` in the dispatch
+    ///      body (the inlined `can_enter_jit!()`).
     ///   2. The byte immediately after the LH opcode is in valid const-pool
     ///      range and stores the jdindex constant (`0i64` for this invocation).
-    ///   3. ZERO `BC_LOOP_HEADER` opcodes appear in the dispatch JitCode
-    ///      body itself — strict parity with PyPy where the LH lives at
-    ///      the user's source-level `can_enter_jit()` call site, NOT at
-    ///      arm boundaries.
+    ///   3. No residual Nop/Halt sub-JitCode emits LH of its own.
     #[test]
     fn dispatch_oparg_minimal_pins_loop_header_jdindex() {
-        use majit_metainterp::BC_GOTO;
         use majit_metainterp::jitcode::insns::BC_LOOP_HEADER;
 
         let dispatch_jc = build_oparg_minimal();
         let dispatch_code = &dispatch_jc.code;
 
-        // Step 3 (negative parity at dispatch level): the dispatch JitCode
-        // body must NOT contain any [BC_LOOP_HEADER, slot_in_pool, BC_GOTO]
-        // 3-byte triple — the previous per-arm-back-edge emit always
-        // produced this exact triple at every arm's loop-back location.
-        // Anchoring on the trailing BC_GOTO disambiguates payload-byte
-        // coincidences (a const-pool slot byte that happens to equal
-        // BC_LOOP_HEADER is not a real op start).
         let dispatch_num_regs_i = dispatch_jc.c_num_regs_i as usize;
         let dispatch_const_start = dispatch_num_regs_i;
         let dispatch_const_end = dispatch_num_regs_i + dispatch_jc.constants_i.len();
-        let dispatch_lh_at_back_edge_count = (0..dispatch_code.len().saturating_sub(2))
+        let dispatch_lh_positions: Vec<usize> = (0..dispatch_code.len().saturating_sub(1))
             .filter(|&i| {
                 dispatch_code[i] == BC_LOOP_HEADER
                     && (dispatch_code[i + 1] as usize) >= dispatch_const_start
                     && (dispatch_code[i + 1] as usize) < dispatch_const_end
-                    && dispatch_code[i + 2] == BC_GOTO
             })
-            .count();
+            .collect();
         assert_eq!(
-            dispatch_lh_at_back_edge_count, 0,
-            "A.3.4: dispatch JitCode body must contain ZERO \
-             [BC_LOOP_HEADER, slot, BC_GOTO] triples — LH lives at the \
-             source-level can_enter_jit!() call site INSIDE the arm body \
-             sub-JitCode, mirroring `interp_jit.py:118` placement inside \
-             `jump_absolute()`'s backward-branch only.  Got {} occurrences.",
-            dispatch_lh_at_back_edge_count
+            dispatch_lh_positions.len(),
+            1,
+            "A.3.4: dispatch JitCode body must contain exactly one \
+             const-pool-anchored BC_LOOP_HEADER from the inlined \
+             OP_JUMP_BACK can_enter_jit!() site; got {}",
+            dispatch_lh_positions.len()
+        );
+        let lh_pos = dispatch_lh_positions[0];
+        let slot_byte = dispatch_code[lh_pos + 1] as usize;
+        let const_idx = slot_byte - dispatch_num_regs_i;
+        let stored_jdindex = dispatch_jc.constants_i[const_idx];
+        assert_eq!(
+            stored_jdindex, 0i64,
+            "A.3.4: BC_LOOP_HEADER const-pool slot must store jdindex=0; got {}",
+            stored_jdindex
         );
 
-        // Step 1 (positive parity): EXACTLY ONE arm sub-JitCode contains
-        // exactly one BC_LOOP_HEADER op (the OP_JUMP_BACK arm whose body
-        // is `can_enter_jit!(...)`).  Forward-progress arms (OP_NOP /
-        // OP_ADD_I) emit no LH.
-        let arm_lh_emitting: Vec<_> = dispatch_jc
+        let arm_lh_emitting = dispatch_jc
             .exec
             .descrs
             .iter()
@@ -1230,53 +1211,11 @@ mod oparg_minimal {
                         && (sub.code[i + 1] as usize) < cend
                 })
             })
-            .collect();
+            .count();
         assert_eq!(
-            arm_lh_emitting.len(),
-            1,
-            "A.3.4: exactly one arm sub-JitCode must emit BC_LOOP_HEADER \
-             (the OP_JUMP_BACK arm carrying can_enter_jit!()); got {}",
-            arm_lh_emitting.len()
-        );
-        let jump_back_jc = arm_lh_emitting[0];
-
-        // Locate BC_LOOP_HEADER inside the OP_JUMP_BACK sub-JitCode and
-        // verify the slot byte addresses the const-pool entry that
-        // stores the jdindex value.  Anchor on slot-in-const-pool to
-        // disambiguate payload coincidences inside the sub-JitCode.
-        let sub_num_regs_i = jump_back_jc.c_num_regs_i as usize;
-        let sub_const_start = sub_num_regs_i;
-        let sub_const_end = sub_num_regs_i + jump_back_jc.constants_i.len();
-        let sub_lh_pos = (0..jump_back_jc.code.len().saturating_sub(1))
-            .find(|&i| {
-                jump_back_jc.code[i] == BC_LOOP_HEADER
-                    && (jump_back_jc.code[i + 1] as usize) >= sub_const_start
-                    && (jump_back_jc.code[i + 1] as usize) < sub_const_end
-            })
-            .expect(
-                "A.3.4: BC_LOOP_HEADER must appear in OP_JUMP_BACK arm sub-JitCode \
-                 (lower_stmt Stmt::Macro recognition emit-site)",
-            );
-
-        // Step 2: the byte immediately after BC_LOOP_HEADER is the const-pool
-        // slot byte; valid range already enforced by the anchor.
-        let sub_slot_byte = jump_back_jc.code[sub_lh_pos + 1] as usize;
-
-        // Step 2 (cont.): the constant value at that slot equals jdindex (0i64).
-        let sub_const_idx = sub_slot_byte - sub_num_regs_i;
-        let stored_jdindex = jump_back_jc.constants_i[sub_const_idx];
-        assert_eq!(
-            stored_jdindex, 0i64,
-            "A.3.4: BC_LOOP_HEADER const-pool slot must store jdindex=0; got {}",
-            stored_jdindex
-        );
-
-        let _ = (
-            dispatch_lh_at_back_edge_count,
-            sub_lh_pos,
-            sub_slot_byte,
-            sub_const_idx,
-            stored_jdindex,
+            arm_lh_emitting, 0,
+            "A.3.4: residual Nop/Halt sub-JitCodes must not emit BC_LOOP_HEADER; got {}",
+            arm_lh_emitting
         );
     }
 
@@ -2633,18 +2572,7 @@ mod residual_call_not_dropped {
         let _ = asm.ensure_canonical_liveness_offset();
         let dispatch_jc = __dispatch_jitcode_dispatch_residual_call(&mut asm, 0i64)
             .expect("dispatch lower must succeed");
-        let store_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| {
-                sub.code
-                    .iter()
-                    .filter(|&&b| b == BC_STORE_STATE_FIELD)
-                    .count()
-            })
-            .sum();
+        let store_count = super::count_op_in_dispatch_tree(&dispatch_jc, BC_STORE_STATE_FIELD);
         // Only `OP_PURE` contributes one state-field store.  `OP_LOOP_CALL`
         // holds an unregistered qualified call, so its whole body must abort
         // lowering (interpreter fallback) instead of unrolling with the call
@@ -2739,49 +2667,13 @@ mod float_compare_branch_gate {
         let _ = asm.ensure_canonical_liveness_offset();
         let dispatch_jc = __dispatch_jitcode_dispatch_float_cmp(&mut asm, 0i64)
             .expect("dispatch lower must succeed");
-        let ge_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| sub.code.iter().filter(|&&b| b == BC_FLOAT_GE).count())
-            .sum();
-        let guard_ge_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| {
-                sub.code
-                    .iter()
-                    .filter(|&&b| b == BC_GOTO_IF_NOT_FLOAT_GE)
-                    .count()
-            })
-            .sum();
-        let int_guard_ge_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| {
-                sub.code
-                    .iter()
-                    .filter(|&&b| b == BC_GOTO_IF_NOT_INT_GE)
-                    .count()
-            })
-            .sum();
-        let negated_guard_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| {
-                sub.code
-                    .iter()
-                    .filter(|&&b| b == BC_GOTO_IF_NOT_INT_IS_ZERO)
-                    .count()
-            })
-            .sum();
+        let ge_count = super::count_op_in_dispatch_tree(&dispatch_jc, BC_FLOAT_GE);
+        let guard_ge_count =
+            super::count_op_in_dispatch_tree(&dispatch_jc, BC_GOTO_IF_NOT_FLOAT_GE);
+        let int_guard_ge_count =
+            super::count_op_in_dispatch_tree(&dispatch_jc, BC_GOTO_IF_NOT_INT_GE);
+        let negated_guard_count =
+            super::count_op_in_dispatch_tree(&dispatch_jc, BC_GOTO_IF_NOT_INT_IS_ZERO);
         // The value and odd-negation arms retain float_ge/ff>i. The direct
         // branch arm has no materialized boolean and emits the fused ffL
         // exitswitch instead.
@@ -2865,18 +2757,7 @@ mod huge_range_for_loop_falls_back {
         let _ = asm.ensure_canonical_liveness_offset();
         let dispatch_jc = __dispatch_jitcode_dispatch_huge_range(&mut asm, 0i64)
             .expect("dispatch lower must succeed");
-        let store_count: usize = dispatch_jc
-            .exec
-            .descrs
-            .iter()
-            .filter_map(|descr| descr.as_jitcode())
-            .map(|sub| {
-                sub.code
-                    .iter()
-                    .filter(|&&b| b == BC_STORE_STATE_FIELD)
-                    .count()
-            })
-            .sum();
+        let store_count = super::count_op_in_dispatch_tree(&dispatch_jc, BC_STORE_STATE_FIELD);
         // Only the `OP_PURE` arm inlines its single store; the oversized
         // `OP_HUGE` loop exceeds the unroll cap and aborts the arm.
         assert_eq!(

--- a/majit/majit-metainterp/tests/jit_interp_polymorphic_liveness.rs
+++ b/majit/majit-metainterp/tests/jit_interp_polymorphic_liveness.rs
@@ -221,30 +221,17 @@ fn factory_does_not_grow_asm_after_prebuild() {
 
 #[test]
 fn distinct_arms_emit_distinct_bc_live_offsets() {
-    // The polymorphism core has two layers:
+    // The four Lowerable arms (OP_GUARD_A / OP_SUM_AB / OP_SUM_ABC /
+    // OP_SUM_ABCD) are force-inlined into the dispatch JitCode
+    // (`try_inline_dispatch_arm`). Survival and polymorphism therefore
+    // live in the dispatch body:
     //
-    // (1) Per-arm survival: every lowerable arm's sub-JitCode embedded
-    //     under the dispatch JitCode (`BC_INLINE_CALL` target,
-    //     `jitcode_lower/dispatch.rs`'s `lower_dispatch_chain`) must emit at least one
-    //     per-pc BC_LIVE marker past the leading canonical.  If the
-    //     dispatch arm lowerer fell to `__sub_builder.abort()` at
-    //     `jitcode_lower/dispatch.rs`'s `lower_dispatch_chain` for one of the four
-    //     `SUM`/`GUARD_A` arms, the resulting sub-JitCode body is a
-    //     single `BC_ABORT` byte with zero BC_LIVE markers — the
-    //     per-arm assertion below catches that regression.  The
-    //     Polymorphic4State fixture has four lowerable arms, so at
-    //     least four sub-JitCodes must satisfy this guarantee.
-    //
-    // (2) Polymorphism: the union of all per-pc offsets across the
-    //     lowerable sub-JitCodes must contain at least two distinct
-    //     values.  A regression to "every arm uses the canonical
-    //     triple" would collapse this set to size 1.
-    //
-    // The dispatch JitCode body itself emits only the canonical
-    // `live_placeholder()` markers (jit_merge_point pre/post + the
-    // trailing -live- after each inline_call_*), so the per-pc
-    // distinctness signal lives in the embedded sub-JitCodes — one
-    // per arm — rather than the parent dispatch body.
+    // (1) Each arm writes `state.a`, so four `BC_STORE_STATE_FIELD`s
+    //     prove none of them fell to `__sub_builder.abort()`.
+    // (2) The union of per-pc BC_LIVE offsets in that same body (past
+    //     the leading canonical marker) must contain at least two
+    //     distinct values. A regression to "every arm uses the
+    //     canonical triple" would collapse this set to size 1.
     let mut asm = Assembler::new();
     let canonical: Vec<u8> = (0..4u8).collect();
     install_canonical_for_test(&mut asm, &canonical);
@@ -252,66 +239,30 @@ fn distinct_arms_emit_distinct_bc_live_offsets() {
     let dispatch = __dispatch_jitcode_polymorphic_mainloop(&mut asm, 0i64)
         .expect("dispatch lower must succeed for fixture");
 
-    // Identify lowerable arm sub-JitCodes by the leading
-    // `__sub_builder.live_placeholder()` (`jitcode_lower/dispatch.rs`'s
-    // `lower_dispatch_chain`):
-    // a lowerable sub-JitCode body starts with BC_LIVE at offset 0.
-    // Halt/Nop arms produce an empty body (no BC_LIVE); the
-    // abort-fallback path in the same function produces a single BC_ABORT byte
-    // (also no BC_LIVE) — both shapes collapse to "no BC_LIVE markers"
-    // and are filtered out here.  An abort-fallback regression on a
-    // *lowerable* arm therefore reduces the count of qualifying
-    // sub-JitCodes, which the lowerable-count assertion below catches.
-    let mut per_arm_offsets: Vec<Vec<u16>> = Vec::new();
-    for d in dispatch.exec.descrs.iter() {
-        if let majit_metainterp::jitcode::RuntimeBhDescr::JitCode(jc) = d {
-            let offs = collect_bc_live_offsets(jc);
-            if offs.is_empty() {
-                // Halt/Nop arm (empty body) or abort-fallback (`BC_ABORT`
-                // only).  Skip — not a lowerable arm sub-JitCode.
-                continue;
-            }
-            // The first offset is the canonical marker; the rest are per-pc
-            // liveness markers emitted inside the arm body.
-            let per_pc: Vec<u16> = offs.into_iter().skip(1).collect();
-            assert!(
-                !per_pc.is_empty(),
-                "lowerable arm sub-JitCode must emit at least one per-pc \
-                 BC_LIVE marker past the leading canonical; got none — \
-                 the dispatch arm lowerer at \
-                 jitcode_lower/dispatch.rs:1874 may have dropped a real \
-                 per-pc -live- entry, or the body emitted only the \
-                 leading `live_placeholder()`"
-            );
-            per_arm_offsets.push(per_pc);
-        }
-    }
-
-    // Polymorphic4State fixture: four lowerable arms (OP_GUARD_A /
-    // OP_SUM_AB / OP_SUM_ABC / OP_SUM_ABCD).  Fewer than four
-    // qualifying sub-JitCodes means at least one lowerable arm fell to
-    // the abort-fallback in `jitcode_lower/dispatch.rs`'s `lower_dispatch_chain`.
+    let store_count = dispatch
+        .code
+        .iter()
+        .filter(|&&b| b == majit_metainterp::jitcode::insns::BC_STORE_STATE_FIELD)
+        .count();
     assert!(
-        per_arm_offsets.len() >= 4,
-        "expected at least 4 lowerable arm sub-JitCodes (one per \
-         OP_GUARD_A/OP_SUM_AB/OP_SUM_ABC/OP_SUM_ABCD); got {} — the \
-         dispatch arm lowerer dropped one or more lowerable bodies to \
-         `__sub_builder.abort()` at jitcode_lower/dispatch.rs:1874",
-        per_arm_offsets.len()
+        store_count >= 4,
+        "expected at least 4 inlined state-field stores (one per \
+         OP_GUARD_A/OP_SUM_AB/OP_SUM_ABC/OP_SUM_ABCD); got {store_count} — \
+         a lowerable arm fell to abort instead of try_inline_dispatch_arm"
     );
 
-    // Polymorphism: the union of all per-pc marker offsets across the
-    // lowerable sub-JitCodes must contain at least two distinct values.
-    let all_offsets: std::collections::BTreeSet<u16> = per_arm_offsets
-        .iter()
-        .flat_map(|offs| offs.iter().copied())
-        .collect();
+    let offs = collect_bc_live_offsets(&dispatch);
+    let per_pc: Vec<u16> = offs.into_iter().skip(1).collect();
+    assert!(
+        !per_pc.is_empty(),
+        "inlined lowerable arms must emit at least one per-pc BC_LIVE \
+         marker past the leading canonical; got none"
+    );
+    let all_offsets: std::collections::BTreeSet<u16> = per_pc.iter().copied().collect();
     assert!(
         all_offsets.len() >= 2,
         "polymorphic per-pc liveness regressed: every per-pc BC_LIVE marker \
-         across embedded sub-JitCodes points at the same offset — saw \
-         {all_offsets:?} across {} arms",
-        per_arm_offsets.len()
+         in the dispatch body points at the same offset — saw {all_offsets:?}"
     );
 }
 
@@ -363,26 +314,16 @@ fn dispatch_inline_call_descrs_have_jitcode_entries() {
     let dispatch = __dispatch_jitcode_polymorphic_mainloop(&mut asm, 0i64)
         .expect("dispatch lower must succeed for fixture");
 
-    let mut jitcode_count = 0;
+    // Every Lowerable arm is force-inlined; `_ => break` is the default
+    // label, not a residual INLINE_CALL. Residual Nop/Halt/abort stubs,
+    // if any remain, must still be non-empty JitCode descrs — never
+    // fnaddr wrappers (`pyjitpl/dispatch.rs` `run_one_step`).
     for d in dispatch.exec.descrs.iter() {
         if let majit_metainterp::jitcode::RuntimeBhDescr::JitCode(jc) = d {
-            jitcode_count += 1;
-            // Each sub-jitcode body is at least 1 byte. Cross-scope arms
-            // fall back to a single abort byte
-            // (`jitcode_lower/dispatch.rs`'s `lower_dispatch_chain`),
-            // which is intentional — but a zero-byte body would mean the
-            // build pipeline silently dropped the sub-jitcode entirely.
             assert!(
                 !jc.code.is_empty(),
                 "BC_INLINE_CALL target sub-jitcode body must be non-empty"
             );
         }
     }
-    assert!(
-        jitcode_count >= 1,
-        "dispatch must emit at least one BC_INLINE_CALL JitCode descr; \
-         a fnaddr-only descr table would mean the lowerer wired native \
-         call targets instead of frame-chain sub-jitcodes, regressing \
-         the dispatch.rs:1690-1692 contract"
-    );
 }

--- a/majit/majit-metainterp/tests/jitcode_names.rs
+++ b/majit/majit-metainterp/tests/jitcode_names.rs
@@ -114,10 +114,13 @@ fn arm_names(dispatch: &JitCode) -> Vec<String> {
 fn each_arm_subjitcode_names_the_arm_it_came_from() {
     let dispatch = build_named_dispatch();
     let names = arm_names(&dispatch);
+    // OP_NOP is residual (ArmPattern::Nop) and keeps a named sub-JitCode.
+    // OP_INC_A is Lowerable and is force-inlined into the dispatch body, so
+    // it does not register a sibling JitCode.
     assert_eq!(
         names.len(),
-        2,
-        "one sub-JitCode per non-default arm; got {names:?}",
+        1,
+        "one residual Nop sub-JitCode; got {names:?}",
     );
 
     // The interp prefix is what makes a name readable in a log that carries
@@ -129,19 +132,8 @@ fn each_arm_subjitcode_names_the_arm_it_came_from() {
         );
     }
 
-    // The arm's own spelling, and the reason the whole exercise is worth
-    // anything: two arms of one machine must not answer with the same string.
     assert!(
         names.iter().any(|n| n.contains("OP_NOP")),
-        "the nop arm names its own pattern; got {names:?}",
-    );
-    assert!(
-        names.iter().any(|n| n.contains("OP_INC_A")),
-        "the lowered arm names its own pattern; got {names:?}",
-    );
-    assert_ne!(
-        names[0], names[1],
-        "two arms sharing a name identify nothing, the same as sharing the \
-         empty one; got {names:?}",
+        "the residual nop arm names its own pattern; got {names:?}",
     );
 }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -931,6 +931,222 @@ fn variable_has_declared_unsigned_type(
         })
 }
 
+/// Whether `variable` carries RPython's `BoolRepr`, before the codewriter's
+/// `getkind(Bool) == 'int'` projection erases that distinction.
+///
+/// Production still feeds jtransform the rich model graph rather than the
+/// rtyper-rewritten flowspace graph. Read the rich result declaration just
+/// as [`variable_has_declared_unsigned_type`] does; retain the raw
+/// `Variable.concretetype == lltype.Bool` check for graphs that did pass
+/// through the rtyper. This is the representation test behind
+/// `rbool.py BoolRepr.rtype_bool`: a Bool from an input, field, call,
+/// comparison, CFG phi, nested `bool`, or JIT query has the same identity
+/// rule. Comparison semantics outrank the rich storage carrier because a few
+/// front rewrites retain `Int`/`Unsigned` there.
+fn variable_has_bool_repr(
+    graph: &FunctionGraph,
+    variable: &crate::flowspace::model::Variable,
+) -> bool {
+    use crate::flowspace::model::ConstValue;
+    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+    fn op_result_has_bool_repr(kind: &OpKind) -> bool {
+        if matches!(
+            kind,
+            OpKind::ConstBool(_)
+                | OpKind::ConstSymbolic {
+                    ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::Input {
+                    ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::FieldRead {
+                    ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::VableFieldRead {
+                    ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::ArrayRead {
+                    item_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::InteriorFieldRead {
+                    item_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::VableArrayRead {
+                    item_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::RawLoad {
+                    item_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::Call {
+                    result_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::IndirectCall {
+                    result_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::BinOp {
+                    result_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::UnaryOp {
+                    result_ty: ValueType::Bool,
+                    ..
+                }
+                | OpKind::IsConstant { .. }
+                | OpKind::IsVirtual { .. }
+                | OpKind::IsInstance { .. }
+                | OpKind::LoadStatic {
+                    ty: ValueType::Bool,
+                    ..
+                }
+        ) {
+            return true;
+        }
+
+        // Several front rewrites retain the source storage carrier on a
+        // comparison (`Int` in slice_get, `Unsigned` in saturating_sub).
+        // RPython's annotator/rtyper still gives every comparison result
+        // BoolRepr. Read the operation semantics before the carrier so these
+        // take the same `rtype_bool` identity path.
+        match kind {
+            OpKind::BinOp { op, .. } => matches!(
+                op.as_str(),
+                "is_"
+                    | "lt"
+                    | "le"
+                    | "eq"
+                    | "ne"
+                    | "gt"
+                    | "ge"
+                    | "int_lt"
+                    | "int_le"
+                    | "int_eq"
+                    | "int_ne"
+                    | "int_gt"
+                    | "int_ge"
+                    | "uint_lt"
+                    | "uint_le"
+                    | "uint_eq"
+                    | "uint_ne"
+                    | "uint_gt"
+                    | "uint_ge"
+                    | "float_lt"
+                    | "float_le"
+                    | "float_eq"
+                    | "float_ne"
+                    | "float_gt"
+                    | "float_ge"
+                    | "ptr_eq"
+                    | "ptr_ne"
+            ),
+            OpKind::UnaryOp { op, .. } => matches!(
+                op.as_str(),
+                "bool" | "int_is_zero" | "int_is_true" | "ptr_iszero" | "ptr_nonzero"
+            ),
+            _ => false,
+        }
+    }
+
+    fn classify(
+        graph: &FunctionGraph,
+        variable: &crate::flowspace::model::Variable,
+        visiting: &mut std::collections::HashSet<u64>,
+    ) -> Option<bool> {
+        if matches!(
+            variable.concretetype.borrow().as_ref(),
+            Some(LowLevelType::Bool)
+        ) {
+            return Some(true);
+        }
+        if !visiting.insert(variable.id()) {
+            // A loop-carried phi may point back to itself. The other incoming
+            // roots decide its representation; a pure cycle has no evidence.
+            return None;
+        }
+
+        let producer = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find(|op| op.result.as_ref() == Some(variable));
+        let classified = if let Some(op) = producer {
+            match &op.kind {
+                // These operations preserve their operand representation.
+                OpKind::Hint { value, .. } => classify(graph, value, visiting),
+                OpKind::UnaryOp { op, operand, .. }
+                    if matches!(op.as_str(), "same_as" | "deref") =>
+                {
+                    classify(graph, operand, visiting)
+                }
+                kind => Some(op_result_has_bool_repr(kind)),
+            }
+        } else if let Some((target, slot)) = graph.blocks.iter().find_map(|block| {
+            block
+                .inputargs
+                .iter()
+                .position(|arg| arg == variable)
+                .map(|slot| (block.id, slot))
+        }) {
+            // RPythonAnnotator.follow_link/mergeinputargs unions each link
+            // argument with the matching Block.inputarg. Recover that
+            // relation from the graph: every non-cyclic incoming root must
+            // be Bool, and at least one root must provide positive evidence.
+            // This admits loop-carried Bool phis without treating an
+            // evidence-free cycle as Bool.
+            let mut saw_incoming = false;
+            let mut saw_bool_root = false;
+            let mut contradicted = false;
+            for link in graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.exits)
+                .filter(|link| link.target == target)
+            {
+                saw_incoming = true;
+                let incoming = match link.args.get(slot) {
+                    Some(LinkArg::Value(value)) => classify(graph, value, visiting),
+                    Some(LinkArg::Const(constant)) => Some(
+                        constant.concretetype.as_ref() == Some(&LowLevelType::Bool)
+                            || matches!(&constant.value, ConstValue::Bool(_)),
+                    ),
+                    None => Some(false),
+                };
+                match incoming {
+                    Some(true) => saw_bool_root = true,
+                    Some(false) => {
+                        contradicted = true;
+                        break;
+                    }
+                    None => {}
+                }
+            }
+            if contradicted || !saw_incoming {
+                Some(false)
+            } else if saw_bool_root {
+                Some(true)
+            } else {
+                None
+            }
+        } else {
+            Some(false)
+        };
+        visiting.remove(&variable.id());
+        classified
+    }
+
+    classify(graph, variable, &mut std::collections::HashSet::new()) == Some(true)
+}
+
 /// Preserve the MIR distinction between reading a by-value field and taking
 /// the address of an inline substructure. RPython receives distinct
 /// `getfield`/`getsubstruct` operations from its rtyper; Rust references are
@@ -1175,10 +1391,9 @@ impl<'a> Transformer<'a> {
         // (`ExitSwitch::Fused`), eliding the standalone compare op.  Runs
         // after the exitswitch/exits remap is committed; it never alters
         // link targets, so the exceptblock note below is unaffected.
-        // `rbool.py BoolRepr.rtype_bool` — erase the identity `bool` hop
-        // `set_branch` wrapped the condition in, so the scan below sees
-        // the comparison the post-rtyper graph upstream fuses carries.
-        rtype_bool_identity(graph, block_idx);
+        // The ordinary identity rewrite above has already applied
+        // `rbool.py BoolRepr.rtype_bool`, so a branch truthification over a
+        // Bool comparison reaches this scan as the comparison itself.
         optimize_goto_if_not(graph, block_idx);
 
         // `jtransform.py:124-127` — a virtualizable array read must be
@@ -1834,6 +2049,25 @@ impl<'a> Transformer<'a> {
                         result_ty: result_ty.clone(),
                     },
                 }])
+            }
+            // `rbool.py BoolRepr.rtype_bool`:
+            //
+            //     vlist = hop.inputargs(bool_repr)
+            //     return vlist[0]
+            //
+            // The returned input replaces the result everywhere. Route the
+            // identity through the same alias machinery as `same_as`: later
+            // operations are remapped while the block is rewritten, and the
+            // exitswitch plus every link argument are remapped when the block
+            // is committed. In particular this handles shared results and
+            // nested `bool(bool(x))`; neither requires a special branch-only
+            // substitution.
+            OpKind::UnaryOp {
+                op: unop_name,
+                operand,
+                ..
+            } if unop_name == "bool" && variable_has_bool_repr(graph, operand) => {
+                RewriteResult::Identity(operand.clone())
             }
             OpKind::UnaryOp {
                 op: unop_name,
@@ -7297,105 +7531,6 @@ fn sum_variant_ctor(target: &CallTarget) -> Option<SumVariantCtor> {
     })
 }
 
-/// `rbool.py BoolRepr.rtype_bool` — the identity `bool` over an operand
-/// that is already Bool.
-///
-/// ```python
-/// class BoolRepr(IntegerRepr):
-///     lowleveltype = Bool
-///     def rtype_bool(_, hop):
-///         vlist = hop.inputargs(bool_repr)
-///         return vlist[0]
-/// ```
-///
-/// [`crate::model::FunctionGraph::set_branch`] wraps every branch
-/// condition in the `bool` hop `flowcontext.py` applies unconditionally
-/// before `guessbool`, which is why a block's `exitswitch` always names a
-/// `bool` result.  Upstream then specialises that hop per repr in the
-/// rtyper, and `BoolRepr` returns the operand itself — no operation is
-/// emitted — so the post-rtyper `block.exitswitch` names the
-/// *comparison*, and that is the graph shape
-/// [`optimize_goto_if_not`] was written against.
-///
-/// Pyre's MIR front end does not run the rtyper over these graphs, so the
-/// hop survives.  [`optimize_goto_if_not`]'s backward scan stops at the
-/// first op producing the exitswitch, so it fuses the truthify
-/// (`goto_if_not_int_is_true` over the compare's *result*) where upstream
-/// fuses the compare (`goto_if_not_int_lt` over its *operands*).  Both
-/// answer the same branch; the second is one jitcode instruction and one
-/// recorded trace op shorter, and it is the only thing that makes the
-/// `goto_if_not_{int,float,ptr}_*` keys reachable at all — every one of
-/// them is registered in `insns`, `blackhole`, the pyjitpl dispatch and
-/// the walker, and none of them can be produced while the hop stands.
-///
-/// The identity is applied only when the operand is produced, in this
-/// same block, by an op [`goto_if_not_fusable`] already names — i.e. one
-/// whose result is a Bool, which is what makes `bool(u) == u` true.  Over
-/// anything else `bool` is a real `u != 0` test
-/// (`rint.py IntegerRepr.rtype_bool` → `int_is_true`) and has to stay.
-fn rtype_bool_identity(graph: &mut FunctionGraph, block_idx: usize) -> bool {
-    use crate::model::ExitSwitch;
-
-    let Some(ExitSwitch::Value(v)) = graph.blocks[block_idx].exitswitch.clone() else {
-        return false;
-    };
-    let Some(hop_idx) = graph.blocks[block_idx]
-        .operations
-        .iter()
-        .position(|op| op.result.as_ref() == Some(&v))
-    else {
-        return false;
-    };
-    let OpKind::UnaryOp { op, operand, .. } = &graph.blocks[block_idx].operations[hop_idx].kind
-    else {
-        return false;
-    };
-    if op != "bool" {
-        return false;
-    }
-    let u = operand.clone();
-
-    // `hop.inputargs(bool_repr)` — the operand's repr has to be Bool for
-    // `BoolRepr` to be the one that answers.  Pyre carries no repr on the
-    // Variable (`concretetype_of` collapses Bool into `Signed`, the
-    // `getkind` projection), so the producing op stands in for it: the
-    // ops upstream lists as fusable are exactly the Bool-producing ones.
-    // A `bool` hop over another `bool` hop is left alone; it is already
-    // an identity and folding it changes nothing this pass reads.
-    let operand_is_bool = graph.blocks[block_idx].operations.iter().any(|cand| {
-        cand.result.as_ref() == Some(&u)
-            && !matches!(&cand.kind, OpKind::UnaryOp { op, .. } if op == "bool")
-            && goto_if_not_fusable(&cand.kind).is_some()
-    });
-    if !operand_is_bool {
-        return false;
-    }
-
-    // Dropping the hop retires `v`, so no other op in the block may read
-    // it.  Link arguments that carry it are rewritten to `u`, which holds
-    // the same value — the substitution upstream never has to make
-    // because its `v` was never a distinct Variable in the first place.
-    let read_elsewhere = graph.blocks[block_idx]
-        .operations
-        .iter()
-        .enumerate()
-        .any(|(i, cand)| i != hop_idx && crate::inline::op_variable_refs(&cand.kind).contains(&v));
-    if read_elsewhere {
-        return false;
-    }
-
-    graph.blocks[block_idx].operations.remove(hop_idx);
-    graph.blocks[block_idx].exitswitch = Some(ExitSwitch::Value(u.clone()));
-    for link in graph.blocks[block_idx].exits.iter_mut() {
-        for arg in link.args.iter_mut() {
-            if arg.as_variable() == Some(&v) {
-                *arg = LinkArg::Value(u.clone());
-            }
-        }
-    }
-    true
-}
-
 /// `jtransform.py Transformer.optimize_goto_if_not` — fuse a
 /// comparison op into the block's `exitswitch`.
 ///
@@ -9238,7 +9373,7 @@ mod tests {
     #[test]
     fn a_truthify_condition_over_an_unresolved_operand_declines() {
         let (mut graph, _cond, _operand, start) = {
-            let (mut g, c, o, s) = truthify_fixture(LlType::Signed, LlType::Signed);
+            let (g, c, o, s) = truthify_fixture(LlType::Signed, LlType::Signed);
             o.set_concretetype(None);
             (g.clone(), c, o, s)
         };
@@ -9294,78 +9429,148 @@ mod tests {
     fn a_truthify_over_a_comparison_folds_to_the_comparison() {
         use crate::model::{ExitCase, ExitSwitch, Link};
 
-        let mut graph = FunctionGraph::new("truthify_over_compare");
-        let a = graph.alloc_value_var();
-        let b = graph.alloc_value_var();
-        // `front::mir::canonical_binop_label` leaves the comparison bare;
-        // the `int_` prefix is applied by the assembler, after flatten.
-        a.set_concretetype(Some(LlType::Signed));
-        b.set_concretetype(Some(LlType::Signed));
-        let t = graph
-            .push_op_var(
+        // Some front rewrites retain the comparison's storage carrier rather
+        // than its semantic result type. Both still rtype to Bool upstream.
+        for (comparison_carrier, operand_type) in [
+            (ValueType::Int, LlType::Signed),
+            (ValueType::Unsigned, LlType::Unsigned),
+        ] {
+            let mut graph = FunctionGraph::new("truthify_over_compare");
+            let a = graph.alloc_value_var();
+            let b = graph.alloc_value_var();
+            // `front::mir::canonical_binop_label` leaves the comparison bare;
+            // the `int_` prefix is applied by the assembler, after flatten.
+            a.set_concretetype(Some(operand_type.clone()));
+            b.set_concretetype(Some(operand_type));
+            let t = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: "lt".to_string(),
+                        lhs: a.clone(),
+                        rhs: b.clone(),
+                        result_ty: comparison_carrier.clone(),
+                    },
+                    true,
+                )
+                .unwrap();
+            t.set_concretetype(Some(LlType::Signed));
+            // `set_branch`'s unconditional `op.bool(w_value)` hop.
+            let cond = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::UnaryOp {
+                        op: "bool".to_string(),
+                        operand: t.clone(),
+                        result_ty: ValueType::Bool,
+                    },
+                    true,
+                )
+                .unwrap();
+            cond.set_concretetype(Some(LlType::Signed));
+            let if_false = graph.create_block();
+            let if_true = graph.create_block();
+            let start = graph.startblock.0;
+            graph.set_control_flow_metadata(
                 graph.startblock,
-                OpKind::BinOp {
-                    op: "lt".to_string(),
-                    lhs: a.clone(),
-                    rhs: b.clone(),
-                    result_ty: ValueType::Bool,
-                },
-                true,
-            )
-            .unwrap();
-        t.set_concretetype(Some(LlType::Signed));
-        // `set_branch`'s unconditional `op.bool(w_value)` hop.
-        let cond = graph
-            .push_op_var(
-                graph.startblock,
-                OpKind::UnaryOp {
-                    op: "bool".to_string(),
-                    operand: t.clone(),
-                    result_ty: ValueType::Bool,
-                },
-                true,
-            )
-            .unwrap();
-        cond.set_concretetype(Some(LlType::Signed));
-        let if_false = graph.create_block();
-        let if_true = graph.create_block();
-        let start = graph.startblock.0;
-        graph.set_control_flow_metadata(
-            graph.startblock,
-            Some(ExitSwitch::Value(cond.clone())),
-            vec![
-                Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
-                Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
-            ],
-        );
+                Some(ExitSwitch::Value(cond.clone())),
+                vec![
+                    Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                    Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
+                ],
+            );
 
-        assert!(
-            super::rtype_bool_identity(&mut graph, start),
-            "a `bool` over a comparison result must fold to the comparison"
-        );
-        assert!(
-            !graph.blocks[start]
-                .operations
-                .iter()
-                .any(|op| matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "bool")),
-            "the identity hop must be removed"
-        );
-        assert_eq!(
-            graph.blocks[start].exitswitch,
-            Some(ExitSwitch::Value(t.clone())),
-            "the exitswitch must name the comparison result"
-        );
-
-        assert!(
-            super::optimize_goto_if_not(&mut graph, start),
-            "the comparison must then fuse"
-        );
-        match &graph.blocks[start].exitswitch {
-            Some(ExitSwitch::Fused { opname, args }) => {
-                assert_eq!(opname, "int_lt");
-                assert_eq!(args, &vec![a.clone(), b.clone()]);
+            let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+            let block = &transformed.graph.blocks[start];
+            assert!(
+                !block
+                    .operations
+                    .iter()
+                    .any(|op| matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "bool")),
+                "the identity hop must be removed"
+            );
+            match &block.exitswitch {
+                Some(ExitSwitch::Fused { opname, args }) => {
+                    assert_eq!(opname, "int_lt");
+                    assert_eq!(args, &vec![a.clone(), b.clone()]);
+                }
+                other => panic!("expected a Fused int_lt exitswitch, got {other:?}"),
             }
-            other => panic!("expected a Fused int_lt exitswitch, got {other:?}"),
+        }
+    }
+
+    /// `uint_*` and rich-graph `is_` comparisons have no direct fused
+    /// `goto_if_not` form. They still produce BoolRepr, so only the redundant
+    /// truthification is removed and the comparison remains as the
+    /// exitswitch value.
+    #[test]
+    fn a_truthify_over_an_unfused_comparison_is_identity() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+
+        for (opname, operand_type, comparison_carrier) in [
+            ("uint_lt", LlType::Unsigned, ValueType::Int),
+            (
+                "is_",
+                crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+                ValueType::Int,
+            ),
+        ] {
+            let mut graph = FunctionGraph::new(format!("truthify_over_{opname}"));
+            let a = graph.alloc_value_var();
+            let b = graph.alloc_value_var();
+            a.set_concretetype(Some(operand_type.clone()));
+            b.set_concretetype(Some(operand_type));
+            let comparison = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: opname.into(),
+                        lhs: a,
+                        rhs: b,
+                        result_ty: comparison_carrier,
+                    },
+                    true,
+                )
+                .unwrap();
+            comparison.set_concretetype(Some(LlType::Signed));
+            let truthified = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::UnaryOp {
+                        op: "bool".into(),
+                        operand: comparison.clone(),
+                        result_ty: ValueType::Bool,
+                    },
+                    true,
+                )
+                .unwrap();
+            truthified.set_concretetype(Some(LlType::Signed));
+            let if_false = graph.create_block();
+            let if_true = graph.create_block();
+            let start = graph.startblock.0;
+            graph.set_control_flow_metadata(
+                graph.startblock,
+                Some(ExitSwitch::Value(truthified.clone())),
+                vec![
+                    Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
+                    Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
+                ],
+            );
+
+            let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+            let block = &transformed.graph.blocks[start];
+            assert!(
+                !block
+                    .operations
+                    .iter()
+                    .any(|op| op.result.as_ref() == Some(&truthified)),
+                "the Bool identity operation must be removed for {opname}"
+            );
+            assert_eq!(
+                block.exitswitch,
+                Some(ExitSwitch::Value(comparison)),
+                "the unfused {opname} comparison must become the branch value directly"
+            );
         }
     }
 
@@ -9419,15 +9624,8 @@ mod tests {
             ],
         );
 
-        assert!(
-            !super::rtype_bool_identity(&mut graph, start),
-            "a `bool` over an arithmetic result is a real int_is_true test"
-        );
-        assert!(
-            super::optimize_goto_if_not(&mut graph, start),
-            "the truthify itself still fuses"
-        );
-        match &graph.blocks[start].exitswitch {
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        match &transformed.graph.blocks[start].exitswitch {
             Some(ExitSwitch::Fused { opname, args }) => {
                 assert_eq!(opname, "int_is_true");
                 assert_eq!(args, &vec![t.clone()]);
@@ -9436,11 +9634,10 @@ mod tests {
         }
     }
 
-    /// Dropping the hop retires its result, so a second reader of that
-    /// result declines: nothing else may be left naming a Variable no op
-    /// produces.
+    /// `BoolRepr.rtype_bool` returns the input Variable, so every reader of
+    /// the result is renamed to that input just like upstream's rtyper graph.
     #[test]
-    fn a_truthify_whose_result_has_another_reader_declines() {
+    fn a_truthify_whose_result_has_another_reader_renames_it() {
         use crate::model::{ExitCase, ExitSwitch, Link};
 
         let mut graph = FunctionGraph::new("truthify_second_reader");
@@ -9474,7 +9671,7 @@ mod tests {
             .unwrap();
         cond.set_concretetype(Some(LlType::Signed));
         // A second consumer of the truthify result.
-        graph
+        let negated = graph
             .push_op_var(
                 graph.startblock,
                 OpKind::UnaryOp {
@@ -9487,19 +9684,260 @@ mod tests {
             .unwrap();
         let if_false = graph.create_block();
         let if_true = graph.create_block();
+        let carried = graph.alloc_value_var();
+        graph.push_inputarg_var(if_true, carried);
         let start = graph.startblock.0;
         graph.set_control_flow_metadata(
             graph.startblock,
             Some(ExitSwitch::Value(cond.clone())),
             vec![
                 Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false))),
-                Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true))),
+                Link::new_mixed(
+                    vec![LinkArg::Value(cond.clone())],
+                    if_true,
+                    Some(ExitCase::Bool(true)),
+                ),
             ],
         );
 
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        let block = &transformed.graph.blocks[start];
         assert!(
-            !super::rtype_bool_identity(&mut graph, start),
-            "a second reader of the truthify result must decline the fold"
+            !block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&cond)),
+            "the identity result must have no defining operation"
+        );
+        let negated_op = block
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&negated))
+            .expect("the second consumer must survive");
+        assert!(
+            matches!(&negated_op.kind, OpKind::UnaryOp { operand, .. } if operand == &t),
+            "the second consumer must read the Bool input directly"
+        );
+        assert_eq!(
+            block.exitswitch,
+            Some(ExitSwitch::Value(t.clone())),
+            "the branch must read the Bool input; the comparison stays separate because its second reader prevents fusion"
+        );
+        assert_eq!(
+            block.exits[1].args[0].as_variable(),
+            Some(&t),
+            "an outgoing link must carry the Bool input rather than the removed identity result"
+        );
+    }
+
+    /// A Bool input is not one of `optimize_goto_if_not`'s comparison
+    /// producers, but `BoolRepr.rtype_bool` is still identity. This guards
+    /// the representation-based rule rather than the old fusion whitelist.
+    #[test]
+    fn a_truthify_over_a_non_fusable_bool_input_is_identity() {
+        let mut graph = FunctionGraph::new("truthify_bool_input");
+        let source = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "flag".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        source.set_concretetype(Some(LlType::Signed));
+        let truthified = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::UnaryOp {
+                    op: "bool".into(),
+                    operand: source.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        truthified.set_concretetype(Some(LlType::Signed));
+        let negated = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::UnaryOp {
+                    op: "int_neg".into(),
+                    operand: truthified.clone(),
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(negated.clone()));
+
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        let block = transformed.graph.block(graph.startblock);
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&truthified)),
+            "the Bool identity operation must be removed"
+        );
+        let negated_op = block
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&negated))
+            .expect("the consumer must survive");
+        assert!(
+            matches!(&negated_op.kind, OpKind::UnaryOp { operand, .. } if operand == &source),
+            "the consumer must read the original Bool input"
+        );
+        assert_eq!(
+            block.exits[0].args[0].as_variable(),
+            Some(&negated),
+            "the return link remains well formed"
+        );
+    }
+
+    /// A block inputarg has no operation producer of its own. RPython types
+    /// the phi by unioning the matching incoming link arguments, so a Bool
+    /// source must retain BoolRepr after crossing the edge.
+    #[test]
+    fn a_truthify_over_a_bool_phi_is_identity() {
+        let mut graph = FunctionGraph::new("truthify_bool_phi");
+        let source = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "flag".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        source.set_concretetype(Some(LlType::Signed));
+
+        let (join, inputargs) = graph.create_block_with_arg_vars(1);
+        let phi = inputargs[0].clone();
+        phi.set_concretetype(Some(LlType::Signed));
+        graph.set_goto(graph.startblock, join, vec![source.clone()]);
+
+        let truthified = graph
+            .push_op_var(
+                join,
+                OpKind::UnaryOp {
+                    op: "bool".into(),
+                    operand: phi.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        truthified.set_concretetype(Some(LlType::Signed));
+        let negated = graph
+            .push_op_var(
+                join,
+                OpKind::UnaryOp {
+                    op: "int_neg".into(),
+                    operand: truthified.clone(),
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(join, Some(negated.clone()));
+
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        let block = transformed.graph.block(join);
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&truthified)),
+            "the Bool identity operation must be removed after the CFG edge"
+        );
+        let negated_op = block
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&negated))
+            .expect("the consumer must survive");
+        assert!(
+            matches!(&negated_op.kind, OpKind::UnaryOp { operand, .. } if operand == &phi),
+            "the consumer must read the Bool phi directly"
+        );
+    }
+
+    /// A loop-header inputarg has its own backedge as one incoming value.
+    /// Classification must use the entry Bool as positive evidence without
+    /// recursing forever on the loop-carried edge.
+    #[test]
+    fn a_truthify_over_a_loop_carried_bool_phi_is_identity() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+
+        let mut graph = FunctionGraph::new("truthify_loop_bool_phi");
+        let source = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "flag".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        source.set_concretetype(Some(LlType::Signed));
+
+        let (header, inputargs) = graph.create_block_with_arg_vars(1);
+        let phi = inputargs[0].clone();
+        phi.set_concretetype(Some(LlType::Signed));
+        graph.set_goto(graph.startblock, header, vec![source]);
+
+        let truthified = graph
+            .push_op_var(
+                header,
+                OpKind::UnaryOp {
+                    op: "bool".into(),
+                    operand: phi.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        truthified.set_concretetype(Some(LlType::Signed));
+
+        let (body, body_inputs) = graph.create_block_with_arg_vars(1);
+        let body_phi = body_inputs[0].clone();
+        body_phi.set_concretetype(Some(LlType::Signed));
+        let done = graph.create_block();
+        graph.set_control_flow_metadata(
+            header,
+            Some(ExitSwitch::Value(truthified.clone())),
+            vec![
+                Link::new_mixed(vec![], done, Some(ExitCase::Bool(false))),
+                Link::new_mixed(
+                    vec![LinkArg::Value(phi.clone())],
+                    body,
+                    Some(ExitCase::Bool(true)),
+                ),
+            ],
+        );
+        graph.set_goto(body, header, vec![body_phi]);
+        graph.set_return(done, None);
+
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        let block = transformed.graph.block(header);
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&truthified)),
+            "the loop-header Bool identity operation must be removed"
+        );
+        assert_eq!(
+            block.exitswitch,
+            Some(ExitSwitch::Value(phi)),
+            "the loop header must branch on its Bool inputarg directly"
         );
     }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -948,7 +948,33 @@ fn variable_has_bool_repr(
     variable: &crate::flowspace::model::Variable,
 ) -> bool {
     use crate::flowspace::model::ConstValue;
+    use crate::model::BlockId;
     use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+    // One linear pass builds the producer / phi / predecessor indexes.
+    // `classify` then answers in the size of the reachable DAG: a memoized
+    // walk that used to re-enter every diamond (and every `bool()` query
+    // rebuilt the walk from scratch) exploded the prepass into a multi-hour
+    // hang on interpreter graphs.
+    let mut producer: std::collections::HashMap<u64, &crate::model::SpaceOperation> =
+        std::collections::HashMap::new();
+    let mut inputarg: std::collections::HashMap<u64, (BlockId, usize)> =
+        std::collections::HashMap::new();
+    let mut incoming: std::collections::HashMap<BlockId, Vec<&crate::model::Link>> =
+        std::collections::HashMap::new();
+    for block in &graph.blocks {
+        for op in &block.operations {
+            if let Some(result) = op.result.as_ref() {
+                producer.insert(result.id(), op);
+            }
+        }
+        for (slot, arg) in block.inputargs.iter().enumerate() {
+            inputarg.insert(arg.id(), (block.id, slot));
+        }
+        for link in &block.exits {
+            incoming.entry(link.target).or_default().push(link);
+        }
+    }
 
     fn op_result_has_bool_repr(kind: &OpKind) -> bool {
         if matches!(
@@ -1057,9 +1083,16 @@ fn variable_has_bool_repr(
         }
     }
 
+    struct BoolReprIndex<'g> {
+        producer: std::collections::HashMap<u64, &'g crate::model::SpaceOperation>,
+        inputarg: std::collections::HashMap<u64, (BlockId, usize)>,
+        incoming: std::collections::HashMap<BlockId, Vec<&'g crate::model::Link>>,
+    }
+
     fn classify(
-        graph: &FunctionGraph,
+        index: &BoolReprIndex<'_>,
         variable: &crate::flowspace::model::Variable,
+        cache: &mut std::collections::HashMap<u64, Option<bool>>,
         visiting: &mut std::collections::HashSet<u64>,
     ) -> Option<bool> {
         if matches!(
@@ -1068,35 +1101,27 @@ fn variable_has_bool_repr(
         ) {
             return Some(true);
         }
+        if let Some(&cached) = cache.get(&variable.id()) {
+            return cached;
+        }
         if !visiting.insert(variable.id()) {
             // A loop-carried phi may point back to itself. The other incoming
             // roots decide its representation; a pure cycle has no evidence.
             return None;
         }
 
-        let producer = graph
-            .blocks
-            .iter()
-            .flat_map(|block| &block.operations)
-            .find(|op| op.result.as_ref() == Some(variable));
-        let classified = if let Some(op) = producer {
+        let classified = if let Some(op) = index.producer.get(&variable.id()) {
             match &op.kind {
                 // These operations preserve their operand representation.
-                OpKind::Hint { value, .. } => classify(graph, value, visiting),
+                OpKind::Hint { value, .. } => classify(index, value, cache, visiting),
                 OpKind::UnaryOp { op, operand, .. }
                     if matches!(op.as_str(), "same_as" | "deref") =>
                 {
-                    classify(graph, operand, visiting)
+                    classify(index, operand, cache, visiting)
                 }
                 kind => Some(op_result_has_bool_repr(kind)),
             }
-        } else if let Some((target, slot)) = graph.blocks.iter().find_map(|block| {
-            block
-                .inputargs
-                .iter()
-                .position(|arg| arg == variable)
-                .map(|slot| (block.id, slot))
-        }) {
+        } else if let Some(&(target, slot)) = index.inputarg.get(&variable.id()) {
             // RPythonAnnotator.follow_link/mergeinputargs unions each link
             // argument with the matching Block.inputarg. Recover that
             // relation from the graph: every non-cyclic incoming root must
@@ -1106,15 +1131,16 @@ fn variable_has_bool_repr(
             let mut saw_incoming = false;
             let mut saw_bool_root = false;
             let mut contradicted = false;
-            for link in graph
-                .blocks
-                .iter()
-                .flat_map(|block| &block.exits)
-                .filter(|link| link.target == target)
-            {
+            let empty: [&crate::model::Link; 0] = [];
+            let links = index
+                .incoming
+                .get(&target)
+                .map(|links| links.as_slice())
+                .unwrap_or(&empty);
+            for link in links {
                 saw_incoming = true;
                 let incoming = match link.args.get(slot) {
-                    Some(LinkArg::Value(value)) => classify(graph, value, visiting),
+                    Some(LinkArg::Value(value)) => classify(index, value, cache, visiting),
                     Some(LinkArg::Const(constant)) => Some(
                         constant.concretetype.as_ref() == Some(&LowLevelType::Bool)
                             || matches!(&constant.value, ConstValue::Bool(_)),
@@ -1141,10 +1167,21 @@ fn variable_has_bool_repr(
             Some(false)
         };
         visiting.remove(&variable.id());
+        cache.insert(variable.id(), classified);
         classified
     }
 
-    classify(graph, variable, &mut std::collections::HashSet::new()) == Some(true)
+    let index = BoolReprIndex {
+        producer,
+        inputarg,
+        incoming,
+    };
+    classify(
+        &index,
+        variable,
+        &mut std::collections::HashMap::new(),
+        &mut std::collections::HashSet::new(),
+    ) == Some(true)
 }
 
 /// Preserve the MIR distinction between reading a by-value field and taking
@@ -9938,6 +9975,81 @@ mod tests {
             block.exitswitch,
             Some(ExitSwitch::Value(phi)),
             "the loop header must branch on its Bool inputarg directly"
+        );
+    }
+
+    /// A chain of two-predecessor phis is a DAG, not a cycle. Without a
+    /// memo the BoolRepr walk re-enters every diamond, which is what hung
+    /// the pyre-jit-trace prepass on interpreter graphs.
+    #[test]
+    fn bool_repr_on_a_phi_diamond_chain_does_not_explode() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+
+        let mut graph = FunctionGraph::new("bool_repr_phi_diamonds");
+        let mut current = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "flag".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        current.set_concretetype(Some(LlType::Signed));
+        let mut pred = graph.startblock;
+        for _ in 0..32 {
+            let (left, left_args) = graph.create_block_with_arg_vars(1);
+            let (right, right_args) = graph.create_block_with_arg_vars(1);
+            let (join, join_args) = graph.create_block_with_arg_vars(1);
+            left_args[0].set_concretetype(Some(LlType::Signed));
+            right_args[0].set_concretetype(Some(LlType::Signed));
+            let phi = join_args[0].clone();
+            phi.set_concretetype(Some(LlType::Signed));
+            graph.set_control_flow_metadata(
+                pred,
+                Some(ExitSwitch::Value(current.clone())),
+                vec![
+                    Link::new_mixed(
+                        vec![LinkArg::Value(current.clone())],
+                        left,
+                        Some(ExitCase::Bool(false)),
+                    ),
+                    Link::new_mixed(
+                        vec![LinkArg::Value(current.clone())],
+                        right,
+                        Some(ExitCase::Bool(true)),
+                    ),
+                ],
+            );
+            graph.set_goto(left, join, vec![left_args[0].clone()]);
+            graph.set_goto(right, join, vec![right_args[0].clone()]);
+            current = phi;
+            pred = join;
+        }
+        let truthified = graph
+            .push_op_var(
+                pred,
+                OpKind::UnaryOp {
+                    op: "bool".into(),
+                    operand: current.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        truthified.set_concretetype(Some(LlType::Signed));
+        graph.set_return(pred, Some(truthified.clone()));
+
+        let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+        let block = transformed.graph.block(pred);
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&truthified)),
+            "the Bool identity over the phi chain must still fold"
         );
     }
 

--- a/pyre/bench/synth/for_iter_nested_method_inline.py
+++ b/pyre/bench/synth/for_iter_nested_method_inline.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4.4
+# pyre-check: max-pypy-ratio=3.6
 # A FOR_ITER caller should inline a method-form callee whose body performs a
 # nested method-form call.  The nested `LOAD_METHOD` path emits a
 # `load_method_self` residual after the attribute lookup; deferring it lets the

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -756,7 +756,13 @@ fn dispatch_op(
             let label_id = builder_label(state, &label.name);
             state.builder.jump(label_id);
         }
-        "goto_if_not" | "goto_if_not_int_is_true" => {
+        "goto_if_not" => {
+            let cond = expect_reg(&args[0], Kind::Int);
+            let label = expect_tlabel(&args[1]);
+            let label_id = builder_label(state, &label.name);
+            state.builder.goto_if_not(cond, label_id);
+        }
+        "goto_if_not_int_is_true" => {
             let cond = expect_reg(&args[0], Kind::Int);
             let label = expect_tlabel(&args[1]);
             let label_id = builder_label(state, &label.name);


### PR DESCRIPTION
## Summary

Follow-up to #1690. RPython `BoolRepr.rtype_bool` returns every Bool input unchanged, while the merged branch-only fold only erased same-block, `goto_if_not`-fusable producers with no other reader.

This moves the fold into the existing jtransform identity-alias path. BoolRepr is recovered from raw `lltype.Bool`, exact rich declarations, comparison semantics even when a front rewrite retains an `Int` or `Unsigned` carrier, and CFG inputargs through their positional incoming links. The CFG walk is cycle-safe: loop backedges do not count as evidence, at least one Bool root is required, and any non-Bool incoming root declines the identity. Existing alias machinery then rewrites all later consumers, the exitswitch, and outgoing link arguments.

`bool` over a non-Bool representation remains a real truth test.

## Upstream parity and structural adaptation

- `rpython/rtyper/rbool.py` `BoolRepr.rtype_bool` returns `hop.inputargs(bool_repr)[0]`.
- `rpython/annotator/annrpython.py` `RPythonAnnotator.follow_link` and `mergeinputargs` establish the positional link-argument to Block.inputarg relation used for CFG Bool inference.
- Structural adaptation: pyre runs jtransform over the rich model graph, where the integer register-kind projection can erase Bool and several front rewrites retain non-Bool storage carriers on semantic comparison results. Producer semantics and incoming links reconstruct the representation information that upstream still carries directly.

## Validation

- focused Bool identity/fusion tests: 10/10 passed at `858950c805d`
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- majit boundary check: passed
- synthetic fixture headers: 533 read, 27 expectations parsed
- new line citation check: 480 added Rust lines checked, no new line-number citations
- upstream RPython `rtyper/test/test_rbool.py`: 8/8 passed
- upstream RPython annotator bool selection: 8/8 passed
- PyPy/RPython probes: comparisons and loop-carried Bool values retain BoolRepr; the PyPy JIT branches directly on the pointer comparison without an extra truth test
- LLBC re-extraction, release prepass, full cargo gate, and three-backend `pyre/check.py`: in progress

## Review feedback addressed

- Comparison results are recognized by semantic opname before inspecting the rich carrier; tests cover `Int` and `Unsigned` retained carriers plus unfused `uint_lt` and `is_` forms.
- CFG inputargs are classified through positional incoming links with explicit join and loop-carried-phi coverage.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected integer division and remainder behavior to follow Rust’s truncation rules.
  - Improved conversions between unsigned integers and floating-point values.
  - Fixed boolean handling across comparisons, inputs, and loop-carried values.
  - Improved checked-overflow handling and zero-comparison branches.
  - Prevented invalid writes to protected execution state.
  - Corrected raw memory operation validation and dispatch behavior.
  - Labelled `continue` statements now reject invalid targets instead of silently retargeting.
  - Improved dispatch execution by inlining eligible branches directly into the dispatch flow.
  - Corrected conditional branch handling to preserve integer truth-test semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->