### PR TITLE
rtyper: preserve residual and prebuilt representations

### DIFF
--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -31,8 +31,12 @@
 //! bytecode, `GILReleaseAction` (gil.py) yields it from the periodic
 //! action; [`yield_thread`] is that yield.
 
-use parking_lot::{Condvar, Mutex, MutexGuard};
 use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+// thread_pthread.c's mutex1_t and mutex2_t own native synchronization objects.
+// rpy_init_mutexes resets them in the forked child. A parking_lot mutex also
+// has waiters in a process-global queue: replacing its local bytes would leave
+// vanished parent threads queued at the same address and lose child wakeups.
+use std::sync::{Condvar, Mutex, MutexGuard};
 use std::time::Duration;
 
 use crate::gc_sync;
@@ -90,7 +94,7 @@ impl Mutex2 {
     /// thread_pthread.c:570-575 `mutex2_unlock`. The signal is sent after the
     /// mutex is dropped, as in the C.
     fn unlock(&self) {
-        *self.locked.lock() = false;
+        *self.locked.lock().unwrap() = false;
         self.cond.notify_one();
     }
 
@@ -107,7 +111,7 @@ impl Mutex2 {
     /// lock the stealer keeps for the whole steal loop, and is dropped in place
     /// of `mutex2_loop_stop` (:579-581).
     fn loop_start(&self) -> MutexGuard<'_, bool> {
-        self.locked.lock()
+        self.locked.lock().unwrap()
     }
 
     /// thread_pthread.c:582-595 `mutex2_lock_timeout`. Returns the guard along
@@ -120,7 +124,7 @@ impl Mutex2 {
     ) -> (MutexGuard<'a, bool>, bool) {
         let mut guard = guard;
         if *guard {
-            self.cond.wait_for(&mut guard, delay);
+            (guard, _) = self.cond.wait_timeout(guard, delay).unwrap();
         }
         let result = !*guard;
         *guard = true;
@@ -129,8 +133,8 @@ impl Mutex2 {
 }
 
 /// thread_gil.c:89-90. Held in one cell because `rpy_init_mutexes` re-creates
-/// both of them together, and a `parking_lot::Mutex` can only be reset by
-/// overwriting it.
+/// both of them together. The native wait queues do not retain the parent
+/// threads when the child replaces these synchronization objects.
 struct GilMutexes {
     stealer: Mutex<()>,
     gil: Mutex2,
@@ -391,7 +395,7 @@ fn acquire_slow_path(ident: usize) {
     // first-in-first-out order, this gives the threads a round-robin chance.
     {
         let mutexes = mutexes();
-        let _stealer = mutexes.stealer.lock();
+        let _stealer = mutexes.stealer.lock().unwrap();
         let mut gil = mutexes.gil.loop_start();
 
         // We are now the stealer thread. Steals!
@@ -412,9 +416,11 @@ fn acquire_slow_path(ident: usize) {
                 break;
             }
         }
+        // RPyGilAcquireSlowPath decrements while both queue locks are still
+        // held, before mutex2_loop_stop and mutex1_unlock publish the exit.
+        RPY_WAITING_THREADS.fetch_sub(1, Ordering::SeqCst);
     }
 
-    RPY_WAITING_THREADS.fetch_sub(1, Ordering::SeqCst);
     gc_sync::rejoin_running_after_gil(census);
     // Both exits from the steal loop leave *this* thread's ident in the word,
     // so the exit condition is ownership, not merely that the word is taken.
@@ -468,6 +474,7 @@ impl Drop for GilGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use parking_lot::Mutex;
 
     /// `RPY_FASTGIL` and `RPY_WAITING_THREADS` are process-global and the test
     /// harness runs test functions on concurrent threads, so a second test
@@ -493,5 +500,76 @@ mod tests {
         let _guard = GilGuard::acquire();
         assert!(!yield_thread());
         assert!(am_i_holding_the_gil());
+    }
+
+    /// thread_gil.c's rpy_init_mutexes must leave only the surviving thread
+    /// in the child's wait queues, not just reset the local lock bytes.
+    #[cfg(unix)]
+    #[test]
+    fn fork_reinitialization_drops_vanished_stealer_waiters() {
+        const CHILD_ENV: &str = "MAJIT_RGIL_FORK_REINIT_TEST";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            // Other GC tests share these process-global locks. Fork only in
+            // a fresh test process running this one case.
+            let result = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "rgil::tests::fork_reinitialization_drops_vanished_stealer_waiters",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .output()
+                .unwrap();
+            assert!(
+                result.status.success(),
+                "fork probe failed: {}\n{}",
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr)
+            );
+            return;
+        }
+
+        fn start_waiter() -> std::thread::JoinHandle<()> {
+            // A channel can park through libdispatch on macOS, which traps
+            // after a multithreaded fork. Keep the probe's readiness signal
+            // independent of that runtime; only the GIL lock should park.
+            let ready = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let started = ready.clone();
+            let waiter = std::thread::spawn(move || {
+                started.store(true, Ordering::Release);
+                let _guard = mutexes().stealer.lock().unwrap();
+            });
+            while !ready.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            // Allow the contended lock call to park after its entry signal.
+            std::thread::sleep(Duration::from_millis(100));
+            waiter
+        }
+
+        allocate(); // Installs the real rpy_init_mutexes child hook.
+        let held = mutexes().stealer.lock().unwrap();
+        let parent_waiter = start_waiter();
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork failed");
+        if child == 0 {
+            // The atfork callback already replaced the mutex. Do not unlock
+            // that new mutex through the guard for its old incarnation.
+            std::mem::forget(held);
+            unsafe { libc::alarm(5) };
+            let held = mutexes().stealer.lock().unwrap();
+            let child_waiter = start_waiter();
+            drop(held);
+            child_waiter.join().unwrap();
+            unsafe { libc::_exit(0) };
+        }
+        drop(held);
+        parent_waiter.join().unwrap();
+        let mut status = 0;
+        assert_eq!(unsafe { libc::waitpid(child, &mut status, 0) }, child);
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "child stalled after GIL mutex reinitialization: wait status {status}"
+        );
     }
 }

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1445,13 +1445,11 @@ pub struct CallControl {
     pub immutable_array_types: HashSet<String>,
     /// Metadata-only registration carrier — `(name_path segments,
     /// Signature, return token)`.  Populated in `lib.rs` from
-    /// `program.unsafe_fn_stubs`, which chains
-    /// `front::mir::collect_unsafe_fn_stubs_from_llbc` (local `unsafe fn`s
-    /// whose return projects to a token
-    /// `translator::rtyper::cutover::residual_return_shell` can model)
-    /// with `front::mir::collect_marked_class_ctor_stubs_from_llbc` (the
-    /// `#[pyre_class]` `<Owner>::allocate[_stable]` constructors) — so the
-    /// contents are wider than the field name says.
+    /// `program.unsafe_fn_stubs`, which chains unsafe path aliases,
+    /// `dont_look_inside` declarations, and `#[pyre_class]`
+    /// `<Owner>::allocate[_stable]` constructors whose return projects to a
+    /// token `translator::rtyper::cutover::residual_return_shell` can model.
+    /// The contents are therefore wider than the historical field name says.
     /// `CodeWriter::dual_gate_registry` hands the carrier to
     /// `cutover::populate_call_registry_from_call_graphs`, which seeds it
     /// through `cutover::register_unsafe_fn_stubs` *between* that
@@ -1462,12 +1460,8 @@ pub struct CallControl {
     /// un-aliased — the spelling an `OpKind::Call::FunctionPath` site
     /// emits — where the `function_graphs` pass registers the
     /// crate-stripped `{module_path, name}` plus its alias fan-out.
-    /// `register_unsafe_fn_stubs` yields to any key already present, so
-    /// the two never fight.  Measured on the `pyre-jit-trace` prepass over
-    /// the production LLBC set: 10837 specs, 3296 already resolved and
-    /// skipped, 7541 newly registered — the new ones led by impl methods
-    /// spelled with an `<Impl>` segment and by raw-pointer / allocation
-    /// plumbing.
+    /// `register_unsafe_fn_stubs` yields to any key already present, so the
+    /// channels never fight.
     ///
     /// An `unsafe fn` is NOT held back from body lowering: no gate reads
     /// `signature.is_unsafe` anywhere except the collector above, and

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7988,7 +7988,7 @@ impl<'a> Lowering<'a> {
         // PyType address would reinterpret a `PyreClassDescriptor`/scalar as
         // `PyType`.  Select the exact trait item first, then use identity only
         // for the part it actually proves: which class owns that `PYTYPE`.
-        if !is_pyre_class_pytype_assoc_const(&item_path, &trait_path) {
+        if !is_class_pytype_assoc_const(&item_path, &trait_path) {
             return None;
         }
         // `impl_trait.generics.types[0]` is the `Self` of `impl Trait for
@@ -24787,7 +24787,7 @@ fn path_ends_with_segments(path: &str, key: &str) -> bool {
 /// three axes separate mirrors RPython's prebuilt lookup: object identity
 /// chooses the owner while the attribute lookup still chooses one field of
 /// that object.
-fn is_pyre_class_pytype_assoc_const(item_path: &str, trait_path: &str) -> bool {
+fn is_class_pytype_assoc_const(item_path: &str, trait_path: &str) -> bool {
     item_path.rsplit("::").next() == Some("PYTYPE")
         && path_ends_with_segments(trait_path, "pyre_object::lltype::PyreClassPyTypeOf")
 }
@@ -28346,10 +28346,10 @@ mod tests {
         DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
-        is_core_result_map_err_path, is_pyre_class_pytype_assoc_const,
-        json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
-        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
-        tyref_is_raw_byte_ptr, tyref_positional_aggregate_root, tyref_to_value_type,
+        is_class_pytype_assoc_const, is_core_result_map_err_path, json_ty_is_thin_pointer_element,
+        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
+        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
+        tyref_positional_aggregate_root, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -28390,19 +28390,19 @@ mod tests {
     #[test]
     fn pytype_identity_lane_selects_the_trait_item_before_the_impl_owner() {
         let trait_path = "pyre_object::lltype::PyreClassPyTypeOf";
-        assert!(is_pyre_class_pytype_assoc_const(
+        assert!(is_class_pytype_assoc_const(
             "pyre_object::functional::<Impl>::PYTYPE",
             trait_path,
         ));
-        assert!(!is_pyre_class_pytype_assoc_const(
+        assert!(!is_class_pytype_assoc_const(
             "pyre_object::functional::<Impl>::DESCRIPTOR",
             trait_path,
         ));
-        assert!(!is_pyre_class_pytype_assoc_const(
+        assert!(!is_class_pytype_assoc_const(
             "pyre_object::functional::<Impl>::PYNAME",
             trait_path,
         ));
-        assert!(!is_pyre_class_pytype_assoc_const(
+        assert!(!is_class_pytype_assoc_const(
             "other_crate::<Impl>::PYTYPE",
             "other_crate::lltype::PyreClassPyTypeOf",
         ));

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7085,20 +7085,13 @@ impl<'a> Lowering<'a> {
                     });
                     return Ok(res);
                 }
-                // A prebuilt object-space singleton whose declared type is
-                // a zero-field unit struct (the dict-strategy singletons
-                // `EMPTY_DICT_STRATEGY`, `OBJECT_DICT_STRATEGY`, …).  Narrow
-                // the raw GCREF address through `__cast_instance_intrinsic[<impl>]`
-                // so the read types `SomeInstance(<impl>)` — the prebuilt
-                // instance the annotator would give it (`immutablevalue`).
-                // The bare `ConstRefAddr` types `SomePtr`, which cannot union
-                // with the classdef-less `dstrategy` field cell (`_ptr ∪
-                // <other>`); a classed instance unions cleanly (the None-side
-                // widen arm in `SomeInstance ∪ SomeInstance`).  Gated to
-                // zero-field structs so the field-bearing object singletons
-                // (`None` / `True` / `False` / `Ellipsis` / `NotImplemented`)
-                // in the same `refs` bucket keep their raw-pointer lowering.
-                if let Some(root) = self.refs_static_zerofield_struct_root(&place_ty)
+                // Bookkeeper.immutablevalue annotates a prebuilt instance
+                // with its class regardless of whether that class has fields.
+                // Preserve that owner on both unit strategy implementations
+                // and field-bearing strategy holders, whose address is stored
+                // in W_DictObject.dstrategy. A bare ConstRefAddr would instead
+                // annotate the latter as SomePtr and lose its instance repr.
+                if let Some(root) = self.refs_static_struct_root(&place_ty)
                     && let Some(op @ OpKind::ConstRefAddr(_)) = self.static_addr_op(&segments)
                 {
                     let bb_id = self.block_id[mir_bb];
@@ -17471,14 +17464,15 @@ impl<'a> Lowering<'a> {
         Some(v)
     }
 
-    /// The struct-root canonical name of `ty` when it resolves to a
-    /// zero-field unit struct — the shape of the prebuilt dict-strategy
-    /// singletons (`EmptyDictStrategy`, `ObjectDictStrategy`, …).  The
-    /// `PlaceKind::Global` reader narrows a `refs`-bucket static of such a
-    /// type through `__cast_instance_intrinsic[<root>]` to a classed
-    /// `SomeInstance`.  Returns `None` for a field-bearing struct (the
-    /// object singletons `W_NoneObject` / `W_BoolObject` / … in the same
-    /// bucket keep their raw-pointer lowering) or any non-struct shape.
+    /// The canonical owner of a prebuilt ref whose declared type is a known
+    /// struct. Mirrors Bookkeeper.immutablevalue's SomeInstance classification
+    /// and InstanceRepr.convert_const_exact's per-instance representation.
+    /// Field-bearing instances need the same owner as zero-field ones.
+    ///
+    /// Opaque declarations do not prove the pointed-to layout. In particular,
+    /// the OnceLock globals used to initialize Python singletons are opaque in
+    /// LLBC, and their registered refs identify the initialized Python objects,
+    /// not the OnceLock containers. Keep those on their existing raw-ref path.
     ///
     /// The name is crate-stripped ([`strip_crate_prefix`]) so it matches
     /// the canonical `module::Leaf` spelling every other classdef path keys
@@ -17490,14 +17484,12 @@ impl<'a> Lowering<'a> {
     /// instance would have no `basedef` and two sibling strategy singletons
     /// (`EmptyDictStrategy` / `EmptyKwargsDictStrategy`) `commonbase` to
     /// nothing at a `mergeinputargs` join (`UnionError: no common base`).
-    fn refs_static_zerofield_struct_root(&self, ty: &TyRef) -> Option<String> {
+    fn refs_static_struct_root(&self, ty: &TyRef) -> Option<String> {
         let v = self.tyref_adt_body(ty)?;
         let def_id = inline_adt_def_id(v)?;
         let td = self.llbc.type_by_id(def_id)?;
         match &td.kind {
-            TypeDeclKind::Struct(fields) if fields.is_empty() => {
-                Some(strip_crate_prefix(&td.item_meta.name_path()))
-            }
+            TypeDeclKind::Struct(_) => Some(strip_crate_prefix(&td.item_meta.name_path())),
             _ => None,
         }
     }
@@ -37552,6 +37544,87 @@ mod tests {
                 "native/runtime leaf {expected} must remain residual; got {residuals:?}"
             );
         }
+    }
+
+    /// A prebuilt holder is an instance even when it has fields. Preserve its
+    /// registered identity and class when installing it into a dict, matching
+    /// Bookkeeper.immutablevalue and W_DictObject's strategy instance slot.
+    #[test]
+    #[ignore = "requires the extracted pyre-object LLBC"]
+    fn prebuilt_strategy_holder_keeps_its_instance_repr() {
+        let llbc = Llbc::load(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        ))
+        .expect("load object LLBC");
+        let addr = 0x1234_5678;
+        let refs = [("dictmultiobject::EMPTY_KWARGS_DICT_STRATEGY_REF", addr)];
+        let graph = super::lower_function_with_static_addrs(
+            &llbc,
+            "pyre_object::dictmultiobject::w_dict_new_kwargs",
+            crate::HostStaticAddrs {
+                refs: &refs,
+                ..Default::default()
+            },
+        )
+        .expect("lower kwargs dict constructor");
+        let raw = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::ConstRefAddr(value) if *value == addr => op.result.clone(),
+                _ => None,
+            })
+            .expect("the holder retains its registered prebuilt address");
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    matches!(&op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        result_ty: ValueType::Ref(Some(owner)),
+                    } if segments.first().map(String::as_str)
+                        == Some(crate::runtime_names::shims::CAST_INSTANCE)
+                        && owner == "dictmultiobject::DictStrategyRef"
+                        && args.as_slice() == std::slice::from_ref(&raw))
+                }),
+            "a field-bearing prebuilt holder must enter annotation as its own instance"
+        );
+
+        // This registry row is the Python object returned by the accessor,
+        // not the opaque OnceLock global that initializes it. Do not infer
+        // the container's class from the registered object's address.
+        let refs = [("noneobject::NONE_SINGLETON", addr)];
+        let graph = super::lower_function_with_static_addrs(
+            &llbc,
+            "pyre_object::noneobject::w_none",
+            crate::HostStaticAddrs {
+                refs: &refs,
+                ..Default::default()
+            },
+        )
+        .expect("lower singleton accessor");
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(&op.kind, OpKind::ConstRefAddr(value) if *value == addr))
+        );
+        assert!(
+            !graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(&op.kind,
+                OpKind::Call { result_ty: ValueType::Ref(Some(owner)), .. }
+                    if owner.contains("OnceLock")))
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7976,8 +7976,21 @@ impl<'a> Lowering<'a> {
     /// class singleton — each of which leaves the ordinary path-keyed
     /// handling below to answer.
     fn pytype_addr_by_impl_identity(&self, def_id: u64) -> Option<i64> {
-        let impl_id = self.llbc.global_by_id(def_id)?.item_meta.trait_impl_id()?;
+        let global = self.llbc.global_by_id(def_id)?;
+        let item_path = global.item_meta.name_path();
+        let impl_id = global.item_meta.trait_impl_id()?;
         let row = self.llbc.trait_impl_by_id(impl_id)?;
+        let trait_id = row.get("impl_trait")?.get("id")?.as_u64()?;
+        let trait_path = self.llbc.trait_by_id(trait_id)?.item_meta.name_path();
+        // The impl identity names the OWNER, not which associated item was
+        // read.  `PyreClassPyTypeOf` also defines `DESCRIPTOR`, `PYNAME`, and
+        // the CPython flag constants; mapping any of those to the owner's
+        // PyType address would reinterpret a `PyreClassDescriptor`/scalar as
+        // `PyType`.  Select the exact trait item first, then use identity only
+        // for the part it actually proves: which class owns that `PYTYPE`.
+        if !is_pyre_class_pytype_assoc_const(&item_path, &trait_path) {
+            return None;
+        }
         // `impl_trait.generics.types[0]` is the `Self` of `impl Trait for
         // Self`. Charon puts it first whatever else the trait is generic
         // over, so this is the implementing type, not a trait parameter.
@@ -8412,6 +8425,13 @@ impl<'a> Lowering<'a> {
                 // the Some-arm `__pos_0` payload) resolves against the Option classdef
                 // instead of blocking on a classdef-less GCREF.
                 .or_else(|| self.option_residual_narrow_root(&call.dest.ty))
+                // A tuple/array returned across a call boundary has the same
+                // synthetic positional layout as one built in the caller,
+                // but `tyref_to_value_type` deliberately classifies every
+                // non-scalar as `Ref(None)`.  Recover the exact shaped owner
+                // here so the caller's `.N` reads see the TupleRepr fields
+                // registered from the callee's aggregate construction.
+                .or_else(|| tyref_positional_aggregate_root(&call.dest.ty, self.llbc))
         } else {
             None
         };
@@ -20134,10 +20154,46 @@ pub fn collect_unsafe_fn_stubs_from_llbc(
     crate::flowspace::argument::Signature,
     Option<String>,
 )> {
+    collect_fn_stubs_from_llbc_if(llbc, error_carrier, |fd| fd.signature.is_unsafe)
+}
+
+/// Collect signature-only residual stubs for every local function marked
+/// `#[dont_look_inside]`, including functions which the JIT policy correctly
+/// omitted from `CallControl::function_graphs`.
+///
+/// RPython creates the `FunctionDesc` from the callable independently of
+/// `find_all_graphs`, then `JitPolicy.look_inside_graph` merely keeps its body
+/// out of the JitCode closure.  Feeding these declarations through the same
+/// annotator-only stub carrier restores that ordering: a caller can annotate
+/// the declared residual call even though there is intentionally no body to
+/// compile.
+pub(crate) fn collect_dont_look_inside_fn_stubs_from_llbc(
+    llbc: &Llbc,
+    error_carrier: crate::ErrorCarrierSpec<'_>,
+) -> Vec<(
+    Vec<String>,
+    crate::flowspace::argument::Signature,
+    Option<String>,
+)> {
+    let marked = dont_look_inside_set_of(llbc);
+    collect_fn_stubs_from_llbc_if(llbc, error_carrier, |fd| {
+        marked.contains(&strip_crate_prefix(&fd.item_meta.name_path()))
+    })
+}
+
+fn collect_fn_stubs_from_llbc_if(
+    llbc: &Llbc,
+    error_carrier: crate::ErrorCarrierSpec<'_>,
+    include: impl Fn(&FunDecl) -> bool,
+) -> Vec<(
+    Vec<String>,
+    crate::flowspace::argument::Signature,
+    Option<String>,
+)> {
     use crate::flowspace::argument::Signature;
     let mut out = Vec::new();
     for fd in llbc.iter_local_fns() {
-        if !fd.signature.is_unsafe {
+        if !include(fd) {
             continue;
         }
         // Global initializers are synthetic, not user-callable fns; the
@@ -24042,6 +24098,34 @@ fn tyref_positional_aggregate_suffix(ty: &TyRef, llbc: &Llbc) -> String {
     }
 }
 
+/// Exact synthetic owner of a non-empty tuple or fixed-size array type.
+///
+/// RPython carries a function-return tuple as `SomeTuple` and its rtyper
+/// chooses the matching per-shape `TupleRepr`.  Charon's call destination
+/// retains that complete element shape even though [`tyref_to_value_type`]
+/// only reports the common reference bank, so call-result narrowing uses this
+/// owner to preserve the same positional representation across the boundary.
+fn tyref_positional_aggregate_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
+    let node = tyref_node(ty, llbc)?;
+    let suffix = tyref_positional_aggregate_suffix(ty, llbc);
+    if suffix.is_empty() {
+        return None;
+    }
+    if node
+        .as_object()
+        .and_then(|body| body.get("Adt"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|adt| adt.get("id"))
+        .and_then(serde_json::Value::as_str)
+        == Some("Tuple")
+    {
+        return Some(format!("Tuple{suffix}"));
+    }
+    node.as_object()
+        .is_some_and(|body| body.contains_key("Array"))
+        .then(|| format!("Array{suffix}"))
+}
+
 /// The `<X>` enum-instantiation suffix for a destination `Option<X>` /
 /// `Result<X, E>` local `ty`.  A runtime-discriminant decomposition
 /// (`checked_neg`, `usize::try_from`) constructs the enum ROOT — no static
@@ -24692,6 +24776,20 @@ fn path_has_suffix_ignoring_raw(path: &str, key: &str) -> bool {
 /// the only input whose answer changes.
 fn path_ends_with_segments(path: &str, key: &str) -> bool {
     path_eq_ignoring_raw(path, key) || path_has_suffix_ignoring_raw(path, key)
+}
+
+/// Whether an impl-owned global is exactly
+/// `PyreClassPyTypeOf::PYTYPE`.
+///
+/// The associated-item name selects the value; the trait path selects the
+/// namespace that gives that name its meaning.  The impl id deliberately does
+/// neither — it identifies only the implementing `Self` type.  Keeping these
+/// three axes separate mirrors RPython's prebuilt lookup: object identity
+/// chooses the owner while the attribute lookup still chooses one field of
+/// that object.
+fn is_pyre_class_pytype_assoc_const(item_path: &str, trait_path: &str) -> bool {
+    item_path.rsplit("::").next() == Some("PYTYPE")
+        && path_ends_with_segments(trait_path, "pyre_object::lltype::PyreClassPyTypeOf")
 }
 
 fn static_key_matches(full: &str, stripped: &str, key: &str) -> bool {
@@ -28248,9 +28346,10 @@ mod tests {
         DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
-        is_core_result_map_err_path, json_ty_is_thin_pointer_element,
-        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
-        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr, tyref_to_value_type,
+        is_core_result_map_err_path, is_pyre_class_pytype_assoc_const,
+        json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
+        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
+        tyref_is_raw_byte_ptr, tyref_positional_aggregate_root, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -28286,6 +28385,27 @@ mod tests {
             checked_arith_uint_atom_is_word_sized("Usize"),
             crate::layout::target_word_size() == 8
         );
+    }
+
+    #[test]
+    fn pytype_identity_lane_selects_the_trait_item_before_the_impl_owner() {
+        let trait_path = "pyre_object::lltype::PyreClassPyTypeOf";
+        assert!(is_pyre_class_pytype_assoc_const(
+            "pyre_object::functional::<Impl>::PYTYPE",
+            trait_path,
+        ));
+        assert!(!is_pyre_class_pytype_assoc_const(
+            "pyre_object::functional::<Impl>::DESCRIPTOR",
+            trait_path,
+        ));
+        assert!(!is_pyre_class_pytype_assoc_const(
+            "pyre_object::functional::<Impl>::PYNAME",
+            trait_path,
+        ));
+        assert!(!is_pyre_class_pytype_assoc_const(
+            "other_crate::<Impl>::PYTYPE",
+            "other_crate::lltype::PyreClassPyTypeOf",
+        ));
     }
 
     #[test]
@@ -31854,6 +31974,25 @@ mod tests {
     }
 
     #[test]
+    fn positional_call_result_recovers_its_exact_tuple_repr_owner() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let usize_ty = serde_json::json!({"Literal": {"UInt": "Usize"}});
+        let pair = TyRef::Other(serde_json::json!({
+            "Adt": {
+                "id": "Tuple",
+                "generics": {"types": [usize_ty.clone(), usize_ty]}
+            }
+        }));
+        let scalar = TyRef::Other(serde_json::json!({"Literal": {"UInt": "Usize"}}));
+
+        assert_eq!(
+            tyref_positional_aggregate_root(&pair, &llbc).as_deref(),
+            Some("Tuple<usize,usize>")
+        );
+        assert_eq!(tyref_positional_aggregate_root(&scalar, &llbc), None);
+    }
+
+    #[test]
     fn positional_shapes_register_distinct_pointer_aware_struct_layouts() {
         let mut graph = FunctionGraph::new("array_shapes");
         let entry = graph.startblock;
@@ -34378,6 +34517,49 @@ mod tests {
             unwrap_residuals, 0,
             "checked conversion Result::unwrap must become a discriminant guard"
         );
+    }
+
+    /// `complex_val` returns the RPython spelling of an optional pair.  The
+    /// arithmetic helpers call `unwrap` only after their numeric dispatch has
+    /// established the value is present, so the opaque Rust combinator must be
+    /// translated to the ordinary payload guard instead of becoming a method
+    /// lookup on an Option shell.
+    #[test]
+    #[ignore]
+    fn complex_arithmetic_unwraps_lower_to_payload_guards() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real interpreter LLBC");
+        for name in [
+            "pyre_interpreter::objspace::descroperation::complex_add",
+            "pyre_interpreter::objspace::descroperation::complex_sub",
+            "pyre_interpreter::objspace::descroperation::complex_mul",
+            "pyre_interpreter::objspace::descroperation::complex_truediv",
+            "pyre_interpreter::objspace::descroperation::complex_neg",
+        ] {
+            let graph = super::lower_function(&llbc, name)
+                .unwrap_or_else(|err| panic!("lower {name}: {err:?}"));
+            let residuals: Vec<_> = graph
+                .blocks
+                .iter()
+                .enumerate()
+                .flat_map(|(block, bb)| {
+                    bb.operations.iter().filter_map(move |op| match &op.kind {
+                        OpKind::Call {
+                            target: CallTarget::Method { name, .. },
+                            ..
+                        } if name == "unwrap" => Some((block, op.clone(), bb.exits.clone())),
+                        _ => None,
+                    })
+                })
+                .collect();
+            assert!(
+                residuals.is_empty(),
+                "{name}: Option::unwrap must become a payload guard: {residuals:#?}"
+            );
+        }
     }
 
     /// The unwrapped-list storage adapters are Rust spellings of
@@ -37370,6 +37552,39 @@ mod tests {
                 "native/runtime leaf {expected} must remain residual; got {residuals:?}"
             );
         }
+    }
+
+    #[test]
+    #[ignore]
+    fn getset_direct_residual_keeps_a_functiondesc_without_a_jitcode_body() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let specs = super::collect_dont_look_inside_fn_stubs_from_llbc(
+            &llbc,
+            crate::ErrorCarrierSpec::default(),
+        );
+        let expected = ["pyre_interpreter", "typedef", "call_getset_fget_direct"];
+        let (_, signature, token) = specs
+            .iter()
+            .find(|(segments, _, _)| {
+                segments
+                    .iter()
+                    .map(String::as_str)
+                    .eq(expected.iter().copied())
+            })
+            .expect("dont_look_inside getset trampoline must have a residual stub");
+
+        assert_eq!(signature.argnames.len(), 3);
+        assert!(
+            super::super::super::translator::rtyper::cutover::residual_return_shell(
+                token.as_deref()
+            )
+            .is_some(),
+            "the declared Result<PyObjectRef, PyError> return must be annotatable"
+        );
     }
 
     /// PyPy's deque mutation marker is an object-resident `lock` identity:

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -104,14 +104,47 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
         })
         .ok_or_else(|| format!("{name}: unwrap result var has no producer block"))?;
 
-    // The call must be A's last op (lower_call closes the block right after
-    // pushing it) so removing it leaves the receiver construction as the tail.
-    let call_idx = graph.blocks[a].operations.len() - 1;
-    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
+    // The call sits at the block tail, optionally followed by the single
+    // `__cast_instance_intrinsic(result)` that restores a returned aggregate's
+    // RPython repr identity.  This is the same lower_call shape accepted by
+    // `option_unwrap_or`: the cast is a jitcode identity, but the continuation
+    // consumes its result rather than the raw call value, so it must move into
+    // the successful arm with the extracted payload.
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .expect("result var producer resolved to block A above");
+    let last_idx = graph.blocks[a].operations.len() - 1;
+    let (cast, out_var): (Option<(Vec<String>, ValueType)>, Variable) = if call_idx == last_idx {
+        (None, site.result_var.clone())
+    } else if call_idx == last_idx - 1 {
+        let tail = &graph.blocks[a].operations[last_idx];
+        match (&tail.kind, tail.result.clone()) {
+            (
+                OpKind::Call {
+                    target: crate::model::CallTarget::FunctionPath { segments },
+                    args,
+                    result_ty,
+                },
+                Some(narrowed),
+            ) if segments.first().map(String::as_str)
+                == Some(crate::runtime_names::shims::CAST_INSTANCE)
+                && args.as_slice() == std::slice::from_ref(&site.result_var) =>
+            {
+                (Some((segments.clone(), result_ty.clone())), narrowed)
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: unwrap call is not the last op of block {a}"
+                ));
+            }
+        }
+    } else {
         return Err(format!(
             "{name}: unwrap call is not the last op of block {a}"
         ));
-    }
+    };
     // Capture the receiver enum operand (the sole argument).
     let recv = match &graph.blocks[a].operations[call_idx].kind {
         OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
@@ -143,7 +176,7 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     let mut carried: Vec<Variable> = Vec::new();
     for arg in &saved_exit.args {
         if let LinkArg::Value(v) = arg
-            && *v != site.result_var
+            && *v != out_var
             && !carried.contains(v)
         {
             carried.push(v.clone());
@@ -187,10 +220,12 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
         });
         payload
     };
+    let payload_value =
+        crate::front::option_unwrap_or::emit_narrow(graph, payload_bb, &cast, payload);
     let payload_link_args = reproduce_exit_args(
         &saved_exit,
-        &site.result_var,
-        &payload,
+        &out_var,
+        &payload_value,
         &payload_sources,
         &payload_inputs,
         &name,
@@ -204,6 +239,9 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     // The receiver construction ops stay as A's tail. `Option::Some = 1`, so
     // its payload is the true arm; `Result::Ok = 0`, so its payload is false.
     let a_id = graph.blocks[a].id;
+    if cast.is_some() {
+        graph.blocks[a].operations.remove(last_idx);
+    }
     graph.blocks[a].operations.remove(call_idx);
     let disc = graph.alloc_value_var();
     if site.niche {
@@ -342,6 +380,68 @@ mod tests {
             .filter(|blk| blk.exits.iter().any(|link| link.target == g.exceptblock))
             .count();
         assert_eq!(raises, 1, "the None arm raises to exceptblock");
+    }
+
+    /// A returned tuple/instance is narrowed immediately after `unwrap` by
+    /// `lower_call`.  The guard rewrite must move that identity cast into the
+    /// payload arm and forward the narrowed value, exactly as `unwrap_or` does.
+    #[test]
+    fn rewrite_lifts_unwrap_with_trailing_narrowing_cast() {
+        let mut g = FunctionGraph::new("test_option_unwrap_narrow");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_target(),
+                    args: vec![opt],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let narrowed = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
+                            "Tuple<f64,f64>".to_string(),
+                        ],
+                    },
+                    args: vec![result.clone()],
+                    result_ty: ValueType::Ref(Some("Tuple<f64,f64>".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![narrowed]);
+
+        let rewritten = rewire_unwrap_call_sites(
+            &mut g,
+            &[UnwrapSite {
+                result_var: result,
+                enum_owner: "core::option::Option<(f64,f64)>".into(),
+                payload_owner: "core::option::Option<(f64,f64)>::Some".into(),
+                payload_ty: ValueType::Ref(None),
+                payload_on_disc_true: true,
+                niche: false,
+            }],
+        );
+        assert_eq!(rewritten, 1);
+        assert!(!g.blocks.iter().flat_map(|bb| &bb.operations).any(|op| {
+            matches!(&op.kind, OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                if name == "unwrap")
+        }));
+        assert!(g.blocks.iter().flat_map(|bb| &bb.operations).any(|op| {
+            matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                if segments.first().map(String::as_str)
+                    == Some(crate::runtime_names::shims::CAST_INSTANCE))
+        }));
     }
 
     /// `Result::Ok = 0`, so its payload arm is the `bool(disc)`-false exit;

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -351,7 +351,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
 /// an arm's `raw` payload value.  `None` (no cast on the original result) is a
 /// pass-through: the raw value flows on unchanged.  The cast is jitcode-identity
 /// (`cast_pointer` → `same_as`), so duplicating it per arm is sound.
-fn emit_narrow(
+pub(crate) fn emit_narrow(
     graph: &mut FunctionGraph,
     bb: crate::model::BlockId,
     cast: &Option<(Vec<String>, ValueType)>,

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -317,16 +317,13 @@ pub struct SemanticProgram {
     /// only hold a string (`llmemory::FieldOffset`'s `st._name`, a nested
     /// field's rendered type) can reach the identity-keyed layout maps.
     pub struct_ids: HashMap<String, Option<majit_ir::descr::StructId>>,
-    /// `(path-segments, Signature, return-lltype)` for every local
-    /// `unsafe fn` / unsafe impl-method whose return type resolves to
-    /// unit or bool, harvested from the LLBC by
-    /// `front::mir::collect_unsafe_fn_stubs_from_llbc`.  Feeds
-    /// `CallControl.unsafe_fn_stubs` →
-    /// `cutover::register_unsafe_fn_stubs` so the dual gate registers a
-    /// stub PyGraph for each, covering the "not registered in
-    /// CallRegistry" Skip cluster dominated by `pyre_object::is_*`.
-    /// These callees' bodies access raw pointers the flowspace adapter
-    /// does not model, so only a typed signature stub is registered.
+    /// Annotator-only residual declarations `(path-segments, Signature,
+    /// return-lltype)`.  The historical field name covers three sources:
+    /// unsafe path aliases, `dont_look_inside` functions whose bodies JitPolicy
+    /// excludes, and marked allocation constructors.  All retain an RPython
+    /// `FunctionDesc`-equivalent signature without becoming JitCode bodies.
+    /// Feeds `CallControl.unsafe_fn_stubs` →
+    /// `cutover::register_unsafe_fn_stubs`.
     pub unsafe_fn_stubs: Vec<(
         Vec<String>,
         crate::flowspace::argument::Signature,

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -277,19 +277,23 @@ fn build_semantic_program_via_active_frontend(
             // (`rclass.py _parse_field_list`).
             program.immutable_fields =
                 front::llbc_hints::harvest_immutable_fields_from_llbcs(&llbcs);
-            // Re-source the unsafe-fn stub carrier from Charon: walk the
-            // full LLBC set for every local `unsafe fn` / unsafe
-            // impl-method projecting to a unit/bool return.  The consumer
-            // at `call_control.unsafe_fn_stubs` (lib.rs) reads this carrier.
-            // Same carrier also feeds the `#[pyre_class]` allocation
-            // constructors (`<Owner>::allocate[_stable](payload: Self)`): the
-            // non-numeric boxing ctors have no ported `malloc->new` lowering,
-            // so they residualize through the same annotator-only stub path.
+            // Re-source the annotator-only residual-stub carrier from Charon:
+            // unsafe function paths missing from GraphStore, every
+            // `dont_look_inside` declaration (whose body JitPolicy correctly
+            // excludes), and the `#[pyre_class]` allocation constructors all
+            // need a FunctionDesc signature even though they must not become
+            // JitCode candidates.
             program.unsafe_fn_stubs = llbcs
                 .iter()
                 .flat_map(|llbc| {
                     front::mir::collect_unsafe_fn_stubs_from_llbc(llbc, static_addrs.error_carrier)
                 })
+                .chain(llbcs.iter().flat_map(|llbc| {
+                    front::mir::collect_dont_look_inside_fn_stubs_from_llbc(
+                        llbc,
+                        static_addrs.error_carrier,
+                    )
+                }))
                 .chain(
                     llbcs
                         .iter()
@@ -1356,14 +1360,11 @@ fn analyze_pipeline_from_module_paths(
     // `arraydescrof_concrete` can fold field-level immutability into the
     // shared per-ARRAY descr's `is_pure` flag.
     call_control.recompute_immutable_array_types();
-    // The `unsafe_fn_stubs` carrier lets the codewriter's
-    // `dual_gate_registry` register every `unsafe fn` / unsafe
-    // impl-method as a stub-pygraph entry in CallRegistry, covering
-    // the bulk of the "not registered in CallRegistry" Skip cluster
-    // dominated by `pyre_object::is_*` predicates.  What a stub adds is the
-    // registry key those call sites spell, not a body the lowering refused
-    // — see `CallControl::unsafe_fn_stubs`.  Sourced from Charon via
-    // `front::mir::collect_unsafe_fn_stubs_from_llbc`, populated on the
+    // Historical `unsafe_fn_stubs` carrier for every annotator-only residual
+    // declaration: unsafe path aliases, `dont_look_inside` functions, and
+    // marked allocation constructors.  Each adds the FunctionDesc-equivalent
+    // key/signature the annotator needs, never a JitCode body — see
+    // `CallControl::unsafe_fn_stubs`.  Sourced from Charon and populated on the
     // SemanticProgram in `build_semantic_program_via_active_frontend`.
     call_control.unsafe_fn_stubs = program.unsafe_fn_stubs.clone();
     // `rpython.rtyper.extregistry.register_external` parity for the three

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2712,7 +2712,7 @@ fn declared_funcptr_type_from_legacy(
     Some(crate::translator::rtyper::lltypesystem::lltype::FuncType { args, result })
 }
 
-/// Register a batch of unsafe-fn stub
+/// Register a batch of annotator-only residual
 /// `(segments, signature, FUNC.RESULT token)` specs into `registry`.
 /// Each entry is wrapped through [`residual_return_shell`] +
 /// [`build_stub_pygraph_with_result_shell`]
@@ -2722,17 +2722,17 @@ fn declared_funcptr_type_from_legacy(
 ///   the dual gate no longer Skips with "not registered in
 ///   CallRegistry" for these paths.
 ///
-/// `specs` is typically the output of
-/// `front::mir::collect_unsafe_fn_stubs_from_llbc` (the Charon/LLBC-
-/// sourced stub-spec list).  Per-fn failures ([`residual_return_shell`]
+/// `specs` is the Charon/LLBC-sourced carrier assembled from unsafe path
+/// aliases, `dont_look_inside` declarations, and marked constructors. Per-fn
+/// failures ([`residual_return_shell`]
 /// declines the token, or registry already has the same key
 /// at a conflicting signature) propagate as silent skips — the
 /// upstream "not registered" Skip path then absorbs that specific fn
 /// while the rest of the batch lands.
 ///
 /// Mirrors `populate_call_registry_from_call_graphs`'s "register and
-/// prefill" contract but feeds from `collect_unsafe_fn_stubs_from_llbc`
-/// rather than from the `function_graphs` `GraphStore`.  The two key
+/// prefill" contract but feeds from declarations rather than from the
+/// `function_graphs` `GraphStore`.  The two key
 /// differently, so both can hold the same fn; `CallControl::unsafe_fn_stubs`
 /// carries the measured split.
 ///

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1537,7 +1537,16 @@ pub(super) fn rtype_jit_force_virtualizable(
         })?;
     let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_frame.as_ref())])?;
     hop.exception_cannot_occur()?;
-    Ok(hop.genop("jit_force_virtualizable", vlist, GenopResult::Void))
+    // This is a call returning None, not an operation with an impossible
+    // result. LowLevelOpList.genop(resulttype=lltype.Void) returns its Void
+    // Variable, as ExtLoopHeader.specialize_call does for a source marker.
+    // Omitting resulttype returns no Variable and makes translate_hl_to_ll
+    // require s_ImpossibleValue instead of the marker's s_None annotation.
+    Ok(hop.genop(
+        "jit_force_virtualizable",
+        vlist,
+        GenopResult::LLType(LowLevelType::Void),
+    ))
 }
 
 /// `BigInt::from(i64) -> BigInt` residual lowering, reached through
@@ -4749,12 +4758,16 @@ mod tests {
             Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int")));
         hop.args_r.borrow_mut().push(Some(frame_repr));
 
-        // Void genop yields no result variable to the caller.
-        let result = rtype_jit_force_virtualizable(&hop, &HashMap::new()).unwrap();
-        assert!(result.is_none());
+        // The marker returns None normally. Returning no Hlvalue here would
+        // tell translate_hl_to_ll that the call never returns and reject the
+        // annotator's s_None result at every descriptor gateway.
+        let result = rtype_jit_force_virtualizable(&hop, &HashMap::new())
+            .unwrap()
+            .expect("a None-returning marker must return its Void Variable");
 
         let llops = hop.llops.borrow();
         let last = llops.ops.last().expect("the force llop is emitted");
+        assert_eq!(result, last.result);
         assert_eq!(last.opname, "jit_force_virtualizable");
         assert_eq!(
             last.args.len(),

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -2904,16 +2904,10 @@ impl InstanceRepr {
     /// concretetype=self.lowleveltype)` (the upstream `convert_const`
     /// `value is None` branch).
     pub fn null_instance(&self) -> Result<_ptr, TyperError> {
-        let object_lltype = match self.object_type.clone() {
-            LowLevelType::ForwardReference(fwd) => fwd.resolved().ok_or_else(|| {
-                TyperError::message(
-                    "InstanceRepr.null_instance: object_type ForwardReference not \
-                     resolved (call setup() first)",
-                )
-            })?,
-            other => other,
-        };
-        lltype::nullptr(object_lltype).map_err(TyperError::message)
+        // rclass.InstanceRepr.null_instance passes object_type directly.
+        // A null pointer needs no object layout; Ptr retains an unresolved
+        // ForwardReference until ordinary repr setup resolves that identity.
+        lltype::nullptr(self.object_type.clone()).map_err(TyperError::message)
     }
 
     /// RPython `InstanceRepr.upcast(self, result)` (rclass.py):
@@ -5969,7 +5963,10 @@ mod tests {
         };
         let cd = crate::annotator::classdesc::ClassDesc::getuniqueclassdef(rc).unwrap();
         let inst = getinstancerepr(&rtyper, Some(&cd), Flavor::Gc).expect("getinstancerepr");
-        Repr::setup(inst.as_ref() as &dyn Repr).expect("setup InstanceRepr");
+        assert!(matches!(
+            &inst.object_type,
+            LowLevelType::ForwardReference(fwd) if fwd.resolved().is_none()
+        ));
 
         let c = (inst.as_ref() as &dyn Repr)
             .convert_const(&ConstValue::None)
@@ -5979,6 +5976,9 @@ mod tests {
             panic!("convert_const(None) must produce LLPtr, got {:?}", c.value);
         };
         assert!(!ptr.nonzero(), "null_instance must be a null pointer");
+        Repr::setup(inst.as_ref() as &dyn Repr).expect("setup InstanceRepr after null creation");
+        assert_eq!(c.concretetype.as_ref(), Some(inst.lowleveltype()));
+        assert!(!ptr.nonzero());
     }
 
     #[test]

--- a/majit/rtyper-skip-subjects.darwin.txt
+++ b/majit/rtyper-skip-subjects.darwin.txt
@@ -2,7 +2,7 @@
 # Ratcheted by scripts/check-rtyper-skip-subjects.py: a name may
 # leave this list, and may not join it.  Empty is the epic's
 # done-when.
-# corpus=e3524ccdb5313147 platform=darwin
+# corpus=f770b300ef98943f platform=darwin
 direct-skip (never reaches unported_category)	pyre_interpreter::gateway::builtin_code_get
 direct-skip (never reaches unported_category)	pyre_interpreter::module::_hashlib::hash_state_class::__majit_wrap___new__
 direct-skip (never reaches unported_category)	pyre_interpreter::module::_hashlib::hmac_class::__majit_wrap___new__
@@ -209,8 +209,6 @@ two-phase-never-a-subject	pyre_interpreter::call::call_function_impl_raw
 two-phase-never-a-subject	pyre_interpreter::call::call_user_function_plain_with_ctx
 two-phase-never-a-subject	pyre_interpreter::call::call_user_function_with_ctx
 two-phase-never-a-subject	pyre_interpreter::call::check_type_instantiable
-two-phase-never-a-subject	pyre_interpreter::call::enter_native_dispatch
-two-phase-never-a-subject	pyre_interpreter::call::enter_recursive_frame
 two-phase-never-a-subject	pyre_interpreter::call::frame_into_generator_for_function
 two-phase-never-a-subject	pyre_interpreter::call::make_user_call_frame
 two-phase-never-a-subject	pyre_interpreter::call::prepare_user_call
@@ -1842,8 +1840,6 @@ two-phase-never-a-subject	pyre_object::unicodeobject::w_str_get_index_storage
 two-phase-never-a-subject	pyre_object::unicodeobject::w_str_slot_get
 two-phase-never-a-subject	pyre_object::weakref::w_weakref_new
 two-phase-never-a-subject	pyre_object::weakref::w_weakref_object_slot_get
-two-phase-rtype-skipped	pyre_interpreter::builtins::exc_exception_new
-two-phase-rtype-skipped	pyre_interpreter::builtins::split_builtin_kwargs
 two-phase-rtype-skipped	pyre_interpreter::builtins::topframe_for_locals
 two-phase-rtype-skipped	pyre_interpreter::pyframe::__majit_wrap_descr_typecheck_fdel_f_trace
 two-phase-rtype-skipped	pyre_interpreter::pyframe::__majit_wrap_descr_typecheck_fget_f_trace

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -285,24 +285,51 @@ thread_local! {
 /// it never received.
 type RecursionHome = *mut crate::PyExecutionContext;
 
+/// Read the bootstrap recursion state used before an execution context is
+/// installed.  PyPy's translated hot path owns this state on its live
+/// execution context; this Rust TLS is only the pre-context fallback and has
+/// no source-translatable object graph.
+#[majit_macros::dont_look_inside]
+fn detached_recursion_state_get() -> (usize, usize) {
+    DETACHED_RECURSION.with(|c| c.get())
+}
+
+/// Write the bootstrap recursion state used before an execution context is
+/// installed.  Keep only this TLS plumbing residual; the normal
+/// execution-context write in [`recursion_state_set`] remains visible to the
+/// translator.
+#[majit_macros::dont_look_inside]
+fn detached_recursion_state_set(depth: usize, accounted: usize) {
+    DETACHED_RECURSION.with(|c| c.set((depth, accounted)));
+}
+
 /// Read `(py_recursion_depth, accounted_activation)` from `home`.
 #[inline]
 fn recursion_state_get(home: RecursionHome) -> (usize, usize) {
-    match unsafe { home.as_ref() } {
-        Some(ec) => (ec.py_recursion_depth, ec.accounted_activation),
-        None => DETACHED_RECURSION.with(|c| c.get()),
+    if home.is_null() {
+        detached_recursion_state_get()
+    } else {
+        // PyPy reads recursion state directly from the live execution
+        // context.  Keep that field access visible to source translation;
+        // `raw_ptr::as_ref` would introduce a Rust-only `Option` call between
+        // the context and its fields.
+        let ec = unsafe { &*home };
+        (ec.py_recursion_depth, ec.accounted_activation)
     }
 }
 
 /// Write `(py_recursion_depth, accounted_activation)` back to `home`.
 #[inline]
 fn recursion_state_set(home: RecursionHome, depth: usize, accounted: usize) {
-    match unsafe { home.as_mut() } {
-        Some(ec) => {
-            ec.py_recursion_depth = depth;
-            ec.accounted_activation = accounted;
-        }
-        None => DETACHED_RECURSION.with(|c| c.set((depth, accounted))),
+    if home.is_null() {
+        detached_recursion_state_set(depth, accounted);
+    } else {
+        // This is the write-side twin of `recursion_state_get`: the
+        // execution-context fields, rather than a Rust pointer/Option helper,
+        // are the translated state.
+        let ec = unsafe { &mut *home };
+        ec.py_recursion_depth = depth;
+        ec.accounted_activation = accounted;
     }
 }
 
@@ -3931,14 +3958,17 @@ pub fn call_function_impl_result(
     // clears a thread-local and builds an error on the other one -- so an
     // unmoved run means the incoming slice already holds the live words, and
     // rebuilding it would allocate a list per call to copy them.
-    let rooted_args = roots_moved.then(|| {
-        let mut rooted_args = Vec::with_capacity(args.len());
+    let rooted_args;
+    let args = if roots_moved {
+        let mut reloaded = Vec::with_capacity(args.len());
         for i in 0..args.len() {
-            rooted_args.push(_roots.get(root_base + 1 + i));
+            reloaded.push(_roots.get(root_base + 1 + i));
         }
-        rooted_args
-    });
-    let args = rooted_args.as_deref().unwrap_or(args);
+        rooted_args = reloaded;
+        rooted_args.as_slice()
+    } else {
+        args
+    };
 
     // Binding an override descriptor below runs `baseobjspace::get`, whose
     // property and general `__get__` arms execute Python.  That updates the

--- a/scripts/check-rtyper-skip-subjects.py
+++ b/scripts/check-rtyper-skip-subjects.py
@@ -70,6 +70,11 @@ CENSUS_BANNER = "=== majit decline census [analyze_pipeline]"
 # subject is the last token before the first `": "`.
 DECLINE = re.compile(r"^\[decline\] " + re.escape(GATE) + r" (?P<body>.*?): ", re.M)
 
+# The summary prints a gate header even when its only row is the ACCEPT arm.
+# That makes a genuine zero-Skip run distinguishable from a stale `GATE`
+# spelling that matched no event at all.
+GATE_SUMMARY = re.compile(r"^  " + re.escape(GATE) + r"$", re.M)
+
 
 def corpus_key() -> tuple[str, list[str]]:
     """What the prepass read, named so a moved corpus is visible.
@@ -198,8 +203,8 @@ def run_build() -> pathlib.Path:
 def parse(text: str) -> dict[str, set[str]]:
     """`class -> {subject}` for every Skip in the census.
 
-    A run with no `[decline]` line at all is not a clean run: it is a run
-    whose census never came on, and the two must not share a spelling.
+    The caller separately requires [`GATE_SUMMARY`] when this returns empty,
+    distinguishing a terminal zero-Skip reading from a gate that never ran.
     """
     found: dict[str, set[str]] = {}
     for m in DECLINE.finditer(text):
@@ -211,12 +216,15 @@ def parse(text: str) -> dict[str, set[str]]:
     return found
 
 
-def read_baseline() -> tuple[dict[str, str], dict[str, set[str]]]:
-    if not baseline_path().is_file():
-        return {}, {}
+def read_baseline(
+    path: pathlib.Path | None = None,
+) -> tuple[bool, dict[str, str], dict[str, set[str]]]:
+    path = baseline_path() if path is None else path
+    if not path.is_file():
+        return False, {}, {}
     header: dict[str, str] = {}
     want: dict[str, set[str]] = {}
-    for line in baseline_path().read_text().splitlines():
+    for line in path.read_text().splitlines():
         if line.startswith("#"):
             for field in line[1:].split():
                 key, _, value = field.partition("=")
@@ -227,7 +235,7 @@ def read_baseline() -> tuple[dict[str, str], dict[str, set[str]]]:
             continue
         cls, _, subject = line.partition("\t")
         want.setdefault(cls, set()).add(subject)
-    return header, want
+    return True, header, want
 
 
 def write_baseline(header: dict[str, str], got: dict[str, set[str]]) -> None:
@@ -268,19 +276,18 @@ def main() -> int:
             "nothing about what was declined."
         )
     got = parse(census)
-    if not got:
+    if not got and not GATE_SUMMARY.search(census):
         sys.exit(
             f"error: {stderr_path.relative_to(ROOT)} holds no `[decline] {GATE}` "
-            "line.\n"
-            "  Zero Skips and a census that never came on print the same "
-            "nothing, so this is an error rather than a pass.  If the Skip set "
-            "is genuinely empty, that is the epic's done-when: record it with "
-            "--update and turn this arm into the invariant."
+            "line and no summary row for that gate.\n"
+            "  The census ran, but it never observed the dual gate under the "
+            "spelling this checker pins; treating that as zero Skips would hide "
+            "a renamed or unreachable gate."
         )
 
     corpus, unstamped = corpus_key()
     header = {"corpus": corpus, "platform": platform_key()}
-    recorded, want = read_baseline()
+    baseline_exists, recorded, want = read_baseline()
 
     if args.update:
         write_baseline(header, got)
@@ -289,7 +296,7 @@ def main() -> int:
               f"{len(got)} classes [{header['platform']}]")
         return 0
 
-    if not want:
+    if not baseline_exists:
         sys.exit(
             f"error: {baseline_path().relative_to(ROOT)} does not exist.\n"
             "  Seed it from a run on this platform: "

--- a/scripts/test_check_rtyper_skip_subjects.py
+++ b/scripts/test_check_rtyper_skip_subjects.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).with_name("check-rtyper-skip-subjects.py")
+SPEC = importlib.util.spec_from_file_location("check_rtyper_skip_subjects", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class SkipSubjectRatchetTests(unittest.TestCase):
+    @staticmethod
+    def empty_skip_census() -> str:
+        return (
+            "=== majit decline census [analyze_pipeline]: 3 events, 1 rows ===\n"
+            f"  {CHECKER.GATE}\n"
+            "         3         3  match-real-rtyper (ACCEPT, not a decline)\n"
+        )
+
+    def test_gate_summary_makes_an_empty_skip_set_observable(self) -> None:
+        census = self.empty_skip_census()
+        self.assertEqual(CHECKER.parse(census), {})
+        self.assertIsNotNone(CHECKER.GATE_SUMMARY.search(census))
+
+    def test_an_absent_gate_is_not_mistaken_for_zero_skips(self) -> None:
+        census = (
+            "=== majit decline census [analyze_pipeline]: 0 events, 0 rows ===\n"
+            "  (no instrumented gate recorded a decline in this process)\n"
+        )
+        self.assertIsNone(CHECKER.GATE_SUMMARY.search(census))
+
+    def test_main_rejects_a_census_that_never_observed_the_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            stderr = root / "stderr"
+            baseline = root / "baseline.txt"
+            stderr.write_text(
+                "=== majit decline census [analyze_pipeline]: 0 events, 0 rows ===\n"
+                "  (no instrumented gate recorded a decline in this process)\n"
+            )
+            baseline.write_text("# corpus=abc platform=test\n")
+            with (
+                mock.patch.object(CHECKER, "scan_for_stderr", return_value=stderr),
+                mock.patch.object(CHECKER, "baseline_path", return_value=baseline),
+                mock.patch.object(CHECKER, "ROOT", root),
+                mock.patch.object(sys, "argv", [str(SCRIPT), "--no-build"]),
+            ):
+                with self.assertRaisesRegex(SystemExit, "never observed the dual gate"):
+                    CHECKER.main()
+
+    def test_existing_empty_baseline_differs_from_missing_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "baseline.txt"
+            exists, header, subjects = CHECKER.read_baseline(path)
+            self.assertFalse(exists)
+            self.assertEqual((header, subjects), ({}, {}))
+
+            path.write_text("# corpus=abc platform=test\n")
+            exists, header, subjects = CHECKER.read_baseline(path)
+            self.assertTrue(exists)
+            self.assertEqual(header, {"corpus": "abc", "platform": "test"})
+            self.assertEqual(subjects, {})
+
+    def test_main_accepts_an_existing_empty_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            stderr = root / "stderr"
+            baseline = root / "baseline.txt"
+            stderr.write_text(self.empty_skip_census())
+            baseline.write_text("# corpus=abc platform=test\n")
+            with (
+                mock.patch.object(CHECKER, "scan_for_stderr", return_value=stderr),
+                mock.patch.object(CHECKER, "baseline_path", return_value=baseline),
+                mock.patch.object(CHECKER, "ROOT", root),
+                mock.patch.object(CHECKER, "corpus_key", return_value=("abc", [])),
+                mock.patch.object(CHECKER, "platform_key", return_value="test"),
+                mock.patch.object(sys, "argv", [str(SCRIPT), "--no-build"]),
+            ):
+                self.assertEqual(CHECKER.main(), 0)
+
+    def test_update_can_record_the_terminal_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            stderr = root / "stderr"
+            baseline = root / "baseline.txt"
+            stderr.write_text(self.empty_skip_census())
+            with (
+                mock.patch.object(CHECKER, "scan_for_stderr", return_value=stderr),
+                mock.patch.object(CHECKER, "baseline_path", return_value=baseline),
+                mock.patch.object(CHECKER, "ROOT", root),
+                mock.patch.object(CHECKER, "corpus_key", return_value=("abc", [])),
+                mock.patch.object(CHECKER, "platform_key", return_value="test"),
+                mock.patch.object(
+                    sys, "argv", [str(SCRIPT), "--no-build", "--update"]
+                ),
+            ):
+                self.assertEqual(CHECKER.main(), 0)
+            exists, header, subjects = CHECKER.read_baseline(baseline)
+            self.assertTrue(exists)
+            self.assertEqual(header, {"corpus": "abc", "platform": "test"})
+            self.assertEqual(subjects, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continues #346's PyPy-faithful translator work. This is not the terminal
cutover: the legacy walker and nonzero prepass/Skip sets still remain.

Existing branch changes preserve residual FunctionDesc declarations separately
from JitPolicy's JitCode body selection, keep aggregate repr identity through
Option success arms, and keep normal recursion accounting execution-context
owned. The associated PyType lookup uses the exact trait-item identity.
The Skip ratchet distinguishes a genuine zero census from an absent gate;
the initial branch slice recorded 1848 → 1844 subjects on its own corpus.

This follow-up fixes three more representation boundaries:

- Classify registered field-bearing prebuilt strategy holders as instances of
  their declared struct, like unit strategy objects. Preserve their registered
  address and keep opaque OnceLock declarations excluded.
- Return an explicit Void Variable for the normally-returning force marker.
  An omitted result means impossible normal return, not Python None.
- Construct null instance pointers before layout setup when necessary,
  retaining their ForwardReference identity through ordinary repr setup.

## PyPy/RPython comparison

- `Bookkeeper.immutablevalue` and `InstanceRepr.convert_const_exact` retain
  prebuilt class and identity independently of whether it has fields.
- `LowLevelOpList.genop` distinguishes absent resulttype from explicit
  `lltype.Void`; source markers such as `ExtLoopHeader.specialize_call`
  use explicit Void for normal return.
- `InstanceRepr.null_instance` passes object_type directly to `nullptr`;
  null construction does not require the target's resolved layout.

The MIR frontend and explicit source-marker reification remain structural
adapters, not literal upstream modules. No permissive union, fabricated
annotation, mutable initializer constant, or new runtime storage owner is
introduced by these three fixes.

## Fork synchronization follow-up

CI's Linux dynasm lane timed out in test_threading. Investigation found a
reproducible defect in rgil's real atfork path: resetting a parking_lot mutex
at its existing address leaves vanished parent waiters in the process-global
parking queue, so a new child waiter can lose its wakeup indefinitely.

Use std native mutex/condition-variable storage, matching the ownership shape
of `thread_pthread.c`'s `mutex1_t` and `mutex2_t`. Also move the waiting-thread
decrement before releasing the queue locks, as in `RPyGilAcquireSlowPath`.
The isolated production-path regression fails before the change (child alarm)
and passes afterward; all 333 majit-gc unit tests pass (11 ignored).

The final regression uses atomic readiness signaling: a blocking std channel
can enter libdispatch in a multithreaded macOS fork child and trap for an
unrelated reason. After removing that test-only channel, the parking_lot
negative arm still times out and the native-lock arm passes 100 consecutive
runs. The unrelated test serialization mutex remains parking_lot.

This proves the fork defect and its fix locally; it does not yet prove it
explains the CI finalization timeout. No timeout, skip or baseline is relaxed.

## Verification

Translator commit `3b721ad10ef`:

- Real-LLBC prebuilt holder/opaque singleton regression: 1 passed.
- Release translator unit tests: 3515 passed, 0 failed, 94 ignored; explicit
  Void and pre-setup null pointer regression tests passed individually too.
- `cargo test --all --no-default-features --features dynasm`: passed.
- Full `python3 pyre/check.py`: dynasm 546/546, cranelift 546/546,
  wasm 539/539; all three backends passed.
- Skip-ratchet script tests: 6 passed.
- LLBC fingerprint check: all four snapshots current; translator-only changes.
- Formatting and diff whitespace checks passed.

The fixed-corpus comparison is phaseA 1864 → 1864 subjects, phaseB 12 → 3
records (11 → 3 distinct subjects), Skip 1846 → 1841. No new failing or Skip
subject is introduced. Twenty-nine phaseA subjects change their reported
leaf reason but remain failing and are not counted as lifted.

The older 1844 Skip measurement in this PR was on a different corpus; its two
additions already exist before this follow-up. No tracked Skip or jitstats
baseline was rewritten by these follow-up fixes.

The rgil follow-up changes an LLBC input. All four snapshots were re-extracted
and their fingerprints verified before restarting the workspace and full
three-backend gates. On the final rgil code, the full workspace gate passed
(9096 passed, 0 failed, 169 ignored), as did test_threading and
test_threading_local on the rebuilt dynasm release binary at the original
300s module timeout. Full check.py passed all three backends: dynasm 546/546,
cranelift 546/546, wasm 539/539. The preceding
fixed-corpus comparison is retained separately, not recomputed across this
corpus change.

## Remaining work

Finish the shared annotator/rtyper closure, remove per-subject recovery and
legacy fallback, and demonstrate repeated zero named failure/Skip/divergence
sets before deleting the migration machinery. The next identified roots are
the low-level vtable/high-level class rewrite and prebuilt mutable static data
linkage, including preservation of atomic publication semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process-fork safety by correctly resetting synchronization state in child processes.
  - Improved translation of prebuilt static objects, aggregate return values, and optional-value unwrapping.
  - Improved handling of virtualizable operations and unresolved type references during translation.
  - Added support for additional declarations used during translation without generating executable bodies.
  - Removed obsolete platform-specific skip exceptions.

- **Tests**
  - Added coverage for fork behavior, translation edge cases, and empty or missing skip-check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->