### PR TITLE
win32: fix platform-specific stdlib failures

### DIFF
--- a/pyre/extra_tests/snippets/mmap_find_buffer_pattern_arguments.py
+++ b/pyre/extra_tests/snippets/mmap_find_buffer_pattern_arguments.py
@@ -1,0 +1,229 @@
+# pyre-check: gate=1
+# CPython-suite gap: test_mmap reaches find/rfind only through `bytes` and
+# `bytearray` patterns, always with a well-formed argument count and never with
+# an explicit None bound, so the gateway the two methods share is unpinned
+# there apart from the one case where an `__index__` closes the mapping.
+# parity-tests reason: test_mmap is not in the suite gate, so nothing in the
+# vendored suite protects any of this today.
+
+"""`mmap.find`/`rfind` take their pattern through the buffer protocol.
+
+`view: Py_buffer` is the pattern's converter, so the acquisition -- not a
+bytes-only type test -- decides both what counts as a pattern and what a
+refusal says.  The export it takes outlives the `start` and `end` conversions,
+which run arbitrary `__index__`, so an in-place edit one of them makes is what
+the search compares against and a resize one attempts is refused.
+
+The gateway around it orders three refusals: the argument count is checked
+before the pattern is acquired, and the pattern before the mapping is checked.
+And `end` is converted only when `start` is not None, which is what makes
+`m.find(b"Z", None, 5)` a search to the end of the mapping rather than a
+rejected None.
+"""
+
+import array
+import mmap
+import sys
+
+DATA = b"a" * 25 + b"Z" + b"b" * 6
+LEGACY_CPYTHON = sys.implementation.name == "cpython" and sys.version_info < (3, 14)
+
+
+def mapping():
+    m = mmap.mmap(-1, len(DATA))
+    m[:] = DATA
+    return m
+
+
+def raises(kind, message, call, *args):
+    try:
+        call(*args)
+    except kind as error:
+        assert str(error) == message, (str(error), message)
+    else:
+        raise AssertionError("%s%r did not raise %s" % (call, args, kind.__name__))
+
+
+m = mapping()
+
+# Every exporter is a pattern, not only the two bytes-like builtins.
+one = mmap.mmap(-1, 1)
+one[0:1] = b"Z"
+for pattern in (
+    b"Z",
+    bytearray(b"Z"),
+    memoryview(b"Z"),
+    memoryview(b"xZy")[1:2],
+    array.array("b", [90]),
+    one,
+):
+    assert m.find(pattern) == 25, pattern
+    assert m.rfind(pattern) == 25, pattern
+one.close()
+
+# The acquisition names the type it turned down.
+for bad in (1, "Z", None, object()):
+    message = "a bytes-like object is required, not '%s'" % type(bad).__name__
+    raises(TypeError, message, m.find, bad)
+    raises(TypeError, message, m.rfind, bad)
+
+# A strided view is refused by the acquisition, which reports why rather than
+# naming a wrong argument type.
+strided = memoryview(bytearray(b"ZxZx"))[::2]
+raises(
+    BufferError,
+    "memoryview: underlying buffer is not C-contiguous",
+    m.find,
+    strided,
+)
+raises(
+    BufferError,
+    "memoryview: underlying buffer is not C-contiguous",
+    m.rfind,
+    strided,
+)
+
+# CPython moved mmap.find/rfind to Argument Clinic in 3.14.  The generic local
+# runner may itself be 3.13, so give that oracle its historical spelling while
+# requiring pyre (and 3.14+) to expose the pinned gateway's spelling.
+for who in ("find", "rfind"):
+    method = getattr(m, who)
+    if LEGACY_CPYTHON:
+        raises(TypeError, "%s() takes at least 1 argument (0 given)" % who, method)
+        raises(
+            TypeError,
+            "%s() takes at most 3 arguments (4 given)" % who,
+            method,
+            b"Z",
+            0,
+            32,
+            99,
+        )
+    else:
+        raises(TypeError, "%s expected at least 1 argument, got 0" % who, method)
+        raises(
+            TypeError,
+            "%s expected at most 3 arguments, got 4" % who,
+            method,
+            b"Z",
+            0,
+            32,
+            99,
+        )
+
+# In the 3.14 gateway the argument count is checked before the pattern is
+# acquired, and the pattern before the mapping: a closed mapping reports all
+# three in that order.  The pre-Clinic CPython gateway checked the mapping
+# first, so this pinned-version assertion does not apply to the runner's 3.13.
+closed = mapping()
+closed.close()
+if not LEGACY_CPYTHON:
+    for who in ("find", "rfind"):
+        method = getattr(closed, who)
+        raises(TypeError, "%s expected at least 1 argument, got 0" % who, method)
+        raises(
+            TypeError,
+            "%s expected at most 3 arguments, got 4" % who,
+            method,
+            b"Z",
+            0,
+            32,
+            99,
+        )
+        raises(TypeError, "a bytes-like object is required, not 'int'", method, 1)
+        raises(ValueError, "mmap closed or invalid", method, b"Z")
+
+
+class Boom:
+    def __index__(self):
+        raise AssertionError("an end alongside a None start must not be converted")
+
+
+# `end` is converted only when `start` is not None, so a None start leaves both
+# bounds at the mapping's own and the end argument is never looked at.
+if not LEGACY_CPYTHON:
+    assert m.find(b"Z", None, 5) == 25, m.find(b"Z", None, 5)
+    assert m.rfind(b"Z", None, 5) == 25, m.rfind(b"Z", None, 5)
+    assert m.find(b"Z", None, Boom()) == 25
+    assert m.rfind(b"Z", None, Boom()) == 25
+    assert m.find(b"Z", None, "not an index") == 25
+
+# A None end alongside a real start is the mapping's size, as the default is.
+if not LEGACY_CPYTHON:
+    assert m.find(b"Z", 0, None) == 25
+    assert m.rfind(b"Z", 0, None) == 25
+    assert m.find(b"Z", 26, None) == -1
+
+needle = bytearray(b"a")
+
+
+class EditsPattern:
+    def __index__(self):
+        needle[0:1] = b"Z"
+        return 0
+
+
+class ResizesPattern:
+    def __index__(self):
+        needle.extend(b"!")
+        return 0
+
+
+class RaisesFromIndex:
+    def __index__(self):
+        raise RuntimeError("boom")
+
+
+# The pattern's bytes are read after the conversions, so the edit is visible.
+assert m.find(needle, EditsPattern()) == 25, needle
+assert needle == bytearray(b"Z")
+
+# The export is held across them, so the resize is refused -- and released
+# afterwards, so the same resize succeeds once the search is over.
+raises(
+    BufferError,
+    "Existing exports of data: object cannot be re-sized",
+    m.find,
+    needle,
+    ResizesPattern(),
+)
+needle.extend(b"!")
+assert needle == bytearray(b"Z!")
+
+# A conversion that raises releases the export too.
+raises(RuntimeError, "boom", m.find, needle, RaisesFromIndex())
+needle.extend(b"?")
+assert needle == bytearray(b"Z!?")
+
+# Both optional conversions finish before the mapping is checked again.  A
+# start hook which closes it therefore does not suppress the end hook.
+events = []
+victim = mapping()
+
+
+class ClosesMapping:
+    def __index__(self):
+        events.append("start")
+        victim.close()
+        return 0
+
+
+class EndStillRuns:
+    def __index__(self):
+        events.append("end")
+        return len(DATA)
+
+
+raises(
+    ValueError,
+    "mmap closed or invalid",
+    victim.find,
+    b"Z",
+    ClosesMapping(),
+    EndStillRuns(),
+)
+assert events == ["start", "end"], events
+
+m.close()
+
+print("OK")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -21015,6 +21015,23 @@ fn fileio_set_non_inheritable(fd: i32, w_name: PyObjectRef) -> Result<(), crate:
 /// choose exactly one buffered class, and only then add the text wrapper.  In
 /// particular, binary unbuffered I/O returns that raw stream.
 pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    builtin_open_impl(args, true)
+}
+
+/// Standard-stream entry to PyPy `_io.open`, retaining the same construction
+/// while allowing CPython's Windows legacy-stdio compatibility flag to bypass
+/// the console raw class for these three streams only.
+pub(crate) fn builtin_open_stdio(
+    args: &[PyObjectRef],
+    allow_windows_console: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    builtin_open_impl(args, allow_windows_console)
+}
+
+fn builtin_open_impl(
+    args: &[PyObjectRef],
+    allow_windows_console: bool,
+) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = split_builtin_kwargs(args);
     // Every declared slot binds before the unrecognized keywords are
     // reported, so a call missing `file` names `file`.
@@ -21224,14 +21241,19 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
     let (raw_type, console) = {
         let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
-        if crate::module::_io::winconsoleio::pyio_get_console_type(file) != '\0' {
+        if allow_windows_console
+            && crate::module::_io::winconsoleio::pyio_get_console_type(file) != '\0'
+        {
             (crate::module::_io::windows_console_io_type(), true)
         } else {
             (crate::module::_io::fileio_type(), false)
         }
     };
     #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
-    let (raw_type, console) = (crate::module::_io::fileio_type(), false);
+    let (raw_type, console) = {
+        let _ = allow_windows_console;
+        (crate::module::_io::fileio_type(), false)
+    };
     let raw = crate::call::call_function_impl_result(
         raw_type,
         &[

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19673,16 +19673,26 @@ pub(crate) unsafe fn acquire_readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], c
         }
         if pyre_object::memoryview::is_w_memoryview(obj) {
             memoryview_check_released(obj)?;
-            if memoryview_contiguity(obj).0 {
-                let view = pyre_object::memoryview::w_memoryview_view(obj);
-                let full = view.backing().as_bytes();
-                let off = view.offset() as usize;
-                let len = pyre_object::memoryview::w_memoryview_length(obj) as usize;
-                if off <= full.len() && len <= full.len() - off {
-                    return Ok(&full[off..off + len]);
-                }
+            if !memoryview_contiguity(obj).0 {
+                // `PyBUF_SIMPLE` asks for the bytes in address order, and a
+                // strided view cannot hand them over without copying, so the
+                // request is refused rather than answered with the wrong ones.
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::BufferError,
+                    "memoryview: underlying buffer is not C-contiguous",
+                ));
+            }
+            let view = pyre_object::memoryview::w_memoryview_view(obj);
+            let full = view.backing().as_bytes();
+            let off = view.offset() as usize;
+            let len = pyre_object::memoryview::w_memoryview_length(obj) as usize;
+            if off <= full.len() && len <= full.len() - off {
+                return Ok(&full[off..off + len]);
             }
         }
+        // This is the object-space acquisition layer; public gateways that
+        // own a more specific refusal (for example mmap's `Py_buffer`
+        // converter) translate this TypeError at their boundary.
         Err(crate::PyError::type_error(
             "a bytes-like object is required",
         ))

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3527,6 +3527,7 @@ static SYS_BYTES_WARNING: AtomicI64 = AtomicI64::new(0);
 static SYS_DONT_WRITE_BYTECODE: AtomicBool = AtomicBool::new(false);
 static SYS_FAULTHANDLER: AtomicBool = AtomicBool::new(false);
 static SYS_UNBUFFERED: AtomicBool = AtomicBool::new(false);
+static SYS_LEGACY_WINDOWS_STDIO: AtomicBool = AtomicBool::new(false);
 // pypy/interpreter/app_main.py keeps the raw `-X` strings in
 // `options['_xoptions']` (a list) until sys initialization builds the public
 // dict.  Preserve that owner/storage shape rather than introducing a map here.
@@ -3584,6 +3585,7 @@ pub fn set_runtime_flags(flags: &crate::launch_env::LaunchFlags) {
     SYS_FAULTHANDLER.store(flags.faulthandler, Ordering::Relaxed);
     *SYS_PYCACHE_PREFIX.lock() = flags.pycache_prefix.clone();
     SYS_UNBUFFERED.store(flags.unbuffered, Ordering::Relaxed);
+    SYS_LEGACY_WINDOWS_STDIO.store(flags.legacy_windows_stdio, Ordering::Relaxed);
     *SYS_XOPTIONS.lock() = flags.xoptions.clone();
     *SYS_WARNOPTIONS.lock() = flags.warnoptions.clone();
     *SYS_STDIO_ENCODING.lock() = flags.stdio_encoding.clone();
@@ -3641,6 +3643,10 @@ pub fn load_pyc_script(bytes: &[u8]) -> Result<pyre_object::PyObjectRef, crate::
 
 pub fn unbuffered_flag() -> bool {
     SYS_UNBUFFERED.load(Ordering::Relaxed)
+}
+
+pub fn legacy_windows_stdio_flag() -> bool {
+    SYS_LEGACY_WINDOWS_STDIO.load(Ordering::Relaxed)
 }
 
 pub fn warnoptions() -> Vec<std::ffi::OsString> {

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -38,6 +38,11 @@ pub struct LaunchFlags {
     /// Read only on Windows, the only platform whose `PyPreConfig` carries it,
     /// and left false everywhere else.
     pub legacy_windows_fs_encoding: bool,
+    /// CPython's PEP 528 compatibility switch.  PyPy owns standard-stream
+    /// construction in `app_main.create_stdio`; on Windows the 3.14-visible
+    /// contract additionally requires this environment flag to keep those
+    /// streams on `_io.FileIO` instead of `_io._WindowsConsoleIO`.
+    pub legacy_windows_stdio: bool,
     /// CPython 3.14 `code_debug_ranges == 0`, selected by either
     /// `-X no_debug_ranges` or the PYTHONNODEBUGRANGES presence flag.
     pub no_debug_ranges: bool,
@@ -120,6 +125,7 @@ pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "PYTHONUTF8",
     "PYTHONWARNDEFAULTENCODING",
     "PYTHONLEGACYWINDOWSFSENCODING",
+    "PYTHONLEGACYWINDOWSSTDIO",
     "PYTHONWARNINGS",
     "PYTHONIOENCODING",
     "PYTHONNODEBUGRANGES",
@@ -319,6 +325,15 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
             &flags,
             flags.legacy_windows_fs_encoding,
             "PYTHONLEGACYWINDOWSFSENCODING",
+        );
+        // [3.14-spec] `CmdLineTest.test_python_legacy_windows_stdio` observes
+        // the raw standard-stream type in a fresh console.  PyPy's
+        // `app_main.create_stdio` remains the owner of stream construction;
+        // only CPython's compatibility flag is folded into that decision.
+        flags.legacy_windows_stdio = fold_int_flag(
+            &flags,
+            flags.legacy_windows_stdio,
+            "PYTHONLEGACYWINDOWSSTDIO",
         );
     }
     flags.utf8_mode = Some(resolve_utf8_mode(&flags)?);

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -1635,7 +1635,7 @@ mod ssl_socket_methods {
                     }
                     PumpExit::Failed { write, code }
                         if wait_for_transport(transport, fd, write, code)? => {}
-                    exit => return Err(pump_error(transport, exit)),
+                    exit => return Err(pump_error(transport, backend, exit)),
                 }
             }
         }
@@ -1832,13 +1832,45 @@ mod ssl_socket_methods {
     /// interpreter is back.  Every caller answers the exits that are not
     /// failures - and `Rejected`, whose alert has to go out first - before
     /// reaching here.
-    fn pump_error(transport: PyObjectRef, exit: PumpExit) -> crate::PyError {
+    fn pump_error(
+        transport: PyObjectRef,
+        backend: *const pyre_native::ssl::TlsConnection,
+        exit: PumpExit,
+    ) -> crate::PyError {
         match exit {
             PumpExit::Eof => tls_error(
                 pyre_native::ssl::TLS_ERROR_EOF,
                 "EOF occurred in violation of protocol".to_string(),
             ),
             PumpExit::Failed { write, code } => {
+                #[cfg(windows)]
+                if !write
+                    && !unsafe { pyre_native::ssl::connection_is_handshaking(backend) }
+                    && matches!(
+                        code,
+                        windows_sys::Win32::Networking::WinSock::WSAECONNABORTED
+                            | windows_sys::Win32::Networking::WinSock::WSAECONNRESET
+                    )
+                {
+                    // [3.14-spec] `ThreadedTests.test_wrong_cert_tls13`
+                    // accepts a protocol EOF when the server's fatal alert
+                    // races its close.  PyPy `_cffi_ssl.error.pyssl_error`
+                    // normally preserves a WinSock error, but rustls rejects
+                    // the client certificate early enough that `closesocket`
+                    // can replace the queued alert with WSAECONNABORTED or
+                    // WSAECONNRESET when the client's first application
+                    // record is already unread.  Once the handshake has
+                    // completed, that abrupt transport loss is the same
+                    // missing-close-notify protocol EOF.  A reset during the
+                    // handshake is not rewritten: CPython
+                    // `TestPreHandshakeClose` relies on that transport error
+                    // to distinguish pre-authentication data, and raw socket
+                    // operations likewise continue to expose 10053/10054.
+                    return tls_error(
+                        pyre_native::ssl::TLS_ERROR_EOF,
+                        "EOF occurred in violation of protocol".to_string(),
+                    );
+                }
                 if code != 0 {
                     let error = crate::module::_socket::interp_socket::socket_error_for_operation(
                         transport, code,
@@ -2184,7 +2216,7 @@ mod ssl_socket_methods {
                             let _ = flush_transport(self);
                             return tls_result(Err(error));
                         }
-                        exit => return Err(pump_error(transport, exit)),
+                        exit => return Err(pump_error(transport, self.backend, exit)),
                     }
                 }
                 flush_transport(self)?;
@@ -2311,7 +2343,7 @@ mod ssl_socket_methods {
                             let _ = flush_transport(self);
                             return tls_result(Err(error));
                         }
-                        exit => return Err(pump_error(transport, exit)),
+                        exit => return Err(pump_error(transport, self.backend, exit)),
                     }
                 }
             } else {
@@ -2569,7 +2601,7 @@ mod ssl_socket_methods {
                             let _ = flush_transport(self);
                             return tls_result(Err(error));
                         }
-                        exit => return Err(pump_error(transport, exit)),
+                        exit => return Err(pump_error(transport, self.backend, exit)),
                     }
                 }
             } else if unsafe { is_none(self.incoming) } {

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -148,6 +148,88 @@ pub fn walk_faulthandler_roots(_visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 static FAULTHANDLER_EXC_HANDLER: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Write one unsigned decimal without allocating.  The structured-exception
+/// callback runs at an arbitrary fault point, so it cannot enter formatting
+/// machinery or the managed heap.
+#[cfg(all(windows, feature = "host_env"))]
+fn faulthandler_write_decimal(fd: i32, mut value: usize) {
+    let mut digits = [0u8; 20];
+    let mut start = digits.len();
+    loop {
+        start -= 1;
+        digits[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    rustpython_host_env::faulthandler::write_fd(fd, &digits[start..]);
+}
+
+/// Write the current thread's application frames from the same live
+/// `ExecutionContext.topframeref` chain that PyPy's `dumper._dump_callback`
+/// walks.  Every referenced filename/name is immutable storage owned by the
+/// code object, and all scratch space is on the native stack: the exception
+/// callback must remain allocation-free.
+#[cfg(all(windows, feature = "host_env"))]
+unsafe fn faulthandler_dump_current_traceback(fd: i32) {
+    use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+
+    rustpython_host_env::faulthandler::write_fd(fd, b"Current thread 0x");
+    let thread_id = unsafe { GetCurrentThreadId() } as usize;
+    let mut hex = [0u8; 2 * std::mem::size_of::<usize>()];
+    let mut start = hex.len();
+    let mut value = thread_id;
+    loop {
+        start -= 1;
+        hex[start] = b"0123456789abcdef"[value & 0xf];
+        value >>= 4;
+        if value == 0 {
+            break;
+        }
+    }
+    rustpython_host_env::faulthandler::write_fd(fd, &hex[start..]);
+    rustpython_host_env::faulthandler::write_fd(fd, b" (most recent call first):\n");
+
+    let ec = crate::call::getexecutioncontext();
+    let mut frame = if ec.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe { (*ec).topframeref }
+    };
+    let mut depth = 0usize;
+    while !frame.is_null() && depth < 100 {
+        let pycode = unsafe { (*frame).pycode as *const crate::pycode::PyCode };
+        if pycode.is_null() || unsafe { (*pycode).code_ptr.is_null() } {
+            break;
+        }
+        let code = unsafe { &*((*pycode).code_ptr as *const crate::CodeObject) };
+        let filename = if unsafe { (*pycode).filename_bytes.is_null() } {
+            code.source_path.as_bytes()
+        } else {
+            unsafe { &*(*pycode).filename_bytes }.as_slice()
+        };
+        rustpython_host_env::faulthandler::write_fd(fd, b"  File \"");
+        rustpython_host_env::faulthandler::write_fd(fd, filename);
+        rustpython_host_env::faulthandler::write_fd(fd, b"\", line ");
+        let lineno = unsafe { (*frame).get_lineno_at((*frame).last_instr) }.max(0) as usize;
+        faulthandler_write_decimal(fd, lineno);
+        rustpython_host_env::faulthandler::write_fd(fd, b" in ");
+        rustpython_host_env::faulthandler::write_fd(fd, code.obj_name.as_bytes());
+        rustpython_host_env::faulthandler::write_fd(fd, b"\n");
+        frame = unsafe { (*frame).f_backref };
+        depth += 1;
+    }
+
+    // CPython's `_Py_DumpStack` prints this section after the Python stack.
+    // Pyre has no async-safe native symbolizer yet; its accepted failure form
+    // is preferable to calling an allocator or loader lock from an SEH hook.
+    rustpython_host_env::faulthandler::write_fd(
+        fd,
+        b"Current thread's C stack trace (most recent call first):\n<C stack unavailable>\n",
+    );
+}
+
 /// `faulthandler.c:280-330 faulthandler_exc_handler`.  A fatal fault on Windows
 /// arrives as a structured exception, not as a signal — a null read never
 /// reaches the `SIGSEGV` handler — so without this, `enable()` there prints
@@ -194,6 +276,7 @@ unsafe extern "system" fn faulthandler_exc_handler(
     msg[end + 1] = b'\n';
     let fd = FAULTHANDLER_FD.load(std::sync::atomic::Ordering::Relaxed);
     rustpython_host_env::faulthandler::write_fd(fd, &msg[..end + 2]);
+    unsafe { faulthandler_dump_current_traceback(fd) };
     // `faulthandler.c:326-334`: the access violation is also delivered to the
     // program as SIGSEGV, and reporting it twice helps nobody.
     if rustpython_host_env::faulthandler::is_access_violation(code) {
@@ -742,7 +825,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     None => 0,
                 };
                 #[cfg(feature = "host_env")]
-                rustpython_host_env::faulthandler::raise_exception(code, flags);
+                {
+                    // CPython's test helper raises the C++ and CLR status
+                    // values only to verify that the vectored handler ignores
+                    // them.  Letting either unwind through Rust's
+                    // `std::sys::thread::thread_start` is converted into
+                    // `panic_cannot_unwind`, so finish with the same silent
+                    // process status the unhandled SEH would have produced.
+                    if code == 0xE06D_7363 || code == 0xE043_4352 {
+                        unsafe {
+                            windows_sys::Win32::System::Threading::TerminateProcess(
+                                windows_sys::Win32::System::Threading::GetCurrentProcess(),
+                                code,
+                            );
+                        }
+                    }
+                    rustpython_host_env::faulthandler::raise_exception(code, flags);
+                }
                 Ok(pyre_object::w_none())
             }),
         );

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -1738,10 +1738,20 @@ fn mmap_new_object(
     let _roots = pyre_object::gc_roots::push_roots();
     let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let obj = W_MMap::allocate_stable(W_MMap {
+    // PyPy `mmap_new` / `W_MMap.__init__` creates the wrapper through
+    // `space.allocate_instance(W_MMap, w_subtype)`: it is an ordinary young
+    // GC object, not a non-moving side owner.  That placement is observable
+    // on Windows because the lightweight destructor closes the mapping
+    // section that otherwise prevents a mapped file from being truncated or
+    // unlinked.  The native mapping itself lives in the stable `Box` behind
+    // `backend`; no address derived from this movable wrapper is retained.
+    let pytype = unsafe {
+        &*<W_MMap as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE
+    };
+    let obj = pyre_object::lltype::malloc_typed_managed(W_MMap {
         ob: pyre_object::PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
+            ob_type: pytype,
+            w_class: pyre_object::pyobject::get_instantiate(pytype),
         },
         map: 0,
         storage: std::ptr::null_mut(),
@@ -1751,10 +1761,17 @@ fn mmap_new_object(
         mode: mode as i64,
         offset,
         exports: 0,
-    });
-    crate::typedef::tag_subclass_instance(obj, unsafe {
-        pyre_object::gc_roots::shadow_stack_get(cls_slot)
-    })
+    }) as pyre_object::PyObjectRef;
+    // `tag_subclass_instance` can allocate while it installs mapdict state;
+    // reload the movable wrapper through the same root bracket that protects
+    // `cls` across the allocation above.
+    let _ = pyre_object::gc_roots::pin_root(obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    crate::typedef::tag_subclass_instance(
+        pyre_object::gc_roots::shadow_stack_get(obj_slot),
+        unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) },
+    );
+    pyre_object::gc_roots::shadow_stack_get(obj_slot)
 }
 
 // `interp_mmap.py:55-130 mmap_new` / CPython 3.14's `trackfd` addition.

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -429,15 +429,22 @@ impl MmapPattern {
     /// # Safety
     /// The caller must uphold every validity, runtime-type, aliasing, and
     /// lifetime invariant required by the object arguments for the entire call.
-    unsafe fn acquire(
-        obj: pyre_object::PyObjectRef,
-        who: &str,
-    ) -> Result<Self, crate::PyError> {
-        if !unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
-            return Err(crate::PyError::type_error(format!(
-                "{who}: pattern must be bytes-like"
-            )));
-        }
+    unsafe fn acquire(obj: pyre_object::PyObjectRef) -> Result<Self, crate::PyError> {
+        // `PyObject_GetBuffer(args[0], &view, PyBUF_SIMPLE)` both admits the
+        // pattern and reports why it is turned down, so every exporter
+        // `readbuf_w` answers is a pattern here — a `memoryview`, an
+        // `array.array` and another mapping alongside `bytes` and `bytearray`.
+        unsafe { crate::builtins::acquire_readbuf(obj) }.map_err(|err| match err.kind {
+            // [3.14-spec] CPython `PyObject_GetBuffer` quotes `tp_name` in
+            // this gateway's refusal; PyPy `ObjSpace._getarg_error`, reached
+            // by `W_MMap.find` / `rfind`, reports it without quotes (and
+            // spells its None case simply `None`).
+            crate::PyErrorKind::TypeError => crate::PyError::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                crate::error::type_name_of(obj)
+            )),
+            _ => err,
+        })?;
         let _ = pyre_object::gc_roots::pin_root(obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let held = unsafe {
@@ -453,11 +460,9 @@ impl MmapPattern {
     /// # Safety
     /// The caller must uphold every validity, runtime-type, aliasing, and
     /// lifetime invariant required by the object arguments for the entire call.
-    unsafe fn data(&self) -> &'static [u8] {
+    unsafe fn data(&self) -> Result<&'static [u8], crate::PyError> {
         unsafe {
-            pyre_object::bytesobject::bytes_like_data(pyre_object::gc_roots::shadow_stack_get(
-                self.slot,
-            ))
+            crate::builtins::acquire_readbuf(pyre_object::gc_roots::shadow_stack_get(self.slot))
         }
     }
 }
@@ -470,6 +475,115 @@ impl Drop for MmapPattern {
             unsafe { crate::builtins::buffer_export_decref(obj) };
         }
     }
+}
+
+/// `mmap_gfind_lock_held` — the search `find` and `rfind` share, `reverse`
+/// apart.
+///
+/// [3.14-spec] CPython's generated `mmap_mmap_find` / `mmap_mmap_rfind`
+/// gateways count the arguments and acquire the `view: Py_buffer` export
+/// before `mmap_gfind_lock_held`, so a wrong argument count is reported ahead
+/// of a wrong pattern type and both ahead of the closed-mapping check.  PyPy's
+/// gateway counts first too, but `W_MMap.find` / `rfind` check the mapping
+/// before `ObjSpace.bufferstr_w` acquires the pattern; its argument-count and
+/// rejected-pattern wording differs as well.
+///
+/// [3.14-spec] `end` is converted only when `start` is not `None`, so
+/// `m.find(b"Z", None, 5)` searches to the end of the mapping and never runs
+/// the `__index__` of `5`.  `interp_mmap.py find` converts each argument on its
+/// own and has no `None` to pass through, so it rejects an explicit one.
+#[cfg(any(unix, windows))]
+fn mmap_gfind(
+    who: &str,
+    args: &[pyre_object::PyObjectRef],
+    reverse: bool,
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    // `_PyArg_CheckPositional(who, nargs, 1, 3)` over the arguments the
+    // gateway is given, the receiver the descriptor bound aside.
+    let nargs = args.len().saturating_sub(1);
+    if !(1..=3).contains(&nargs) {
+        let (bound, limit) = if nargs < 1 {
+            ("at least", 1)
+        } else {
+            ("at most", 3)
+        };
+        let plural = if limit == 1 { "" } else { "s" };
+        return Err(crate::PyError::type_error(format!(
+            "{who} expected {bound} {limit} argument{plural}, got {nargs}"
+        )));
+    }
+    let obj = args[0];
+    let _roots = pyre_object::gc_roots::push_roots();
+    // Taken before the conversions below, which run `__index__`, and released
+    // when this returns — the `Py_buffer` converter's export brackets the whole
+    // call.  `interp_mmap.py find` snapshots `space.bufferstr_w(w_tofind)` here
+    // instead, which neither sees an in-place edit made by one of those hooks
+    // nor refuses a resize.
+    let pattern = unsafe { MmapPattern::acquire(args[1]) }?;
+    // `mmap_gfind_lock_held` takes the `self->pos` and `self->size` defaults
+    // and performs its first `CHECK_VALID` before either conversion.
+    let (_, len_at_entry) = mmap_ptr(obj)?;
+    let cur = mmap_get_attr_i64(obj, "_pos") as usize;
+    let (start_raw, end_raw) = match args.get(2) {
+        Some(&start_obj) if !unsafe { pyre_object::is_none(start_obj) } => {
+            // Both upstreams finish converting the optional arguments before
+            // checking the mapping again.  In particular, an end conversion
+            // still runs after the start conversion closes the mapping.
+            let start = crate::baseobjspace::int_w(crate::baseobjspace::space_index(start_obj)?)?;
+            let end = match args.get(3) {
+                Some(&end_obj) if !unsafe { pyre_object::is_none(end_obj) } => {
+                    Some(crate::baseobjspace::int_w(
+                        crate::baseobjspace::space_index(end_obj)?,
+                    )?)
+                }
+                _ => None,
+            };
+            (Some(start), end)
+        }
+        _ => (None, None),
+    };
+    // `rmmap.find` reads `self.data` and `self.size` at this point, after the
+    // `check_valid()` that follows `getindex_w`: an `__index__` above is free
+    // to `resize()` the mapping, which installs a new view at a new address.
+    // Both the pointer and every bound are therefore taken from the mapping as
+    // it is now.
+    let (p, len) = mmap_ptr(obj)?;
+    let clamp = |v: i64| {
+        if v < 0 {
+            ((v + len as i64).max(0)) as usize
+        } else {
+            (v as usize).min(len)
+        }
+    };
+    let start = start_raw.map_or_else(|| cur.min(len), clamp);
+    // [3.14-spec] the clamp below the `end = self->size` default only ever
+    // lowers the value, so a mapping grown by one of the conversions above
+    // keeps the size it had on the way in.  `interp_mmap.py find` reads
+    // `self.mmap.size` after the start conversion instead, which reports the
+    // new one.
+    let end = end_raw.map_or_else(|| len_at_entry.min(len), clamp);
+    if start > end {
+        return Ok(pyre_object::w_int_new(-1));
+    }
+    let needle = unsafe { pattern.data() }?;
+    if needle.is_empty() {
+        let empty = if reverse { end } else { start };
+        return Ok(pyre_object::w_int_new(empty as i64));
+    }
+    let hay = unsafe { std::slice::from_raw_parts(p.add(start), end - start) };
+    if needle.len() > hay.len() {
+        return Ok(pyre_object::w_int_new(-1));
+    }
+    let last = hay.len() - needle.len();
+    let matches = |i: &usize| &hay[*i..*i + needle.len()] == needle;
+    let pos = if reverse {
+        (0..=last).rev().find(matches)
+    } else {
+        (0..=last).find(matches)
+    };
+    Ok(pyre_object::w_int_new(
+        pos.map_or(-1, |i| (start + i) as i64),
+    ))
 }
 
 /// Sweep-time counterpart of PyPy `W_MMap.__del__` / `rmmap.MMap.close`.
@@ -967,133 +1081,13 @@ fn init_mmap_type(ns: pyre_object::PyObjectRef) {
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "find",
-        crate::make_builtin_function("find", |args| {
-            if args.len() < 2 {
-                return Err(crate::PyError::type_error("find() missing pattern"));
-            }
-            let obj = args[0];
-            let (_, len_at_entry) = mmap_ptr(obj)?;
-            let _roots = pyre_object::gc_roots::push_roots();
-            // Taken before the conversions below, which run `__index__`, and
-            // released when this returns — `mmap.mmap.find` reaches its pattern
-            // through the `Py_buffer` converter, whose export brackets the
-            // whole call.  `interp_mmap.py find` snapshots
-            // `space.bufferstr_w(w_tofind)` here instead, which neither sees an
-            // in-place edit made by one of those hooks nor refuses a resize.
-            let pattern = unsafe { MmapPattern::acquire(args[1], "find") }?;
-            // `interp_mmap.py find(w_tofind, w_start=None,
-            // w_end=None)` defaults w_start to `self.mmap.pos` then
-            // routes through rmmap.find which handles negative start /
-            // end by adding `size` and clamping to 0.
-            let cur = mmap_get_attr_i64(obj, "_pos") as usize;
-            let start_raw = match args.get(2) {
-                Some(&value) => Some(mmap_index_w(obj, value)?),
-                None => None,
-            };
-            let end_raw = match args.get(3) {
-                Some(&value) => Some(mmap_index_w(obj, value)?),
-                None => None,
-            };
-            // `rmmap.find` reads `self.data` and `self.size` at this point,
-            // after the `check_valid()` that follows `getindex_w`: an
-            // `__index__` above is free to `resize()` the mapping, which
-            // installs a new view at a new address.  Both the pointer and
-            // every bound are therefore taken from the mapping as it is now.
-            let (p, len) = mmap_ptr(obj)?;
-            let clamp = |v: i64| {
-                if v < 0 {
-                    ((v + len as i64).max(0)) as usize
-                } else {
-                    (v as usize).min(len)
-                }
-            };
-            let start = start_raw.map_or_else(|| cur.min(len), clamp);
-            // [3.14-spec] `mmap_gfind_lock_held` evaluates `end = self->size`
-            // at entry and the clamp below it only ever lowers the value, so a
-            // mapping grown by one of the conversions above keeps the size it
-            // had on the way in.  `interp_mmap.py find` reads `self.mmap.size`
-            // after the start conversion instead, which reports the new one.
-            let end = end_raw.map_or_else(|| len_at_entry.min(len), clamp);
-            if start > end {
-                return Ok(pyre_object::w_int_new(-1));
-            }
-            let needle = unsafe { pattern.data() };
-            if needle.is_empty() {
-                return Ok(pyre_object::w_int_new(start as i64));
-            }
-            let hay = unsafe { std::slice::from_raw_parts(p.add(start), end - start) };
-            if needle.len() > hay.len() {
-                return Ok(pyre_object::w_int_new(-1));
-            }
-            let pos = (0..=hay.len().saturating_sub(needle.len()))
-                .find(|&i| &hay[i..i + needle.len()] == needle)
-                .map(|i| (start + i) as i64)
-                .unwrap_or(-1);
-            Ok(pyre_object::w_int_new(pos))
-        }),
+        crate::make_builtin_function("find", |args| mmap_gfind("find", args, false)),
     ) };
 
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "rfind",
-        crate::make_builtin_function("rfind", |args| {
-            if args.len() < 2 {
-                return Err(crate::PyError::type_error("rfind() missing pattern"));
-            }
-            let obj = args[0];
-            let (_, len_at_entry) = mmap_ptr(obj)?;
-            let _roots = pyre_object::gc_roots::push_roots();
-            // Taken before the conversions below, which run `__index__`, and
-            // released when this returns — `mmap.mmap.rfind` reaches its pattern
-            // through the `Py_buffer` converter, whose export brackets the
-            // whole call.  `interp_mmap.py rfind` snapshots
-            // `space.bufferstr_w(w_tofind)` here instead, which neither sees an
-            // in-place edit made by one of those hooks nor refuses a resize.
-            let pattern = unsafe { MmapPattern::acquire(args[1], "rfind") }?;
-            // `interp_mmap.py rfind(w_tofind, w_start=None,
-            // w_end=None)` defaults w_start to `self.mmap.pos`, not 0.
-            // Negative args run through rmmap.find which adds `size`
-            // and clamps to 0.
-            let cur = mmap_get_attr_i64(obj, "_pos") as usize;
-            let start_raw = match args.get(2) {
-                Some(&value) => Some(mmap_index_w(obj, value)?),
-                None => None,
-            };
-            let end_raw = match args.get(3) {
-                Some(&value) => Some(mmap_index_w(obj, value)?),
-                None => None,
-            };
-            // As in `find`: the mapping `getindex_w` left behind is the one
-            // this reads, so the address and every bound come from it.
-            let (p, len) = mmap_ptr(obj)?;
-            let clamp = |v: i64| {
-                if v < 0 {
-                    ((v + len as i64).max(0)) as usize
-                } else {
-                    (v as usize).min(len)
-                }
-            };
-            let start = start_raw.map_or_else(|| cur.min(len), clamp);
-            // As in `find`: the entry size bounds the default end.
-            let end = end_raw.map_or_else(|| len_at_entry.min(len), clamp);
-            if start > end {
-                return Ok(pyre_object::w_int_new(-1));
-            }
-            let needle = unsafe { pattern.data() };
-            if needle.is_empty() {
-                return Ok(pyre_object::w_int_new(end as i64));
-            }
-            let hay = unsafe { std::slice::from_raw_parts(p.add(start), end - start) };
-            if needle.len() > hay.len() {
-                return Ok(pyre_object::w_int_new(-1));
-            }
-            let pos = (0..=hay.len().saturating_sub(needle.len()))
-                .rev()
-                .find(|&i| &hay[i..i + needle.len()] == needle)
-                .map(|i| (start + i) as i64)
-                .unwrap_or(-1);
-            Ok(pyre_object::w_int_new(pos))
-        }),
+        crate::make_builtin_function("rfind", |args| mmap_gfind("rfind", args, true)),
     ) };
 
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -12212,11 +12212,119 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             }),
         );
 
+        /// PyPy `os_symlink_impl`, including its bounded `_check_dirW` probe.
+        ///
+        /// The probe is intentionally limited to `MAX_PATH`: the upstream C
+        /// helper uses two `WCHAR[MAX_PATH]` arrays and treats an overflowing
+        /// join as "not a directory".  That boundary is observable for an
+        /// existing directory target (and is exercised by CPython 3.14's
+        /// `TestExtractionFilters.test_realpath_limit_attack`), so the
+        /// unbounded `host_nt::symlink` probe is not equivalent here.
+        fn win_symlink(
+            src: &widestring::WideCString,
+            dst: &widestring::WideCString,
+            target_is_directory: bool,
+        ) -> std::io::Result<()> {
+            use std::sync::atomic::{AtomicBool, Ordering};
+            use windows_sys::Win32::{
+                Foundation::{ERROR_INVALID_PARAMETER, GetLastError},
+                Storage::FileSystem::{
+                    CreateSymbolicLinkW, FILE_ATTRIBUTE_DIRECTORY,
+                    GetFileAttributesExW, GetFileExInfoStandard,
+                    SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE,
+                    SYMBOLIC_LINK_FLAG_DIRECTORY, WIN32_FILE_ATTRIBUTE_DATA,
+                },
+            };
+
+            fn check_dir(
+                src: &widestring::WideCString,
+                dst: &widestring::WideCString,
+            ) -> bool {
+                let src = src.as_slice();
+                let dst = dst.as_slice();
+                let max_path = host_nt::MAX_PATH_USIZE;
+
+                // `_dirnameW` first copies the complete destination into its
+                // fixed buffer, then truncates it at the last separator.
+                if dst.len() >= max_path {
+                    return false;
+                }
+                let parent_len = dst
+                    .iter()
+                    .rposition(|&unit| unit == b'\\' as u16 || unit == b'/' as u16)
+                    .unwrap_or(0);
+                let parent = &dst[..parent_len];
+                let absolute = src.first().is_some_and(|&unit| {
+                    unit == b'\\' as u16 || unit == b'/' as u16
+                }) || (src.first().is_some_and(|&unit| unit != 0)
+                    && src.get(1) == Some(&(b':' as u16)));
+
+                let mut resolved = Vec::with_capacity(max_path);
+                if absolute {
+                    if src.len() >= max_path {
+                        return false;
+                    }
+                    resolved.extend_from_slice(src);
+                } else {
+                    let separator_len = usize::from(!parent.is_empty());
+                    if parent.len() + separator_len + src.len() >= max_path {
+                        return false;
+                    }
+                    resolved.extend_from_slice(parent);
+                    if !parent.is_empty() {
+                        resolved.push(b'\\' as u16);
+                    }
+                    resolved.extend_from_slice(src);
+                }
+                resolved.push(0);
+
+                let mut info: WIN32_FILE_ATTRIBUTE_DATA = unsafe { std::mem::zeroed() };
+                let ok = unsafe {
+                    GetFileAttributesExW(
+                        resolved.as_ptr(),
+                        GetFileExInfoStandard,
+                        (&mut info as *mut WIN32_FILE_ATTRIBUTE_DATA).cast(),
+                    )
+                };
+                ok != 0 && info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0
+            }
+
+            // `windows_has_symlink_unprivileged_flag` in `os_symlink_impl` is
+            // process-global semantic state, not per-thread state.
+            static HAS_UNPRIVILEGED_FLAG: AtomicBool = AtomicBool::new(true);
+            let has_unprivileged_flag = HAS_UNPRIVILEGED_FLAG.load(Ordering::Relaxed);
+            let mut flags = if has_unprivileged_flag {
+                SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+            } else {
+                0
+            };
+            if target_is_directory || check_dir(src, dst) {
+                flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+            }
+
+            let mut result = unsafe { CreateSymbolicLinkW(dst.as_ptr(), src.as_ptr(), flags) };
+            if !result
+                && has_unprivileged_flag
+                && unsafe { GetLastError() } == ERROR_INVALID_PARAMETER
+            {
+                flags &= !SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+                result = unsafe { CreateSymbolicLinkW(dst.as_ptr(), src.as_ptr(), flags) };
+                if result || unsafe { GetLastError() } != ERROR_INVALID_PARAMETER {
+                    HAS_UNPRIVILEGED_FLAG.store(false, Ordering::Relaxed);
+                }
+            }
+            if result {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        }
+
         // os.symlink(src, dst, target_is_directory=False) -> None.
         // `CreateSymbolicLinkW` names the link first and its target second,
         // and a link to a directory is a different kind of reparse point from
-        // a link to a file — which is what `target_is_directory` picks, since
-        // the target need not exist yet for the link to be made.
+        // a link to a file. `os_symlink_impl` picks the kind from the explicit
+        // argument or its bounded existing-target probe.
         crate::module_ns_store(
             ns,
             "symlink",
@@ -12247,25 +12355,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     None => false,
                 };
                 let (wide_src, wide_dst) = (wide_path(&src.as_bytes)?, wide_path(&dst.as_bytes)?);
-                // The kind is not read off `target_is_directory` alone.
-                // `os_symlink_impl` also asks `_check_dirW`, which resolves a
-                // relative `src` against `dirname(dst)` and reports whether
-                // `GetFileAttributesExW` calls it a directory — so
-                // `os.symlink(os.path.join('a', 'bcd'), 'sym3')` makes a link
-                // that can be walked into rather than a file link nothing can
-                // list.  Creating either is a privilege the account may not
-                // hold, so the call asks for the developer-mode path and
-                // retries without it on the Windows too old to know the flag.
-                // The host wrapper carries both, including the
-                // `windows_has_symlink_unprivileged_flag` latch that stops
-                // paying for the first attempt once it is known to fail.
-                rustpython_host_env::nt::symlink(
-                    &path_from_bytes(&src.as_bytes),
-                    &path_from_bytes(&dst.as_bytes),
-                    &wide_src,
-                    &wide_dst,
-                    target_is_directory,
-                )
+                win_symlink(&wide_src, &wide_dst, target_is_directory)
                 .map_err(|e| fs_err_with_filename2(e, 0, src.w_path(), dst.w_path()))?;
                 Ok(pyre_object::w_none())
             }),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -4250,15 +4250,19 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     // the descriptor without going through the buffer, so a descriptor the
     // host does not open — the sandbox controller mounts no real files —
     // leaves the buffer absent instead of removing `sys.stdout` outright.
-    let buffer = crate::builtins::builtin_open(&[
-        w_int_new(i64::from(fd)),
-        w_str_new(if writable { "wb" } else { "rb" }),
-        w_int_new(if unbuffered { 0 } else { -1 }),
-        w_none(),
-        w_none(),
-        w_none(),
-        w_bool_from(false),
-    ])
+    let allow_windows_console = !crate::importing::legacy_windows_stdio_flag();
+    let buffer = crate::builtins::builtin_open_stdio(
+        &[
+            w_int_new(i64::from(fd)),
+            w_str_new(if writable { "wb" } else { "rb" }),
+            w_int_new(if unbuffered { 0 } else { -1 }),
+            w_none(),
+            w_none(),
+            w_none(),
+            w_bool_from(false),
+        ],
+        allow_windows_console,
+    )
     .unwrap_or_else(|_| w_none());
     let _roots = pyre_object::gc_roots::push_roots();
     let buffer = pyre_object::gc_roots::pin_root(buffer);

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -429,7 +429,24 @@ pub unsafe fn context_add_roots(
 pub type NativeResult<T> = Result<T, (i32, String)>;
 
 fn io_error(error: std::io::Error) -> (i32, String) {
-    (error.raw_os_error().unwrap_or(-1), error.to_string())
+    // PyPy `_SSLContext.keylog_filename` raises the errno returned by
+    // `BIO_new_file`, and CPython `_Py_GetErrorHandler` likewise exposes a C
+    // errno to the OSError subclass machinery.  Rust's `raw_os_error()` is a
+    // Win32 status on Windows, so normalise the kinds used by SSL file I/O to
+    // their POSIX errno before crossing the native/interpreter boundary.
+    #[cfg(windows)]
+    let errno = match error.kind() {
+        std::io::ErrorKind::NotFound => libc::ENOENT,
+        std::io::ErrorKind::AlreadyExists => libc::EEXIST,
+        std::io::ErrorKind::PermissionDenied => libc::EACCES,
+        std::io::ErrorKind::Interrupted => libc::EINTR,
+        std::io::ErrorKind::InvalidInput => libc::EINVAL,
+        _ => error.raw_os_error().unwrap_or(libc::EIO),
+    };
+    #[cfg(not(windows))]
+    let errno = error.raw_os_error().unwrap_or(-1);
+
+    (errno, error.to_string())
 }
 
 fn pem_error(message: impl std::fmt::Display) -> (i32, String) {

--- a/pyre/pyre-wasm-runner/src/host_path.rs
+++ b/pyre/pyre-wasm-runner/src/host_path.rs
@@ -1,0 +1,88 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+/// Spell a native host path in the POSIX path grammar used by wasm32.
+///
+/// A Windows drive path is not absolute to `std::path::Path` on wasm32. Give
+/// it a leading slash and normalize separators while it is in the guest, then
+/// remove that transport-only slash in `guest_path_to_host`.
+pub(crate) fn host_path_to_guest(path: &Path) -> Option<Vec<u8>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Some(path.as_os_str().as_bytes().to_vec())
+    }
+    #[cfg(windows)]
+    {
+        let path = path.to_str()?.replace('\\', "/");
+        let drive_absolute = path.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+            && path.as_bytes().get(1) == Some(&b':')
+            && path.as_bytes().get(2) == Some(&b'/');
+        Some(match drive_absolute {
+            true => format!("/{path}").into_bytes(),
+            false => path.into_bytes(),
+        })
+    }
+}
+
+/// Decode the POSIX spelling used by the wasm guest into a native host path.
+pub(crate) fn guest_path_to_host(bytes: Vec<u8>) -> Option<OsString> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Some(OsString::from_vec(bytes))
+    }
+    #[cfg(windows)]
+    {
+        let mut path = String::from_utf8(bytes).ok()?;
+        let transport_drive = path.as_bytes().first() == Some(&b'/')
+            && path.as_bytes().get(1).is_some_and(u8::is_ascii_alphabetic)
+            && path.as_bytes().get(2) == Some(&b':')
+            && (path.len() == 3 || path.as_bytes().get(3) == Some(&b'/'));
+        if transport_drive {
+            path.remove(0);
+            if path.len() == 2 {
+                path.push('/');
+            }
+        }
+        Some(OsString::from(path.replace('/', "\\")))
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::{guest_path_to_host, host_path_to_guest};
+    use std::path::Path;
+
+    #[test]
+    fn windows_drive_path_round_trips_through_guest_absolute_path() {
+        let host = Path::new(r"Z:\pyre\lib-python\3");
+        let guest = host_path_to_guest(host).unwrap();
+        assert_eq!(guest, b"/Z:/pyre/lib-python/3");
+        assert_eq!(guest_path_to_host(guest).unwrap(), host.as_os_str());
+    }
+
+    #[test]
+    fn windows_relative_path_round_trips() {
+        let host = Path::new(r"build\fixture.py");
+        let guest = host_path_to_guest(host).unwrap();
+        assert_eq!(guest, b"build/fixture.py");
+        assert_eq!(guest_path_to_host(guest).unwrap(), host.as_os_str());
+    }
+
+    #[test]
+    fn windows_unc_path_is_guest_absolute() {
+        let host = Path::new(r"\\server\share\fixture.py");
+        let guest = host_path_to_guest(host).unwrap();
+        assert_eq!(guest, b"//server/share/fixture.py");
+        assert_eq!(guest_path_to_host(guest).unwrap(), host.as_os_str());
+    }
+
+    #[test]
+    fn guest_drive_component_decodes_as_host_drive_root() {
+        assert_eq!(
+            guest_path_to_host(b"/Z:".to_vec()).unwrap(),
+            Path::new(r"Z:\").as_os_str()
+        );
+    }
+}

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -20,6 +20,7 @@
 //! wasm module is located via `$PYRE_WASM_MODULE` or `--module <path>`, else the
 //! default release artifact path.
 
+mod host_path;
 mod wasmi_host;
 
 use std::path::{Path, PathBuf};
@@ -29,6 +30,8 @@ use wasmtime::{
     AsContext, AsContextMut, Caller, Config, Engine, Error, Extern, Func, Instance, Linker, Memory,
     Module, Ref, Result, Store, Table, Val, ValType,
 };
+
+use crate::host_path::{guest_path_to_host, host_path_to_guest};
 
 // Frame call-area offsets — must match `majit-backend-wasm/src/codegen.rs`.
 // Shared with `wasmi_host`, which mirrors the same call-area protocol.
@@ -2008,11 +2011,13 @@ fn host_cwd(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
     let Ok(cwd) = std::env::current_dir() else {
         return -1;
     };
-    let bytes = cwd.as_os_str().as_encoded_bytes();
+    let Some(bytes) = host_path_to_guest(&cwd) else {
+        return -1;
+    };
     if bytes.len() > buf_cap as usize {
         return bytes.len() as i64;
     }
-    match memory.write(&mut *caller, buf_ptr as usize, bytes) {
+    match memory.write(&mut *caller, buf_ptr as usize, &bytes) {
         Ok(()) => bytes.len() as i64,
         Err(_) => -1,
     }
@@ -2053,9 +2058,9 @@ fn host_sleep_ns(nanos: i64) {
 /// Read a host path argument out of wasm linear memory as the filesystem name
 /// it spells.
 ///
-/// The guest sends the bytes its own `OsStr` is.  On unix those are the bytes
-/// the filesystem takes, and a name with no UTF-8 spelling is one
-/// `host_list_dir` can report -- so it has to be one this can take back.
+/// The guest sends the bytes its own `OsStr` is. `guest_path_to_host` keeps
+/// Unix bytes intact and decodes the absolute-path transport spelling used on
+/// Windows; see `host_path_to_guest`.
 fn host_path(
     caller: &mut Caller<'_, Host>,
     path_ptr: u32,
@@ -2064,17 +2069,7 @@ fn host_path(
     let memory = caller.data().memory?;
     let mut bytes = vec![0u8; path_len as usize];
     memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::ffi::OsStringExt;
-        Some(std::ffi::OsString::from_vec(bytes))
-    }
-    // A Windows name is UTF-16, so bytes with no UTF-8 spelling name nothing
-    // there and are refused rather than guessed at.
-    #[cfg(not(unix))]
-    {
-        String::from_utf8(bytes).ok().map(std::ffi::OsString::from)
-    }
+    guest_path_to_host(bytes)
 }
 
 /// `pyre_host.host_stdlib_root`: write `$PYRE_STDLIB` into the wasm buffer.
@@ -2082,7 +2077,9 @@ fn host_stdlib_root(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -
     let Some(root) = caller.data().stdlib_root.clone() else {
         return -1;
     };
-    let bytes = root.as_bytes();
+    let Some(bytes) = host_path_to_guest(Path::new(&root)) else {
+        return -1;
+    };
     if bytes.len() > buf_cap as usize {
         // Report the needed length without writing; the caller can retry.
         return bytes.len() as i64;
@@ -2090,7 +2087,10 @@ fn host_stdlib_root(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -
     let Some(memory) = caller.data().memory else {
         return -1;
     };
-    if memory.write(&mut *caller, buf_ptr as usize, bytes).is_err() {
+    if memory
+        .write(&mut *caller, buf_ptr as usize, &bytes)
+        .is_err()
+    {
         return -1;
     }
     bytes.len() as i64

--- a/pyre/pyre-wasm-runner/src/wasmi_host.rs
+++ b/pyre/pyre-wasm-runner/src/wasmi_host.rs
@@ -18,6 +18,7 @@ use wasmi::{
 };
 
 use crate::CALL_RESULT_OFS;
+use crate::host_path::{guest_path_to_host, host_path_to_guest};
 
 /// Per-store host state, mirroring the wasmtime path's `Host`. wasmi needs the
 /// engine handle stored too, because trace modules are compiled from inside an
@@ -418,11 +419,13 @@ fn host_cwd(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
     let Ok(cwd) = std::env::current_dir() else {
         return -1;
     };
-    let bytes = cwd.as_os_str().as_encoded_bytes();
+    let Some(bytes) = host_path_to_guest(&cwd) else {
+        return -1;
+    };
     if bytes.len() > buf_cap as usize {
         return bytes.len() as i64;
     }
-    match memory.write(&mut *caller, buf_ptr as usize, bytes) {
+    match memory.write(&mut *caller, buf_ptr as usize, &bytes) {
         Ok(()) => bytes.len() as i64,
         Err(_) => -1,
     }
@@ -463,9 +466,9 @@ fn host_sleep_ns(nanos: i64) {
 /// Read a host path argument out of wasm linear memory as the filesystem name
 /// it spells.
 ///
-/// The guest sends the bytes its own `OsStr` is.  On unix those are the bytes
-/// the filesystem takes, and a name with no UTF-8 spelling is one
-/// `host_list_dir` can report -- so it has to be one this can take back.
+/// The guest sends the bytes its own `OsStr` is. `guest_path_to_host` keeps
+/// Unix bytes intact and decodes the absolute-path transport spelling used on
+/// Windows; see `host_path_to_guest`.
 fn host_path(
     caller: &mut Caller<'_, Host>,
     path_ptr: u32,
@@ -474,17 +477,7 @@ fn host_path(
     let memory = caller.data().memory?;
     let mut bytes = vec![0u8; path_len as usize];
     memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::ffi::OsStringExt;
-        Some(std::ffi::OsString::from_vec(bytes))
-    }
-    // A Windows name is UTF-16, so bytes with no UTF-8 spelling name nothing
-    // there and are refused rather than guessed at.
-    #[cfg(not(unix))]
-    {
-        String::from_utf8(bytes).ok().map(std::ffi::OsString::from)
-    }
+    guest_path_to_host(bytes)
 }
 
 /// `pyre_host.host_stdlib_root`: write `$PYRE_STDLIB` into the wasm buffer.
@@ -492,14 +485,19 @@ fn host_stdlib_root(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -
     let Some(root) = caller.data().stdlib_root.clone() else {
         return -1;
     };
-    let bytes = root.as_bytes();
+    let Some(bytes) = host_path_to_guest(Path::new(&root)) else {
+        return -1;
+    };
     if bytes.len() > buf_cap as usize {
         return bytes.len() as i64;
     }
     let Some(memory) = caller.data().memory else {
         return -1;
     };
-    if memory.write(&mut *caller, buf_ptr as usize, bytes).is_err() {
+    if memory
+        .write(&mut *caller, buf_ptr as usize, &bytes)
+        .is_err()
+    {
         return -1;
     }
     bytes.len() as i64


### PR DESCRIPTION
## Summary

- port the CPython 3.14 `mmap.find`/`rfind` buffer gateway while preserving PyPy-style managed wrapper lifetime
- fix Windows SSL errno/EOF handling, faulthandler SEH reporting, legacy stdio, and symlink behavior
- round-trip native Windows drive and UNC paths across the wasm host boundary

## Validation

- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py`: dynasm 543/543, cranelift 543/543; all wasm functional fixtures pass
- CPython `test_ssl`: pass
- CPython `test_tarfile --full`: pass
- Windows-specific coverage: faulthandler 5/5, `Win32SymlinkTests` 9/9, legacy Windows stdio pass, targeted mmap find/rfind cases pass individually

The Windows CPython sweep improved from PASS 282 / FAIL 58 / CRASH 3 / TIMEOUT 11 to PASS 284 / FAIL 57 / CRASH 2 / TIMEOUT 11.

## Known gate finding

`wasm/fib_recursive` still exceeds the existing performance ratio gate (6.1x versus 4x). It has no functional mismatch and does not exercise these Windows fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows support for structured-exception tracebacks in fault handling.
  - Added reliable host-to-guest path translation for WebAssembly, including Windows drive and UNC paths.
  - Added support for the `PYTHONLEGACYWINDOWSSTDIO` setting.

- **Bug Fixes**
  - Improved `mmap.find` and `mmap.rfind` validation and buffer handling.
  - Improved Windows symbolic-link creation and SSL error reporting.
  - Corrected Windows console stream behavior and common file-I/O error mapping.
  - Improved reporting of certain Windows connection-abort errors as SSL end-of-file conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->