### PR TITLE
jit: rewind declined subwalk state without side tables

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -223,7 +223,7 @@ cover the condition they diagnose.
 
 - Read sites: 1 — `majit/majit-gc/src/collector.rs`
 - Accessor: `read_uint_from_env("MAJIT_GC_BH_PROBE_CLASSES")`, default 10
-- What it does: How many distinct classes the probe above reports. Reached through a name-taking helper rather than a literal `env::var`, which is why the completeness brake in `pyre/pyrex/tests/gate_triage_complete.rs` does not see it — it is listed here because this document, not the brake, is what claims to hold every live gate.
+- What it does: How many distinct classes the probe above reports.
 - Retirement condition: with `MAJIT_GC_BH_PROBE`, whose report it shapes.
 
 ### `MAJIT_GC_BH_PROBE_MINOR`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13442,10 +13442,14 @@ impl<'a> Lowering<'a> {
     /// (`slice_first`'s payload note: the front has no pointer-to-slot op, so a
     /// `.first()` payload is already the element VALUE, and `Option<&T>` /
     /// `Option<T>` share the niche discriminant + one-word representation), so
-    /// all three are identities on the receiver.  `as_ref` is additionally
-    /// gated to a pointer-niche receiver and destination: an arbitrary
-    /// `Option<T>` can be wider than `Option<&T>` and must keep its real
-    /// projection.  Without the intercept the call keeps a
+    /// all three are identities on the receiver.  All three are gated to a
+    /// pointer-niche receiver and destination: an arbitrary `Option<T>` can be
+    /// wider than `Option<&T>` and must keep its real projection.  A nominal
+    /// `Copy`/`Clone` struct is what separates the two for `copied` / `cloned`
+    /// -- `Option<&Foo>` is one nullable word while `Option<Foo>` is a
+    /// discriminant plus the fields, so aliasing the destination to the
+    /// receiver would have later projections read the payload at the wrong
+    /// representation.  Without the intercept the call keeps a
     /// `CallTarget::Method` (`as_ref`/`copied`/`cloned`) getattr the rtyper
     /// cannot route on the classdef-less `Option` receiver (the `getattr
     /// (opt, "copied")` census wall — e.g. `_codecs::lookup_codec`'s
@@ -13453,11 +13457,15 @@ impl<'a> Lowering<'a> {
     /// `positional.first().copied()`).  Bind the destination to the receiver
     /// instead, the same alias shape as `to_string` / `NonNull::as_ptr`.
     ///
-    /// Gated on BOTH the receiver and the destination being `Option`: a
-    /// slice/iterator `.copied()` or a `Vec::clone` — a real copy, not an
-    /// identity — has a non-`Option` receiver/dest and keeps its ordinary
-    /// lowering.  (`Option::clone` on a `Copy` payload is itself an identity, so
-    /// the `cloned` arm is sound for the `Option` family.)
+    /// Gated on BOTH the receiver and the destination: a slice/iterator
+    /// `.copied()` or a `Vec::clone` — a real copy, not an identity — has a
+    /// non-`Option` receiver/dest, which the niche predicate rejects on its
+    /// first line, and keeps its ordinary lowering.  (`Option::clone` on a
+    /// `Copy` payload is itself an identity, so the `cloned` arm is sound for
+    /// the `Option` family.)  The receiver is peeled first because `as_ref`
+    /// takes `&Option<T>` while `copied` / `cloned` take the `Option<&T>` by
+    /// value; [`Self::tyref_peel_ref_to_pointee`] returns a non-reference
+    /// unchanged.
     fn is_option_value_identity(
         &self,
         reg: &RegularCall,
@@ -13483,9 +13491,6 @@ impl<'a> Lowering<'a> {
         });
         if !receiver_is_option {
             return false;
-        }
-        if leaf != "as_ref" {
-            return crate::front::result_exc::tyref_is_option(dest_ty, self.llbc);
         }
         let Some(receiver_ty) = first_arg_ty.and_then(|ty| self.tyref_peel_ref_to_pointee(ty))
         else {

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -215,7 +215,7 @@ Polarity below follows this file's rule, with one correction it needed: an
 | PYRE_WASM_FULL_TEARDOWN | skipping the ~0.2s wasm engine teardown at exit; setting it restores the drops for leak diagnostics | when teardown stops being the dominant fixed startup tax |
 | PYRE_FBW_NO_ADOPT_RESIDUAL_LOCALS | reading back the fastlocals a residual wrote to the frame, whether or not it forced, as a recorded `GETARRAYITEM_GC_R` off `locals_cells_stack_w` (`residual_call.rs adopt_residual_locals_writes`); setting it restores the walk that keeps the box it held before the call and so loses the write | when the walk reads a local through a channel a residual cannot leave stale; until then this is the one-binary control that keeps the defect demonstrable, and the parity fixture's two arms (a forcing call, and an inlined callee whose store forces nothing) are only separable with it |
 
-### §6a2 — Default-OFF experiments (10)
+### §6a2 — Default-OFF experiments (9)
 
 Kept as the switched-off arm of a one-binary comparison, not as latent
 defaults.  Bridge inlining reaches module replacement on its own, so
@@ -250,7 +250,6 @@ build.
 | PYRE_WASM_INLINE_TRIP_BYTES | `=N` prices a deferred inline merge at N bridge entries per byte of the module the merge re-emits (`lib.rs inline_trip_threshold_for`), the guest's flat `INLINE_TRIP_THRESHOLD` staying as the floor; unset leaves the built-in `DEFAULT_INLINE_TRIP_BYTES_FACTOR`, and `=0` restores the flat threshold as the whole rule.  A merge re-emits its owner whole, so its cranelift cost scales with the owner's size while the crossings it removes scale with the standing bridge's entries — the flat threshold reads only the second.  Exists so the conversion between the two rates can be re-swept on ONE binary, the guest having no environment to read it from | the corpus stops disagreeing about the value, or the merge decision stops being a single scalar |
 | PYRE_FBW_INLINE_POISON | admits a callee the replay scan declined and refuses at the scan's poisoned pcs during the walk (`diag.rs fbw_inline_poison_enabled`) | when a refusal that follows an executed effect has a resume leg that neither repeats it nor drops it |
 | PYRE_JD1 | arms the jd1 (`unpackiterable_driver`) compiled-loop experiment — `eval.rs jd1_experiment_enabled` is `PYRE_JD1 == "1"`, so nothing else turns it on.  `PYRE_NO_JD1`, `PYRE_JD1=0` and the master JIT off-switches (`PYRE_NO_JIT`, `PYRE_JIT=0`) each force it back off | the jd1 experiment concludes |
-| PYRE_SUBWALK_CUT_SNAPSHOTS | truncates the snapshot side table when a declined inline sub-walk is cut, as well as the operations (`inline_call.rs cut_declined_subwalk`); unset leaves `cut_trace`, which discards the ops and leaves the snapshots naming positions the cut has handed on — the shape the unroll reports as a `phase2 snapshot remap cache miss`.  The `BINARY_OP` entry already cuts that way at its own rewind.  Off here because no trace has been found that needs it, while `cut_trace`'s own note records that truncating regressed a bench | a declined sub-walk is shown to leave a stale snapshot position, or the truncation is measured to cost nothing and becomes unconditional |
 
 ### §6b — VALUE knobs (17): config, not gates
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -4298,32 +4298,26 @@ pub(crate) fn fbw_binop_rewind_refuse_commit<Sym: WalkSym>(
         return Ok(());
     }
     // A write into an object the region itself allocated is not a write the
-    // cut has to undo — see [`WalkSession::binop_rewind_fresh`].  The
-    // heap-cache reading is asked as well as the membership: `new_object`
-    // raises `HF_IS_UNESCAPED` on the allocation and `escape_box` lowers it,
-    // so an entry that has since been handed to something outside the region
-    // stops answering here without the list having to track the handoff.
+    // cut has to undo — see [`WalkSession::binop_rewind_fresh_from`].  The
+    // position separates an allocation of this region from one the walk made
+    // before it; the heap cache answers the rest, since `new_object` raises
+    // `HF_IS_UNESCAPED` on the allocation and `escape_box` lowers it, so an
+    // object since handed to something outside the region stops answering
+    // here.  A constant or an input arg is neither; matching the `*Op`
+    // variants keeps `raw()` off the inline-`Const` variants it panics on.
     if let Some(obj) = receiver
-        && session.binop_rewind_fresh.contains(&obj)
+        && let Some(from) = session.binop_rewind_fresh_from
+        && matches!(
+            obj,
+            OpRef::IntOp(_) | OpRef::FloatOp(_) | OpRef::RefOp(_) | OpRef::VoidOp(_)
+        )
+        && obj.raw() >= from
         && ctx.trace_ctx.heap_cache().is_unescaped(obj)
     {
         return Ok(());
     }
     session.binop_rewind_refused = true;
     Err(DispatchError::callee_inline_unsupported(pc))
-}
-
-/// Record an allocation the standing `BINARY_OP` / `COMPARE_OP` rewind region
-/// minted, so a store into it is exempt from
-/// [`fbw_binop_rewind_refuse_commit`].  A no-op outside a region.
-pub(crate) fn fbw_binop_rewind_note_fresh<Sym: WalkSym>(
-    ctx: &WalkContext<'_, '_, Sym>,
-    opref: OpRef,
-) {
-    let mut session = ctx.session.borrow_mut();
-    if session.binop_rewind_depth != 0 {
-        session.binop_rewind_fresh.push(opref);
-    }
 }
 
 /// Raises a [`fbw_binop_rewind_refuse_commit`] region for one descent.
@@ -4335,7 +4329,11 @@ pub(crate) struct BinopRewindInlineGuard<'s> {
 }
 
 impl<'s> BinopRewindInlineGuard<'s> {
-    pub(crate) fn enter(session: &'s std::cell::RefCell<WalkSession>) -> Self {
+    /// `from` is the recorder position the region starts at — see
+    /// [`WalkSession::binop_rewind_fresh_from`].  A nested entry keeps the
+    /// outermost one's, so an allocation of the enclosing region stays exempt
+    /// while the inner descent runs.
+    pub(crate) fn enter(session: &'s std::cell::RefCell<WalkSession>, from: u32) -> Self {
         let mut s = session.borrow_mut();
         let outermost = s.binop_rewind_depth == 0;
         // The outermost entry starts from a clean slate, so a flag left behind
@@ -4343,7 +4341,7 @@ impl<'s> BinopRewindInlineGuard<'s> {
         // this one's refusal.
         if outermost {
             s.binop_rewind_refused = false;
-            s.binop_rewind_fresh.clear();
+            s.binop_rewind_fresh_from = Some(from);
         }
         s.binop_rewind_depth += 1;
         drop(s);
@@ -4372,7 +4370,7 @@ impl Drop for BinopRewindInlineGuard<'_> {
         let mut s = self.session.borrow_mut();
         s.binop_rewind_depth -= 1;
         if s.binop_rewind_depth == 0 {
-            s.binop_rewind_fresh.clear();
+            s.binop_rewind_fresh_from = None;
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2967,47 +2967,42 @@ fn binop_nested_filter_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_BINOP_NO_NESTED_INLINE").is_some())
 }
 
-/// Discard a declined inline sub-walk: the operations it recorded, and the
-/// heap cache they populated.
+/// Discard a declined inline sub-walk: the operations it recorded, the
+/// snapshots those operations named, and the heap cache they populated.
 ///
-/// The seven call sites all spelled this out as the same two statements.
+/// The eight call sites all spelled the operations and the cache out as the
+/// same two statements.
 ///
-/// `PYRE_SUBWALK_CUT_SNAPSHOTS` additionally truncates the snapshot side
-/// table, which [`majit_metainterp::history::TraceCtx::cut_trace`] leaves
-/// alone: a guard the speculative walk attached before it declined keeps
-/// naming positions the cut has since handed to other operations, and the
-/// unroll's Phase 2 remap reports such a position as a `phase2 snapshot remap
-/// cache miss`.  The `BINARY_OP` entry cuts that way at its own rewind.
+/// [`majit_metainterp::history::TraceCtx::cut_trace`] leaves the snapshot side
+/// table alone, and a guard the speculative walk attached before it declined
+/// then keeps naming positions the cut has since handed to other operations —
+/// the shape the unroll's Phase 2 remap reports as a `phase2 snapshot remap
+/// cache miss`.  So the cut here takes both.
 ///
-/// Not truncating is the ported behaviour, not a shortcut: `Trace.cut_point`
-/// returns the two snapshot lengths as the last elements of its five-tuple and
-/// `Trace.cut_at` restores only `_pos`, `_count` and `_index` from it, leaving
-/// `_snapshot_data` and `_snapshot_array_data` as they stand -- the same two
-/// elements `cut_trace_from` destructures and never reads.  Upstream is not
-/// exposed by that because its snapshots live inline in the trace byte stream,
-/// where anything past the restored `_pos` is unreachable and the next append
-/// overwrites it; pyre owns them in a `Vec<Snapshot>` beside the stream, where
-/// a stale entry keeps its index.  The exposure is that representation, whose
+/// Upstream restores neither: `Trace.cut_point` returns the two snapshot
+/// lengths as the last elements of its five-tuple and `Trace.cut_at` restores
+/// only `_pos`, `_count` and `_index` from it, leaving `_snapshot_data` and
+/// `_snapshot_array_data` as they stand -- the same two elements
+/// `cut_trace_from` destructures and never reads.  It is not exposed by that
+/// because its snapshots live inline in the trace byte stream, where anything
+/// past the restored `_pos` is unreachable and the next append overwrites it;
+/// pyre owns them in a `Vec<Snapshot>` beside the stream, where a stale entry
+/// keeps its index.  Truncating is what that representation costs, and it is
+/// already what every other speculative rewind in the walker does --
+/// `cut_trace_with_snapshots` has eighteen further call sites across this file
+/// and `specialize.rs`, the `BINARY_OP` entry's own rewind among them.  The
 /// migration to the byte-stream form `TraceRecordBuffer` already carries is
-/// recorded on `TraceCtx::snapshots` -- so this stays off, and truncating is
-/// the deviation held for the trace that needs it.  `cut_trace`'s own note
-/// records that truncating regressed a bench.
+/// recorded on `TraceCtx::snapshots`.
+///
+/// `cut_trace`'s own note records that truncating regressed a bench.  That is
+/// about `cut_trace` truncating for all of its callers, which this does not
+/// change: the seven outside this helper still take the operations alone.
 fn cut_declined_subwalk<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     pre_fold_pos: majit_metainterp::recorder::TracePosition,
 ) {
-    if subwalk_cut_snapshots_enabled() {
-        ctx.trace_ctx.cut_trace_with_snapshots(pre_fold_pos);
-    } else {
-        ctx.trace_ctx.cut_trace(pre_fold_pos);
-    }
+    ctx.trace_ctx.cut_trace_with_snapshots(pre_fold_pos);
     ctx.trace_ctx.heap_cache_mut().reset();
-}
-
-/// `PYRE_SUBWALK_CUT_SNAPSHOTS`: see [`cut_declined_subwalk`].
-fn subwalk_cut_snapshots_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_SUBWALK_CUT_SNAPSHOTS").is_some())
 }
 
 fn callee_body_commits_nothing(w_code: *const ()) -> bool {
@@ -8085,7 +8080,6 @@ fn emit_walker_instance<Sym: WalkSym>(
         instance,
         &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64,
     );
-    fbw_binop_rewind_note_fresh(ctx, instance);
     (instance, concrete_instance)
 }
 
@@ -9198,8 +9192,7 @@ pub(crate) fn try_walker_inline_getattribute_hook<Sym: WalkSym>(
         }),
     )?;
     if inlined.is_none() {
-        ctx.trace_ctx.cut_trace(pre_fold_pos);
-        ctx.trace_ctx.heap_cache_mut().reset();
+        cut_declined_subwalk(ctx, pre_fold_pos);
     }
     Ok(inlined)
 }
@@ -10636,8 +10629,10 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
     let method_const = ctx.trace_ctx.const_ref(method as i64);
     // Copied out before the descent takes `ctx` mutably; the region state is
     // the session's, not this frame's.
+    let region_from = ctx.trace_ctx.get_trace_position()._count;
     let session = ctx.session;
-    let rewind_guard = admitted_on_rewind.then(|| BinopRewindInlineGuard::enter(session));
+    let rewind_guard =
+        admitted_on_rewind.then(|| BinopRewindInlineGuard::enter(session, region_from));
     let descent = try_walker_inline_resolved_user_call(
         ctx,
         op,
@@ -10887,8 +10882,10 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     let method_const = ctx.trace_ctx.const_ref(method as i64);
     // Copied out before the descent takes `ctx` mutably; the region state is
     // the session's, not this frame's.
+    let region_from = ctx.trace_ctx.get_trace_position()._count;
     let session = ctx.session;
-    let rewind_guard = admitted_on_rewind.then(|| BinopRewindInlineGuard::enter(session));
+    let rewind_guard =
+        admitted_on_rewind.then(|| BinopRewindInlineGuard::enter(session, region_from));
     let descent = try_walker_inline_resolved_user_call(
         ctx,
         op,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -647,32 +647,34 @@ pub struct WalkSession {
     /// that raised it knows the descent stopped for that reason and may take
     /// the cut.
     pub binop_rewind_refused: bool,
-    /// Allocations the region above minted, in the order they were emitted.
+    /// The recorder position the region above was raised at.
     ///
-    /// A store into one of these is not a commit the cut has to undo: the cut
-    /// discards the operations that built the object, and the concrete object
-    /// the walker allocated alongside them is unreachable from anything the
-    /// re-execution can name — the same reading
+    /// A store into an object the region itself allocated is not a commit the
+    /// cut has to undo: the cut discards the operations that built the object,
+    /// and the concrete object the walker allocated alongside them is
+    /// unreachable from anything the re-execution can name — the same reading
     /// [`inline_call::try_walker_inline_type_call`] already states for its own
     /// rewind ("the orphaned instance is unreachable and `__init__` has not
     /// run").  Every other route out of the region — a store into a
     /// pre-existing object, an unjournaled residual — is still refused, so an
-    /// entry here cannot escape while the region stands.
+    /// object that predates the region cannot escape while it stands.
     ///
-    /// Emptied by the outermost [`fbw_state::BinopRewindInlineGuard`], so it
-    /// never carries an entry from a region that has already unwound.
+    /// Which of the two an object is stays on the box, where the porting rules
+    /// ask for it: `new_object` raises `HF_SEEN_ALLOCATION` / `HF_IS_UNESCAPED`
+    /// on every allocation the walk records, and `escape_box` and every reset
+    /// of the cache lower them, so an object since handed to something outside
+    /// the region stops answering on its own. This position is only what tells
+    /// an allocation of this region from one the walk made before it:
+    /// `Trace::record_op` numbers each operation from the same `op_count` this
+    /// records, so an `OpRef` at or above it was minted inside the region. A
+    /// rewind taken inside the region cuts to a position the region itself
+    /// took and resets the heap cache with it, so a reused number answers as an
+    /// allocation again only once something re-allocates there.
     ///
-    /// Beside the box rather than on it, which the porting rules otherwise ask
-    /// for, because there is no slot to reach: the record-time store for a
-    /// per-box fact is the heap cache, whose flag word is heapcache.py's own
-    /// six `HF_*` bits with the version counter occupying everything above
-    /// them, and the fact itself is pyre-only -- upstream has no rewind region
-    /// at a dunder entry, so it has nothing that means "allocated inside one".
-    /// What the box does own is consulted: the exemption also requires
-    /// `is_unescaped`, so escaping the object, or any reset of the cache,
-    /// withdraws it. Membership is only ever the instantiations one dunder body
-    /// performs, and both ends of the region clear it.
-    pub binop_rewind_fresh: Vec<OpRef>,
+    /// `None` outside a region: set by the outermost
+    /// [`fbw_state::BinopRewindInlineGuard`] and cleared when it unwinds, so it
+    /// never carries a position from a region that has already ended.
+    pub binop_rewind_fresh_from: Option<u32>,
 }
 
 impl Default for WalkSession {
@@ -696,7 +698,7 @@ impl Default for WalkSession {
             recording_opcode_position: 0,
             binop_rewind_depth: 0,
             binop_rewind_refused: false,
-            binop_rewind_fresh: Vec::new(),
+            binop_rewind_fresh_from: None,
         }
     }
 }

--- a/pyre/pyrex/tests/gate_triage_complete.rs
+++ b/pyre/pyrex/tests/gate_triage_complete.rs
@@ -102,6 +102,12 @@ fn collect_sources(dir: &Path, ext: &str, out: &mut Vec<PathBuf>) {
 /// brakes at once — read but reported as unread, documented but reported as
 /// undocumented. Its sibling `read_float_from_env` is not here because no gate
 /// name reaches it; add it the day one does.
+///
+/// Every form is matched on an identifier boundary: the character before it
+/// must not continue a name, so `my_read_uint_from_env` is not the helper and
+/// `pyre_env::var` is not `std::env::var`. The qualifiers the real read sites
+/// carry — `::` before `env::var`, `getenv` and `host_os::var`, `.` before
+/// `getenv` and `environ.get` — all clear that boundary.
 const READ_FORMS: [&str; 5] = [
     "env::var",
     "host_os::var",
@@ -152,10 +158,22 @@ fn namespace_of(name: &str) -> Option<&'static GateNamespace> {
 /// Matches the read forms above rather than every mention of the name, so a gate
 /// discussed in a comment or held in a Rust const does not count as live. That
 /// is the same distinction `gate-triage.md` §2 draws by hand.
+/// Whether the character before `at` continues an identifier, which makes the
+/// form a tail of a longer name rather than the name itself.
+fn continues_an_identifier(text: &str, at: usize) -> bool {
+    text[..at]
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_alphanumeric() || c == '_')
+}
+
 fn gates_read_by(text: &str) -> Vec<&str> {
     let mut found = Vec::new();
     for form in READ_FORMS {
         for (at, _) in text.match_indices(form) {
+            if continues_an_identifier(text, at) {
+                continue;
+            }
             let rest = &text[at + form.len()..];
             // `env::var_os` is the same read wearing a suffix.
             let rest = rest.strip_prefix("_os").unwrap_or(rest);
@@ -204,6 +222,9 @@ fn gates_read_by_matches_the_read_forms_and_nothing_else() {
         os.getenv("PYRE_G")
         println!("cargo::rerun-if-env-changed=PYRE_H");
         read_uint_from_env("PYRE_I").unwrap_or(0);
+        // a longer name ending in a read form is not that read form
+        my_read_uint_from_env("PYRE_NOT_THE_HELPER");
+        pyre_env::var("PYRE_NOT_STD_ENV");
         # a gate written into a child's environment is not a read of ours
         env["PYRE_NOT_A_READ_EITHER"] = "1"
         // PYRE_MENTIONED_IN_A_COMMENT


### PR DESCRIPTION
## Summary
- rewind speculative subwalk snapshots together with trace operations
- replace the dunder rewind allocation side-table with recorder-position and heap-cache ownership checks
- restrict Option projection aliases to pointer-niche layouts and tighten gate discovery

## Testing
- cargo fmt --all -- --check
- cargo test -p pyrex --no-default-features --features dynasm --test gate_triage_complete
- cargo test --all --no-default-features --features dynasm
- python3 pyre/check.py (pre-rebase: dynasm and cranelift passed; wasm behavior passed with only the stale dict_set 607-to-608 baseline difference already present on current main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of inline arithmetic and comparison operations, including allocation tracking and rewind behavior.
  - Ensured declined inline paths consistently clean up associated snapshots and caches.
  - Improved detection of environment reads in automated gate checks to avoid matching longer identifiers incorrectly.

- **Documentation**
  - Clarified requirements for option-value identity checks.
  - Updated gate-triage documentation to reflect current gate coverage and experiment counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->