### PR TITLE
builtins, ctypes: address #1682 review findings

### DIFF
--- a/pyre/extra_tests/parity_tests/ctypes_py_object_survives_a_moving_collection.py
+++ b/pyre/extra_tests/parity_tests/ctypes_py_object_survives_a_moving_collection.py
@@ -16,6 +16,7 @@ a table slot, and the table is a real object the root walk forwards.
 
 import ctypes
 import gc
+import weakref
 
 payload = ["alpha", "beta"]
 box = ctypes.py_object(payload)
@@ -55,5 +56,70 @@ assert payload[-1] == 199
 number = ctypes.py_object(10**30)
 gc.collect(0)
 assert number.value == 10**30, number.value
+
+
+# CPython's `O_set` hands `PyCData_set` the referent represented by the word
+# it stored.  A same-typed `py_object` assignment therefore retains the value
+# at assignment time, not the wrapper whose `.value` can subsequently change.
+class Payload:
+    pass
+
+
+class ObjectField(ctypes.Structure):
+    _fields_ = [("value", ctypes.py_object)]
+
+
+ObjectArray = ctypes.py_object * 1
+
+
+def assert_wrapper_copy_keeps_referent(destination, write, read):
+    original = Payload()
+    original_ref = weakref.ref(original)
+    holder = ctypes.py_object(original)
+    write(destination, holder)
+    holder.value = Payload()
+    del original
+    gc.collect(0)
+    kept = original_ref()
+    assert kept is not None
+    assert read(destination) is kept
+
+
+field = ObjectField()
+assert_wrapper_copy_keeps_referent(
+    field,
+    lambda destination, value: setattr(destination, "value", value),
+    lambda destination: destination.value,
+)
+
+array = ObjectArray()
+assert_wrapper_copy_keeps_referent(
+    array,
+    lambda destination, value: destination.__setitem__(0, value),
+    lambda destination: destination[0],
+)
+
+pointer_base = ObjectArray()
+pointer = ctypes.cast(pointer_base, ctypes.POINTER(ctypes.py_object))
+assert_wrapper_copy_keeps_referent(
+    pointer,
+    lambda destination, value: destination.__setitem__(0, value),
+    lambda destination: destination[0],
+)
+
+# `None` is already held strongly by PyPy's `GlobalPyobjContainer`, and
+# CPython does not expose a redundant keepalive entry for it.
+none_field = ObjectField()
+none_field.value = None
+assert none_field._objects is None
+
+none_array = ObjectArray()
+none_array[0] = None
+assert none_array._objects is None
+
+none_pointer_base = ObjectArray()
+none_pointer = ctypes.cast(none_pointer_base, ctypes.POINTER(ctypes.py_object))
+none_pointer[0] = None
+assert "0" not in none_pointer._objects
 
 print("OK")

--- a/pyre/extra_tests/snippets/syntax_error_python314_offsets.py
+++ b/pyre/extra_tests/snippets/syntax_error_python314_offsets.py
@@ -336,6 +336,9 @@ for source, message, position in (
     # visible to f-string parsing.  CPython 3.14's tokenizer therefore reads
     # the first replacement field, while doubled braces below stay literal.
     ("f'\\{bu\"x\"}'", "'u' and 'b' prefixes are incompatible", (1, 5, 1, 7)),
+    # A nested replacement inside a format specification switches back from
+    # literal format text to tokenized expression text.
+    ("f'''{1:{bu\"x\"}}'''", "'u' and 'b' prefixes are incompatible", (1, 9, 1, 11)),
     # The tokenizer does not read a comment, so neither does the scan.
     ("x = = 1  # bu'z'", "invalid syntax", (1, 5, 1, 6)),
 ):
@@ -355,6 +358,32 @@ source = "f'\\{{ bu\"x\" }}'; 1=2"
 error = syntax_error(source)
 assert error.msg == "cannot assign to literal here. Maybe you meant '==' instead of '='?"
 assert (error.lineno, error.offset, error.end_lineno, error.end_offset) == (1, 18, 1, 19)
+
+# Format specifications are literal text, and comments disappear from the
+# token stream of a replacement expression.  Prefix-shaped text in either one
+# cannot override the later assignment diagnostic.
+for source, position in (
+    ("f'''{1:bu\"x\"}'''; 1 = 2", (1, 19, 1, 20)),
+    ("f'''{1 # bu\"x\"\n}'''; 1 = 2", (2, 7, 2, 8)),
+):
+    error = syntax_error(source)
+    assert error.msg == "cannot assign to literal here. Maybe you meant '==' instead of '='?"
+    assert (error.lineno, error.offset, error.end_lineno, error.end_offset) == position
+
+# A fatal tokenizer error stops before the later prefix-shaped literal.  A
+# grammar error does not: its whole token stream was already read, as the
+# `f() = bu'x'` cases above demonstrate.
+for source, message, position in (
+    ("0x\nbu'x'", "invalid hexadecimal literal", (1, 2, 1, 2)),
+    (
+        "(]\nbu'x'",
+        "closing parenthesis ']' does not match opening parenthesis '('",
+        (1, 2, 1, 2),
+    ),
+):
+    error = syntax_error(source)
+    assert error.msg == message, (source, error.msg)
+    assert (error.lineno, error.offset, error.end_lineno, error.end_offset) == position
 
 
 # `eval` is `expressions NEWLINE* ENDMARKER` and has no assignment rule at all,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13515,9 +13515,14 @@ fn nonascii_bytes_literal_span(source: &str, raw_index: usize) -> Option<(usize,
 fn incompatible_string_prefix_error(
     source: &str,
     raw_index: usize,
+    tokenizer_stop: Option<usize>,
 ) -> Option<(String, usize, usize)> {
     let bytes = source.as_bytes();
-    first_string_prefix_pair_error(bytes, raw_index.min(bytes.len()))
+    first_string_prefix_pair_error(
+        bytes,
+        raw_index.min(bytes.len()),
+        tokenizer_stop.map(|stop| stop.min(bytes.len())),
+    )
 }
 
 /// The first string token in `bytes` whose prefix is an incompatible pair.
@@ -13534,23 +13539,44 @@ fn incompatible_string_prefix_error(
 /// that field rather than by the tokenizer, so it only stands where it
 /// precedes the error already reported at `anchor`: `s = f'{ub"y"}'; f() = 1`
 /// names the prefix and `f() = 1; s = f'{ub"y"}'` names the assignment.
-fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String, usize, usize)> {
-    /// One literal the walk is inside, and how many braces are open in it --
-    /// a replacement field, and any display written within that field.
+fn first_string_prefix_pair_error(
+    bytes: &[u8],
+    anchor: usize,
+    tokenizer_stop: Option<usize>,
+) -> Option<(String, usize, usize)> {
+    /// One replacement field inside an interpolated literal.  Delimiters are
+    /// the expression's own displays/calls/subscripts; an empty stack is what
+    /// makes `:` enter the format specification rather than a slice or dict.
+    struct ReplacementField {
+        delimiters: Vec<u8>,
+        format_spec: bool,
+    }
+
+    /// One literal the walk is inside, plus the nested replacement fields the
+    /// tokenizer has entered.  A format specification is literal text until
+    /// another `{` opens its own replacement field.
     struct OpenLiteral {
         delimiter: u8,
         triple: bool,
         interpolated: bool,
-        braces: usize,
+        fields: Vec<ReplacementField>,
     }
 
     let mut open: Vec<OpenLiteral> = Vec::new();
     let mut cursor = 0;
     while cursor < bytes.len() {
+        if tokenizer_stop.is_some_and(|stop| cursor > stop) {
+            return None;
+        }
         let byte = bytes[cursor];
-        // The innermost literal's own text, unless a brace of it is open --
-        // inside one the walk is reading tokens again.
-        if let Some(literal) = open.last_mut().filter(|literal| literal.braces == 0) {
+        // The innermost literal's own text, or the literal format-spec text of
+        // its current field.  A nested replacement field switches back to
+        // token mode until its own `}`.
+        if let Some(literal) = open
+            .last_mut()
+            .filter(|literal| literal.fields.last().is_none_or(|field| field.format_spec))
+        {
+            let in_format_spec = !literal.fields.is_empty();
             match byte {
                 // A backslash closes no literal, raw included: `r'\''` keeps
                 // the escape in its text and the quote after it in the token.
@@ -13565,14 +13591,26 @@ fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String
                 }
                 b'\\' => cursor += 2,
                 b'\n' if !literal.triple => return None,
-                // `{{` and `}}` each write one brace and open no field.
+                // `{{` in the outer literal writes one brace.  In a format
+                // specification every `{` starts the nested replacement field
+                // that makes its contents tokenized expression text.
                 b'{' if literal.interpolated => {
-                    let doubled = bytes.get(cursor + 1) == Some(&b'{');
+                    let doubled = !in_format_spec && bytes.get(cursor + 1) == Some(&b'{');
                     cursor += 1 + usize::from(doubled);
-                    literal.braces += usize::from(!doubled);
+                    if !doubled {
+                        literal.fields.push(ReplacementField {
+                            delimiters: Vec::new(),
+                            format_spec: false,
+                        });
+                    }
                 }
                 b'}' if literal.interpolated => {
-                    cursor += 1 + usize::from(bytes.get(cursor + 1) == Some(&b'}'));
+                    if in_format_spec {
+                        literal.fields.pop();
+                        cursor += 1;
+                    } else {
+                        cursor += 1 + usize::from(bytes.get(cursor + 1) == Some(&b'}'));
+                    }
                 }
                 _ if byte == literal.delimiter => {
                     if literal.triple && !bytes[cursor..].starts_with(&[byte; 3]) {
@@ -13587,21 +13625,48 @@ fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String
             continue;
         }
         match byte {
-            // A comment runs to the end of its line.  Only outside a literal:
-            // what a replacement field writes is not one.
-            b'#' if open.is_empty() => {
+            // A comment runs to the end of its line both at module level and
+            // in a replacement expression.  Literal and format-spec text took
+            // the branch above and never reaches this token-mode arm.
+            b'#' => {
                 cursor = bytes[cursor..]
                     .iter()
                     .position(|byte| *byte == b'\n')
                     .map_or(bytes.len(), |newline| cursor + newline + 1);
             }
-            b'{' | b'}' => {
-                if let Some(literal) = open.last_mut() {
-                    literal.braces = if byte == b'{' {
-                        literal.braces + 1
-                    } else {
-                        literal.braces - 1
+            b'(' | b'[' | b'{' => {
+                if let Some(field) = open
+                    .last_mut()
+                    .and_then(|literal| literal.fields.last_mut())
+                {
+                    field.delimiters.push(byte);
+                }
+                cursor += 1;
+            }
+            b')' | b']' | b'}' => {
+                if let Some(literal) = open.last_mut()
+                    && let Some(field) = literal.fields.last_mut()
+                {
+                    let opening = match byte {
+                        b')' => b'(',
+                        b']' => b'[',
+                        _ => b'{',
                     };
+                    if field.delimiters.last() == Some(&opening) {
+                        field.delimiters.pop();
+                    } else if byte == b'}' && field.delimiters.is_empty() {
+                        literal.fields.pop();
+                    }
+                }
+                cursor += 1;
+            }
+            b':' => {
+                if let Some(field) = open
+                    .last_mut()
+                    .and_then(|literal| literal.fields.last_mut())
+                    && field.delimiters.is_empty()
+                {
+                    field.format_spec = true;
                 }
                 cursor += 1;
             }
@@ -13621,7 +13686,7 @@ fn first_string_prefix_pair_error(bytes: &[u8], anchor: usize) -> Option<(String
                     delimiter: byte,
                     triple,
                     interpolated,
-                    braces: 0,
+                    fields: Vec::new(),
                 });
                 cursor += if triple { 3 } else { 1 };
             }
@@ -15230,7 +15295,41 @@ fn compile_err_to_syntax_error_maybe_incomplete(
     }
     let prefix_error = match &e {
         crate::compile::CompileError::Parse(parse_error) => {
-            incompatible_string_prefix_error(source, parse_error.raw_location.start().to_usize())
+            let raw_index = parse_error.raw_location.start().to_usize();
+            // A fatal tokenizer error means no later token exists.  Ruff still
+            // leaves the remaining source available to this diagnostic pass,
+            // so bound the recovery walk at the error it actually reported.
+            // Grammar errors are different: CPython tokenizes the whole input
+            // before parsing it, and a later incompatible prefix can therefore
+            // precede an earlier assignment error.
+            let tokenizer_stopped = parse_error.is_unclosed_bracket
+                || matches!(
+                    &parse_error.error,
+                    ParseErrorType::Lexical(_)
+                        | ParseErrorType::FStringError(_)
+                        | ParseErrorType::TStringError(_)
+                )
+                || matches!(
+                    &parse_error.error,
+                    ParseErrorType::OtherError(message)
+                        if message.starts_with("unmatched ")
+                            || message.starts_with("closing parenthesis ")
+                )
+                // Ruff recovers some malformed number tokens into an
+                // `OtherError` parser shape, but the CPython-shaped message
+                // above has already identified the tokenizer failure.
+                || matches!(
+                    msg.as_str(),
+                    "invalid decimal literal"
+                        | "invalid hexadecimal literal"
+                        | "invalid octal literal"
+                        | "invalid binary literal"
+                );
+            incompatible_string_prefix_error(
+                source,
+                raw_index,
+                tokenizer_stopped.then_some(raw_index),
+            )
         }
         _ => None,
     };

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1289,15 +1289,22 @@ pub(super) fn make_at_address(
     inst
 }
 
-/// Whether a simple-code write has to retain the value it stored.
+/// The object a simple-code write has to retain for the bytes it stored.
 ///
 /// `"O"` writes the word `pyobj_container` hands back, and the container holds
-/// only a weakref, so the buffer is the sole reference to that object -- which
-/// is why `O_set` returns a new reference for `PyCData_set` to keep.  A CData
-/// value is retained for the same reason: the write copied its buffer out and
-/// left no other owner.
-pub(super) fn value_needs_keep(tc: &str, value: PyObjectRef) -> bool {
-    tc == "O" || is_cdata_instance(value)
+/// only a weakref where it can.  CPython's `O_set` returns the actual referent
+/// for `PyCData_set` to keep, including when the input was another `py_object`;
+/// retaining that wrapper would not retain the slot it copied.  `None` needs no
+/// entry because PyPy's `GlobalPyobjContainer.add` already stores it strongly
+/// and CPython leaves the destination's `_objects` unset.  Other CData values
+/// keep the existing behavior: the write copied their buffer out and left no
+/// other owner.
+pub(super) fn value_for_keep(tc: &str, value: PyObjectRef, stored: &[u8]) -> Option<PyObjectRef> {
+    if tc == "O" {
+        let referent = pyobj_container_get(host_ctypes::read_pointer_from_buffer(stored))?;
+        return (!unsafe { pyre_object::is_none(referent) }).then_some(referent);
+    }
+    is_cdata_instance(value).then_some(value)
 }
 
 /// Keep `obj` alive for the lifetime of the buffer that `anchor` views, by

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1455,8 +1455,8 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             cdata::cdata_write(obj, offset, &bytes);
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::value_needs_keep(&tc, value) {
-                cdata::keep_ref(obj, &index.to_string(), value);
+            if let Some(keep) = cdata::value_for_keep(&tc, value, &bytes) {
+                cdata::keep_ref(obj, &index.to_string(), keep);
             }
             Ok(pyre_object::w_none())
         }
@@ -2094,8 +2094,8 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
             cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             cdata::cdata_write(obj, offset, &bytes);
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::value_needs_keep(&tc, value) {
-                cdata::keep_ref(obj, &idx.to_string(), value);
+            if let Some(keep) = cdata::value_for_keep(&tc, value, &bytes) {
+                cdata::keep_ref(obj, &idx.to_string(), keep);
             }
             Ok(pyre_object::w_none())
         }
@@ -2602,8 +2602,8 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
             cdata::release_bstr_slot(&tc, addr);
             unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            if cdata::value_needs_keep(&tc, value) {
-                cdata::keep_ref(obj, &index.to_string(), value);
+            if let Some(keep) = cdata::value_for_keep(&tc, value, &bytes) {
+                cdata::keep_ref(obj, &index.to_string(), keep);
             }
             Ok(pyre_object::w_none())
         }


### PR DESCRIPTION
## Summary

Follow-up to #1682, applying the actionable review findings after that PR merged.

- make incompatible string-prefix recovery respect f-string structure: ignore literal format-spec text and comments, recurse into nested replacement fields, and preserve an earlier tokenizer error
- keep `ctypes.py_object` referents alive from the value actually stored in C data rather than from a mutable source wrapper
- avoid creating a keepalive entry for `py_object(None)`
- add focused syntax-error and moving-GC regression coverage

The ctypes lifetime behavior follows the observable CPython 3.14 contract while retaining PyPy's `GlobalPyobjContainer` ownership model. The review claim that PyPy itself preserves the same-wrapper referent was checked against the real PyPy oracle and was not correct.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py` — dynasm 543/543, cranelift 543/543, wasm 536/536; 3/3 backends
- `python3 pyre/extra_tests/run.py --dynasm-only --filter syntax_error_python314_offsets --verbose`
- `target/release/pyre-dynasm pyre/extra_tests/parity_tests/ctypes_py_object_survives_a_moving_collection.py`
