### PR TITLE
majit: share JIT parameter parsing, wasm calls, and root walking

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2445,6 +2445,64 @@ pub fn direct_word_abi_call(func_ptr: usize, args: &[i64]) -> Option<i64> {
     ]
 }
 
+/// Install the wasm guest-side residual-call trampoline.
+///
+/// Consumers with additional exact-function ABI knowledge can install their
+/// own hook and delegate its fallback to [`residual_host_call`].
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+pub fn install_residual_host_call() {
+    majit_backend::call_stub::set_residual_host_call(Some(residual_host_call));
+}
+
+/// Call a residual target using the backend-owned call area and host import.
+///
+/// This is the wasm transport for `llmodel.py AbstractLLCPU.bh_call_i` and its
+/// siblings. Upstream uses native ABI call builders; wasm requires reflection
+/// for targets whose real signature is not the uniform word ABI. Keep that
+/// platform adaptation here until those calls carry exact typed signatures.
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+pub fn residual_host_call(func_ptr: usize, args: &[i64]) -> i64 {
+    use codegen::{CALL_ARGS_OFS, CALL_FUNC_OFS, CALL_NARGS_OFS, CALL_RESULT_OFS, MAX_CALL_ARGS};
+
+    assert!(
+        args.len() <= MAX_CALL_ARGS,
+        "residual_host_call: arity {} exceeds {MAX_CALL_ARGS}",
+        args.len()
+    );
+    if let Some(result) = direct_word_abi_call(func_ptr, args) {
+        return result;
+    }
+    let base = RESIDUAL_CALL_SCRATCH.0.get() as *mut u8;
+    unsafe {
+        (base.add(CALL_FUNC_OFS as usize) as *mut i64).write_unaligned(func_ptr as i64);
+        (base.add(CALL_NARGS_OFS as usize) as *mut i64).write_unaligned(args.len() as i64);
+        for (i, &arg) in args.iter().enumerate() {
+            (base.add(CALL_ARGS_OFS as usize + i * 8) as *mut i64).write_unaligned(arg);
+        }
+        jit_call_host(base as u32);
+        (base.add(CALL_RESULT_OFS as usize) as *const i64).read_unaligned()
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+#[link(wasm_import_module = "majit_host")]
+unsafe extern "C" {
+    fn jit_call_host(frame_ptr: u32);
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+struct ResidualCallScratch(core::cell::UnsafeCell<[u8; codegen::MIN_FRAME_BYTES]>);
+
+// A wasm module instance is single-threaded. Nested calls synchronously consume
+// their arguments before reusing the buffer and write their result before the
+// outer call reads its own result.
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+unsafe impl Sync for ResidualCallScratch {}
+
+#[cfg(all(target_arch = "wasm32", feature = "host-import"))]
+static RESIDUAL_CALL_SCRATCH: ResidualCallScratch =
+    ResidualCallScratch(core::cell::UnsafeCell::new([0; codegen::MIN_FRAME_BYTES]));
+
 /// Configure the dormant terminal-decline regression hook.
 pub fn set_force_ca_terminal_decline(selector: u64) {
     FORCE_CA_TERMINAL_DECLINE.store(selector, Ordering::Relaxed);

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1400,6 +1400,39 @@ pub fn walk_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
     });
 }
 
+/// Visit the current context's JIT stack roots and the backend's live deadframes.
+///
+/// `shadowstack.py ShadowStackRootWalker.walk_stack_roots` owns this boundary
+/// upstream; `blackhole.py BlackholeInterpreter` and `resume.py
+/// ResumeDataDirectReader` are traced GC objects there. Here their raw register
+/// banks and libc jitframes need explicit walks, which belong to majit rather
+/// than to each embedding interpreter's collector.
+///
+/// The visitor must filter references by its heap's ownership and trace the
+/// interiors of its own managed objects. Libc jitframe interiors are exposed
+/// here through the backend's registered tracer, including the post-epilogue
+/// DEADFRAME lifetime (`llmodel.py AbstractLLCPU.get_ref_value`). Static roots,
+/// extra areas and embedding-runtime root hooks are separate root categories
+/// (`framework.py BaseRootWalker.walk_roots`) and are not called by this API.
+/// Stack sources are current-context only; the backend deadframe registry may
+/// be process-wide. As with the collector's root phase, callers must exclude
+/// concurrent mutation of visited frames. Multi-mutator collectors must also
+/// walk the other mutators' stacks through the `walk_all_*` APIs.
+pub fn walk_jit_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    walk_roots(&mut visitor);
+    walk_jf_roots(|gcref| {
+        visitor(gcref);
+        if !gcref.is_null() && is_libc_jitframe(gcref.0) {
+            trace_libc_jitframe(gcref.0, &mut |slot| unsafe { visitor(&mut *slot) });
+        }
+    });
+    crate::walk_active_live_deadframes(&mut |addr| {
+        trace_libc_jitframe(addr, &mut |slot| unsafe { visitor(&mut *slot) });
+    });
+    walk_bh_regs(&mut visitor);
+    walk_resume_ref_roots(&mut visitor);
+}
+
 /// Walk every registered mutator's resume-construction roots during STW.
 pub fn walk_all_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
     debug_assert!(

--- a/majit/majit-gc/tests/jit_roots.rs
+++ b/majit/majit-gc/tests/jit_roots.rs
@@ -1,0 +1,57 @@
+//! The embedding collector must see live slots, not copies of their values.
+use majit_gc::shadow_stack as roots;
+use majit_ir::GcRef;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DEADFRAME: AtomicUsize = AtomicUsize::new(0);
+
+unsafe fn trace_frame(addr: usize, visit: &mut dyn FnMut(*mut GcRef)) {
+    visit(addr as *mut GcRef);
+}
+
+fn walk_deadframe(visit: &mut dyn FnMut(usize)) {
+    visit(DEADFRAME.load(Ordering::Relaxed));
+}
+
+#[test]
+fn embedding_walk_forwards_stack_blackhole_resume_and_deadframe_slots() {
+    // This integration-test process owns the once-installed tracer.
+    roots::register_libc_jitframe_tracer(trace_frame);
+    let mut frame = Box::new(GcRef(0x2000));
+    let frame_addr = (&mut *frame as *mut GcRef) as usize;
+    roots::register_libc_jitframe(frame_addr);
+    let jf_depth = roots::push_jf(GcRef(frame_addr));
+    let stack = roots::OwnerRootGuard::new(GcRef(0x1000));
+    let mut regs = [0x3000_i64];
+    let mut tmp = 0x4000_i64;
+    let mut exc = 0x5000_i64;
+    let bh_depth = unsafe { roots::push_bh_regs(&mut regs, &mut tmp, &mut exc) };
+    let mut resume = [0x6000_i64];
+    let resume_depth = roots::resume_ref_roots_depth();
+    unsafe { roots::push_resume_ref_roots(&mut resume) };
+    let mut deadframe = Box::new(GcRef(0x7000));
+    DEADFRAME.store((&mut *deadframe as *mut GcRef) as usize, Ordering::Relaxed);
+    majit_gc::set_active_gc_deadframe_hooks(majit_gc::ActiveGcDeadFrameHooks {
+        walk_live_deadframes: Some(walk_deadframe),
+    });
+
+    roots::walk_jit_roots(|slot| {
+        // A separate embedding heap owns these seven references, not jitframes.
+        if (0x1000..=0x7000).contains(&slot.0) {
+            slot.0 += 0x10000;
+        }
+    });
+
+    majit_gc::set_active_gc_deadframe_hooks(Default::default());
+    roots::pop_resume_ref_roots_to(resume_depth);
+    roots::pop_bh_regs_to(bh_depth);
+    roots::pop_jf_to(jf_depth);
+    roots::unregister_libc_jitframe(frame_addr);
+    assert_eq!(stack.get(), GcRef(0x11000));
+    assert_eq!(*frame, GcRef(0x12000));
+    assert_eq!(regs, [0x13000]);
+    assert_eq!(tmp, 0x14000);
+    assert_eq!(exc, 0x15000);
+    assert_eq!(resume, [0x16000]);
+    assert_eq!(*deadframe, GcRef(0x17000));
+}

--- a/majit/majit-metainterp/src/jit.rs
+++ b/majit/majit-metainterp/src/jit.rs
@@ -721,44 +721,66 @@ impl std::error::Error for TraceLimitTooHigh {}
 // ── set_user_param ──
 // rlib/jit.py:836-874
 
+/// The driver argument of `rlib/jit.py set_user_param`, specialized to the
+/// parameter storage or live driver receiving the calls. Rust represents the
+/// upstream integer/string parameter overload with two setters.
+pub trait JitParameterTarget {
+    fn set_param(&mut self, name: &str, value: i64) -> Result<(), JitHintError>;
+    fn set_param_enable_opts(&mut self, value: &str);
+}
+
+impl JitParameterTarget for JitParameters {
+    fn set_param(&mut self, name: &str, value: i64) -> Result<(), JitHintError> {
+        set_param(self, name, value)
+    }
+
+    fn set_param_enable_opts(&mut self, value: &str) {
+        self.enable_opts = if value == "all" {
+            EnableOpts::All
+        } else {
+            EnableOpts::Custom(value.to_string())
+        };
+    }
+}
+
 /// Set the tunable JIT parameters from a user-supplied string
 /// following the format 'param=value,param=value', or 'off' to
 /// disable the JIT.  For programmatic setting of parameters, use
 /// directly `set_param`.
 ///
 /// rlib/jit.py:836
-pub fn set_user_param(params: &mut JitParameters, text: &str) -> Result<(), JitHintError> {
+pub fn set_user_param(
+    driver: &mut impl JitParameterTarget,
+    text: &str,
+) -> Result<(), JitHintError> {
     // rlib/jit.py:842-845
     if text == "off" {
-        set_param(params, "threshold", -1)?;
-        set_param(params, "function_threshold", -1)?;
+        driver.set_param("threshold", -1)?;
+        driver.set_param("function_threshold", -1)?;
         return Ok(());
     }
     // rlib/jit.py:846-849
     if text == "default" {
-        for (name1, _) in UNROLL_PARAMETERS {
-            set_param_to_default(params, name1)?;
+        for (name1, default) in UNROLL_PARAMETERS {
+            driver.set_param(name1, *default)?;
+            // PARAMETERS places the string-valued entry after this integer.
+            if *name1 == "disable_unrolling" {
+                driver.set_param_enable_opts("all");
+            }
         }
         return Ok(());
     }
     // rlib/jit.py:850-874
     for s in text.split(',') {
-        let s = s.trim();
-        if s.is_empty() {
-            continue;
-        }
-        let parts: Vec<&str> = s.splitn(2, '=').collect();
+        let s = s.trim_matches(' ');
+        let parts: Vec<&str> = s.split('=').collect();
         if parts.len() != 2 {
             return Err(JitHintError(format!("malformed token: {s}")));
         }
-        let name = parts[0].trim();
-        let value = parts[1].trim();
+        let name = parts[0];
+        let value = parts[1];
         if name == "enable_opts" {
-            params.enable_opts = if value == "all" {
-                EnableOpts::All
-            } else {
-                EnableOpts::Custom(value.to_string())
-            };
+            driver.set_param_enable_opts(value);
             continue;
         }
         // rlib/jit.py — for name1, _ in unroll_parameters:
@@ -766,9 +788,10 @@ pub fn set_user_param(params: &mut JitParameters, text: &str) -> Result<(), JitH
         for (name1, _) in UNROLL_PARAMETERS {
             if *name1 == name && *name1 != "enable_opts" {
                 let ivalue: i64 = value
+                    .trim()
                     .parse()
                     .map_err(|_| JitHintError(format!("invalid value for {name}: {value}")))?;
-                set_param(params, name1, ivalue)?;
+                driver.set_param(name1, ivalue)?;
                 found = true;
                 break;
             }
@@ -1166,8 +1189,48 @@ mod tests {
     fn test_set_user_param_default() {
         let mut p = PARAMETERS;
         p.threshold = 999;
+        p.enable_opts = EnableOpts::Custom(String::new());
+        p.vec_all = true;
         set_user_param(&mut p, "default").unwrap();
         assert_eq!(p.threshold, 1039);
+        assert_eq!(p.enable_opts, EnableOpts::All);
+        assert!(!p.vec_all);
+    }
+
+    #[test]
+    fn test_set_user_param_oracle_grammar_and_partial_application() {
+        // Measured with pypy3 pypyjit.set_param; rlib/jit.py set_user_param.
+        for text in [
+            "",
+            "threshold=1,",
+            "threshold =1",
+            "enable_opts=a=b",
+            "vectorize=1",
+            "max_inline_depth=7",
+        ] {
+            let mut params = PARAMETERS;
+            assert!(set_user_param(&mut params, text).is_err(), "{text:?}");
+        }
+        let mut p = PARAMETERS;
+        set_user_param(&mut p, " threshold= 17 ,enable_opts=,vec=1").unwrap();
+        assert_eq!(p.threshold, 17);
+        assert_eq!(p.enable_opts, EnableOpts::Custom(String::new()));
+        assert!(p.vec);
+        assert!(set_user_param(&mut p, "threshold=23,bad=1").is_err());
+        assert_eq!(p.threshold, 23);
+    }
+
+    #[test]
+    fn test_set_user_param_live_warmstate() {
+        let mut ws = crate::warmstate::WarmEnterState::new(7);
+        set_user_param(&mut ws, "enable_opts=,vec_all=1").unwrap();
+        assert!(ws.get_enable_opts().is_empty());
+        set_user_param(&mut ws, "off").unwrap();
+        assert_eq!(ws.threshold(), 0);
+        set_user_param(&mut ws, "default").unwrap();
+        assert_eq!(ws.threshold(), PARAMETERS.threshold);
+        assert!(!ws.get_enable_opts().is_empty());
+        assert!(!ws.vec_all());
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2086,6 +2086,23 @@ impl GuardResumeDecline {
     }
 }
 
+impl<S: JitState> crate::jit::JitParameterTarget for JitDriver<S> {
+    fn set_param(&mut self, name: &str, value: i64) -> Result<(), crate::jit::JitHintError> {
+        // warmstate.py JitCounter.compute_threshold: nonpositive thresholds
+        // disable counting. The public driver setter takes unsigned values.
+        let value = match name {
+            "threshold" | "function_threshold" | "trace_eagerness" => value.max(0),
+            _ => value,
+        };
+        self.set_param(name, value);
+        Ok(())
+    }
+
+    fn set_param_enable_opts(&mut self, value: &str) {
+        self.set_param_enable_opts(value);
+    }
+}
+
 impl<S: JitState> JitDriver<S> {
     /// Create a new JitDriver with the given hot-counting threshold.
     pub fn new(threshold: u32) -> Self {

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -791,6 +791,17 @@ pub enum FunctionEntryStep {
     NotHot,
 }
 
+impl crate::jit::JitParameterTarget for WarmEnterState {
+    fn set_param(&mut self, name: &str, value: i64) -> Result<(), crate::jit::JitHintError> {
+        self.set_param(name, value);
+        Ok(())
+    }
+
+    fn set_param_enable_opts(&mut self, value: &str) {
+        self.set_param_enable_opts(value);
+    }
+}
+
 impl WarmEnterState {
     /// warmstate.py: a `JC_DONT_TRACE_HERE` cell that has never seen
     /// a procedure token is retried — immediately the first time

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6819,45 +6819,7 @@ fn apply_jit_param_string(
     ws: &mut majit_metainterp::warmstate::WarmEnterState,
     text: &str,
 ) -> Result<(), ()> {
-    // rlib/jit.py:842-845
-    if text == "off" {
-        ws.set_param("threshold", -1);
-        ws.set_param("function_threshold", -1);
-    } else if text == "default" {
-        ws.set_default_params();
-    } else {
-        // rlib/jit.py:850-874 — "name=value,name=value"
-        for s in text.split(',') {
-            let s = s.trim();
-            if s.is_empty() {
-                continue;
-            }
-            // rlib/jit.py:852-856 — len(parts) != 2 → raise ValueError
-            let parts: Vec<&str> = s.split('=').collect();
-            if parts.len() != 2 {
-                return Err(());
-            }
-            let name = parts[0];
-            let value = parts[1].trim();
-            if name == "enable_opts" {
-                ws.set_param_enable_opts(value);
-                continue;
-            }
-            // rlib/jit.py — the name must be one of unroll_parameters;
-            // anything else falls through to the loop's `else: raise ValueError`.
-            let known = majit_metainterp::jit::UNROLL_PARAMETERS
-                .iter()
-                .any(|&(name1, _)| name1 == name && name1 != "enable_opts");
-            if !known {
-                return Err(());
-            }
-            let Ok(parsed) = value.parse::<i64>() else {
-                return Err(());
-            };
-            ws.set_param(name, parsed);
-        }
-    }
-    Ok(())
+    majit_metainterp::jit::set_user_param(ws, text).map_err(|_| ())
 }
 
 /// interp_jit.py — set_param(space, __args__).

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -151,37 +151,6 @@ static HEAP_PROF_ALLOC: heap_prof::CountingAlloc = heap_prof::CountingAlloc;
 // the callee's wasm signature and coerces each positional argument.
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 mod residual_host {
-    use core::cell::UnsafeCell;
-
-    // Call-area layout shared with `majit-backend-wasm` codegen and the host
-    // runner's `jit_call_trampoline`; offsets are relative to the frame-pointer
-    // base passed to the import. Taken from the backend that defines the ABI
-    // rather than restated, so a layout change reaches this scratch buffer.
-    use majit_backend_wasm::codegen::{
-        CALL_ARGS_OFS as CALL_ARGS_OFS_U64, CALL_FUNC_OFS as CALL_FUNC_OFS_U64,
-        CALL_NARGS_OFS as CALL_NARGS_OFS_U64, CALL_RESULT_OFS as CALL_RESULT_OFS_U64,
-        MAX_CALL_ARGS as MAX_ARGS, MIN_FRAME_BYTES as SCRATCH_LEN,
-    };
-    const CALL_RESULT_OFS: usize = CALL_RESULT_OFS_U64 as usize;
-    const CALL_FUNC_OFS: usize = CALL_FUNC_OFS_U64 as usize;
-    const CALL_NARGS_OFS: usize = CALL_NARGS_OFS_U64 as usize;
-    const CALL_ARGS_OFS: usize = CALL_ARGS_OFS_U64 as usize;
-
-    #[link(wasm_import_module = "majit_host")]
-    unsafe extern "C" {
-        fn jit_call_host(frame_ptr: u32);
-    }
-
-    // A wasm32 module instance is single-threaded, so a shared scratch buffer
-    // needs no synchronization. Residual calls nest synchronously: each level
-    // writes its arguments, the host reads them before invoking the callee, and
-    // each level reads its result immediately after the host returns — so an
-    // inner call that reuses the buffer cannot clobber an outer call's
-    // already-consumed arguments or not-yet-written result.
-    struct Scratch(UnsafeCell<[u8; SCRATCH_LEN]>);
-    unsafe impl Sync for Scratch {}
-    static SCRATCH: Scratch = Scratch(UnsafeCell::new([0u8; SCRATCH_LEN]));
-
     /// Direct-call the blackhole helpers whose real wasm ABI is exactly the
     /// uniform `i64` signature carried by the residual call.
     ///
@@ -240,30 +209,12 @@ mod residual_host {
         ]
     }
 
-    fn residual_host_call(func_ptr: usize, args: &[i64]) -> i64 {
-        assert!(
-            args.len() <= MAX_ARGS,
-            "residual_host_call: arity {} exceeds {MAX_ARGS}",
-            args.len()
-        );
-        if let Some(result) = direct_uniform_i64_call(func_ptr, args) {
-            return result;
-        }
-        let base = SCRATCH.0.get() as *mut u8;
-        unsafe {
-            (base.add(CALL_FUNC_OFS) as *mut i64).write_unaligned(func_ptr as i64);
-            (base.add(CALL_NARGS_OFS) as *mut i64).write_unaligned(args.len() as i64);
-            for (i, &a) in args.iter().enumerate() {
-                (base.add(CALL_ARGS_OFS + i * 8) as *mut i64).write_unaligned(a);
-            }
-            jit_call_host(base as u32);
-            (base.add(CALL_RESULT_OFS) as *const i64).read_unaligned()
-        }
-    }
-
     /// Install the trampoline on the current thread. Idempotent.
     pub fn install() {
-        majit_backend::call_stub::set_residual_host_call(Some(residual_host_call));
+        majit_backend::call_stub::set_residual_host_call(Some(|func_ptr, args| {
+            direct_uniform_i64_call(func_ptr, args)
+                .unwrap_or_else(|| majit_backend_wasm::residual_host_call(func_ptr, args))
+        }));
     }
 }
 


### PR DESCRIPTION
## Summary

Move interpreter-independent runtime services into majit, keeping consumer-specific policy in the interpreters.

- Share canonical JIT parameter parsing across `JitParameters`, `WarmEnterState`, and `JitDriver`; migrate Pyre to it and align grammar/default restoration with PyPy's `set_user_param`.
- Centralize wasm guest residual-call transport in `majit-backend-wasm`; keep Pyre's direct-call allow-list in Pyre.
- Expose a composite JIT root visitor in `majit-gc`, covering shadow/JIT-frame roots, live deadframes, blackhole banks, and resume banks, with an integration test proving in-place forwarding.

Aheui consumer changes were exercised locally in its separate repository and are not included in this PR. Its language-specific storage and allocation policies remain consumer-owned.

## Verification

- `cargo test --all --no-default-features --features dynasm`: 9,113 passed, 166 ignored.
- `python3 pyre/check.py`: dynasm 546/546, cranelift 546/546, wasm 539/539.
- Forced LLBC re-extraction completed with the final sources before the full test runs.
- Twelve parameter acceptance/error cases matched the real PyPy oracle.
- Aheui native and WASI integration: all 124 JIT/nojit output and exit-code comparisons passed on each target. Existing stored-baseline discrepancies remain: `pi.jinseo` guard counts (also reproduced with the unmodified consumer), and WASI's existing exit-code normalization when comparing against native baselines. No statistics baselines were rewritten.

## Follow-up scope

Shared Wasmtime host implementation, pipeline artifact ownership, and raw blackhole store helpers remain separate extraction work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified JIT parameter handling across runtime components.
  - Added support for updating optimization options through JIT configuration settings.
  - Added centralized traversal of live JIT garbage-collection roots.
  - Improved WebAssembly support for residual host calls.

- **Bug Fixes**
  - JIT threshold values are now safely constrained to valid nonnegative values.
  - Parameter parsing now rejects empty settings and malformed assignments while preserving valid updates made before an error.
  - Default JIT settings now explicitly restore all optimization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->