### PR TITLE
majit: restore frozen effects for compiled Grain loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,7 @@ dependencies = [
 name = "majit-metainterp"
 version = "0.0.2"
 dependencies = [
+ "bincode",
  "bit-set",
  "bitflags 2.13.0",
  "indexmap",

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -495,6 +495,14 @@ cover the condition they diagnose.
 - What it does: Setting it to `1` reports structure IDs that resolve to multiple spellings or conflicting concrete layouts during translation, as `conflict`, `variant` and `summary` lines. Unset is inert.
 - Retirement condition: Remove when one structure ID cannot collect conflicting layouts by construction.
 
+### `MAJIT_TEST_SHELL_REGISTRY_CHILD`
+
+- Read sites: 1 — `majit/majit-metainterp/src/optimizeopt/virtualize.rs`, test-only and native-only
+- Accessor: `explicit_sum_inheritance_rejects_a_registered_lookalike()`
+- What it does: Marks the isolated child process that runs the fixture replacing the process-global type registry. The parent sets it only for its exact-test child, preventing recursive child spawning without making production registry identity thread-local.
+- Default polarity: **OFF**; unset launches the isolated child, any present value runs the fixture in that child. It is not a runtime optimization switch.
+- Retirement condition: Remove when this fixture has a dedicated test executable or another process-isolation mechanism that does not need a child marker.
+
 ### `MAJIT_TLDBG`
 
 - Read sites: 1 — `majit/majit-metainterp/src/lib.rs`

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -66,6 +66,7 @@ majit-backend-dynasm = { workspace = true, optional = true }
 majit-backend-wasm = { path = "../majit-backend-wasm", version = "0.0.2", default-features = false }
 
 [dev-dependencies]
+bincode = { workspace = true }
 majit-macros = { workspace = true }
 majit-gc = { workspace = true }
 smallvec = { workspace = true }

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -64,6 +64,47 @@ unsafe impl Send for EmbeddedJitCodeTable {}
 unsafe impl Sync for EmbeddedJitCodeTable {}
 
 impl EmbeddedJitCodeTable {
+    /// Restore an embedded image's complete effect-descriptor population.
+    ///
+    /// `pyjitpl.py::finish_setup_descrs` uses all of GcCache, not merely the
+    /// opcode descriptor table. Publish opcode-owned layouts first, then the
+    /// analyzer-only members and their frozen `compute_bitstrings` stamps.
+    pub fn materialize_with_frozen_effects(
+        canonical: &[Arc<CanonicalJitCode>],
+        mut descrs: Vec<CanonicalBhDescr>,
+        symbolic_paths: &[(i64, String)],
+        runtime_bindings: &[(&str, i64)],
+        effect_mints: &[majit_ir::effectinfo::DescrMintEntry],
+    ) -> &'static Self {
+        for descr in &descrs {
+            if matches!(descr, CanonicalBhDescr::Field { .. }) {
+                crate::pyjitpl::dispatch::field_descr_ref_from_bh(descr);
+            }
+        }
+        super::frozen_effects::publish_mints(effect_mints);
+        for descr in &mut descrs {
+            if let CanonicalBhDescr::Call { calldescr }
+            | CanonicalBhDescr::JitCode { calldescr, .. } = descr
+            {
+                super::frozen_effects::prepare(&mut calldescr.extra_info);
+            }
+        }
+        let canonical: Vec<_> = canonical
+            .iter()
+            .map(|code| {
+                let mut code = (**code).clone();
+                super::frozen_effects::prepare(&mut code.body_mut().calldescr.extra_info);
+                Arc::new(code)
+            })
+            .collect();
+        Self::materialize_with_symbolic_fnaddrs(
+            &canonical,
+            descrs,
+            symbolic_paths,
+            runtime_bindings,
+        )
+    }
+
     /// Join the two serialized lists into runtime shells and their pool.
     ///
     /// `canonical` must be `all_jitcodes` in allocation order, which
@@ -227,6 +268,127 @@ impl RuntimeDescrTable for EmbeddedJitCodeTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A native helper mutating a field must invalidate the very descriptor
+    /// read by a getfield opcode, after serialization has erased raw Arcs.
+    #[test]
+    fn frozen_effects_rejoin_the_opcode_field_after_serialization() {
+        use majit_ir::effectinfo::{DescrMintEntry, DescrMintSpec, DescrSetKeys, DescrSetMember};
+        use majit_ir::{EffectInfo, ExtraEffect, Type};
+        use majit_translate::jitcode::{BhCallDescr, BhFieldSpec, BhSizeSpec};
+        let member = DescrSetMember::Field {
+            struct_id: 0x475241494e454649,
+            field_name: "depth".into(),
+        };
+        let mut writer =
+            EffectInfo::const_new(ExtraEffect::CannotRaise, majit_ir::OopSpecIndex::None);
+        writer.descr_set_keys = Some(
+            DescrSetKeys {
+                write_fields: vec![member.clone()],
+                ..Default::default()
+            }
+            .into(),
+        );
+        let mut reader =
+            EffectInfo::const_new(ExtraEffect::CannotRaise, majit_ir::OopSpecIndex::None);
+        reader.descr_set_keys = Some(
+            DescrSetKeys {
+                readonly_fields: vec![member.clone()],
+                ..Default::default()
+            }
+            .into(),
+        );
+        let layout =
+            majit_ir::effectinfo::compute_frozen_bitstrings(&mut [&mut writer, &mut reader]);
+        let stamp = layout.descr_indices[0][&member];
+        let mint = DescrMintEntry {
+            member,
+            spec: DescrMintSpec::Field {
+                struct_size: 8,
+                offset: 0,
+                field_size: 8,
+                field_type: Type::Int,
+                flag: majit_ir::descr::ArrayFlag::Unsigned,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 0,
+            },
+            ei_index: stamp,
+        };
+        let field = CanonicalBhDescr::Field {
+            offset: 0,
+            field_size: 8,
+            field_type: Type::Int,
+            field_flag: majit_ir::descr::ArrayFlag::Unsigned,
+            is_field_signed: false,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            index_in_parent: Some(0),
+            parent: Some(Arc::new(BhSizeSpec {
+                size: 8,
+                type_id: 0x475241494e454649,
+                vtable: 0,
+                is_gc_managed: false,
+                headerless: true,
+                all_fielddescrs: vec![BhFieldSpec {
+                    index: 0,
+                    field_key: "depth".into(),
+                    name: "Frame.depth".into(),
+                    offset: 0,
+                    field_size: 8,
+                    field_type: Type::Int,
+                    field_flag: majit_ir::descr::ArrayFlag::Unsigned,
+                    is_field_signed: false,
+                    is_immutable: false,
+                    is_quasi_immutable: false,
+                    index_in_parent: 0,
+                    is_class_word: None,
+                }],
+            })),
+            name: "depth".into(),
+            owner: "Frame".into(),
+        };
+        let descrs = vec![
+            field,
+            CanonicalBhDescr::Call {
+                calldescr: BhCallDescr {
+                    extra_info: writer,
+                    ..Default::default()
+                },
+            },
+            CanonicalBhDescr::Call {
+                calldescr: BhCallDescr {
+                    extra_info: reader,
+                    ..Default::default()
+                },
+            },
+        ];
+        let descrs = bincode::deserialize(&bincode::serialize(&descrs).unwrap()).unwrap();
+        let mints: Vec<DescrMintEntry> =
+            bincode::deserialize(&bincode::serialize(&vec![mint]).unwrap()).unwrap();
+        let table =
+            EmbeddedJitCodeTable::materialize_with_frozen_effects(&[], descrs, &[], &[], &mints);
+        let field = table.descrs()[0].as_optimizer_descr().unwrap();
+        assert_eq!(field.get_ei_index(), stamp);
+        let effect = |i: usize| {
+            let CanonicalBhDescr::Call { calldescr } = table.descrs()[i].as_bh_descr().unwrap()
+            else {
+                panic!()
+            };
+            &calldescr.extra_info
+        };
+        assert!(effect(1).check_write_descr_field(field.get_ei_index()));
+        assert!(!effect(2).check_write_descr_field(field.get_ei_index()));
+        assert!(Arc::ptr_eq(
+            field,
+            &effect(1)._write_descrs_fields.as_ref().unwrap()[0]
+        ));
+        assert_ne!(
+            effect(1),
+            effect(2),
+            "typed-call re-interning must not merge different effects"
+        );
+    }
 
     /// Two jitcodes, the second reachable from the first through a `j` slot.
     fn fixture() -> (Vec<Arc<CanonicalJitCode>>, Vec<CanonicalBhDescr>) {

--- a/majit/majit-metainterp/src/jitcode/frozen_effects.rs
+++ b/majit/majit-metainterp/src/jitcode/frozen_effects.rs
@@ -1,0 +1,191 @@
+//! Restore the descriptor mutations made by `effectinfo.compute_bitstrings`.
+//!
+//! RPython's translated image keeps `FieldDescr.ei_index` and the matching
+//! call bitstrings together. An embedded JitCode image crosses a process
+//! boundary, so its `DescrMintEntry` recipes restore the same GcCache slots
+//! before any call or field is consumed. The recipes are setup input, not a
+//! runtime side table; only the descriptors themselves retain the stamps.
+
+use majit_ir::descr::{DescrRef, LLType, gc_cache};
+use majit_ir::effectinfo::{DescrMintEntry, DescrMintSpec, DescrSetMember};
+
+pub(super) fn publish_mints(entries: &[DescrMintEntry]) {
+    for entry in entries {
+        let descr = match (&entry.member, &entry.spec) {
+            (
+                DescrSetMember::Field {
+                    struct_id,
+                    field_name,
+                },
+                spec,
+            ) => mint_field(*struct_id, field_name, spec).map(|d| d as DescrRef),
+            (DescrSetMember::Array { array_id }, spec) => mint_array(*array_id, spec),
+            (
+                DescrSetMember::InteriorField { array_id, name },
+                DescrMintSpec::InteriorField {
+                    array,
+                    field_struct_id,
+                    field_name,
+                    field,
+                },
+            ) => {
+                let array_descr = mint_array(*array_id, array)
+                    .and_then(majit_ir::descr::descr_arc_as_array_descr)
+                    .expect("an interior field has an array descriptor");
+                let field_descr = mint_field(*field_struct_id, field_name, field)
+                    .expect("an interior field has an element field descriptor");
+                Some(gc_cache().lock().get_interiorfield_descr(
+                    LLType::Array(*array_id),
+                    name.clone(),
+                    String::new(),
+                    array_descr,
+                    field_descr,
+                ))
+            }
+            _ => None,
+        }
+        .expect("an embedded effect descriptor's key and recipe must agree");
+        descr.set_ei_index(entry.ei_index);
+    }
+}
+
+fn mint_field(
+    struct_id: u64,
+    name: &str,
+    spec: &DescrMintSpec,
+) -> Option<std::sync::Arc<dyn majit_ir::descr::FieldDescr>> {
+    let DescrMintSpec::Field {
+        struct_size,
+        offset,
+        field_size,
+        field_type,
+        flag,
+        is_immutable,
+        is_quasi_immutable,
+        index_in_parent,
+    } = spec
+    else {
+        return None;
+    };
+    let key = LLType::Struct(struct_id);
+    let mut gc = gc_cache().lock();
+    // descr.py::get_field_descr: a cache hit preserves the original layout.
+    // Opcode descriptors have already published their complete parent groups.
+    if let Some(existing) = gc._cache_field.get(&key).and_then(|m| m.get(name)) {
+        return Some(existing.clone());
+    }
+    gc.get_size_descr(key.clone(), *struct_size, 0, false);
+    Some(gc.get_field_descr(
+        key,
+        name,
+        None,
+        *offset,
+        *field_size,
+        *field_type,
+        *is_immutable,
+        *is_quasi_immutable,
+        *flag,
+        u32::MAX,
+        false,
+        Some(*index_in_parent),
+    ))
+}
+
+fn mint_array(array_id: u64, spec: &DescrMintSpec) -> Option<DescrRef> {
+    let DescrMintSpec::Array {
+        base_size,
+        item_size,
+        flag,
+        item_type,
+        nolength,
+        length_offset,
+        is_pure,
+        concrete_type,
+    } = spec
+    else {
+        return None;
+    };
+    Some(gc_cache().lock().get_array_descr(
+        LLType::Array(array_id),
+        *base_size,
+        *item_size,
+        *flag,
+        *item_type,
+        *nolength,
+        *length_offset,
+        *is_pure,
+        *concrete_type,
+    ))
+}
+
+fn resolve(member: &DescrSetMember) -> DescrRef {
+    let gc = gc_cache().lock();
+    let descr = match member {
+        DescrSetMember::Field {
+            struct_id,
+            field_name,
+        } => gc
+            ._cache_field
+            .get(&LLType::Struct(*struct_id))
+            .and_then(|m| m.get(field_name))
+            .map(|d| d.clone() as DescrRef),
+        DescrSetMember::Array { array_id } => {
+            gc._cache_array.get(&LLType::Array(*array_id)).cloned()
+        }
+        DescrSetMember::InteriorField { array_id, name } => gc
+            ._cache_interiorfield
+            .get(&(LLType::Array(*array_id), name.clone(), String::new()))
+            .cloned(),
+    };
+    descr.unwrap_or_else(|| panic!("embedded EffectInfo member has no descriptor: {member:?}"))
+}
+
+pub(super) fn prepare(ei: &mut majit_ir::EffectInfo) {
+    let raw_set = |members: &[DescrSetMember]| {
+        Some(majit_ir::effectinfo::canonicalize_descr_set(
+            members.iter().map(resolve).collect(),
+        ))
+    };
+    // PRE-EXISTING-ADAPTATION: dispatch.rs passes an EffectInfo value to
+    // TraceCtx's typed call APIs, which re-intern it by the upstream raw-set
+    // identity. Until those APIs carry the original CallDescr (as
+    // pyjitpl.py::MetaInterp._record_helper_varargs does), retain these sets so
+    // calls with different writes cannot collapse to one cache key. The
+    // frozen partition still avoids repartitioning at runtime. Convergence:
+    // thread the embedded CallDescr itself through the typed-call APIs, then
+    // discard the raw sets as effectinfo.py::compute_bitstrings does.
+    if let Some(keys) = ei.descr_set_keys.take() {
+        for member in keys
+            .readonly_fields
+            .iter()
+            .chain(&keys.write_fields)
+            .chain(&keys.readonly_arrays)
+            .chain(&keys.write_arrays)
+            .chain(&keys.readonly_interiorfields)
+            .chain(&keys.write_interiorfields)
+        {
+            assert_ne!(
+                resolve(member).get_ei_index(),
+                u32::MAX,
+                "embedded EffectInfo member has no frozen partition: {member:?}"
+            );
+        }
+        // EffectInfo.__new__ retains this one reference after compaction.
+        ei.single_write_descr_array = match keys.write_arrays.as_slice() {
+            [member] => Some(resolve(member)),
+            _ => None,
+        };
+        ei._readonly_descrs_fields = raw_set(&keys.readonly_fields);
+        ei._write_descrs_fields = raw_set(&keys.write_fields);
+        ei._readonly_descrs_arrays = raw_set(&keys.readonly_arrays);
+        ei._write_descrs_arrays = raw_set(&keys.write_arrays);
+        ei._readonly_descrs_interiorfields = raw_set(&keys.readonly_interiorfields);
+        ei._write_descrs_interiorfields = raw_set(&keys.write_interiorfields);
+    } else {
+        assert_eq!(
+            ei.extraeffect,
+            majit_ir::ExtraEffect::RandomEffects,
+            "a concrete embedded EffectInfo needs its descriptor image"
+        );
+    }
+}

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -1,5 +1,6 @@
 mod assembler;
 mod embedded;
+mod frozen_effects;
 
 pub(crate) use assembler::scalar_size;
 pub use assembler::{JitCodeBuilder, JitCodeIntOperand, live_slots_for_state_field_jit};

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -4058,8 +4058,32 @@ mod tests {
 
     #[test]
     fn explicit_sum_inheritance_rejects_a_registered_lookalike() {
-        static REGISTRY: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
-        let _registry = REGISTRY.lock();
+        // This fixture replaces the process-global type registry. A mutex
+        // local to this test cannot protect other optimizer tests reading it:
+        // clearing the table between their identity lookups made a genuine
+        // Option shell intermittently fail slot_holds_field. Keep the global
+        // owner (descr.py::GcCache's STRUCT identity) and isolate the fixture,
+        // rather than making production identity thread-local for tests.
+        #[cfg(not(target_arch = "wasm32"))]
+        if std::env::var_os("MAJIT_TEST_SHELL_REGISTRY_CHILD").is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "optimizeopt::virtualize::tests::explicit_sum_inheritance_rejects_a_registered_lookalike",
+                    "--nocapture",
+                ])
+                .env("MAJIT_TEST_SHELL_REGISTRY_CHILD", "1")
+                .stdin(std::process::Stdio::null())
+                .output()
+                .expect("the isolated registry fixture runs");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                output.status.success() && stdout.contains("1 passed"),
+                "isolated registry fixture failed:\n{stdout}\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
         let core_some = majit_ir::descr::StructId::from_canonical("core::option::Option::Some");
         let user_some =
             majit_ir::descr::StructId::from_canonical("user_crate::option::Option::Some");


### PR DESCRIPTION
## Summary

- Restore canonical field/array identities and frozen effect descriptor indices when loading embedded JitCode images. This fixes cached `Vm.depth` surviving a residual stack truncation in Grain.
- Retain descriptor-set identity across the existing typed-call interning API and add a serialized field/write-effect regression.
- Isolate the optimizer's process-global type-registry fixture in a child process and document its marker, fixing a parallel-test race.

This follows merged PR #1691. Only the two new engine commits are included; the previously merged lowering changes are excluded. Companion Rhai PR: https://github.com/youknowone/rhai/pull/1.

## Validation

Completed on the original tested commits `680de9b6c56` / `a3e239350f9` before transplanting them onto current main:

- `cargo test --all --no-default-features --features dynasm`: 9,139 passed, 166 ignored, including doctests.
- `python3 pyre/check.py`: dynasm 546/546, Cranelift 546/546, wasm 539/539.
- Serialized effect regression passed on dynasm and Cranelift.
- Isolated optimizer suite: 72 tests passed in 20 parallel repetitions.
- LLBC freshness and built artifact source/content checks passed.

Both cherry-picks applied without conflicts, `git range-diff` reports identical patches, and the PR diff passes `git diff --check`. The full suite has not been rerun on the newer base; CI must verify that integration.

## Limits

The companion integer benchmark now compiles and enters machine code correctly, but remains about 2.01x slower than plain Grain. No timing ceiling or JIT-stat baseline was relaxed. Per-frame stack virtualization, terminal return/exception handoff, and carrying the original CallDescr through typed dispatch remain follow-ups.
