### PR TITLE
jit-trace: key codegen cache on translation inputs

### DIFF
--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -8,6 +8,8 @@
 
 #[path = "../src/call_spec.rs"]
 mod call_spec;
+#[path = "../src/codegen_cache.rs"]
+mod codegen_cache;
 #[path = "../src/llbc_fingerprint.rs"]
 mod llbc_fingerprint;
 #[path = "../src/pypyjit_driver_layout.rs"]
@@ -26,7 +28,7 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 /// Bump whenever the bytes of a cached output change shape. `bincode` is not
 /// self-describing, so a record written by an older generation is not detected
 /// as stale -- it decodes, into the wrong fields.
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v17";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v19";
 /// Retained cache entries, per version. An entry measures ~36 MB -- 32 MB of
 /// it is `jit_metadata.json` -- so eight covers the configurations one checkout
 /// switches between (native/wasm × release/dev) inside 300 MB.
@@ -561,11 +563,12 @@ fn llbc_current_fingerprint(
 ///
 /// The prepass reads `build/llbc/*.ullbc`, never the Rust sources
 /// (AGENTS.md:48), so a field inserted anywhere but last in a `#[repr(C)]`
-/// struct shifts every following descr offset while the build stays green.
-/// The existence test in `preflight_llbc_or_fail` cannot see this, and
-/// `codegen_cache_key` makes it worse rather than better: it hashes every
-/// `<crate>/src`, so a source edit reliably invalidates the codegen cache and
-/// re-runs the prepass — over the same unchanged artefact.
+/// struct shifts every following descr offset while the build stays green
+/// if the artefact is not re-extracted. The existence test in
+/// `preflight_llbc_or_fail` cannot see this. The cache key hashes the
+/// artefact bytes, not the interpreter sources, so a source-only edit
+/// still hits the cache — this check is what refuses that hit when the
+/// artefact is stale.
 ///
 /// The oracle is the extractor's own stamp. The extraction engine already
 /// skips a crate whose stamp still matches, so this is the comparison the
@@ -1943,10 +1946,16 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
     for path in source_paths {
         println!("cargo::rerun-if-changed={path}");
     }
-    emit_rerun_if_changed_recursive(&format!("{repo_root}/majit/majit-translate/src"));
-    println!("cargo::rerun-if-changed=src/virtualizable_spec.rs");
-    println!("cargo::rerun-if-changed=src/call_spec.rs");
-    println!("cargo::rerun-if-changed=src/llbc_fingerprint.rs");
+    let inputs = codegen_cache::discover(
+        std::path::Path::new(repo_root),
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    for rel in &inputs.src_trees {
+        emit_rerun_if_changed_recursive(&format!("{repo_root}/{rel}"));
+    }
+    for rel in inputs.extra_files.iter().chain(&inputs.manifests) {
+        println!("cargo::rerun-if-changed={repo_root}/{rel}");
+    }
     // Neither reaches `codegen_cache_key` -- they choose where the cache lives
     // and how much of it is kept, not what it contains -- but cargo still has
     // to re-run this script when they move so the outputs land in, and are
@@ -2022,25 +2031,28 @@ fn llbc_layout_sidecars() -> Vec<String> {
 /// `cargo clean`, a fresh `CARGO_TARGET_DIR`, or a profile switch does not
 /// re-pay the translation prepass — the same reason the prepass's own inputs
 /// (`build/llbc/*.ullbc`) live there. `codegen_cache_key` already folds
-/// HOST/TARGET/PROFILE/OPT_LEVEL, the feature set, the build-script binary's
-/// own bytes and the LLBC content, so an entry is only ever served back to the
+/// HOST/TARGET/PROFILE/OPT_LEVEL, the feature set, the translator sources
+/// and the LLBC content, so an entry is only ever served back to the
 /// configuration that produced it.
 /// The cache root when several checkouts are pointed at one, or `None` for the
 /// per-worktree default.
 ///
 /// Sharing is sound because `codegen_cache_key` derives the key from content
-/// alone -- workspace sources, `Cargo.lock`, the rustc version string, the LLBC
-/// inputs -- and never from a path, so an entry stored by one checkout is
-/// legible to every other. The store is already safe to race on: it stages into
-/// a pid-suffixed sibling and renames, and concedes without error when another
-/// process got there first.
+/// alone -- translator sources, `Cargo.lock`, the rustc version string, the
+/// LLBC inputs -- and from repo-relative paths, so an entry stored by one
+/// checkout is legible to every other on the same sources and artefacts. The
+/// store is already safe to race on: it stages into a pid-suffixed sibling
+/// and renames, and concedes without error when another process got there
+/// first.
 ///
-/// What that buys is capacity, not deduplication. Checkouts on different
-/// branches disagree on the key -- twelve of them held 77 distinct keys with
-/// none in common -- because the extracted LLBC alone differs wherever the
-/// interpreter does. The win is that one LRU pool hands its slots to whichever
-/// checkouts are building, instead of every idle one holding a local quota that
-/// nothing is going to ask for.
+/// What that buys is capacity, not (usually) deduplication. Checkouts on
+/// different branches disagree on the key -- twelve of them held 77 distinct
+/// keys with none in common -- because the extracted LLBC alone differs
+/// wherever the interpreter does. Two checkouts of the same tree now share
+/// an entry: the key uses repo-relative paths. The remaining win of the
+/// shared pool is that one LRU hands its slots to whichever checkouts are
+/// building, instead of every idle one holding a local quota that nothing
+/// is going to ask for.
 ///
 /// Deliberately absent from `codegen_cache_key`: keying on where the cache
 /// lives would give each worktree its own key again and defeat the point.
@@ -2370,6 +2382,7 @@ fn store_codegen_cache(cache_dir: &std::path::Path, out_dir: &str) -> std::io::R
 
 fn codegen_cache_key(manifest_dir: &str, repo_root: &str, source_paths: &[String]) -> String {
     let mut h = CacheHasher::new();
+    let repo_root = std::path::Path::new(repo_root);
     h.write_str(CODEGEN_CACHE_VERSION);
     for key in ["HOST", "TARGET", "PROFILE", "OPT_LEVEL"] {
         h.write_str(key);
@@ -2391,65 +2404,61 @@ fn codegen_cache_key(manifest_dir: &str, repo_root: &str, source_paths: &[String
         h.write_os(std::env::var_os(key));
     }
 
-    // The codegen output also depends on every crate linked into this
-    // build-script binary — `majit-translate`'s own dependencies
-    // (`majit-ir`, `majit-charon-reader`, `rustpython-compiler-core`, …)
-    // and their serde wire formats — whose sources `majit-translate/src`
-    // below does not cover. Without them the key would stay identical across
-    // such a change and restore a stale snapshot (e.g. `*.bin` written under
-    // an older `majit-ir` bincode layout).
+    // Hash the sources the prepass actually reads, not every workspace crate
+    // the build-script binary happens to link. A walk of `majit/*/src` and
+    // `pyre/*/src` rekeyed the cache on a `majit-gc` comment and re-ran the
+    // analysis over unchanged LLBC. Interpreter/object/jit bodies reach the
+    // prepass only through the artefacts `hash_llbc_inputs` hashes;
+    // `fail_if_llbc_stale` refuses a source/artefact mismatch before the
+    // key is consulted.
     //
-    // Hash their *sources* rather than the build-script executable's bytes.
-    // The binary is not reproducible: recompiling it from unchanged sources —
-    // which `cargo clean`, a fresh `CARGO_TARGET_DIR`, or a touched `build.rs`
-    // all force — yields different bytes, so keying on them rekeyed the cache
-    // on almost every build and made it serve only reruns that skipped the
-    // recompile. Workspace sources plus `Cargo.lock` (external crate
-    // versions) and the compiler's version string cover the same change
-    // surface and are stable across recompiles.
-    hash_file_content(&mut h, &std::path::Path::new(repo_root).join("Cargo.lock"));
+    // Hash sources rather than the build-script executable's bytes. The
+    // binary is not reproducible: recompiling it from unchanged sources —
+    // which `cargo clean`, a fresh `CARGO_TARGET_DIR`, or a touched
+    // `build.rs` all force — yields different bytes, so keying on them
+    // rekeyed the cache on almost every build. `Cargo.lock` covers external
+    // crate versions (`rustpython-compiler-core`, serde, bincode); the
+    // compiler version string covers a toolchain that changes a type layout.
+    hash_file_content(&mut h, repo_root, &repo_root.join("Cargo.lock"));
     h.write_str(&rustc_version_string());
-    for workspace_dir in ["majit", "pyre"] {
-        let root = std::path::Path::new(repo_root).join(workspace_dir);
-        let Ok(crates) = std::fs::read_dir(&root) else {
-            continue;
-        };
-        let mut src_dirs: Vec<std::path::PathBuf> = crates
-            .flatten()
-            .map(|entry| entry.path().join("src"))
-            .filter(|src| src.is_dir())
-            .collect();
-        src_dirs.sort();
-        for src in src_dirs {
-            hash_rs_dir_content(&mut h, &src);
-        }
-    }
-
-    hash_file_content(&mut h, &std::path::Path::new(manifest_dir).join("build.rs"));
+    hash_file_content(
+        &mut h,
+        repo_root,
+        &std::path::Path::new(manifest_dir).join("build.rs"),
+    );
     // The whole `build/` directory, not `build.rs` alone. This prepass now
     // lives in `build/prepass.rs`, `#[path]`-included by that wrapper rather
-    // than sitting under `src/`, so neither the line above nor the `*/src`
-    // walk reaches its bytes. Editing it recompiles the build script and
+    // than sitting under `src/`, so neither the line above nor the discovered
+    // trees reach its bytes. Editing it recompiles the build script and
     // makes Cargo rerun it -- and then an unchanged key restores the previous
     // generated tables over the ones the rerun just wrote. Hashing the
     // directory covers a second module added beside it too.
-    hash_rs_dir_content(&mut h, &std::path::Path::new(manifest_dir).join("build"));
-    hash_file_content(
-        &mut h,
-        &std::path::Path::new(manifest_dir).join("src/virtualizable_spec.rs"),
-    );
-    hash_file_content(
-        &mut h,
-        &std::path::Path::new(manifest_dir).join("src/call_spec.rs"),
-    );
-
-    for path in source_paths {
-        hash_file_content(&mut h, std::path::Path::new(path));
-    }
     hash_rs_dir_content(
         &mut h,
-        &std::path::Path::new(repo_root).join("majit/majit-translate/src"),
+        repo_root,
+        &std::path::Path::new(manifest_dir).join("build"),
     );
+    let inputs = codegen_cache::discover(repo_root, std::path::Path::new(manifest_dir));
+    for rel in &inputs.src_trees {
+        hash_rs_dir_content(&mut h, repo_root, &repo_root.join(rel));
+    }
+    for rel in inputs.extra_files.iter().chain(&inputs.manifests) {
+        hash_file_content(&mut h, repo_root, &repo_root.join(rel));
+    }
+
+    // Paths only. The analyzer derives `module_path` from the filename; the
+    // graph bodies come from LLBC. Hashing contents here re-ran the prepass
+    // on every interpreter edit even when the artefact was unchanged.
+    // Repo-relative so two checkouts of the same tree share a key.
+    let mut rel_sources: Vec<String> = source_paths
+        .iter()
+        .map(|path| codegen_cache::repo_relative(repo_root, std::path::Path::new(path)))
+        .collect();
+    rel_sources.sort();
+    h.write_str("source-paths");
+    for path in &rel_sources {
+        h.write_str(path);
+    }
     hash_llbc_inputs(&mut h, repo_root);
 
     format!("{:016x}", h.finish())
@@ -2470,7 +2479,7 @@ fn rustc_version_string() -> String {
         .unwrap_or_else(|| "rustc-version-unavailable".to_string())
 }
 
-fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
+fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &std::path::Path) {
     // Hash the LLBC by content, not by (len, mtime) signature. The
     // analysis (`analyze_multiple_pipeline_with_modules`) derives every
     // generated artefact from these graph bodies, so a content change that
@@ -2483,7 +2492,7 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     if let Some(paths) = std::env::var_os("MAJIT_MIR_FRONTEND_LLBC") {
         for path in std::env::split_paths(&paths) {
             if !path.as_os_str().is_empty() {
-                hash_file_content(h, &path);
+                hash_file_content(h, repo_root, &path);
             }
         }
         return;
@@ -2493,7 +2502,8 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     for crate_name in LLBC_CRATES {
         hash_file_content(
             h,
-            &std::path::Path::new(repo_root)
+            repo_root,
+            &repo_root
                 .join("build")
                 .join("llbc")
                 .join(format!("{crate_name}.ullbc")),
@@ -2508,15 +2518,13 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     for sidecar in llbc_layout_sidecars() {
         hash_file_content(
             h,
-            &std::path::Path::new(repo_root)
-                .join("build")
-                .join("llbc")
-                .join(&sidecar),
+            repo_root,
+            &repo_root.join("build").join("llbc").join(&sidecar),
         );
     }
 }
 
-fn hash_rs_dir_content(h: &mut CacheHasher, dir: &std::path::Path) {
+fn hash_rs_dir_content(h: &mut CacheHasher, repo_root: &std::path::Path, dir: &std::path::Path) {
     let mut paths = Vec::new();
     for entry in WalkDir::new(dir) {
         let Ok(entry) = entry else { continue };
@@ -2527,12 +2535,12 @@ fn hash_rs_dir_content(h: &mut CacheHasher, dir: &std::path::Path) {
     }
     paths.sort();
     for path in paths {
-        hash_file_content(h, &path);
+        hash_file_content(h, repo_root, &path);
     }
 }
 
-fn hash_file_content(h: &mut CacheHasher, path: &std::path::Path) {
-    h.write_path(path);
+fn hash_file_content(h: &mut CacheHasher, repo_root: &std::path::Path, path: &std::path::Path) {
+    h.write_str(&codegen_cache::repo_relative(repo_root, path));
     let Ok(mut file) = std::fs::File::open(path) else {
         h.write_str("missing");
         return;
@@ -2559,7 +2567,7 @@ fn hash_file_content(h: &mut CacheHasher, path: &std::path::Path) {
 /// produced by one build matches the same build's stored entry. std does
 /// not promise the algorithm is stable across Rust releases, so a toolchain
 /// upgrade changes every key; that is fine here (a miss just regenerates,
-/// and the build-script executable is already in the key, so a toolchain
+/// and `rustc_version_string` is already in the key, so a toolchain
 /// bump rekeys regardless). Inputs are length-prefixed so adjacent fields
 /// cannot run together: `("ab", "c")` and `("a", "bc")` hash differently.
 struct CacheHasher(std::collections::hash_map::DefaultHasher);
@@ -2589,10 +2597,6 @@ impl CacheHasher {
             Some(value) => self.write_str(&value.to_string_lossy()),
             None => self.write_str("<unset>"),
         }
-    }
-
-    fn write_path(&mut self, path: &std::path::Path) {
-        self.write_str(&path.to_string_lossy());
     }
 }
 

--- a/pyre/pyre-jit-trace/src/codegen_cache.rs
+++ b/pyre/pyre-jit-trace/src/codegen_cache.rs
@@ -1,0 +1,481 @@
+//! Inputs the build-script codegen cache key hashes besides the LLBC artefacts.
+//!
+//! PRE-EXISTING-ADAPTATION: RPython's `TranslationDriver` runs
+//! `task_annotate`, `task_rtype_lltype`, and `task_backendopt_lltype` in one
+//! process over its live translation context (`rpython/translator/driver.py`).
+//! Pyre's equivalent prepass runs in a Cargo build script over frozen LLBC and
+//! persists its generated outputs, so this cache reconstructs the input closure
+//! that the live context owns upstream. The still-real blocker is that the
+//! build script and runtime are separate programs; the convergence path is to
+//! run translation in the final program image and remove the persistent cache.
+//!
+//! Derived at runtime from the manifests and sources the prepass actually
+//! reads, so a new translator workspace dep, a new `#[path]` include, or a
+//! new live `pyre_interpreter` function sample joins the key without a
+//! hand-maintained list. Interpreter, object, and jit *bodies* still reach
+//! the prepass only through `build/llbc/*.ullbc`; `fail_if_llbc_stale` is
+//! the source-vs-artefact gate.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/// Workspace crates whose graphs reach the prepass through LLBC artefacts.
+/// Their sources are not hashed: a source-only edit is either refused by
+/// `fail_if_llbc_stale` or already rekeys via the artefact bytes.
+///
+/// `pyre-interpreter` is also a build-dep, but only so the script can
+/// sample the live fnaddr / static tables. Those sampled functions are
+/// added as single files through [`interpreter_fn_calls`], not as a tree.
+const LLBC_OWNED_CRATES: &[&str] = &["majit-rlib", "pyre-interpreter", "pyre-jit", "pyre-object"];
+
+/// Repo-relative trees and files the cache key should hash, plus every
+/// manifest read while discovering them (for `cargo::rerun-if-changed`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheInputs {
+    pub src_trees: Vec<String>,
+    pub extra_files: Vec<String>,
+    pub manifests: Vec<String>,
+}
+
+/// Walk the build-script's workspace closure, `#[path]` includes, and
+/// live `pyre_interpreter::` samples.
+pub fn discover(repo_root: &Path, manifest_dir: &Path) -> CacheInputs {
+    let mut manifests = BTreeSet::new();
+    let workspace_toml = repo_root.join("Cargo.toml");
+    manifests.insert(rel(repo_root, &workspace_toml));
+    let members = workspace_member_paths(&read_to_string(&workspace_toml));
+
+    let crate_toml = manifest_dir.join("Cargo.toml");
+    manifests.insert(rel(repo_root, &crate_toml));
+    let mut trees = BTreeSet::new();
+    let mut pending: Vec<String> =
+        section_workspace_deps(&read_to_string(&crate_toml), "build-dependencies")
+            .into_iter()
+            .filter(|name| !LLBC_OWNED_CRATES.contains(&name.as_str()))
+            .collect();
+
+    let mut seen = BTreeSet::new();
+    while let Some(name) = pending.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        let Some(member) = members.get(&name) else {
+            continue;
+        };
+        let crate_dir = repo_root.join(member);
+        let src = crate_dir.join("src");
+        if src.is_dir() {
+            trees.insert(rel(repo_root, &src));
+        }
+        let dep_toml = crate_dir.join("Cargo.toml");
+        if dep_toml.is_file() {
+            manifests.insert(rel(repo_root, &dep_toml));
+            for dep in section_workspace_deps(&read_to_string(&dep_toml), "dependencies") {
+                if !LLBC_OWNED_CRATES.contains(&dep.as_str()) {
+                    pending.push(dep);
+                }
+            }
+        }
+    }
+
+    let mut extra = BTreeSet::new();
+    let mut script_sources = Vec::new();
+    collect_rs_files(&manifest_dir.join("build"), &mut script_sources);
+    let build_rs = manifest_dir.join("build.rs");
+    if build_rs.is_file() {
+        script_sources.push(build_rs.clone());
+    }
+    // Live samples are in the build script itself. Path-included modules are
+    // data, and this file's tests contain example call spellings that must
+    // not pull every `fn foo`.
+    let mut sampled_names = BTreeSet::new();
+    for path in [&build_rs, &manifest_dir.join("build/prepass.rs")] {
+        sampled_names.extend(interpreter_fn_calls(&read_to_string(path)));
+    }
+    for name in sampled_names {
+        for found in find_fn_files(&repo_root.join("pyre/pyre-interpreter/src"), &name) {
+            extra.insert(rel(repo_root, &found));
+        }
+    }
+    let mut i = 0;
+    while i < script_sources.len() {
+        let path = script_sources[i].clone();
+        i += 1;
+        for include in path_attrs(&read_to_string(&path)) {
+            let resolved = canonicalize(&path.parent().unwrap_or(manifest_dir).join(include));
+            if resolved.is_file() && !script_sources.iter().any(|have| have == &resolved) {
+                script_sources.push(resolved);
+            }
+        }
+    }
+    let build_dir = canonicalize(&manifest_dir.join("build"));
+    let build_rs = canonicalize(&build_rs);
+    for path in &script_sources {
+        let path = canonicalize(path);
+        if path.starts_with(&build_dir) || path == build_rs {
+            continue;
+        }
+        extra.insert(rel(repo_root, &path));
+    }
+
+    CacheInputs {
+        src_trees: trees.into_iter().collect(),
+        extra_files: extra.into_iter().collect(),
+        manifests: manifests.into_iter().collect(),
+    }
+}
+
+/// Repo-relative spelling of an input path for checkout-independent keys.
+///
+/// Cargo supplies `CARGO_MANIFEST_DIR` without `..`, while the prepass builds
+/// its repo and source paths by appending different `..` suffixes. `Path`'s
+/// `strip_prefix` is lexical, so canonicalize both existing paths before the
+/// comparison. Inputs outside the repository deliberately retain their full
+/// path: two arbitrary external LLBC locations are not interchangeable.
+pub fn repo_relative(repo_root: &Path, path: &Path) -> String {
+    let canonical_root = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.into());
+    let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.into());
+    canonical_path
+        .strip_prefix(&canonical_root)
+        .unwrap_or(&canonical_path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn rel(repo_root: &Path, path: &Path) -> String {
+    repo_relative(repo_root, path)
+}
+
+fn read_to_string(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+fn canonicalize(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// `name → repo-relative crate dir` for every `[workspace.dependencies]`
+/// entry that names a path member.
+pub fn workspace_member_paths(toml: &str) -> BTreeMap<String, String> {
+    let Some(body) = table_body(toml, "workspace.dependencies") else {
+        return BTreeMap::new();
+    };
+    let mut out = BTreeMap::new();
+    for line in body.lines() {
+        let Some((name, rhs)) = dep_line(line) else {
+            continue;
+        };
+        if let Some(path) = quoted_value(rhs, "path") {
+            out.insert(name.to_string(), path);
+        }
+    }
+    out
+}
+
+/// Workspace-member dependency names declared in `[table]` (`dependencies`
+/// or `build-dependencies`). Crates.io / git deps are ignored.
+pub fn section_workspace_deps(toml: &str, table: &str) -> Vec<String> {
+    let Some(body) = table_body(toml, table) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let Some((name, rhs)) = dep_line(line) else {
+            continue;
+        };
+        if rhs.contains("workspace") || quoted_value(rhs, "path").is_some() {
+            out.push(name.to_string());
+        }
+    }
+    out
+}
+
+/// `#[path = "relative"]` arguments in the order they appear.
+pub fn path_attrs(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = source;
+    while let Some(start) = rest.find("#[path") {
+        rest = &rest[start + 6..];
+        let after = rest.trim_start();
+        let Some(after) = after.strip_prefix('=') else {
+            continue;
+        };
+        let after = after.trim_start();
+        let Some(after) = after.strip_prefix('"') else {
+            continue;
+        };
+        let Some(end) = after.find('"') else {
+            continue;
+        };
+        out.push(after[..end].to_string());
+    }
+    out
+}
+
+/// Function names in `pyre_interpreter::name(` call position.
+///
+/// A type path (`pyre_interpreter::error::PyError`) is not a call: the
+/// first segment is followed by `::`, not `(`.
+pub fn interpreter_fn_calls(source: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let mut rest = source;
+    const PREFIX: &str = "pyre_interpreter::";
+    while let Some(start) = rest.find(PREFIX) {
+        rest = &rest[start + PREFIX.len()..];
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            continue;
+        }
+        let after = rest[name.len()..].trim_start();
+        if after.starts_with('(') {
+            names.insert(name);
+        }
+    }
+    names
+}
+
+fn find_fn_files(src_root: &Path, name: &str) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![src_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|ext| ext != "rs") {
+                continue;
+            }
+            if file_defines_fn(&read_to_string(&path), name) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn file_defines_fn(source: &str, name: &str) -> bool {
+    let mut rest = source;
+    while let Some(idx) = rest.find("fn") {
+        if idx > 0 {
+            let prev = rest.as_bytes()[idx - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'_' {
+                rest = &rest[idx + 2..];
+                continue;
+            }
+        }
+        let after = rest[idx + 2..].trim_start();
+        if let Some(after_name) = after.strip_prefix(name) {
+            let next = after_name.as_bytes().first().copied();
+            if !next.is_some_and(|b| b.is_ascii_alphanumeric() || b == b'_') {
+                return true;
+            }
+        }
+        rest = &rest[idx + 2..];
+    }
+    false
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn table_body<'a>(toml: &'a str, header: &str) -> Option<&'a str> {
+    let tag = format!("[{header}]");
+    let start = toml.find(&tag)? + tag.len();
+    let rest = &toml[start..];
+    let end = rest.find("\n[").unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+fn dep_line(line: &str) -> Option<(&str, &str)> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+    let eq = line.find('=')?;
+    let name = line[..eq].trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return None;
+    }
+    Some((name, line[eq + 1..].trim()))
+}
+
+fn quoted_value(s: &str, key: &str) -> Option<String> {
+    let mut rest = s;
+    while let Some(idx) = rest.find(key) {
+        let after_key = rest[idx + key.len()..].trim_start();
+        if !after_key.starts_with('=') {
+            rest = &rest[idx + key.len()..];
+            continue;
+        }
+        let value = after_key[1..].trim_start();
+        let value = value.strip_prefix('"')?;
+        let end = value.find('"')?;
+        return Some(value[..end].to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn crate_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+    }
+
+    fn repo_root() -> PathBuf {
+        crate_root().join("../..")
+    }
+
+    #[test]
+    fn workspace_deps_include_translate() {
+        let toml = read_to_string(&repo_root().join("Cargo.toml"));
+        let deps = workspace_member_paths(&toml);
+        assert_eq!(
+            deps.get("majit-translate").map(String::as_str),
+            Some("majit/majit-translate")
+        );
+        assert_eq!(
+            deps.get("majit-charon-reader").map(String::as_str),
+            Some("majit/majit-charon-reader")
+        );
+    }
+
+    #[test]
+    fn discover_tracks_translate_closure_and_live_bindings() {
+        let inputs = discover(&repo_root(), &crate_root());
+        for tree in [
+            "majit/majit-charon-reader/src",
+            "majit/majit-ir/src",
+            "majit/majit-translate/src",
+        ] {
+            assert!(
+                inputs.src_trees.iter().any(|have| have == tree),
+                "missing tree {tree} in {:?}",
+                inputs.src_trees
+            );
+        }
+        for file in [
+            "pyre/pyre-interpreter/src/jit_fnaddr.rs",
+            "pyre/pyre-jit-trace/src/call_spec.rs",
+            "pyre/pyre-jit-trace/src/codegen_cache.rs",
+            "pyre/pyre-jit-trace/src/pypyjit_driver_layout.rs",
+            "pyre/pyre-jit-trace/src/virtualizable_spec.rs",
+        ] {
+            assert!(
+                inputs.extra_files.iter().any(|have| have == file),
+                "missing file {file} in {:?}",
+                inputs.extra_files
+            );
+        }
+        assert!(
+            inputs
+                .manifests
+                .iter()
+                .any(|have| have == "majit/majit-translate/Cargo.toml"),
+            "missing translate manifest in {:?}",
+            inputs.manifests
+        );
+    }
+
+    #[test]
+    fn discover_does_not_walk_unrelated_workspace_crates() {
+        let trees: BTreeSet<_> = discover(&repo_root(), &crate_root())
+            .src_trees
+            .into_iter()
+            .collect();
+        for rel in [
+            "majit/majit-backend-cranelift/src",
+            "majit/majit-backend-dynasm/src",
+            "majit/majit-backend-wasm/src",
+            "majit/majit-gc/src",
+            "majit/majit-metainterp/src",
+            "majit/majit-rlib/src",
+            "pyre/pyre-interpreter/src",
+            "pyre/pyre-jit/src",
+            "pyre/pyre-module/src",
+            "pyre/pyre-native/src",
+            "pyre/pyre-object/src",
+            "pyre/pyre-sandbox/src",
+            "pyre/pyre-wasm/src",
+        ] {
+            assert!(
+                !trees.contains(rel),
+                "{rel} is not a prepass input; hashing it re-runs the prepass on an unrelated edit"
+            );
+        }
+    }
+
+    #[test]
+    fn path_attrs_resolve_quoted_paths() {
+        let src = "#[path = \"../src/call_spec.rs\"]\nmod call_spec;\n";
+        assert_eq!(path_attrs(src), vec!["../src/call_spec.rs".to_string()]);
+    }
+
+    #[test]
+    fn interpreter_calls_ignore_type_paths() {
+        let src = r#"
+            let x = pyre_interpreter::jit_trace_fnaddrs();
+            let p = "pyre_interpreter::error::PyError";
+        "#;
+        assert_eq!(
+            interpreter_fn_calls(src),
+            BTreeSet::from(["jit_trace_fnaddrs".to_string()])
+        );
+    }
+
+    #[test]
+    fn file_defines_fn_matches_exact_name() {
+        assert!(file_defines_fn(
+            "pub fn jit_trace_fnaddrs() -> i32 { 0 }",
+            "jit_trace_fnaddrs"
+        ));
+        assert!(!file_defines_fn(
+            "fn jit_trace_fnaddrs_contains_root() {}",
+            "jit_trace_fnaddrs"
+        ));
+    }
+
+    #[test]
+    fn repo_relative_normalizes_the_prepass_dotdot_spellings() {
+        let root = repo_root();
+        let source = crate_root().join("../pyre-object/src");
+        assert_eq!(repo_relative(&root, &source), "pyre/pyre-object/src");
+        assert_eq!(
+            repo_relative(&root, &crate_root().join("build.rs")),
+            "pyre/pyre-jit-trace/build.rs"
+        );
+    }
+
+    #[test]
+    fn prepass_does_not_walk_the_whole_workspace() {
+        let src = read_to_string(&crate_root().join("build/prepass.rs"));
+        assert!(
+            !src.contains(r#"for workspace_dir in ["majit", "pyre"]"#),
+            "codegen_cache_key must not walk every workspace crate"
+        );
+    }
+}

--- a/pyre/pyre-jit-trace/src/codegen_cache.rs
+++ b/pyre/pyre-jit-trace/src/codegen_cache.rs
@@ -135,11 +135,13 @@ pub fn discover(repo_root: &Path, manifest_dir: &Path) -> CacheInputs {
 pub fn repo_relative(repo_root: &Path, path: &Path) -> String {
     let canonical_root = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.into());
     let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.into());
+    // Forward slashes: Windows `Path::to_string_lossy` emits `\`, and a
+    // backslash key would miss a Unix-built cache entry of the same tree.
     canonical_path
         .strip_prefix(&canonical_root)
         .unwrap_or(&canonical_path)
         .to_string_lossy()
-        .into_owned()
+        .replace('\\', "/")
 }
 
 fn rel(repo_root: &Path, path: &Path) -> String {
@@ -468,6 +470,22 @@ mod tests {
             repo_relative(&root, &crate_root().join("build.rs")),
             "pyre/pyre-jit-trace/build.rs"
         );
+    }
+
+    #[test]
+    fn discover_paths_use_forward_slashes() {
+        let inputs = discover(&repo_root(), &crate_root());
+        for path in inputs
+            .src_trees
+            .iter()
+            .chain(&inputs.extra_files)
+            .chain(&inputs.manifests)
+        {
+            assert!(
+                !path.contains('\\'),
+                "cache key path must be host-independent: {path}"
+            );
+        }
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -124,6 +124,8 @@ mod allocation_counter {
 
 pub mod assembler;
 pub mod callbacks;
+#[cfg(test)]
+mod codegen_cache;
 pub mod ctor_continuation;
 pub mod descr;
 pub mod driver;


### PR DESCRIPTION
## Summary

- derive prepass cache inputs from the translator workspace dependency closure and build-script path modules
- use repository-relative source identities so identical worktrees share cache entries
- hash manifests, translator sources, live binding providers, and LLBC artifacts while excluding unrelated workspace source trees

## PyPy parity

This is the existing Cargo build-script adaptation of RPython TranslationDriver single-process ownership. It changes cache invalidation only and does not change interpreter or JIT semantics. The adaptation comment cites TranslationDriver and names the blocker and convergence path.

## Verification

- cargo test --all --no-default-features --features dynasm
- cargo test --all --no-default-features --features cranelift
- python3 pyre/check.py: dynasm 546/546, cranelift 546/546, wasm 539/539
- forced same-key rebuild restored cache entry 96b97f28921d82a5
- cargo fmt --all --check
- git diff --check
- pypy3 oracle int_loop: 1 loop, 0 bridges, 0 forcings, 0 aborts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build-cache invalidation to detect changes across relevant source files, included files, and manifests.
  - Cache keys now remain consistent across different checkout locations.
  - Reduced unnecessary cache invalidation from unrelated workspace files or file contents that are not read during code generation.

- **Tests**
  - Added coverage for source-path discovery, workspace dependency handling, included files, and interpreter function references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->