### PR TITLE
majit: add eager IR compile API and share done descrs

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -440,6 +440,19 @@ pub fn install_gc_standalone() {
     register_active_hooks(supports_guard_gc_type);
 }
 
+/// Drop this thread's boxed collector.
+///
+/// Embeddings that installed a thread-confined heap through
+/// [`CraneliftBackend::set_gc_allocator`] / [`CraneliftBackend::with_gc_allocator`]
+/// must call this before starting another runtime on the same thread.
+/// `with_cranelift_gc` prefers the leftover box over `gc_sync`, so
+/// [`install_gc_standalone`] cannot displace it. Production pyre uses
+/// [`install_gc_standalone`] and never stores a box. Matches dynasm's
+/// `clear_gc_allocator`.
+pub fn clear_gc_allocator() {
+    gc_box::clear();
+}
+
 /// Follow jf_forward chain to get the final jitframe address.
 ///
 /// RPython jitframe.py jitframe_resolve:
@@ -1546,8 +1559,7 @@ mod gc_box {
 
     /// Backend-teardown counterpart of [`store`], tolerant of a thread whose
     /// thread-locals are already being destroyed.
-    #[cfg(test)]
-    pub(super) fn clear_on_teardown() {
+    pub(super) fn clear() {
         let _ = CRANELIFT_ACTIVE_GC.try_with(|cell| {
             *cell.borrow_mut() = None;
         });
@@ -16873,16 +16885,14 @@ impl Drop for CraneliftBackend {
         for trace_id in std::mem::take(&mut self.registered_call_assembler_bridge_traces) {
             unregister_call_assembler_expectations(CallAssemblerCallerId::BridgeTrace(trace_id));
         }
-        let _ = CALL_ASSEMBLER_DEADFRAMES.try_with(|map| map.borrow_mut().clear());
-        let _ = NEXT_CALL_ASSEMBLER_DEADFRAME_HANDLE.try_with(|cell| cell.set(1));
-        // The active allocator belongs to this execution thread, not to this
-        // transient backend value.  Several JitDrivers can coexist on one
-        // thread and all of their compiled entry trampolines consult this one
-        // slot; clearing it when any one backend dies silently sends every
-        // survivor through HostHeapGc.  dynasm likewise keeps the installed
-        // runtime until an explicit teardown.  Tests that install a private GC
-        // clear it through the test-only helper instead of borrowing an
-        // unrelated backend's Drop as the lifetime boundary.
+        // The active allocator and the call-assembler deadframe map belong to
+        // this execution thread, not to this transient backend value.
+        // Several JitDrivers can coexist on one thread; clearing either slot
+        // when any one backend dies sends surviving compiled loops through
+        // HostHeapGc, or panics them with an unknown deadframe handle.
+        // dynasm likewise keeps the installed runtime until an explicit
+        // teardown.  A boxed collector is released through
+        // [`clear_gc_allocator`].
     }
 }
 
@@ -20086,7 +20096,7 @@ mod tests {
     /// `HostHeapGc`; explicit runtime teardown owns that transition.
     #[test]
     fn dropping_a_backend_keeps_the_thread_gc_installed() {
-        gc_box::clear_on_teardown();
+        clear_gc_allocator();
         let owner = make_gc_backend();
         let jitframe_tid = cranelift_jitframe_type_id()
             .expect("the fixture installed a managed JITFRAME allocator");
@@ -20096,7 +20106,38 @@ mod tests {
 
         drop(owner);
         assert_eq!(cranelift_jitframe_type_id(), Some(jitframe_tid));
-        gc_box::clear_on_teardown();
+        assert!(gc_box::present());
+        clear_gc_allocator();
+        assert!(
+            !gc_box::present(),
+            "clear_gc_allocator is the production path that releases the boxed collector"
+        );
+    }
+
+    /// The call-assembler deadframe map is the same thread-owned slot as the
+    /// active GC.  Dropping a sibling backend must not wipe a live handle or
+    /// reset the counter out from under a surviving backend.
+    #[test]
+    fn dropping_a_backend_keeps_call_assembler_deadframes() {
+        let first = store_call_assembler_deadframe(DeadFrame::boxed(1u64));
+        drop(CraneliftBackend::new());
+        let second = store_call_assembler_deadframe(DeadFrame::boxed(2u64));
+        assert_ne!(
+            first, second,
+            "a sibling Drop must not reset the deadframe handle counter"
+        );
+        let first_frame = take_call_assembler_deadframe(first)
+            .expect("a sibling Drop must not clear a live call_assembler deadframe");
+        let second_frame = take_call_assembler_deadframe(second)
+            .expect("a handle stored after a sibling Drop must still be takeable");
+        match first_frame {
+            DeadFrame::Boxed(value) => assert_eq!(value.downcast_ref::<u64>(), Some(&1)),
+            _ => panic!("expected boxed first handle"),
+        }
+        match second_frame {
+            DeadFrame::Boxed(value) => assert_eq!(value.downcast_ref::<u64>(), Some(&2)),
+            _ => panic!("expected boxed second handle"),
+        }
     }
 
     /// Publish the JitFrame layout descrs so the GC rewriter's

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -295,7 +295,7 @@ use majit_backend::deadframe::FrameHeapOwner;
 use majit_backend::jitframe::{
     BASEITEMOFS, HostHeapGc, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
     JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, check_jitframe_descr, jitframe_is_gc_object,
-    jitframe_write_barrier, malloc_jitframe_no_collect,
+    jitframe_write_barrier, malloc_entry_jitframe_no_collect, malloc_jitframe_no_collect,
 };
 /// Byte offset of `jf_frame_length` from JitFrame start
 /// (`jitframe.py:84` — `jf_frame`'s length word sits at the array base).
@@ -1546,6 +1546,7 @@ mod gc_box {
 
     /// Backend-teardown counterpart of [`store`], tolerant of a thread whose
     /// thread-locals are already being destroyed.
+    #[cfg(test)]
     pub(super) fn clear_on_teardown() {
         let _ = CRANELIFT_ACTIVE_GC.try_with(|cell| {
             *cell.borrow_mut() = None;
@@ -1579,6 +1580,7 @@ fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
 /// when its frames are host blocks — no collector, or one with no type
 /// table. Read by the layout descrs and the tests; the allocation itself
 /// goes through [`with_gc_ll_descr`].
+#[cfg(any(test, feature = "__execute-stage-probe"))]
 fn cranelift_jitframe_type_id() -> Option<u32> {
     with_cranelift_gc(|gc| gc.jitframe_type_id()).flatten()
 }
@@ -8704,7 +8706,7 @@ fn run_compiled_code_inner(
     let (use_gc_alloc, jf) = with_gc_ll_descr(|gc| {
         (
             jitframe_is_gc_object(gc),
-            malloc_jitframe_no_collect(gc, payload_bytes),
+            malloc_entry_jitframe_no_collect(gc, payload_bytes),
         )
     });
     let jf_gcref = GcRef(jf as usize);
@@ -16873,11 +16875,14 @@ impl Drop for CraneliftBackend {
         }
         let _ = CALL_ASSEMBLER_DEADFRAMES.try_with(|map| map.borrow_mut().clear());
         let _ = NEXT_CALL_ASSEMBLER_DEADFRAME_HANDLE.try_with(|cell| cell.set(1));
-        // `llmodel.py:58` `cpu.gc_ll_descr` ownership ends here. Drop the
-        // active allocator so a subsequent backend is free to install
-        // its own; matching dynasm's
-        // `runner.rs DYNASM_ACTIVE_GC` reset on backend teardown.
-        gc_box::clear_on_teardown();
+        // The active allocator belongs to this execution thread, not to this
+        // transient backend value.  Several JitDrivers can coexist on one
+        // thread and all of their compiled entry trampolines consult this one
+        // slot; clearing it when any one backend dies silently sends every
+        // survivor through HostHeapGc.  dynasm likewise keeps the installed
+        // runtime until an explicit teardown.  Tests that install a private GC
+        // clear it through the test-only helper instead of borrowing an
+        // unrelated backend's Drop as the lifetime boundary.
     }
 }
 
@@ -20073,6 +20078,25 @@ mod tests {
         });
         gc.register_type(TypeInfo::simple(16));
         backend_with_gc(gc)
+    }
+
+    /// The active GC is execution-thread state shared by every backend on the
+    /// thread.  Dropping either the backend that installed it or an unrelated
+    /// sibling must not make surviving compiled loops fall through to
+    /// `HostHeapGc`; explicit runtime teardown owns that transition.
+    #[test]
+    fn dropping_a_backend_keeps_the_thread_gc_installed() {
+        gc_box::clear_on_teardown();
+        let owner = make_gc_backend();
+        let jitframe_tid = cranelift_jitframe_type_id()
+            .expect("the fixture installed a managed JITFRAME allocator");
+
+        drop(CraneliftBackend::new());
+        assert_eq!(cranelift_jitframe_type_id(), Some(jitframe_tid));
+
+        drop(owner);
+        assert_eq!(cranelift_jitframe_type_id(), Some(jitframe_tid));
+        gc_box::clear_on_teardown();
     }
 
     /// Publish the JitFrame layout descrs so the GC rewriter's

--- a/majit/majit-backend-cranelift/src/lib.rs
+++ b/majit/majit-backend-cranelift/src/lib.rs
@@ -20,11 +20,10 @@ pub mod compiler;
 pub mod guard;
 
 pub use compiler::{
-    CallAssemblerDescr, CraneliftBackend, FrameRestore, JitFrameLayoutInfo,
+    CallAssemblerDescr, CraneliftBackend, FrameRestore, JitFrameLayoutInfo, clear_gc_allocator,
     force_token_to_dead_frame, get_float_from_deadframe, get_int_from_deadframe,
     get_latest_descr_from_deadframe, get_ref_from_deadframe, get_savedata_ref_from_deadframe,
     install_gc_standalone, jit_exc_class_raw, jit_exc_clear, jit_exc_is_pending, jit_exc_raise,
-    jit_exc_value_peek, jit_exc_value_raw, register_call_assembler_blackhole,
     register_call_assembler_bridge, register_call_assembler_force,
     register_call_assembler_unbox_int, register_jitframe_layout, register_materialize_str_call,
     register_materialize_str_plain, register_prologue_probe_addr, register_resumedata_deopt,

--- a/majit/majit-backend-cranelift/src/lib.rs
+++ b/majit/majit-backend-cranelift/src/lib.rs
@@ -24,6 +24,7 @@ pub use compiler::{
     force_token_to_dead_frame, get_float_from_deadframe, get_int_from_deadframe,
     get_latest_descr_from_deadframe, get_ref_from_deadframe, get_savedata_ref_from_deadframe,
     install_gc_standalone, jit_exc_class_raw, jit_exc_clear, jit_exc_is_pending, jit_exc_raise,
+    jit_exc_value_peek, jit_exc_value_raw, register_call_assembler_blackhole,
     register_call_assembler_bridge, register_call_assembler_force,
     register_call_assembler_unbox_int, register_jitframe_layout, register_materialize_str_call,
     register_materialize_str_plain, register_prologue_probe_addr, register_resumedata_deopt,

--- a/majit/majit-backend-cranelift/tests/eager.rs
+++ b/majit/majit-backend-cranelift/tests/eager.rs
@@ -1,0 +1,6 @@
+fn new_backend() -> Box<dyn majit_backend::Backend> {
+    Box::new(majit_backend_cranelift::CraneliftBackend::new())
+}
+
+#[path = "../../majit-backend/tests/support/eager.rs"]
+mod conformance;

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1780,21 +1780,11 @@ impl DynasmBackend {
         // (matching PyPy's `setup_once` ordering, which builds
         // trampolines after `finish_setup` has installed every CPU
         // descr).
-        let void: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrVoid::new());
-        let int: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrInt::new());
-        let r: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrRef::new());
-        let float: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrFloat::new());
-        let exit_exc: majit_ir::DescrRef =
-            Arc::new(majit_backend::ExitFrameWithExceptionDescrRef::new());
+        majit_backend::make_and_attach_done_descrs(&mut [self as &mut dyn Backend]);
         // `compile.py PropagateExceptionDescr` parity: backend-only
         // tests still need the same descr class identity that production
         // `MetaInterpStaticData.finish_setup` installs.
         let propagate: majit_ir::DescrRef = Arc::new(majit_backend::PropagateExceptionDescr::new());
-        <Self as Backend>::set_done_with_this_frame_descr_void(self, void);
-        <Self as Backend>::set_done_with_this_frame_descr_int(self, int);
-        <Self as Backend>::set_done_with_this_frame_descr_ref(self, r);
-        <Self as Backend>::set_done_with_this_frame_descr_float(self, float);
-        <Self as Backend>::set_exit_frame_with_exception_descr_ref(self, exit_exc);
         <Self as Backend>::set_propagate_exception_descr(self, propagate);
         // `pyjitpl.py self.cpu.setup_once()` parity — production
         // reaches `cpu.setup_once()` via `MetaInterpStaticData::_setup_once`

--- a/majit/majit-backend-dynasm/tests/eager.rs
+++ b/majit/majit-backend-dynasm/tests/eager.rs
@@ -1,0 +1,6 @@
+fn new_backend() -> Box<dyn majit_backend::Backend> {
+    Box::new(majit_backend_dynasm::runner::DynasmBackend::new())
+}
+
+#[path = "../../majit-backend/tests/support/eager.rs"]
+mod conformance;

--- a/majit/majit-backend/EAGER.md
+++ b/majit/majit-backend/EAGER.md
@@ -1,0 +1,105 @@
+# Eager IR compilation
+
+`majit_backend::eager::CompiledIr` (also `majit::eager::CompiledIr`) submits
+backend-ready IR immediately, without a recorder, sample execution, hot counter,
+or `MetaInterp`. Backend selection stays with the embedding: the same entry point
+accepts `&mut dyn Backend` for dynasm, Cranelift, or another implementation.
+
+This is an in-process compilation API, not an object-file writer, CEL compiler,
+generic CFG compiler, or automatic substitute for the tracing frontend. A
+frontend still owns language lowering, optimization if wanted, typed operands,
+call descriptors, guards, and control-flow targets. Backend support for an IR
+operation is unchanged; backend compilation errors propagate to the caller.
+
+## Lifecycle
+
+1. Configure the backend's existing runtime, GC and completion/exception
+   descriptors, then call its ordinary `setup_once`. A backend already configured
+   by the embedding needs no second setup. `CompiledIr` never installs a different
+   collector, reattaches descriptors, or calls setup/teardown behind the caller.
+2. Supply a fresh `Arc<JitCellToken>` from the embedding's existing unique token
+   namespace, input arguments in call order, backend-ready operations, and a
+   `ConstMap`. `unsafe CompiledIr::compile(...)` compiles immediately. A caller
+   supplying raw machine-level IR is responsible for its validity; the API is
+   not a verifier for untrusted IR.
+3. Reuse `unsafe compiled.execute(&values)` for different inputs. Arity and types
+   are checked before entry. `RawExecResult` preserves finish/guard/exception
+   classification and exit values. A guard is not silently resumed, retraced or
+   reported as a successful language evaluation. Pointer inputs and returned
+   references remain subject to the embedding's GC/rooting contract.
+4. The handle keeps the token alive and exclusively borrows the backend; it
+   cannot move to another execution thread. Drop it before reconfiguring or
+   using that backend directly. Retain an `Arc` clone of the token to use the
+   existing `compile_bridge`, `execute_token`, or invalidation APIs afterward.
+   Backend and runtime teardown remain the embedding's responsibility.
+
+The submission replaces the pending backend constant pool and clears it after
+success or error. Do not interleave a partially staged lower-level compilation
+with this API. A backend may partially populate a token before returning an
+error; retry with a fresh token, not the failed token.
+
+Standalone embeddings can share the metainterpreter's descriptor factory:
+
+```rust,ignore
+majit_backend::make_and_attach_done_descrs(&mut [cpu as &mut dyn Backend]);
+cpu.set_propagate_exception_descr(Arc::new(majit_backend::PropagateExceptionDescr::new()));
+cpu.setup_once();
+```
+
+Use this only when initially configuring a CPU, not before each compilation.
+The factory creates the five completion/exception descriptors and shares their
+identities across its targets; it does not install a collector, replace the
+propagate-exception descriptor, or run setup. The metainterpreter's original
+`compile::make_and_attach_done_descrs` signature remains as a forwarding wrapper.
+
+See the module's compiled rustdoc example for an integer `add_one` unit. Native
+conformance tests use directly constructed `Op`/`Operand` graphs, not even a
+test recorder, and cover changing inputs, guard exits, mixed argument banks,
+scalar result banks, void results, rejected arguments, host calls, and reuse
+through the pre-existing backend API.
+
+## Cost and scope
+
+The execution path still uses `execute_token_raw`: the ordinary JITFRAME entry
+and result decoding remain. Eager compilation removes warmup and runtime trace
+discovery; this API does **not** claim to remove the measured per-call entry
+cost, binding cost, GC overhead, or actual host-function invocation cost. A
+dedicated low-overhead scalar ABI is separate work.
+
+For a CEL frontend, short-circuiting, errors, dynamic types and host side effects
+must survive lowering. Compiling an example input and treating the observed path
+as the whole program is not a valid implementation of this API's frontend.
+
+## Compatibility boundary / parity review
+
+This is a user-authorized embedding extension with no new counterpart module in
+RPython. The underlying contract is `rpython/jit/backend/model.py`
+`AbstractCPU.compile_loop` / `execute_token`; upstream's
+`rpython/jit/backend/test/runner_test.py` `Runner.execute_operations` likewise
+compiles supplied operations without a metainterp. This is not limited to
+upstream tests: `rpython/jit/metainterp/compile.py` `compile_tmp_callback` directly
+assembles a call/exception-guard/finish sequence through `cpu.compile_loop` too.
+
+The descriptor factory and its `DescrContainer` contract now live beside the
+existing descriptor classes in `majit-backend::finish_descrs`; their upstream
+owner remains `compile.py` `make_and_attach_done_descrs`. This crate-placement
+adaptation allows standalone embeddings to reuse them without depending on the
+metainterpreter. Dynasm's existing test initializer also uses this factory.
+
+Existing
+`Backend` methods and concrete code generators, PyPy interpreter generation,
+optimizer passes, GC layout, token identity, guard descriptors and resume
+machinery are unchanged by this API addition. Pre-existing worktree changes in
+the Cranelift entry allocator and JitDriver fixture are not part of this addition.
+
+Native conformance command:
+
+```sh
+cargo test -p majit-backend-dynasm -p majit-backend-cranelift --test eager --no-default-features
+cargo test -p majit-backend --doc --no-default-features
+```
+
+The shared API has no native-backend feature gate. This test command executes
+the host's native backends; it does not establish wasm guest execution support
+for a new frontend. Wasm retains its existing host-import/browser runtime setup
+and operation support contract.

--- a/majit/majit-backend/EAGER.md
+++ b/majit/majit-backend/EAGER.md
@@ -31,7 +31,11 @@ operation is unchanged; backend compilation errors propagate to the caller.
    cannot move to another execution thread. Drop it before reconfiguring or
    using that backend directly. Retain an `Arc` clone of the token to use the
    existing `compile_bridge`, `execute_token`, or invalidation APIs afterward.
-   Backend and runtime teardown remain the embedding's responsibility.
+   Backend and runtime teardown remain the embedding's responsibility. A
+   thread-confined boxed collector installed through
+   `CraneliftBackend::set_gc_allocator` / `DynasmBackend::set_gc_allocator`
+   is released with that backend's `clear_gc_allocator`; dropping the
+   backend value does not do it.
 
 The submission replaces the pending backend constant pool and clears it after
 success or error. Do not interleave a partially staged lower-level compilation

--- a/majit/majit-backend/src/eager.rs
+++ b/majit/majit-backend/src/eager.rs
@@ -1,0 +1,218 @@
+//! Explicit, non-tracing compilation of backend-ready majit IR.
+//!
+//! This opt-in embedding API wraps the existing `AbstractCPU.compile_loop`
+//! contract (`rpython/jit/backend/model.py`), just as upstream's
+//! `runner_test.Runner.execute_operations` submits IR without a metainterp.
+//! It is a user-requested API extension, not a replacement for PyPy's tracing,
+//! optimization, guard/resume, or backend lifecycle machinery.
+//!
+//! The caller lowers its language to backend-ready operations (including
+//! descriptors, guards and explicit exits). No sample inputs are executed,
+//! no hot counters are consulted, and no optimizer or interpreter fallback
+//! is implicitly run. This is in-process eager compilation, not object-file
+//! AOT or a general-purpose CFG frontend.
+//!
+//! Pass an already configured backend: its runtime/GC, completion and exception
+//! descriptors, and `setup_once` remain the embedding's responsibility. This
+//! API deliberately does not replace those attachments on a shared PyPy CPU.
+//! Execution retains the ordinary JITFRAME ABI and its costs.
+//!
+//! # Example
+//!
+//! The embedding supplies its initialized dynasm, Cranelift, or other
+//! [`Backend`] and a fresh token from its existing token namespace:
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use majit_backend::{Backend, JitCellToken};
+//! use majit_backend::eager::CompiledIr;
+//! use majit_ir::{ConstMap, InputArg, Op, OpCode, OpRc, OpRef, Type, Value};
+//! use majit_ir::operand::Operand;
+//! use majit_ir::descr::make_finish_descr;
+//!
+//! fn add_one(cpu: &mut dyn Backend, fresh_token: Arc<JitCellToken>) {
+//!     let x = InputArg::new_int_rc(0);
+//!     let add = OpRc::new(Op::new(OpCode::IntAdd, &[
+//!         Operand::from_bound_inputarg(&x),
+//!         Operand::from_opref(OpRef::const_int(1)),
+//!     ]));
+//!     add.pos.set(OpRef::int_op(1));
+//!     let finish = OpRc::new(Op::with_descr(OpCode::Finish,
+//!         &[Operand::from_bound_op(&add)],
+//!         make_finish_descr(0, vec![Type::Int])));
+//!     // SAFETY: well-formed integer-only IR, configured CPU and fresh token.
+//!     let mut compiled = unsafe {
+//!         CompiledIr::compile(cpu, fresh_token, &[x.fresh_value_copy()],
+//!             &[add, finish], ConstMap::default())
+//!     }.expect("backend supports integer addition");
+//!     // SAFETY: no pointers, allocation, or runtime calls in this IR.
+//!     let exit = unsafe { compiled.execute(&[Value::Int(41)]) }.unwrap();
+//!     assert!(exit.is_finish);
+//!     assert_eq!(exit.typed_outputs, vec![Value::Int(42)]);
+//! }
+//! ```
+
+use std::sync::Arc;
+
+use majit_ir::{Const, ConstMap, InputArg, OpRc, Type, Value};
+
+use crate::{AsmInfo, Backend, BackendError, JitCellToken, RawExecResult};
+
+/// An eagerly compiled IR unit, tied to the backend that compiled it.
+///
+/// The exclusive borrow prevents backend replacement or reconfiguration while
+/// this handle is live. The token keeps code and its backend-owned descriptors
+/// alive. Drop the handle to use the backend's lower-level APIs again; retain
+/// a clone of the supplied token if subsequent bridge compilation is needed.
+/// Like the underlying runtime, this handle is execution-thread-affine.
+///
+/// ```compile_fail
+/// use majit_backend::eager::CompiledIr;
+/// fn require_send<T: Send>() {}
+/// require_send::<CompiledIr<'static>>();
+/// ```
+pub struct CompiledIr<'backend> {
+    backend: &'backend mut dyn Backend,
+    token: Arc<JitCellToken>,
+    input_types: Vec<Type>,
+    asm_info: AsmInfo,
+    // Backend is Send, but the runtime's GC/exception state is thread-affine.
+    _thread_affinity: std::marker::PhantomData<std::rc::Rc<()>>,
+}
+
+impl<'backend> CompiledIr<'backend> {
+    /// Compile immediately using the supplied backend, without tracing.
+    ///
+    /// `token` must be fresh and its number unique in the embedding's token
+    /// namespace, including tokens made by a coexisting tracing frontend.
+    /// The caller supplies it rather than this API introducing a second ID
+    /// allocator. Backend errors are returned unchanged, never interpreted as
+    /// a request to execute an interpreter. A failed attempt consumes the token:
+    /// use a fresh token for retries, as backend compilation can partially fill it.
+    ///
+    /// `constants` replaces the backend's pending constant pool for this
+    /// submission and is cleared after either success or failure.
+    ///
+    /// # Safety
+    ///
+    /// The IR must satisfy the selected backend's `compile_loop` contract:
+    /// valid typed operands, descriptors, exits and control-flow targets, with
+    /// any optimizer forwarding already resolved. Runtime hooks and pointer
+    /// constants must be valid, and GC roots, called functions and referenced
+    /// tokens must remain alive for compilation and execution. This API is not
+    /// an IR verifier or a sandbox for untrusted machine-level operations.
+    pub unsafe fn compile(
+        backend: &'backend mut dyn Backend,
+        token: Arc<JitCellToken>,
+        inputargs: &[InputArg],
+        operations: &[OpRc],
+        constants: ConstMap<Const>,
+    ) -> Result<Self, BackendError> {
+        if token.compiled.get().is_some() || token.inputarg_types.get().is_some() {
+            return Err(BackendError::CompilationFailed(
+                "eager compilation requires a fresh JitCellToken".into(),
+            ));
+        }
+        if operations.is_empty() || inputargs.iter().any(|arg| arg.tp == Type::Void) {
+            return Err(BackendError::CompilationFailed(
+                "eager compilation requires nonempty IR and non-void input arguments".into(),
+            ));
+        }
+        let input_types = inputargs.iter().map(|arg| arg.tp).collect();
+        backend.set_constants_pool(constants);
+        let result = backend.compile_loop(inputargs, operations, &token);
+        backend.set_constants_pool(ConstMap::default());
+        let asm_info = result?;
+        // compile.py record_loop_or_bridge: clt.loop_token_wref = wref.
+        // Concrete backends attach ResumeDescr.rd_loop_token during assembly;
+        // complete that existing ownership chain without a metainterp registry.
+        token
+            .compiled_loop_token_expect()
+            .set_loop_token_wref(Arc::downgrade(&token));
+        backend.track_compiled_token(Arc::clone(&token));
+        Ok(Self {
+            backend,
+            token,
+            input_types,
+            asm_info,
+            _thread_affinity: std::marker::PhantomData,
+        })
+    }
+
+    /// The signature in argument-list order, not IR register-number order.
+    pub fn input_types(&self) -> &[Type] {
+        &self.input_types
+    }
+
+    /// Backend-reported code metadata; not a portable callable function pointer.
+    pub fn asm_info(&self) -> &AsmInfo {
+        &self.asm_info
+    }
+
+    /// Execute once, returning the backend's completion, guard or exception exit.
+    ///
+    /// Arity/type mismatches are rejected before entering machine code.
+    /// A guard exit remains an exit (`is_finish == false`), not a successful
+    /// language result: resumption or bridge compilation belongs to the caller.
+    /// There is no hidden warmup, retracing or fallback.
+    ///
+    /// # Safety
+    ///
+    /// The compilation contract must still hold. Pointer-valued arguments
+    /// (including pointers encoded as integers) must be valid for the IR, and
+    /// the embedding must maintain its runtime/GC roots on this thread.
+    /// References returned in `RawExecResult` are not independently rooted:
+    /// root them before another collecting operation or runtime teardown.
+    pub unsafe fn execute(&mut self, args: &[Value]) -> Result<RawExecResult, ArgumentError> {
+        if args.len() != self.input_types.len() {
+            return Err(ArgumentError::Arity {
+                expected: self.input_types.len(),
+                actual: args.len(),
+            });
+        }
+        for (index, (arg, &expected)) in args.iter().zip(&self.input_types).enumerate() {
+            let actual = arg.get_type();
+            if actual != expected {
+                return Err(ArgumentError::Type {
+                    index,
+                    expected,
+                    actual,
+                });
+            }
+        }
+        Ok(self.backend.execute_token_raw(&self.token, args))
+    }
+}
+
+/// Invalid arguments rejected before compiled entry.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ArgumentError {
+    Arity {
+        expected: usize,
+        actual: usize,
+    },
+    Type {
+        index: usize,
+        expected: Type,
+        actual: Type,
+    },
+}
+
+impl std::fmt::Display for ArgumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Arity { expected, actual } => {
+                write!(f, "expected {expected} arguments, got {actual}")
+            }
+            Self::Type {
+                index,
+                expected,
+                actual,
+            } => {
+                write!(f, "argument {index}: expected {expected:?}, got {actual:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArgumentError {}

--- a/majit/majit-backend/src/finish_descrs.rs
+++ b/majit/majit-backend/src/finish_descrs.rs
@@ -13,7 +13,73 @@ use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use majit_ir::{Descr, FailDescr, Type};
+use crate::Backend;
+use majit_ir::{Descr, DescrRef, FailDescr, Type};
+
+/// `compile.py` `def make_and_attach_done_descrs(targets)`.
+///
+/// Creates one instance of each `DoneWithThisFrameDescr*` +
+/// `ExitFrameWithExceptionDescrRef` and attaches them to each target
+/// under the attributes `done_with_this_frame_descr_{void,int,ref,float}`
+/// and `exit_frame_with_exception_descr_ref`.
+///
+/// pyre's `DescrContainer` trait (implemented by `MetaInterpStaticData`
+/// and the CPU stand-in) exposes the five `set_*` hooks that mirror
+/// the RPython `setattr(target, name, descr)` loop.
+pub fn make_and_attach_done_descrs<T: DescrContainer + ?Sized>(targets: &mut [&mut T]) {
+    let void: DescrRef = Arc::new(DoneWithThisFrameDescrVoid::new());
+    let int: DescrRef = Arc::new(DoneWithThisFrameDescrInt::new());
+    let ref_: DescrRef = Arc::new(DoneWithThisFrameDescrRef::new());
+    let float: DescrRef = Arc::new(DoneWithThisFrameDescrFloat::new());
+    let exc_ref: DescrRef = Arc::new(ExitFrameWithExceptionDescrRef::new());
+    for target in targets.iter_mut() {
+        target.set_done_with_this_frame_descr_void(void.clone());
+        target.set_done_with_this_frame_descr_int(int.clone());
+        target.set_done_with_this_frame_descr_ref(ref_.clone());
+        target.set_done_with_this_frame_descr_float(float.clone());
+        target.set_exit_frame_with_exception_descr_ref(exc_ref.clone());
+    }
+}
+
+/// Trait hooked by `make_and_attach_done_descrs`.
+///
+/// `compile.py` `setattr(target, name, descr)` — in RPython each
+/// target is a Python object with settable attributes; in Rust the
+/// five setters make the contract explicit.  `MetaInterpStaticData`
+/// and `dyn Backend` both implement this trait. Calls with
+/// heterogeneous targets use an explicit `&mut [&mut dyn DescrContainer]`.
+/// Homogeneous CPU targets can use `&mut [&mut dyn Backend]` directly.
+pub trait DescrContainer {
+    fn set_done_with_this_frame_descr_void(&mut self, descr: DescrRef);
+    fn set_done_with_this_frame_descr_int(&mut self, descr: DescrRef);
+    fn set_done_with_this_frame_descr_ref(&mut self, descr: DescrRef);
+    fn set_done_with_this_frame_descr_float(&mut self, descr: DescrRef);
+    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: DescrRef);
+}
+
+/// `DescrContainer` blanket impl for `dyn Backend`.  Each setter
+/// forwards to the corresponding `Backend::set_*` trait method so
+/// backends that care about FINISH descr identity (dynasm / cranelift)
+/// can override and store the `Arc`.  Backends that don't override
+/// fall through to the no-op defaults — identity parity is still
+/// maintained on the `MetaInterpStaticData` side.
+impl DescrContainer for dyn Backend + '_ {
+    fn set_done_with_this_frame_descr_void(&mut self, descr: DescrRef) {
+        Backend::set_done_with_this_frame_descr_void(self, descr);
+    }
+    fn set_done_with_this_frame_descr_int(&mut self, descr: DescrRef) {
+        Backend::set_done_with_this_frame_descr_int(self, descr);
+    }
+    fn set_done_with_this_frame_descr_ref(&mut self, descr: DescrRef) {
+        Backend::set_done_with_this_frame_descr_ref(self, descr);
+    }
+    fn set_done_with_this_frame_descr_float(&mut self, descr: DescrRef) {
+        Backend::set_done_with_this_frame_descr_float(self, descr);
+    }
+    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: DescrRef) {
+        Backend::set_exit_frame_with_exception_descr_ref(self, descr);
+    }
+}
 
 /// `compile.py` `class _DoneWithThisFrameDescr(AbstractFailDescr):
 /// final_descr = True`.

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -938,7 +938,11 @@ mod tests {
 
     #[test]
     fn noncollecting_entry_jitframe_stays_in_the_nursery() {
-        let mut gc = majit_gc::collector::MiniMarkGC::new();
+        let mut gc = majit_gc::collector::MiniMarkGC::with_config(majit_gc::collector::GcConfig {
+            nursery_size: 4096,
+            large_object_threshold: 4096,
+            ..majit_gc::collector::GcConfig::default()
+        });
         let tid = gc.register_type(jitframe_type_info());
         gc.set_jitframe_type_id(tid);
         let frame = malloc_entry_jitframe_no_collect(&mut gc, JitFrame::alloc_size(8));
@@ -946,6 +950,25 @@ mod tests {
         assert!(
             gc.is_in_nursery(frame as usize),
             "the non-collecting entry allocator must keep the ordinary nursery placement"
+        );
+
+        // A collecting nursery alloc would run a minor collection once the
+        // nursery is full and then stay young. The no-collect path must not
+        // collect; it falls back to old-gen instead.
+        let pad = gc.register_type(majit_gc::TypeInfo::simple(16));
+        loop {
+            let obj = gc.alloc_nursery_no_collect_typed(pad, 16);
+            if obj.is_null() || !gc.is_in_nursery(obj.0) {
+                break;
+            }
+        }
+        let minors_before = gc.collection_counts().0;
+        let tight = malloc_entry_jitframe_no_collect(&mut gc, JitFrame::alloc_size(8));
+        assert!(!tight.is_null());
+        assert_eq!(
+            gc.collection_counts().0,
+            minors_before,
+            "malloc_entry_jitframe_no_collect must use alloc_nursery_no_collect_typed, not the collecting nursery allocator"
         );
     }
 }

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -346,6 +346,31 @@ pub fn malloc_entry_jitframe(
     }
 }
 
+/// [`malloc_entry_jitframe`] for a caller whose Rust-stack inputs are not
+/// rooted across a collecting allocation.
+///
+/// This is the compiled-entry counterpart of [`malloc_jitframe_no_collect`]:
+/// it preserves that function's non-collecting nursery allocation while
+/// keeping the entry allocator's narrower initialization contract.  The
+/// generated entry writes every live spill before publishing its GC map, so
+/// clearing trailing frame slots here has no upstream counterpart.
+pub fn malloc_entry_jitframe_no_collect(
+    gc: &mut dyn majit_gc::GcAllocator,
+    size_bytes: usize,
+) -> *mut JitFrame {
+    match gc.jitframe_type_id() {
+        Some(type_id) => {
+            let gcref = if jitframe_prefer_oldgen() {
+                gc.alloc_oldgen_typed(type_id, size_bytes)
+            } else {
+                gc.alloc_nursery_no_collect_typed(type_id, size_bytes)
+            };
+            entry_gc_frame(gcref)
+        }
+        None => malloc_host_jitframe(size_bytes),
+    }
+}
+
 /// `llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`,
 /// reached through `GcLLDescription.malloc_jitframe` (gc.py:132) and
 /// `jitframe_allocate` (`jitframe.py:48`).
@@ -908,6 +933,19 @@ mod tests {
         assert!(
             gc.is_in_nursery(frame as usize),
             "a false prefer-oldgen flag must not land the frame in mark-sweep old-gen"
+        );
+    }
+
+    #[test]
+    fn noncollecting_entry_jitframe_stays_in_the_nursery() {
+        let mut gc = majit_gc::collector::MiniMarkGC::new();
+        let tid = gc.register_type(jitframe_type_info());
+        gc.set_jitframe_type_id(tid);
+        let frame = malloc_entry_jitframe_no_collect(&mut gc, JitFrame::alloc_size(8));
+        assert!(!frame.is_null());
+        assert!(
+            gc.is_in_nursery(frame as usize),
+            "the non-collecting entry allocator must keep the ordinary nursery placement"
         );
     }
 }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -69,6 +69,7 @@ pub fn fallback_cpu_tracker() -> &'static CpuTotalTracker {
 
 pub mod call_stub;
 pub mod deadframe;
+pub mod eager;
 pub mod finish_descrs;
 pub mod jitframe;
 pub mod libc_deadframe;
@@ -80,9 +81,10 @@ pub mod resume_value;
 pub mod synthetic_cpu;
 
 pub use finish_descrs::{
-    DoneWithThisFrameDescrFloat, DoneWithThisFrameDescrInt, DoneWithThisFrameDescrMulti,
-    DoneWithThisFrameDescrRef, DoneWithThisFrameDescrVoid, ExitFrameWithExceptionDescrRef,
-    PropagateExceptionDescr, get_or_attach_done_with_this_frame_descr_multi,
+    DescrContainer, DoneWithThisFrameDescrFloat, DoneWithThisFrameDescrInt,
+    DoneWithThisFrameDescrMulti, DoneWithThisFrameDescrRef, DoneWithThisFrameDescrVoid,
+    ExitFrameWithExceptionDescrRef, PropagateExceptionDescr,
+    get_or_attach_done_with_this_frame_descr_multi, make_and_attach_done_descrs,
 };
 pub use jitframe::JitFrameInfo;
 pub use rd_payload::RdPayload;

--- a/majit/majit-backend/tests/done_descrs.rs
+++ b/majit/majit-backend/tests/done_descrs.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use majit_backend::{DescrContainer, make_and_attach_done_descrs};
+use majit_ir::DescrRef;
+
+#[derive(Default)]
+struct Target {
+    descrs: [Option<DescrRef>; 5],
+}
+
+impl DescrContainer for Target {
+    fn set_done_with_this_frame_descr_void(&mut self, descr: DescrRef) {
+        self.descrs[0] = Some(descr);
+    }
+    fn set_done_with_this_frame_descr_int(&mut self, descr: DescrRef) {
+        self.descrs[1] = Some(descr);
+    }
+    fn set_done_with_this_frame_descr_ref(&mut self, descr: DescrRef) {
+        self.descrs[2] = Some(descr);
+    }
+    fn set_done_with_this_frame_descr_float(&mut self, descr: DescrRef) {
+        self.descrs[3] = Some(descr);
+    }
+    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: DescrRef) {
+        self.descrs[4] = Some(descr);
+    }
+}
+
+#[test]
+fn targets_share_descriptors_but_separate_runtimes_do_not() {
+    let mut first = Target::default();
+    let mut second = Target::default();
+    let mut separate = Target::default();
+    // Exercise the heterogeneous API retained by the metainterpreter.
+    let targets: &mut [&mut dyn DescrContainer] = &mut [&mut first, &mut second];
+    make_and_attach_done_descrs(targets);
+    make_and_attach_done_descrs(&mut [&mut separate]);
+    for i in 0..5 {
+        let descr = first.descrs[i].as_ref().unwrap();
+        assert!(Arc::ptr_eq(descr, second.descrs[i].as_ref().unwrap()));
+        assert!(!Arc::ptr_eq(descr, separate.descrs[i].as_ref().unwrap()));
+        for j in 0..i {
+            assert!(!Arc::ptr_eq(descr, first.descrs[j].as_ref().unwrap()));
+        }
+    }
+}

--- a/majit/majit-backend/tests/eager_errors.rs
+++ b/majit/majit-backend/tests/eager_errors.rs
@@ -1,0 +1,124 @@
+//! Error-path contracts independent of any concrete backend or runtime.
+
+use std::sync::Arc;
+
+use majit_backend::eager::CompiledIr;
+use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, ExitRecoveryLayout, JitCellToken};
+use majit_ir::{Const, ConstMap, DescrRef, FailDescr, GcRef, InputArg, Op, OpCode, OpRc, Value};
+
+#[derive(Default)]
+struct RejectingBackend {
+    constants: ConstMap<Const>,
+    compilations: usize,
+}
+
+impl Backend for RejectingBackend {
+    fn backend_name(&self) -> &'static str {
+        "rejecting-test-backend"
+    }
+    fn set_constants_pool(&mut self, constants: ConstMap<Const>) {
+        self.constants = constants;
+    }
+    fn setup_once(&mut self) {
+        panic!("eager compilation must not redo runtime setup");
+    }
+    fn finish_once(&mut self) {
+        panic!("eager compilation must not tear down the runtime");
+    }
+    fn set_done_with_this_frame_descr_void(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn set_done_with_this_frame_descr_int(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn set_done_with_this_frame_descr_ref(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn set_done_with_this_frame_descr_float(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn set_exit_frame_with_exception_descr_ref(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn set_propagate_exception_descr(&mut self, _: DescrRef) {
+        panic!("eager compilation must preserve CPU descriptors");
+    }
+    fn compile_loop(
+        &mut self,
+        _: &[InputArg],
+        _: &[OpRc],
+        _: &JitCellToken,
+    ) -> Result<AsmInfo, BackendError> {
+        self.compilations += 1;
+        assert_eq!(
+            self.constants.len(),
+            1,
+            "submission's pool must reach the backend"
+        );
+        Err(BackendError::Unsupported(
+            "deliberate compile decline".into(),
+        ))
+    }
+    fn compile_bridge(
+        &mut self,
+        _: &dyn FailDescr,
+        _: &[InputArg],
+        _: &[OpRc],
+        _: &JitCellToken,
+        _: &[Arc<JitCellToken>],
+        _: Option<&ExitRecoveryLayout>,
+    ) -> Result<AsmInfo, BackendError> {
+        unreachable!()
+    }
+    fn execute_token(&self, _: &JitCellToken, _: &[Value]) -> DeadFrame {
+        panic!("compile failure must not run code or a fallback");
+    }
+    fn get_latest_descr<'a>(&'a self, _: &'a DeadFrame) -> &'a dyn FailDescr {
+        unreachable!()
+    }
+    fn get_latest_descr_arc(&self, _: &DeadFrame) -> DescrRef {
+        unreachable!()
+    }
+    fn get_int_value(&self, _: &DeadFrame, _: usize) -> i64 {
+        unreachable!()
+    }
+    fn get_value_direct(&self, _: &DeadFrame, _: usize) -> i64 {
+        unreachable!()
+    }
+    fn get_float_value(&self, _: &DeadFrame, _: usize) -> f64 {
+        unreachable!()
+    }
+    fn get_ref_value(&self, _: &DeadFrame, _: usize) -> GcRef {
+        unreachable!()
+    }
+    fn invalidate_loop(&self, _: &JitCellToken) {
+        unreachable!()
+    }
+}
+
+#[test]
+fn backend_decline_propagates_and_pending_constants_are_cleared() {
+    let mut backend = RejectingBackend::default();
+    let finish = OpRc::new(Op::with_descr(
+        OpCode::Finish,
+        &[],
+        majit_ir::descr::make_finish_descr(0, vec![]),
+    ));
+    let mut constants = ConstMap::default();
+    constants.insert(0, Const::Int(42));
+    let result = unsafe {
+        CompiledIr::compile(
+            &mut backend,
+            Arc::new(JitCellToken::new(1)),
+            &[],
+            &[finish],
+            constants,
+        )
+    };
+    assert!(
+        matches!(result, Err(BackendError::Unsupported(ref message)) if message == "deliberate compile decline")
+    );
+    drop(result);
+    assert_eq!(backend.compilations, 1);
+    assert!(backend.constants.is_empty());
+}

--- a/majit/majit-backend/tests/support/eager.rs
+++ b/majit/majit-backend/tests/support/eager.rs
@@ -1,0 +1,297 @@
+//! Shared native-backend conformance tests. No recorder, JitDriver or warmup.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use majit_backend::eager::{ArgumentError, CompiledIr};
+use majit_backend::{Backend, BackendError, JitCellToken};
+use majit_ir::descr::make_finish_descr;
+use majit_ir::operand::Operand;
+use majit_ir::{ConstMap, InputArg, Op, OpCode, OpRc, OpRef, Type, Value};
+
+fn token() -> Arc<JitCellToken> {
+    static NEXT: AtomicU64 = AtomicU64::new(1_000_000);
+    Arc::new(JitCellToken::new(NEXT.fetch_add(1, Ordering::Relaxed)))
+}
+
+fn backend() -> Box<dyn Backend> {
+    let mut backend = super::new_backend();
+    // The embedding, not CompiledIr, owns AbstractCPU setup and the
+    // compile.make_and_attach_done_descrs / propagate-exception attachments.
+    majit_backend::make_and_attach_done_descrs(&mut [&mut *backend]);
+    backend.set_propagate_exception_descr(Arc::new(majit_backend::PropagateExceptionDescr::new()));
+    backend.setup_once();
+    backend
+}
+
+fn op(opcode: OpCode, args: &[Operand], pos: u32) -> OpRc {
+    let op = Op::new(opcode, args);
+    op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
+    OpRc::new(op)
+}
+
+fn finish(args: &[Operand], types: Vec<Type>) -> OpRc {
+    OpRc::new(Op::with_descr(
+        OpCode::Finish,
+        args,
+        make_finish_descr(90, types),
+    ))
+}
+
+#[test]
+fn compiles_before_first_execution_and_reuses_code_for_new_inputs() {
+    let mut backend = backend();
+    let tracker = Arc::clone(backend.cpu_tracker());
+    let before = tracker.total_compiled_loops.load(Ordering::Relaxed);
+    let x = InputArg::from_type_rc(Type::Int, 10);
+    let y = InputArg::from_type_rc(Type::Int, 20);
+    let add = op(
+        OpCode::IntAdd,
+        &[
+            Operand::from_bound_inputarg(&x),
+            Operand::from_bound_inputarg(&y),
+        ],
+        30,
+    );
+    let operations = vec![
+        add.clone(),
+        finish(&[Operand::from_bound_op(&add)], vec![Type::Int]),
+    ];
+    let inputs = vec![x.fresh_value_copy(), y.fresh_value_copy()];
+    let token = token();
+    let mut code = unsafe {
+        CompiledIr::compile(
+            &mut *backend,
+            token.clone(),
+            &inputs,
+            &operations,
+            ConstMap::default(),
+        )
+    }
+    .unwrap();
+    assert_eq!(
+        tracker.total_compiled_loops.load(Ordering::Relaxed),
+        before + 1
+    );
+    assert!(code.asm_info().code_size > 0);
+    assert_eq!(code.input_types(), &[Type::Int, Type::Int]);
+    // Compilation does not need the frontend op graph to survive.
+    drop(operations);
+    drop(inputs);
+    for (a, b) in [(4, 5), (-19, 3), (i64::MAX, 1)] {
+        let result = unsafe { code.execute(&[Value::Int(a), Value::Int(b)]) }.unwrap();
+        assert!(result.is_finish);
+        assert_eq!(result.typed_outputs, vec![Value::Int(a.wrapping_add(b))]);
+    }
+    assert_eq!(
+        tracker.total_compiled_loops.load(Ordering::Relaxed),
+        before + 1
+    );
+    assert!(matches!(
+        unsafe { code.execute(&[]) },
+        Err(ArgumentError::Arity {
+            expected: 2,
+            actual: 0
+        })
+    ));
+    assert!(matches!(
+        unsafe { code.execute(&[Value::Float(1.0), Value::Int(2)]) },
+        Err(ArgumentError::Type {
+            index: 0,
+            expected: Type::Int,
+            actual: Type::Float
+        })
+    ));
+    drop(code);
+
+    // Same CPU/token still works through the pre-existing PyPy backend API.
+    let frame = backend.execute_token(&token, &[Value::Int(40), Value::Int(2)]);
+    assert_eq!(backend.get_int_value(&frame, 0), 42);
+    drop(frame);
+    assert!(matches!(
+        unsafe { CompiledIr::compile(&mut *backend, token, &[], &[], ConstMap::default()) },
+        Err(BackendError::CompilationFailed(_))
+    ));
+}
+
+#[test]
+fn guard_failure_is_returned_without_fallback_or_recompilation() {
+    let mut backend = backend();
+    let tracker = Arc::clone(backend.cpu_tracker());
+    let x = InputArg::from_type_rc(Type::Int, 0);
+    let arg = Operand::from_bound_inputarg(&x);
+    let compare = op(
+        OpCode::IntGt,
+        &[arg.clone(), Operand::from_opref(OpRef::const_int(0))],
+        1,
+    );
+    // Native guard assembly writes AbstractFailDescr.rd_locs. Use the real
+    // shared guard descriptor, not SimpleFailDescr (which lacks that slot).
+    let descr = majit_backend::make_resume_guard_descr_typed(vec![Type::Int]);
+    let fail_index = descr.as_fail_descr().unwrap().fail_index();
+    let guard = Op::with_descr(
+        OpCode::GuardTrue,
+        &[Operand::from_bound_op(&compare)],
+        descr.clone(),
+    );
+    guard.setfailargs([arg.clone()].into_iter().collect());
+    let operations = vec![compare, OpRc::new(guard), finish(&[arg], vec![Type::Int])];
+    let compiled_token = token();
+    let mut code = unsafe {
+        CompiledIr::compile(
+            &mut *backend,
+            compiled_token.clone(),
+            &[x.fresh_value_copy()],
+            &operations,
+            ConstMap::default(),
+        )
+    }
+    .unwrap();
+    let compiled = tracker.total_compiled_loops.load(Ordering::Relaxed);
+    for input in [7, -3, 0, 12] {
+        let result = unsafe { code.execute(&[Value::Int(input)]) }.unwrap();
+        assert_eq!(result.is_finish, input > 0);
+        assert_eq!(result.typed_outputs, vec![Value::Int(input)]);
+        if input <= 0 {
+            assert!(Arc::ptr_eq(&result.descr_arc, &descr));
+            assert_eq!(result.fail_index, fail_index);
+            let owner = majit_backend::descr_owning_jct(result.descr_arc.as_fail_descr().unwrap())
+                .expect(
+                    "a guard must resolve its owner through the ordinary PyPy descriptor chain",
+                );
+            assert!(Arc::ptr_eq(&owner, &compiled_token));
+        }
+    }
+    assert_eq!(
+        tracker.total_compiled_loops.load(Ordering::Relaxed),
+        compiled
+    );
+}
+
+#[test]
+fn mixed_types_and_void_results_preserve_the_backend_contract() {
+    let mut backend = backend();
+    let int = InputArg::from_type_rc(Type::Int, 0);
+    let float = InputArg::from_type_rc(Type::Float, 1);
+    let reference = InputArg::from_type_rc(Type::Ref, 2);
+    let inputs = vec![
+        int.fresh_value_copy(),
+        float.fresh_value_copy(),
+        reference.fresh_value_copy(),
+    ];
+    let args = [&int, &float, &reference].map(Operand::from_bound_inputarg);
+    let values = [
+        Value::Int(42),
+        Value::Float(-0.0),
+        Value::Ref(majit_ir::GcRef::NULL),
+    ];
+    // FINISH has one language result; exercise every bank with a mixed
+    // argument list without requiring a backend-specific multi-return ABI.
+    for (arg, value) in args.iter().zip(values) {
+        let operations = vec![finish(std::slice::from_ref(arg), vec![value.get_type()])];
+        let mut code = unsafe {
+            CompiledIr::compile(
+                &mut *backend,
+                token(),
+                &inputs,
+                &operations,
+                ConstMap::default(),
+            )
+        }
+        .unwrap();
+        let result = unsafe { code.execute(&values) }.unwrap();
+        assert!(result.is_finish);
+        assert_eq!(result.typed_outputs, vec![value]);
+    }
+
+    let mut code = unsafe {
+        CompiledIr::compile(
+            &mut *backend,
+            token(),
+            &[],
+            &[finish(&[], vec![])],
+            ConstMap::default(),
+        )
+    }
+    .unwrap();
+    let result = unsafe { code.execute(&[]) }.unwrap();
+    assert!(result.is_finish);
+    assert!(result.typed_outputs.is_empty());
+}
+
+#[test]
+fn empty_submission_does_not_reach_codegen() {
+    let mut backend = backend();
+    let before = backend
+        .cpu_tracker()
+        .total_compiled_loops
+        .load(Ordering::Relaxed);
+    let result =
+        unsafe { CompiledIr::compile(&mut *backend, token(), &[], &[], ConstMap::default()) };
+    assert!(matches!(result, Err(BackendError::CompilationFailed(_))));
+    drop(result);
+    assert_eq!(
+        backend
+            .cpu_tracker()
+            .total_compiled_loops
+            .load(Ordering::Relaxed),
+        before
+    );
+}
+
+#[test]
+fn host_function_runs_only_on_explicit_execution() {
+    static CALLS: AtomicU64 = AtomicU64::new(0);
+    extern "C" fn twice(value: i64) -> i64 {
+        CALLS.fetch_add(1, Ordering::Relaxed);
+        value.wrapping_mul(2)
+    }
+
+    let mut backend = backend();
+    let x = InputArg::new_int_rc(0);
+    let descr = majit_ir::make_call_descr(
+        vec![Type::Int],
+        Type::Int,
+        majit_ir::EffectInfo::const_new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    let call = OpRc::new(Op::with_descr(
+        OpCode::CallI,
+        &[
+            Operand::from_opref(OpRef::const_int(twice as *const () as usize as i64)),
+            Operand::from_bound_inputarg(&x),
+        ],
+        descr,
+    ));
+    call.pos.set(OpRef::int_op(1));
+    let operations = vec![
+        call.clone(),
+        finish(&[Operand::from_bound_op(&call)], vec![Type::Int]),
+    ];
+    let mut code = unsafe {
+        CompiledIr::compile(
+            &mut *backend,
+            token(),
+            &[x.fresh_value_copy()],
+            &operations,
+            ConstMap::default(),
+        )
+    }
+    .unwrap();
+    assert_eq!(
+        CALLS.load(Ordering::Relaxed),
+        0,
+        "compilation must not call the host function"
+    );
+    // Bad arguments must not execute either.
+    assert!(unsafe { code.execute(&[Value::Float(3.0)]) }.is_err());
+    assert_eq!(CALLS.load(Ordering::Relaxed), 0);
+    for (count, input) in [3, 21].into_iter().enumerate() {
+        let result = unsafe { code.execute(&[Value::Int(input)]) }.unwrap();
+        assert!(result.is_finish);
+        assert_eq!(result.typed_outputs, vec![Value::Int(input * 2)]);
+        assert_eq!(CALLS.load(Ordering::Relaxed), count as u64 + 1);
+    }
+}

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2361,8 +2361,8 @@ pub(crate) fn patch_backend_terminal_recovery_layouts_for_trace(
 
 // `rpython/jit/metainterp/compile.py:623-674` — finish/propagate descrs.
 //
-// These are ported as backend-agnostic `FailDescr` impls on the
-// `majit-metainterp` side so `compile_tmp_callback` and
+// These are ported as backend-agnostic `FailDescr` impls in the
+// shared backend crate so `compile_tmp_callback` and
 // `finish_setup` can reference the same singletons RPython does.
 //
 // `pyjitpl.py` `compile.make_and_attach_done_descrs([self, cpu])` —
@@ -2371,8 +2371,8 @@ pub(crate) fn patch_backend_terminal_recovery_layouts_for_trace(
 // backend observes is the same Arc the metainterp reads back in
 // `handle_fail`. pyre mirrors the same shape through the
 // `DescrContainer` trait implemented on both `MetaInterpStaticData`
-// (pyjitpl.rs) and `Backend` (majit-backend/lib.rs via the blanket
-// impl below), so `MetaInterp::new` installs a single `Arc` on both
+// (pyjitpl.rs) and `dyn Backend` (majit-backend/finish_descrs.rs),
+// so `MetaInterp::new` installs a single `Arc` on both
 // halves; `attach_descrs_to_cpu` forwards the clones to the backend.
 
 // `compile.py, 1092-1099` `_DoneWithThisFrameDescr` family /
@@ -2386,70 +2386,12 @@ pub use majit_backend::{
     DoneWithThisFrameDescrVoid, ExitFrameWithExceptionDescrRef, PropagateExceptionDescr,
 };
 
-/// `compile.py` `def make_and_attach_done_descrs(targets)`.
-///
-/// Creates one instance of each `DoneWithThisFrameDescr*` +
-/// `ExitFrameWithExceptionDescrRef` and attaches them to each target
-/// under the attributes `done_with_this_frame_descr_{void,int,ref,float}`
-/// and `exit_frame_with_exception_descr_ref`.
-///
-/// pyre's `DescrContainer` trait (implemented by `MetaInterpStaticData`
-/// and the CPU stand-in) exposes the five `set_*` hooks that mirror
-/// the RPython `setattr(target, name, descr)` loop.
+pub use majit_backend::DescrContainer;
+
+/// Compatibility entry point for `compile.py` `make_and_attach_done_descrs`.
+/// The shared backend implementation preserves the same descriptor identities.
 pub fn make_and_attach_done_descrs(targets: &mut [&mut dyn DescrContainer]) {
-    let void: DescrRef = Arc::new(DoneWithThisFrameDescrVoid::new());
-    let int: DescrRef = Arc::new(DoneWithThisFrameDescrInt::new());
-    let ref_: DescrRef = Arc::new(DoneWithThisFrameDescrRef::new());
-    let float: DescrRef = Arc::new(DoneWithThisFrameDescrFloat::new());
-    let exc_ref: DescrRef = Arc::new(ExitFrameWithExceptionDescrRef::new());
-    for target in targets.iter_mut() {
-        target.set_done_with_this_frame_descr_void(void.clone());
-        target.set_done_with_this_frame_descr_int(int.clone());
-        target.set_done_with_this_frame_descr_ref(ref_.clone());
-        target.set_done_with_this_frame_descr_float(float.clone());
-        target.set_exit_frame_with_exception_descr_ref(exc_ref.clone());
-    }
-}
-
-/// Trait hooked by `make_and_attach_done_descrs`.
-///
-/// `compile.py` `setattr(target, name, descr)` — in RPython each
-/// target is a Python object with settable attributes; in Rust the
-/// five setters make the contract explicit.  `MetaInterpStaticData`
-/// and `dyn Backend` both implement this trait so a single call to
-/// `make_and_attach_done_descrs(&mut [&mut sd, &mut *backend])`
-/// mirrors RPython's `make_and_attach_done_descrs([self, cpu])`
-/// exactly.
-pub trait DescrContainer {
-    fn set_done_with_this_frame_descr_void(&mut self, descr: DescrRef);
-    fn set_done_with_this_frame_descr_int(&mut self, descr: DescrRef);
-    fn set_done_with_this_frame_descr_ref(&mut self, descr: DescrRef);
-    fn set_done_with_this_frame_descr_float(&mut self, descr: DescrRef);
-    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: DescrRef);
-}
-
-/// `DescrContainer` blanket impl for `dyn Backend`.  Each setter
-/// forwards to the corresponding `Backend::set_*` trait method so
-/// backends that care about FINISH descr identity (dynasm / cranelift)
-/// can override and store the `Arc`.  Backends that don't override
-/// fall through to the no-op defaults — identity parity is still
-/// maintained on the `MetaInterpStaticData` side.
-impl DescrContainer for dyn Backend + '_ {
-    fn set_done_with_this_frame_descr_void(&mut self, descr: DescrRef) {
-        Backend::set_done_with_this_frame_descr_void(self, descr);
-    }
-    fn set_done_with_this_frame_descr_int(&mut self, descr: DescrRef) {
-        Backend::set_done_with_this_frame_descr_int(self, descr);
-    }
-    fn set_done_with_this_frame_descr_ref(&mut self, descr: DescrRef) {
-        Backend::set_done_with_this_frame_descr_ref(self, descr);
-    }
-    fn set_done_with_this_frame_descr_float(&mut self, descr: DescrRef) {
-        Backend::set_done_with_this_frame_descr_float(self, descr);
-    }
-    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: DescrRef) {
-        Backend::set_exit_frame_with_exception_descr_ref(self, descr);
-    }
+    majit_backend::make_and_attach_done_descrs(targets);
 }
 
 /// `rpython/jit/metainterp/compile.py` `compile_tmp_callback`.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -9681,8 +9681,13 @@ mod tests {
             vec![pc as i64, 0, code as i64],
             vec![Type::Int, Type::Int, Type::Ref],
         );
-        let hash = key.get_uhash();
         let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        // A real frontend constructs its JitDriver before hashing any Ref
+        // greens: WarmEnterState::new installs the GC-owned identity-hash
+        // resolver.  Keep the fixture in that order too, otherwise `hash`
+        // uses raw pointer bits while the compiled-entry door recomputes the
+        // same key through the installed, move-stable identity hash.
+        let hash = key.get_uhash();
         // `resume.py blackhole_from_resumedata` indexes
         // `metainterp_sd.jitcodes[jitcode_pos]` unconditionally.  The guard
         // snapshot below names jitcode 0, so give the fixture the same

--- a/majit/majit/src/lib.rs
+++ b/majit/majit/src/lib.rs
@@ -33,6 +33,9 @@ pub use majit_trace as trace;
 /// Backend abstraction: Backend trait, JitCellToken, DeadFrame.
 pub use majit_backend as backend;
 
+/// Explicit compilation of backend-ready IR without tracing or warmup.
+pub use majit_backend::eager;
+
 /// Cranelift backend: native code generation. Present under the `cranelift`
 /// feature, which is what pulls the backend crate in.
 #[cfg(feature = "cranelift")]


### PR DESCRIPTION
## Summary

- Add `majit_backend::eager::CompiledIr` (re-exported as `majit::eager`) to compile backend-ready IR immediately, without a recorder, warmup, or `MetaInterp`.
- Move `make_and_attach_done_descrs` and `DescrContainer` into the backend crate so standalone embeddings can attach the same done/exception descriptors. The metainterp keeps a forwarding wrapper.
- Allocate compiled-entry JITFRAMEs through `malloc_entry_jitframe_no_collect`.
- Stop clearing Cranelift's thread GC from backend `Drop`. Hash JitDriver green keys after the driver is constructed.
- Add backend tests for eager compilation, argument/error cases, and shared done descriptors. Document the API in `majit/majit-backend/EAGER.md`.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an eager compilation API for compiling and executing IR directly, without tracing or warmup.
  - Added validation and clear errors for incorrect argument counts and types.
  - Added shared descriptor setup across backend implementations.
  - Exposed the eager API through the main package.

- **Bug Fixes**
  - Improved JIT frame allocation and garbage-collector state handling when backends are dropped.

- **Documentation**
  - Added guidance covering eager compilation, lifecycle, compatibility, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->