### PR TITLE
majit: share JitCode artifacts and wasm host transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "majit-backend-wasm-host"
+version = "0.0.2"
+dependencies = [
+ "majit-backend-wasm",
+ "wasmtime",
+]
+
+[[package]]
 name = "majit-charon-reader"
 version = "0.0.2"
 dependencies = [
@@ -2088,6 +2096,7 @@ dependencies = [
 name = "majit-translate"
 version = "0.0.2"
 dependencies = [
+ "bincode",
  "bit-set",
  "indexmap",
  "libc",
@@ -2909,6 +2918,7 @@ name = "pyre-wasm-runner"
 version = "0.0.2"
 dependencies = [
  "getrandom 0.4.3",
+ "majit-backend-wasm-host",
  "parking_lot",
  "rustc-demangle",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "majit/majit-backend-cranelift",
     "majit/majit-backend-dynasm",
     "majit/majit-backend-wasm",
+    "majit/majit-backend-wasm-host",
     "majit/majit-gc",
     "majit/majit-macros",
     "majit/majit-metainterp",
@@ -105,6 +106,7 @@ majit-backend = { version = "0.0.2", path = "majit/majit-backend" }
 majit-backend-cranelift = { version = "0.0.2", path = "majit/majit-backend-cranelift" }
 majit-backend-dynasm = { version = "0.0.2", path = "majit/majit-backend-dynasm" }
 majit-backend-wasm = { version = "0.0.2", path = "majit/majit-backend-wasm" }
+majit-backend-wasm-host = { version = "0.0.2", path = "majit/majit-backend-wasm-host" }
 majit-gc = { version = "0.0.2", path = "majit/majit-gc" }
 majit-macros = { version = "0.0.2", path = "majit/majit-macros" }
 majit-rlib = { version = "0.0.2", path = "majit/majit-rlib" }

--- a/majit/majit-backend-wasm-host/Cargo.toml
+++ b/majit/majit-backend-wasm-host/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "majit-backend-wasm-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared native Wasmtime execution host for majit wasm traces"
+
+[dependencies]
+wasmtime = { workspace = true }
+majit-backend-wasm = { version = "0.0.2", path = "../majit-backend-wasm", default-features = false }

--- a/majit/majit-backend-wasm-host/src/lib.rs
+++ b/majit/majit-backend-wasm-host/src/lib.rs
@@ -1,0 +1,239 @@
+//! Native half of the wasm CPU's execution/call transport.
+//!
+//! Corresponds to `llmodel.py AbstractLLCPU`'s code publication, execution
+//! and call boundary. Wasmtime module/table operations are target-specific;
+//! interpreters own their imports, I/O and diagnostics, not this ABI.
+
+use std::collections::BTreeSet;
+
+pub use majit_backend_wasm::codegen::{
+    CALL_ARGS_OFS, CALL_FUNC_OFS, CALL_RESULT_OFS, MAX_CALL_ARGS,
+};
+use wasmtime::error::Context;
+use wasmtime::{
+    Caller, Error, Extern, Func, Instance, Memory, Module, Ref, Result, Table, Val, ValType,
+};
+
+#[derive(Default)]
+pub struct TraceState {
+    pub memory: Option<Memory>,
+    pub table: Option<Table>,
+    pub trace_base: u64,
+    // Published wide entries cannot be dropped by a replacement. Sorted slot
+    // membership is sufficient; there is no language-specific registry here.
+    wide_slots: BTreeSet<u32>,
+}
+
+pub trait HostState {
+    fn traces(&self) -> &TraceState;
+    fn traces_mut(&mut self) -> &mut TraceState;
+}
+
+impl HostState for TraceState {
+    fn traces(&self) -> &TraceState {
+        self
+    }
+    fn traces_mut(&mut self) -> &mut TraceState {
+        self
+    }
+}
+
+pub fn memory<T: HostState>(caller: &Caller<'_, T>) -> Result<Memory> {
+    caller
+        .data()
+        .traces()
+        .memory
+        .context("guest memory not initialized")
+}
+
+pub fn table<T: HostState>(caller: &Caller<'_, T>) -> Result<Table> {
+    caller
+        .data()
+        .traces()
+        .table
+        .context("guest function table not initialized")
+}
+
+/// Instantiate a compiled trace against the guest's memory and table.
+pub fn instantiate<T: HostState + 'static>(
+    caller: &mut Caller<'_, T>,
+    module: &Module,
+    call: fn(&mut Caller<'_, T>, u32, u32) -> Result<()>,
+) -> Result<(Func, Option<Func>, Instance)> {
+    let memory = memory(caller)?;
+    let table = table(caller)?;
+    let jit_call = Func::wrap(
+        &mut *caller,
+        move |mut caller: Caller<'_, T>, frame: i32| {
+            if let Err(error) = call(&mut caller, frame as u32, CALL_RESULT_OFS as u32) {
+                eprintln!("[jit_call] {error:?}");
+            }
+        },
+    );
+    let jit_call_compact = Func::wrap(
+        &mut *caller,
+        move |mut caller: Caller<'_, T>, frame: i32, offset: i32| {
+            if let Err(error) = call(&mut caller, frame as u32, offset as u32) {
+                eprintln!("[jit_call_compact] {error:?}");
+            }
+        },
+    );
+    let mut imports = Vec::new();
+    for import in module.imports() {
+        imports.push(match (import.module(), import.name()) {
+            ("env", "memory") => Extern::Memory(memory),
+            ("env", "__indirect_function_table") => Extern::Table(table),
+            ("env", "jit_call") => Extern::Func(jit_call),
+            ("env", "jit_call_compact") => Extern::Func(jit_call_compact),
+            (m, n) => return Err(Error::msg(format!("unexpected trace import {m}.{n}"))),
+        });
+    }
+    let instance = Instance::new(&mut *caller, module, &imports)?;
+    let trace = instance
+        .get_func(&mut *caller, "trace")
+        .context("trace export missing")?;
+    let wide = instance.get_func(&mut *caller, "trace_wide");
+    Ok((trace, wide, instance))
+}
+
+/// Every trace reserves a pair, including a narrow trace that may become wide.
+pub fn publish<T: HostState>(
+    caller: &mut Caller<'_, T>,
+    trace: Func,
+    wide: Option<Func>,
+) -> Result<u32> {
+    let table = table(caller)?;
+    let slot = u32::try_from(table.grow(&mut *caller, 2, Ref::Func(Some(trace)))?)?;
+    if let Some(wide) = wide {
+        table.set(&mut *caller, slot as u64 + 1, Ref::Func(Some(wide)))?;
+        caller.data_mut().traces_mut().wide_slots.insert(slot);
+    }
+    Ok(slot)
+}
+
+pub fn replace<T: HostState>(
+    caller: &mut Caller<'_, T>,
+    slot: u32,
+    trace: Func,
+    wide: Option<Func>,
+) -> Result<u32> {
+    let table = table(caller)?;
+    live_trace(caller, slot)?;
+    if wide.is_none() && caller.data().traces().wide_slots.contains(&slot) {
+        return Err(Error::msg("replacement would drop a published wide entry"));
+    }
+    // Store keeps an old instance alive while an active guest frame uses it.
+    table.set(&mut *caller, slot as u64, Ref::Func(Some(trace)))?;
+    if let Some(wide) = wide {
+        table.set(&mut *caller, slot as u64 + 1, Ref::Func(Some(wide)))?;
+        caller.data_mut().traces_mut().wide_slots.insert(slot);
+    }
+    Ok(slot)
+}
+
+fn live_trace<T: HostState>(caller: &mut Caller<'_, T>, slot: u32) -> Result<Func> {
+    if (slot as u64) < caller.data().traces().trace_base {
+        return Err(Error::msg(format!(
+            "slot {slot} belongs to the guest, not a trace"
+        )));
+    }
+    match table(caller)?.get(&mut *caller, slot as u64) {
+        Some(Ref::Func(Some(trace))) => Ok(trace),
+        _ => Err(Error::msg(format!("trace {slot} is not live"))),
+    }
+}
+
+pub fn execute<T: HostState>(caller: &mut Caller<'_, T>, slot: u32, frame: u32) -> Result<u32> {
+    let trace = live_trace(caller, slot)?;
+    let mut result = [Val::I32(0)];
+    trace.call(&mut *caller, &[Val::I32(frame as i32)], &mut result)?;
+    match result[0] {
+        Val::I32(value) => Ok(value as u32),
+        _ => Err(Error::msg("trace returned a non-i32 result")),
+    }
+}
+
+pub fn free<T: HostState>(caller: &mut Caller<'_, T>, slot: u32) -> Result<()> {
+    if (slot as u64) < caller.data().traces().trace_base {
+        return Ok(());
+    }
+    let table = table(caller)?;
+    table.set(&mut *caller, slot as u64, Ref::Func(None))?;
+    table.set(&mut *caller, slot as u64 + 1, Ref::Func(None))?;
+    caller.data_mut().traces_mut().wide_slots.remove(&slot);
+    Ok(())
+}
+
+/// Caller records a histogram or a missing-slot diagnostic without owning ABI decoding.
+pub fn residual_call<T: HostState>(
+    caller: &mut Caller<'_, T>,
+    frame: u32,
+    offset: u32,
+    mut observe: impl FnMut(u32, bool),
+) -> Result<()> {
+    let memory = memory(caller)?;
+    let table = table(caller)?;
+    let area = frame as usize + offset as usize;
+    let mut word = [0; 8];
+    let mut slot_bytes = [0; 4];
+    memory.read(
+        &*caller,
+        area + (CALL_FUNC_OFS - CALL_RESULT_OFS) as usize,
+        &mut slot_bytes,
+    )?;
+    let slot = u32::from_le_bytes(slot_bytes);
+    let func = match table.get(&mut *caller, slot as u64) {
+        Some(Ref::Func(Some(func))) if slot != 0 => Some(func),
+        _ => None,
+    };
+    observe(slot, func.is_some());
+    let Some(func) = func else {
+        memory.write(&mut *caller, area, &0_i64.to_le_bytes())?;
+        return Ok(());
+    };
+    let ty = func.ty(&*caller);
+    if ty.params().len() > MAX_CALL_ARGS {
+        return Err(Error::msg("residual argument area overflow"));
+    }
+    let mut args = Vec::with_capacity(ty.params().len());
+    for (i, ty) in ty.params().enumerate() {
+        memory.read(
+            &*caller,
+            area + (CALL_ARGS_OFS - CALL_RESULT_OFS) as usize + i * 8,
+            &mut word,
+        )?;
+        let raw = i64::from_le_bytes(word);
+        args.push(match ty {
+            ValType::I32 => Val::I32(raw as i32),
+            ValType::I64 => Val::I64(raw),
+            ValType::F32 => Val::F32(raw as u32),
+            ValType::F64 => Val::F64(raw as u64),
+            other => return Err(Error::msg(format!("unsupported residual param {other:?}"))),
+        });
+    }
+    let mut results: Vec<Val> = ty
+        .results()
+        .map(|ty| match ty {
+            ValType::I64 => Val::I64(0),
+            ValType::F32 => Val::F32(0),
+            ValType::F64 => Val::F64(0),
+            _ => Val::I32(0),
+        })
+        .collect();
+    // Existing wasm/browser transport contract: report a trap and return zero.
+    let result = match func.call(&mut *caller, &args, &mut results) {
+        Err(error) => {
+            eprintln!("[jit_call] residual target trapped: {error:?}");
+            0
+        }
+        Ok(()) => match results.first() {
+            Some(Val::I32(v)) => (*v as u32) as i64,
+            Some(Val::I64(v)) => *v,
+            Some(Val::F32(v)) => *v as i64,
+            Some(Val::F64(v)) => *v as i64,
+            _ => 0,
+        },
+    };
+    memory.write(&mut *caller, area, &result.to_le_bytes())?;
+    Ok(())
+}

--- a/majit/majit-backend-wasm-host/tests/transport.rs
+++ b/majit/majit-backend-wasm-host/tests/transport.rs
@@ -1,0 +1,103 @@
+use majit_backend_wasm_host::*;
+use wasmtime::{Caller, Engine, Func, Linker, Module, Ref, Store};
+
+fn with_caller(test: fn(&mut Caller<'_, TraceState>)) {
+    let engine = Engine::default();
+    let mut store = Store::new(&engine, TraceState::default());
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap("test", "run", move |mut caller: Caller<'_, TraceState>| {
+            test(&mut caller)
+        })
+        .unwrap();
+    let guest = Module::new(
+        &engine,
+        r#"(module
+        (import "test" "run" (func $run))
+        (memory (export "memory") 1)
+        (table (export "__indirect_function_table") 2 funcref)
+        (func (export "main") call $run))"#,
+    )
+    .unwrap();
+    let instance = linker.instantiate(&mut store, &guest).unwrap();
+    store.data_mut().memory = instance.get_memory(&mut store, "memory");
+    store.data_mut().table = instance.get_table(&mut store, "__indirect_function_table");
+    store.data_mut().trace_base = 2;
+    instance
+        .get_typed_func::<(), ()>(&mut store, "main")
+        .unwrap()
+        .call(&mut store, ())
+        .unwrap();
+}
+
+#[test]
+fn trace_pairs_publish_replace_and_free() {
+    with_caller(|caller| {
+        let module = Module::new(
+            caller.engine(),
+            r#"(module
+            (func (export "trace") (param i32) (result i32) i32.const 7)
+            (func (export "trace_wide") (param i32) (result i32) i32.const 8))"#,
+        )
+        .unwrap();
+        let (trace, wide, _) = instantiate(caller, &module, |_, _, _| Ok(())).unwrap();
+        let slot = publish(caller, trace, wide).unwrap();
+        assert_eq!(slot, 2);
+        assert_eq!(table(caller).unwrap().size(&*caller), 4);
+        assert_eq!(execute(caller, slot, 0).unwrap(), 7);
+        assert!(replace(caller, slot, trace, None).is_err());
+        assert_eq!(execute(caller, slot, 0).unwrap(), 7);
+        assert!(replace(caller, 0, trace, wide).is_err());
+        assert!(execute(caller, 0, 0).is_err());
+        free(caller, slot).unwrap();
+        assert!(execute(caller, slot, 0).is_err());
+        assert!(matches!(
+            table(caller).unwrap().get(&mut *caller, slot as u64 + 1),
+            Some(Ref::Func(None))
+        ));
+    });
+}
+
+#[test]
+fn reflective_call_uses_declared_width_and_zero_extends_result() {
+    with_caller(|caller| {
+        let target = Func::wrap(&mut *caller, |value: i32, wide: i64| -> i32 {
+            assert_eq!(value, -1);
+            assert_eq!(wide, 1_i64 << 40);
+            -2
+        });
+        table(caller)
+            .unwrap()
+            .set(&mut *caller, 1, Ref::Func(Some(target)))
+            .unwrap();
+        let mem = memory(caller).unwrap();
+        let area = CALL_RESULT_OFS as usize;
+        mem.write(&mut *caller, CALL_FUNC_OFS as usize, &1_u32.to_le_bytes())
+            .unwrap();
+        mem.write(
+            &mut *caller,
+            CALL_ARGS_OFS as usize,
+            &(-1_i64).to_le_bytes(),
+        )
+        .unwrap();
+        mem.write(
+            &mut *caller,
+            CALL_ARGS_OFS as usize + 8,
+            &(1_i64 << 40).to_le_bytes(),
+        )
+        .unwrap();
+        residual_call(caller, 0, area as u32, |slot, live| {
+            assert_eq!(slot, 1);
+            assert!(live);
+        })
+        .unwrap();
+        let mut result = [0; 8];
+        mem.read(&*caller, area, &mut result).unwrap();
+        assert_eq!(i64::from_le_bytes(result), 0xffff_fffe);
+        mem.write(&mut *caller, CALL_FUNC_OFS as usize, &0_u32.to_le_bytes())
+            .unwrap();
+        residual_call(caller, 0, area as u32, |_, live| assert!(!live)).unwrap();
+        mem.read(&*caller, area, &mut result).unwrap();
+        assert_eq!(result, [0; 8]);
+    });
+}

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -64,6 +64,14 @@ unsafe impl Send for EmbeddedJitCodeTable {}
 unsafe impl Sync for EmbeddedJitCodeTable {}
 
 impl EmbeddedJitCodeTable {
+    /// Codewriter support functions shared by every embedded interpreter.
+    /// `support.py _ll_2_int_floordiv/_ll_2_int_mod` use truncating word arithmetic.
+    pub fn builtin_fnaddrs() -> [(&'static str, i64); 2] {
+        let div = crate::blackhole::_ll_2_int_floordiv as *const () as usize as i64;
+        let rem = crate::blackhole::_ll_2_int_mod as *const () as usize as i64;
+        [("_ll_2_int_floordiv", div), ("_ll_2_int_mod", rem)]
+    }
+
     /// Restore an embedded image's complete effect-descriptor population.
     ///
     /// `pyjitpl.py::finish_setup_descrs` uses all of GcCache, not merely the
@@ -134,11 +142,13 @@ impl EmbeddedJitCodeTable {
         symbolic_paths: &[(i64, String)],
         runtime_bindings: &[(&str, i64)],
     ) -> &'static Self {
+        let builtins = Self::builtin_fnaddrs();
         let replacements: Vec<(i64, i64)> = symbolic_paths
             .iter()
             .filter_map(|(symbolic, path)| {
                 runtime_bindings
                     .iter()
+                    .chain(builtins.iter())
                     .find(|(binding_path, _)| *binding_path == path)
                     .map(|(_, runtime)| *runtime)
                     .map(|runtime| (*symbolic, runtime))
@@ -493,5 +503,34 @@ mod tests {
         assert_eq!(loaded.fnaddr, runtime);
         assert_eq!(loaded.body().constants_i, vec![runtime, 11]);
         assert!(Arc::ptr_eq(loaded, table.descrs()[0].as_jitcode().unwrap()));
+    }
+
+    #[test]
+    fn support_bindings_are_automatic_but_allow_runtime_override() {
+        for (path, address) in EmbeddedJitCodeTable::builtin_fnaddrs() {
+            for override_address in [None, Some(0x1234_i64)] {
+                let symbolic = -97;
+                let mut code = CanonicalJitCode::new("support");
+                code.fnaddr = symbolic;
+                code.set_index(0);
+                code.set_body(majit_translate::jitcode::JitCodeBody {
+                    constants_i: vec![symbolic],
+                    ..Default::default()
+                });
+                let bindings: Vec<_> = override_address.map(|a| (path, a)).into_iter().collect();
+                let table = EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs(
+                    &[Arc::new(code)],
+                    Vec::new(),
+                    &[(symbolic, path.into())],
+                    &bindings,
+                );
+                let loaded = table.by_index(0).unwrap();
+                assert_eq!(loaded.fnaddr, override_address.unwrap_or(address));
+                assert_eq!(
+                    loaded.body().constants_i,
+                    [override_address.unwrap_or(address)]
+                );
+            }
+        }
     }
 }

--- a/majit/majit-translate/Cargo.toml
+++ b/majit/majit-translate/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Rust port of RPython's translation pipeline (flowspace → annotator → rtyper → translator → jit/codewriter)"
 
 [dependencies]
+bincode = "1.3"
 parking_lot = { workspace = true }
 syn = { workspace = true, features = ["parsing"] }
 quote = { workspace = true }

--- a/majit/majit-translate/src/artifacts.rs
+++ b/majit/majit-translate/src/artifacts.rs
@@ -1,0 +1,196 @@
+//! Build-process transport for `CodeWriter.make_jitcodes` and `Assembler` tables.
+//!
+//! RPython's translator retains these objects in process. Rust build scripts
+//! serialize them for the final binary; consumers supply paths and runtime
+//! symbol bindings, while this module owns the wire format and validation.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::jitcode::{BhDescr, JitCode};
+
+/// Dense allocation order, with a separate graph key for colliding leaf names.
+#[derive(Serialize, Deserialize)]
+pub struct JitCodeIndex {
+    pub names: Vec<String>,
+    pub paths: Vec<String>,
+    pub offsets: Vec<u32>,
+}
+
+impl JitCodeIndex {
+    pub fn encode(
+        jitcodes: &[Arc<JitCode>],
+        paths: Vec<String>,
+    ) -> bincode::Result<(Self, Vec<u8>)> {
+        assert_eq!(paths.len(), jitcodes.len());
+        let mut bodies = Vec::new();
+        let mut index = Self {
+            names: Vec::new(),
+            paths,
+            offsets: vec![0],
+        };
+        for jitcode in jitcodes {
+            index.names.push(jitcode.name.clone());
+            bincode::serialize_into(&mut bodies, jitcode)?;
+            index
+                .offsets
+                .push(u32::try_from(bodies.len()).expect("JitCode archive exceeds u32 offsets"));
+        }
+        Ok((index, bodies))
+    }
+
+    pub fn decode(bytes: &[u8], bodies: &[u8]) -> bincode::Result<Self> {
+        let index: Self = bincode::deserialize(bytes)?;
+        index.validate(bodies)?;
+        Ok(index)
+    }
+
+    fn validate(&self, bodies: &[u8]) -> bincode::Result<()> {
+        if self.paths.len() != self.names.len()
+            || self.offsets.len() != self.names.len() + 1
+            || self.offsets.first().copied() != Some(0)
+            || self.offsets.last().map(|&n| n as usize) != Some(bodies.len())
+            || !self.offsets.windows(2).all(|p| p[0] <= p[1])
+        {
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "invalid JitCode archive index".into(),
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn load(&self, bodies: &[u8], index: usize) -> bincode::Result<Arc<JitCode>> {
+        let start = self.offsets.get(index).copied();
+        let end = index
+            .checked_add(1)
+            .and_then(|i| self.offsets.get(i))
+            .copied();
+        let bytes = start
+            .zip(end)
+            .and_then(|(s, e)| bodies.get(s as usize..e as usize))
+            .ok_or_else(|| {
+                Box::new(bincode::ErrorKind::Custom(
+                    "JitCode index out of bounds".into(),
+                ))
+            })?;
+        bincode::deserialize(bytes)
+    }
+}
+
+/// Encoded bodies remain bytes until requested, so this envelope is Send+Sync
+/// without publishing translation-time graphs across threads.
+#[derive(Serialize, Deserialize)]
+pub struct EmbeddedArtifacts {
+    version: u32,
+    pub index: JitCodeIndex,
+    bodies: Vec<u8>,
+    descrs: Vec<u8>,
+    pub symbolic_fnaddrs: Vec<(i64, String)>,
+    pub liveness: Vec<u8>,
+}
+
+impl EmbeddedArtifacts {
+    pub fn from_pipeline(
+        pipeline: &crate::pipeline::ProgramPipelineResult,
+    ) -> bincode::Result<Self> {
+        let mut paths = vec![String::new(); pipeline.jitcodes.len()];
+        for (path, jitcode) in &pipeline.jitcodes_by_path {
+            paths[jitcode.index()] = path.canonical_key();
+        }
+        let (index, bodies) = JitCodeIndex::encode(&pipeline.jitcodes, paths)?;
+        Ok(Self {
+            version: 1,
+            index,
+            bodies,
+            descrs: bincode::serialize(&pipeline.descrs)?,
+            symbolic_fnaddrs: pipeline.symbolic_fnaddr_paths.clone(),
+            liveness: pipeline.all_liveness.clone(),
+        })
+    }
+
+    pub fn encode(&self) -> bincode::Result<Vec<u8>> {
+        bincode::serialize(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> bincode::Result<Self> {
+        let artifacts: Self = bincode::deserialize(bytes)?;
+        if artifacts.version != 1 {
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "unsupported JitCode artifact version".into(),
+            )));
+        }
+        artifacts.index.validate(&artifacts.bodies)?;
+        Ok(artifacts)
+    }
+
+    pub fn jitcodes(&self) -> bincode::Result<Vec<Arc<JitCode>>> {
+        (0..self.index.names.len())
+            .map(|i| self.index.load(&self.bodies, i))
+            .collect()
+    }
+
+    pub fn descrs(&self) -> bincode::Result<Vec<BhDescr>> {
+        bincode::deserialize(&self.descrs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_format_preserves_existing_tuple_wire_format() {
+        let old = bincode::serialize(&(
+            vec!["same".to_string(); 2],
+            vec!["a::same".to_string(), "b::same".to_string()],
+            vec![0_u32, 1, 2],
+        ))
+        .unwrap();
+        let index = JitCodeIndex::decode(&old, &[0, 0]).unwrap();
+        assert_eq!(index.paths, ["a::same", "b::same"]);
+        assert_eq!(bincode::serialize(&index).unwrap(), old);
+    }
+
+    #[test]
+    fn rejects_corrupt_offsets_and_lengths() {
+        for offsets in [vec![], vec![1_u32, 2], vec![0, 3], vec![0, 2, 1]] {
+            let bytes =
+                bincode::serialize(&(vec!["one".to_string()], vec![String::new()], offsets))
+                    .unwrap();
+            assert!(JitCodeIndex::decode(&bytes, &[0, 0]).is_err());
+        }
+    }
+
+    #[test]
+    fn envelope_roundtrip_preserves_bodies_and_side_tables() {
+        let code = Arc::new(JitCode::new("helper"));
+        code.set_index(0);
+        code.set_body(crate::jitcode::JitCodeBody {
+            constants_i: vec![17, -4],
+            ..Default::default()
+        });
+        let (index, bodies) = JitCodeIndex::encode(&[code], vec!["module::helper".into()]).unwrap();
+        let mut original = EmbeddedArtifacts {
+            version: 1,
+            index,
+            bodies,
+            descrs: bincode::serialize(&Vec::<BhDescr>::new()).unwrap(),
+            symbolic_fnaddrs: vec![(17, "runtime::helper".into())],
+            liveness: vec![1, 2, 3],
+        };
+        let loaded = EmbeddedArtifacts::decode(&original.encode().unwrap()).unwrap();
+        let codes = loaded.jitcodes().unwrap();
+        assert_eq!(codes[0].name, "helper");
+        assert_eq!(codes[0].index(), 0);
+        assert_eq!(codes[0].body().constants_i, [17, -4]);
+        assert_eq!(loaded.index.paths, ["module::helper"]);
+        assert_eq!(loaded.symbolic_fnaddrs, original.symbolic_fnaddrs);
+        assert_eq!(loaded.liveness, original.liveness);
+        assert!(loaded.descrs().unwrap().is_empty());
+        assert!(loaded.index.load(&loaded.bodies, 1).is_err());
+        assert!(loaded.index.load(&loaded.bodies, usize::MAX).is_err());
+        original.version = 2;
+        assert!(EmbeddedArtifacts::decode(&original.encode().unwrap()).is_err());
+    }
+}

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -22,6 +22,7 @@
     )
 )]
 pub mod annotator;
+pub mod artifacts;
 #[cfg_attr(
     test,
     expect(

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -1385,50 +1385,14 @@ fn real_main() {
         // MetaInterpStaticData jitcodes store — same single-store model as
         // RPython warmspot.py `WarmRunnerDesc.__init__` `self.metainterp_sd.jitcodes =
         // codewriter.make_jitcodes()`.
-        let mut jitcodes_bin = Vec::new();
-        let mut jitcode_names = Vec::with_capacity(frozen_jitcodes.len());
-        let mut jitcode_offsets = Vec::with_capacity(frozen_jitcodes.len() + 1);
-        // Graph identity per jitcode, index-aligned with `jitcode_names`.
-        // `CallControl::get_jitcode` keys its map by `CallPath` exactly as
-        // `call.py get_jitcode` keys by graph, but the name it stores beside
-        // it is the path's last segment, chosen to stay readable in dumps.
-        // That display name is not unique — this pipeline has 238 colliding
-        // groups, `from_obj` 52 ways — so a runtime consumer resolving a
-        // descent target by name cannot address the collided bodies at all.
-        // Carrying the allocation key lets it name one unambiguously.
-        let mut jitcode_paths: Vec<String> = Vec::with_capacity(frozen_jitcodes.len());
-        let path_by_ptr: std::collections::HashMap<usize, String> = pipeline
-            .jitcodes_by_path
-            .iter()
-            .map(|(path, jitcode)| {
-                (
-                    std::sync::Arc::as_ptr(jitcode) as usize,
-                    path.canonical_key(),
-                )
-            })
-            .collect();
-        jitcode_offsets.push(0_u32);
-        for (index, jitcode) in frozen_jitcodes.iter().enumerate() {
-            jitcode_names.push(jitcode.name.clone());
-            // `frozen_jitcodes` is a clone-per-entry of `pipeline.jitcodes`
-            // built in place, so the two share an index but not an identity;
-            // key the lookup off the original Arc. A jitcode the codewriter
-            // minted without a graph key (synthetic shells) carries the empty
-            // string, which `compute_pathed_jitcode_index` refuses to match.
-            jitcode_paths.push(
-                path_by_ptr
-                    .get(&(std::sync::Arc::as_ptr(&pipeline.jitcodes[index]) as usize))
-                    .cloned()
-                    .unwrap_or_default(),
-            );
-            jitcodes_bin.extend(bincode::serialize(jitcode).unwrap());
-            jitcode_offsets.push(
-                u32::try_from(jitcodes_bin.len())
-                    .expect("serialized jitcodes.bin exceeds the u32 offset range"),
-            );
+        let mut paths = vec![String::new(); frozen_jitcodes.len()];
+        for (path, jitcode) in &pipeline.jitcodes_by_path {
+            paths[jitcode.index()] = path.canonical_key();
         }
-        let jitcodes_index_bin =
-            bincode::serialize(&(jitcode_names, jitcode_paths, jitcode_offsets)).unwrap();
+        let (index, jitcodes_bin) =
+            majit_translate::artifacts::JitCodeIndex::encode(&frozen_jitcodes, paths)
+                .expect("encode JitCode archive");
+        let jitcodes_index_bin = bincode::serialize(&index).unwrap();
         std::fs::write(format!("{out_dir}/jitcodes.bin"), &jitcodes_bin).unwrap();
         std::fs::write(format!("{out_dir}/jitcodes_index.bin"), &jitcodes_index_bin).unwrap();
         // Keep the shell fnaddr beside each dense index.  A translated PyPy

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -25,14 +25,7 @@ use majit_ir::DescrRef;
 use majit_translate::CompiledJitDriver;
 use majit_translate::jitcode::{BhDescr, DescrTable, JitCode};
 
-struct JitCodeIndex {
-    names: Vec<String>,
-    /// The `CallPath` each jitcode was allocated under, `::`-joined by
-    /// `CallPath::canonical_key`, index-aligned with `names`. Empty for a
-    /// jitcode the codewriter minted without a graph key.
-    paths: Vec<String>,
-    offsets: Vec<u32>,
-}
+use majit_translate::artifacts::JitCodeIndex;
 
 /// Runtime-frozen canonical JitCode.
 ///
@@ -84,36 +77,7 @@ static INDIRECTCALLTARGETS: LazyLock<Box<[Arc<majit_metainterp::jitcode::JitCode
 fn load_jitcode_index() -> JitCodeIndex {
     const INDEX_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes_index.bin"));
     const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes.bin"));
-    let (names, paths, offsets): (Vec<String>, Vec<String>, Vec<u32>) =
-        bincode::deserialize(INDEX_BYTES).unwrap_or_else(|e| {
-            panic!(
-                "pyre-jit-trace: failed to deserialize jitcodes_index.bin \
-                 ({} bytes): {e}",
-                INDEX_BYTES.len(),
-            )
-        });
-    assert_eq!(
-        offsets.len(),
-        names.len() + 1,
-        "pyre-jit-trace: jitcode index has {} names but {} offsets",
-        names.len(),
-        offsets.len(),
-    );
-    assert_eq!(
-        paths.len(),
-        names.len(),
-        "pyre-jit-trace: jitcode index has {} names but {} graph keys",
-        names.len(),
-        paths.len(),
-    );
-    assert_eq!(offsets.first().copied(), Some(0));
-    assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
-    assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
-    JitCodeIndex {
-        names,
-        paths,
-        offsets,
-    }
+    JitCodeIndex::decode(INDEX_BYTES, BODY_BYTES).expect("pyre JitCode index")
 }
 
 fn jitcode_index() -> &'static JitCodeIndex {
@@ -126,15 +90,8 @@ pub fn jitcode_count() -> usize {
 
 fn load_jitcode(index: usize) -> Arc<JitCode> {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes.bin"));
-    let offsets = &jitcode_index().offsets;
-    let start = offsets[index] as usize;
-    let end = offsets[index + 1] as usize;
-    let mut jitcode: Arc<JitCode> = bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
-        panic!(
-            "pyre-jit-trace: failed to deserialize jitcodes.bin entry {index} \
-             ({start}..{end} of {} bytes): {e}",
-            BYTES.len()
-        )
+    let mut jitcode = jitcode_index().load(BYTES, index).unwrap_or_else(|e| {
+        panic!("pyre-jit-trace: failed to deserialize jitcodes.bin entry {index}: {e}")
     });
     // RPython's translator AOT-compiles every helper into the same binary so
     // `JitCode.fnaddr` / `constants_i` funcptrs are linker-resolved.  Pyre's

--- a/pyre/pyre-wasm-runner/Cargo.toml
+++ b/pyre/pyre-wasm-runner/Cargo.toml
@@ -10,6 +10,7 @@ name = "pyre-wasm-runner"
 path = "src/main.rs"
 
 [dependencies]
+majit-backend-wasm-host = { workspace = true }
 parking_lot = { workspace = true }
 # wasmtime vendors its own error type (`wasmtime::Error`) and re-exports a
 # `Context` trait, so the runner needs no separate `anyhow` dependency.

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -8,7 +8,7 @@
 //!     `majit_host.{jit_compile_wasm, jit_execute_wasm, jit_free_wasm}` and
 //!     exports `memory`, `__indirect_function_table`, `pyre_alloc`,
 //!     `pyre_dealloc`, and `pyre_run_python`;
-//!   * each JIT-emitted trace module imports `env.memory` (shared with the
+//!   * each JIT-emitted trace module imports `env.jit.memory` (shared with the
 //!     main module) plus an optional `env.jit_call` trampoline, and exports a
 //!     `trace` function `(i32) -> i32`;
 //!   * the trampoline reads func_ptr / args from the frame call area, dispatches
@@ -27,15 +27,15 @@ use std::path::{Path, PathBuf};
 
 use wasmtime::error::Context;
 use wasmtime::{
-    AsContext, AsContextMut, Caller, Config, Engine, Error, Extern, Func, Instance, Linker, Memory,
-    Module, OptLevel, Ref, Result, Store, Table, Val, ValType,
+    AsContext, Caller, Config, Engine, Error, Func, Instance, Linker, Memory, Module, OptLevel,
+    Result, Store, Table,
 };
 
 use crate::host_path::{guest_path_to_host, host_path_to_guest};
 
 // Frame call-area offsets — must match `majit-backend-wasm/src/codegen.rs`.
 // Shared with `wasmi_host`, which mirrors the same call-area protocol.
-pub(crate) const CALL_RESULT_OFS: usize = 2000;
+pub(crate) const CALL_RESULT_OFS: usize = majit_backend_wasm_host::CALL_RESULT_OFS as usize;
 // The arg count also lives at offset 2016, but the trampoline derives arity
 // (and the exact value types) from the resolved function's wasm signature
 // instead, which is authoritative on wasm32. Kept for layout documentation.
@@ -68,21 +68,7 @@ impl WasmEngine {
 /// Per-store host state shared by all import callbacks.
 #[derive(Default)]
 struct Host {
-    /// The main module's exported linear memory, shared with every trace.
-    memory: Option<Memory>,
-    /// The main module's `__indirect_function_table`, used by the trampoline.
-    table: Option<Table>,
-    /// First `__indirect_function_table` slot that is a JIT trace. The main
-    /// module's table is pre-populated with its own functions (`[0,
-    /// trace_base)`); `jit_compile` only ever appends (`table.grow`), so every
-    /// slot `>= trace_base` is a trace. That, plus the table itself (a freed
-    /// trace's slot is reset to `Func(None)`), is the sole record of trace
-    /// liveness — no id→trace map is kept, since the slot IS the id and the
-    /// table is the single source of truth: `jit_execute` accepts an `id >=
-    /// trace_base` whose slot is still a function, and `jit_free` clears only
-    /// such slots (nulling a runtime slot would corrupt dispatch). The table
-    /// also roots each trace's instance for the `Store`'s lifetime.
-    trace_base: u64,
+    jit: majit_backend_wasm_host::TraceState,
     /// Real stdlib root the wasm module's `pyre_host.*` imports read source
     /// from (`$PYRE_STDLIB`, forwarded by `pyre/check.py`). The wasm side
     /// seeds it on `sys.path`, so the host serves genuine absolute paths.
@@ -142,13 +128,15 @@ struct Host {
     /// Epoch samples whose innermost frame was anywhere else — the interpreter
     /// itself, and any sample taken with no wasm frame on the stack.
     trace_samples_elsewhere: u64,
-    /// Trace slots whose compile exported a `trace_wide`, and whose `slot + 1`
-    /// is therefore a published call target. The reserved spare slot holds the
-    /// narrow function when a compile had no wide entry, so the table alone
-    /// cannot tell the two apart; a replacement that would drop the wide entry
-    /// is rejected against this set rather than leaving `slot + 1` pointing at
-    /// the replaced compile.
-    wide_slots: std::collections::HashSet<u32>,
+}
+
+impl majit_backend_wasm_host::HostState for Host {
+    fn traces(&self) -> &majit_backend_wasm_host::TraceState {
+        &self.jit
+    }
+    fn traces_mut(&mut self) -> &mut majit_backend_wasm_host::TraceState {
+        &mut self.jit
+    }
 }
 
 /// Report `PYRE_*` / `MAJIT_*` settings the guest cannot see.
@@ -467,9 +455,9 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
     // return, i.e. the first JIT-trace id; everything below it is a main-module
     // function that must never be dispatched as, or freed like, a trace.
     let trace_base = table.size(&store);
-    store.data_mut().memory = Some(memory);
-    store.data_mut().table = Some(table);
-    store.data_mut().trace_base = trace_base;
+    store.data_mut().jit.memory = Some(memory);
+    store.data_mut().jit.table = Some(table);
+    store.data_mut().jit.trace_base = trace_base;
 
     let alloc = instance.get_typed_func::<u32, u32>(&mut store, "pyre_alloc")?;
     let run_python = instance.get_typed_func::<(u32, u32), u64>(&mut store, "pyre_run_python")?;
@@ -1881,23 +1869,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
         "majit_host",
         "jit_free_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32| {
-            // Only a trace slot may be cleared; nulling a main-module slot
-            // (`id < trace_base`) would corrupt the shared dispatch table.
-            if (func_id as u64) >= caller.data().trace_base {
-                // Release the table's hold on the trace function; the slots
-                // themselves stay (wasm tables cannot shrink).  `jit_compile`
-                // appends the entry as a pair, so `func_id + 1` holds this
-                // same trace — the wide entry where one was published, the
-                // spare copy of the narrow function otherwise.  Clearing only
-                // the first half leaves the freed trace reachable through
-                // `call_indirect func_id + 1` and rooted for the store's
-                // lifetime, so both halves and the wide record go together.
-                caller.data_mut().wide_slots.remove(&func_id);
-                if let Some(table) = caller.data().table {
-                    let _ = table.set(&mut caller, func_id as u64, Ref::Func(None));
-                    let _ = table.set(&mut caller, func_id as u64 + 1, Ref::Func(None));
-                }
-            }
+            let _ = majit_backend_wasm_host::free(&mut caller, func_id);
         },
     )?;
 
@@ -2011,7 +1983,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
 /// wasm32-unknown-unknown has no OS entropy of its own, so `os.urandom`,
 /// `secrets` and the string hash key all end up here.
 fn host_random(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i32 {
-    let Some(memory) = caller.data().memory else {
+    let Some(memory) = caller.data().jit.memory else {
         return -1;
     };
     let mut bytes = vec![0u8; buf_cap as usize];
@@ -2027,7 +1999,7 @@ fn host_random(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i32
 /// `pyre_host.host_cwd`: write the runner's working directory into the guest
 /// buffer, reporting its length whether or not it fitted.
 fn host_cwd(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
-    let Some(memory) = caller.data().memory else {
+    let Some(memory) = caller.data().jit.memory else {
         return -1;
     };
     let Ok(cwd) = std::env::current_dir() else {
@@ -2088,7 +2060,7 @@ fn host_path(
     path_ptr: u32,
     path_len: u32,
 ) -> Option<std::ffi::OsString> {
-    let memory = caller.data().memory?;
+    let memory = caller.data().jit.memory?;
     let mut bytes = vec![0u8; path_len as usize];
     memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
     guest_path_to_host(bytes)
@@ -2106,7 +2078,7 @@ fn host_stdlib_root(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -
         // Report the needed length without writing; the caller can retry.
         return bytes.len() as i64;
     }
-    let Some(memory) = caller.data().memory else {
+    let Some(memory) = caller.data().jit.memory else {
         return -1;
     };
     if memory
@@ -2134,7 +2106,7 @@ fn host_read(
         Err(_) => return -1,
     };
     let n = data.len().min(buf_cap as usize);
-    let Some(memory) = caller.data().memory else {
+    let Some(memory) = caller.data().jit.memory else {
         return -1;
     };
     if memory
@@ -2183,7 +2155,7 @@ fn host_list_dir(
     if packed.len() > buf_cap as usize {
         return packed.len() as i64;
     }
-    let Some(memory) = caller.data().memory else {
+    let Some(memory) = caller.data().jit.memory else {
         return -1;
     };
     if memory
@@ -2206,9 +2178,14 @@ fn jit_compile_trace(
     caller.data_mut().jit_compile_count += 1;
     let memory = caller
         .data()
+        .jit
         .memory
         .context("main memory not initialized")?;
-    let table = caller.data().table.context("main table not initialized")?;
+    let table = caller
+        .data()
+        .jit
+        .table
+        .context("main table not initialized")?;
 
     let mut bytes = vec![0u8; bytes_len as usize];
     memory
@@ -2249,49 +2226,10 @@ fn jit_compile_trace(
         }
     };
 
-    // A fresh trampoline per trace; it reads all state from `caller.data()`.
-    let jit_call = Func::wrap(
-        &mut *caller,
-        |mut inner: Caller<'_, Host>, frame_ptr: i32| {
-            if let Err(e) = jit_call_trampoline(
-                &mut inner,
-                frame_ptr as u32,
-                CALL_RESULT_OFS as u32,
-                "trace",
-            ) {
-                eprintln!("[jit_call] {e:?}");
-            }
-        },
-    );
-    let jit_call_compact = Func::wrap(
-        &mut *caller,
-        |mut inner: Caller<'_, Host>, frame_ptr: i32, call_area_ofs: i32| {
-            if let Err(e) =
-                jit_call_trampoline(&mut inner, frame_ptr as u32, call_area_ofs as u32, "trace")
-            {
-                eprintln!("[jit_call_compact] {e:?}");
-            }
-        },
-    );
-
-    // Supply imports in the module's declared order.
-    let mut externs: Vec<Extern> = Vec::new();
-    for import in module.imports() {
-        match (import.module(), import.name()) {
-            ("env", "memory") => externs.push(Extern::Memory(memory)),
-            ("env", "jit_call") => externs.push(Extern::Func(jit_call)),
-            ("env", "jit_call_compact") => externs.push(Extern::Func(jit_call_compact)),
-            ("env", "__indirect_function_table") => externs.push(Extern::Table(table)),
-            (m, n) => {
-                return Err(Error::msg(format!(
-                    "trace module has unexpected import {m}.{n}"
-                )));
-            }
-        }
-    }
-
-    let instance =
-        Instance::new(&mut *caller, &module, &externs).context("instantiate trace module")?;
+    let (trace, trace_wide, instance) =
+        majit_backend_wasm_host::instantiate(caller, &module, |caller, frame, offset| {
+            jit_call_trampoline(caller, frame, offset, "trace")
+        })?;
     if std::env::var_os("PYRE_WASM_DUMP_ALL_TRACES").is_some() {
         let trace_id = instance
             .get_global(&mut *caller, "trace_entry_census_id")
@@ -2306,39 +2244,16 @@ fn jit_compile_trace(
             Err(pe) => eprintln!("[jit_compile_wasm] wat print failed: {pe}"),
         }
     }
-    let trace = instance
-        .get_func(&mut *caller, "trace")
-        .context("trace module is missing its `trace` export")?;
-    let trace_wide = instance.get_func(&mut *caller, "trace_wide");
-
     Ok((table, trace, trace_wide, module))
 }
-
 /// Compile and instantiate a trace, then append its export to the trace table.
 fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) -> Result<u32> {
-    let (table, trace, trace_wide, module) =
+    let (_table, trace, trace_wide, module) =
         jit_compile_trace(caller, bytes_ptr, bytes_len, "compile")?;
-    // Register the trace into the shared indirect function table so it is
-    // reachable by table index. `grow` returns the newly appended slot.
-    //
-    // The pair is appended even for a narrow module. An emitted module names
-    // its wide entry `handle + 1`, and `jit_replace` may install a wide entry
-    // where this compile had none; without the reservation that write would
-    // land on the next trace's own entry. The spare slot holds the narrow
-    // function, which nothing calls: absence is encoded as `wide_slot == 0`.
-    let slot = table
-        .grow(&mut *caller, 2, Ref::Func(Some(trace)))
-        .context("register trace into shared table")? as u32;
-    if let Some(wide) = trace_wide {
-        table
-            .set(&mut *caller, slot as u64 + 1, Ref::Func(Some(wide)))
-            .context("register wide trace entry into shared table")?;
-        caller.data_mut().wide_slots.insert(slot);
-    }
+    let slot = majit_backend_wasm_host::publish(caller, trace, trace_wide)?;
     record_trace_module(caller, module, slot);
     Ok(slot)
 }
-
 /// Name a freshly installed trace module by its table slot, so an epoch sample
 /// taken inside it can say which trace it was in. Only the profiling mode keeps
 /// the list; every other run leaves it empty and pays nothing.
@@ -2358,76 +2273,22 @@ fn jit_replace(
     bytes_ptr: u32,
     bytes_len: u32,
 ) -> Result<u32> {
-    if (func_id as u64) < caller.data().trace_base {
-        return Err(Error::msg(format!(
-            "jit_replace_wasm: id {func_id} is not a trace slot"
-        )));
+    if (func_id as u64) < caller.data().jit.trace_base {
+        return Err(Error::msg("cannot replace a guest function"));
     }
-    let (table, trace, trace_wide, module) =
+    let (_table, trace, trace_wide, module) =
         jit_compile_trace(caller, bytes_ptr, bytes_len, "replace")?;
-    if !matches!(
-        table.get(&mut *caller, func_id as u64),
-        Some(Ref::Func(Some(_)))
-    ) {
-        return Err(Error::msg(format!(
-            "jit_replace_wasm: id {func_id} is not a live trace"
-        )));
-    }
-    // Modules emitted while this slot was wide carry `call_indirect func_id +
-    // 1` baked in. A narrow replacement cannot retract those, so accepting one
-    // would leave the pair straddling two compiles: `func_id` on the new trace
-    // and `func_id + 1` still on the old. Reject the shape change before
-    // either table is touched; a narrow-to-wide replacement stays allowed.
-    if trace_wide.is_none() && caller.data().wide_slots.contains(&func_id) {
-        return Err(Error::msg(format!(
-            "jit_replace_wasm: id {func_id} has a published wide entry the replacement does not"
-        )));
-    }
-    // The Store retains every instantiated module. Replacing this table entry
-    // therefore leaves an old trace live when a non-tail indirect call still
-    // has one of its frames on the guest stack.
-    table
-        .set(&mut *caller, func_id as u64, Ref::Func(Some(trace)))
-        .context("replace trace in shared table")?;
-    if let Some(wide) = trace_wide {
-        table
-            .set(&mut *caller, func_id as u64 + 1, Ref::Func(Some(wide)))
-            .context("replace wide trace entry in shared table")?;
-        caller.data_mut().wide_slots.insert(func_id);
-    }
-    record_trace_module(caller, module, func_id);
-    Ok(func_id)
+    let slot = majit_backend_wasm_host::replace(caller, func_id, trace, trace_wide)?;
+    record_trace_module(caller, module, slot);
+    Ok(slot)
 }
-
 /// Run a previously compiled trace, returning its guard-exit index.
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
     caller.data_mut().jit_execute_count += 1;
-    if (func_id as u64) < caller.data().trace_base {
-        return Err(Error::msg(format!(
-            "jit_execute_wasm: id {func_id} is not a trace slot"
-        )));
-    }
-    let table = caller.data().table.context("main table not initialized")?;
-    // The id IS the table slot; dispatch through the shared table by index —
-    // the same lookup an in-module `call_indirect` would perform. A freed trace
-    // (slot reset to `Func(None)`) or out-of-range id misses here.
-    let trace = match table.get(&mut *caller, func_id as u64) {
-        Some(Ref::Func(Some(f))) => f,
-        _ => {
-            return Err(Error::msg(format!(
-                "jit_execute_wasm: id {func_id} is not a live trace (unknown or freed)"
-            )));
-        }
-    };
-    let mut results = [Val::I32(0)];
-    trace.call(&mut *caller, &[Val::I32(frame_ptr as i32)], &mut results)?;
-    let ret = match results[0] {
-        Val::I32(x) => x as u32,
-        _ => 0,
-    };
+    let ret = majit_backend_wasm_host::execute(caller, func_id, frame_ptr)?;
     // Diagnostic: record which (trace, guard-exit fail_index) round-tripped.
     if std::env::var_os("PYRE_WASM_EXEC_TRACE").is_some()
-        && let Some(mem) = caller.data().memory
+        && let Some(mem) = caller.data().jit.memory
     {
         let fail_index = read_u32(&mem, &*caller, frame_ptr as usize);
         *caller
@@ -2438,7 +2299,6 @@ fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> R
     }
     Ok(ret)
 }
-
 /// Name a call-area FUNC field that indexes no live function, once per value.
 ///
 /// The zero sentinel above is the only slot that legitimately has no function
@@ -2628,82 +2488,19 @@ fn jit_call_trampoline_inner(
     source: &'static str,
 ) -> Result<()> {
     caller.data_mut().jit_call_count += 1;
-    let memory = caller.data().memory.context("memory")?;
-    let table = caller.data().table.context("table")?;
-    let call_area = frame_ptr as usize + call_area_ofs as usize;
-
-    let func_ptr = read_u32(&memory, &*caller, call_area + 8);
-    if probe_call_hist_enabled() {
-        let mut g = PROBE_CALL_HIST.lock();
-        *g.get_or_insert_with(Default::default)
-            .entry((source, func_ptr))
-            .or_insert(0) += 1;
-    }
-
-    // `func_ptr == 0` is the "newstr" sentinel; without a host string
-    // allocator (matching the browser glue's null table slot) it yields 0.
-    if func_ptr == 0 {
-        write_i64(&memory, &mut *caller, call_area, 0)?;
-        return Ok(());
-    }
-
-    let func = match table.get(&mut *caller, func_ptr as u64) {
-        Some(Ref::Func(Some(f))) => f,
-        _ => {
-            report_dead_call_slot(func_ptr);
-            write_i64(&memory, &mut *caller, call_area, 0)?;
-            return Ok(());
+    majit_backend_wasm_host::residual_call(caller, frame_ptr, call_area_ofs, |slot, live| {
+        if probe_call_hist_enabled() {
+            *PROBE_CALL_HIST
+                .lock()
+                .get_or_insert_with(Default::default)
+                .entry((source, slot))
+                .or_insert(0) += 1;
         }
-    };
-
-    let ty = func.ty(&*caller);
-    let params: Vec<ValType> = ty.params().collect();
-    let mut args: Vec<Val> = Vec::with_capacity(params.len());
-    for (i, pty) in params.iter().enumerate() {
-        let raw = read_i64(&memory, &*caller, call_area + 24 + i * 8);
-        args.push(match pty {
-            ValType::I32 => Val::I32(raw as i32),
-            ValType::I64 => Val::I64(raw),
-            // Floats cross the call area as their raw bit pattern in an i64 slot.
-            ValType::F32 => Val::F32(raw as u32),
-            ValType::F64 => Val::F64(raw as u64),
-            other => {
-                return Err(Error::msg(format!(
-                    "unsupported residual-call param type {other:?}"
-                )));
-            }
-        });
-    }
-
-    let mut results: Vec<Val> = ty
-        .results()
-        .map(|t| match t {
-            ValType::I64 => Val::I64(0),
-            ValType::F32 => Val::F32(0),
-            ValType::F64 => Val::F64(0),
-            _ => Val::I32(0),
-        })
-        .collect();
-
-    // Mirror the browser glue's try/catch: a trapping residual target is
-    // reported as a zero result rather than aborting the whole run.
-    if let Err(e) = func.call(&mut *caller, &args, &mut results) {
-        eprintln!("[jit_call] residual target trapped: {e:?}");
-        write_i64(&memory, &mut *caller, call_area, 0)?;
-        return Ok(());
-    }
-
-    let result = match results.first() {
-        Some(Val::I32(x)) => (*x as u32) as i64, // zero-extend; high word stays 0
-        Some(Val::I64(x)) => *x,
-        Some(Val::F64(x)) => *x as i64,
-        Some(Val::F32(x)) => (*x as u64) as i64,
-        _ => 0,
-    };
-    write_i64(&memory, &mut *caller, call_area, result)?;
-    Ok(())
+        if !live && slot != 0 {
+            report_dead_call_slot(slot);
+        }
+    })
 }
-
 /// Drain the guest's fd-2 buffer through `pyre_take_stderr`.
 ///
 /// The guest has no descriptors, so everything it writes to fd 2 accumulates in
@@ -2771,17 +2568,6 @@ fn read_u32(mem: &Memory, store: impl AsContext, off: usize) -> u32 {
     let mut b = [0u8; 4];
     let _ = mem.read(store, off, &mut b);
     u32::from_le_bytes(b)
-}
-
-fn read_i64(mem: &Memory, store: impl AsContext, off: usize) -> i64 {
-    let mut b = [0u8; 8];
-    let _ = mem.read(store, off, &mut b);
-    i64::from_le_bytes(b)
-}
-
-fn write_i64(mem: &Memory, mut store: impl AsContextMut, off: usize, v: i64) -> Result<()> {
-    mem.write(&mut store, off, &v.to_le_bytes())
-        .context("write call-area result")
 }
 
 /// Dump the module's imports and exports, for debugging the host contract.


### PR DESCRIPTION
Add `majit-translate::artifacts` for the JitCode archive index and
`EmbeddedArtifacts` envelope. `pyre-jit-trace` encodes and loads that
format instead of a local tuple serializer.

Add `majit-backend-wasm-host` for Wasmtime instantiate, publish,
replace, execute, free, and residual-call. `pyre-wasm-runner` keeps
language I/O and delegates the trace transport.

`EmbeddedJitCodeTable` binds `_ll_2_int_floordiv` and `_ll_2_int_mod`
unless the consumer overrides them.

Verified locally: `python3 pyre/check.py` — dynasm 548/548, cranelift 548/548, wasm 541/541.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native WebAssembly trace hosting, including trace publication, replacement, execution, freeing, indirect calls, and residual-call handling.
  * Added portable serialization and loading for JIT artifacts, with validation and version checks.
  * Added automatic resolution for built-in integer division and modulo support functions, with runtime overrides.

* **Bug Fixes**
  * Improved handling of invalid or unavailable trace targets, traps, argument widths, and result values.

* **Refactor**
  * Centralized WebAssembly trace management for more consistent behavior across the runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->