### PR TITLE
gc: guard reservation credit and port immobility helper

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6309,9 +6309,12 @@ impl MiniMarkGC {
             // another bare `_minor_collection()` before the next major step;
             // repeating only the major step lets a high-survival nursery keep
             // growing faster than marking observes it.
-            let threshold = self.threshold_bytes_made_old.saturating_sub(extrasize);
-            if self.bytes_made_old_since_cycle <= threshold {
-                break;
+            let mut threshold = self.threshold_bytes_made_old;
+            if threshold >= extrasize {
+                threshold -= extrasize;
+                if self.bytes_made_old_since_cycle <= threshold {
+                    break;
+                }
             }
             self.minor_collection_body();
         }
@@ -12911,6 +12914,44 @@ mod tests {
         assert!(gc.minor_collections > minors_before);
         gc.pending_reserving_size = 0;
         gc.roots.clear();
+    }
+
+    #[test]
+    fn reserving_more_than_credit_requires_progress_even_without_promotions() {
+        // `IncrementalMiniMarkGC.minor_collection_with_major_progress` only
+        // tests target A2 after `threshold >= extrasize`. Saturating the
+        // subtraction would let zero promoted bytes satisfy a negative budget.
+        for (extrasize, extra_minors) in [(0, 0), (512, 0), (513, 1), (1024, 1), (1025, 2)] {
+            let word = std::mem::size_of::<GcRef>();
+            let mut gc = test_gc(1024);
+            let tid = gc.register_type(TypeInfo::with_gc_ptrs(word, vec![0]));
+            let mut root = GcRef::NULL;
+            for _ in 0..8 {
+                let object = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + word);
+                unsafe { *(object.0 as *mut GcRef) = root };
+                root = object;
+            }
+            unsafe { gc.roots.add(&mut root) };
+            gc.set_mark_budget(1);
+            gc.start_incremental_cycle();
+            gc.bytes_made_old_since_cycle = 0;
+            gc.threshold_bytes_made_old = 0;
+            gc.pending_reserving_size = extrasize;
+            let minors_before = gc.minor_collections;
+
+            gc.run_major_progress_after_minor();
+
+            assert_eq!(gc.gc_state, GcState::Marking);
+            assert_eq!(gc.bytes_made_old_since_cycle, 0);
+            assert_eq!(
+                gc.minor_collections - minors_before,
+                extra_minors,
+                "reservation {extrasize} must fit the credit even without promotions"
+            );
+            assert!(gc.threshold_bytes_made_old >= extrasize);
+            gc.pending_reserving_size = 0;
+            gc.roots.clear();
+        }
     }
 
     #[test]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -2175,6 +2175,49 @@ pub fn is_pinned(gcref: GcRef) -> bool {
     ACTIVE_IS_PINNED.get().is_some_and(|f| f(gcref))
 }
 
+/// `rpython/rlib/rgc.py` `_make_sure_does_not_move`: force collections until
+/// a non-null object is permanently non-moving, or decline a pinned object.
+///
+/// `p` is the caller's local GC reference. Its root is reread after each
+/// collection and copied back on return, including when unwinding.
+/// The owner-root slot supplies the live-variable save/reload that upstream's
+/// framework GC transform inserts around `collect(i)`. Other live references
+/// in the caller still need their own roots, as for any collecting operation.
+/// The error is upstream's `NotImplementedError` for a collector that cannot
+/// make the object non-moving after trying generations -1 through 6.
+pub fn _make_sure_does_not_move(p: &mut GcRef) -> Result<bool, &'static str> {
+    assert!(!p.is_null());
+    if is_pinned(*p) {
+        // A pin can be released at any time; it is not permanent immobility.
+        return Ok(false);
+    }
+    // `BaseFrameworkGCTransformer.gct_gc__collect` saves/reloads livevars
+    // across the collecting call. A native Rust unwind must reload too: the
+    // collector can have moved the object before reporting a failure.
+    struct ReloadRoot<'a> {
+        saved: shadow_stack::OwnerRootGuard,
+        local: &'a mut GcRef,
+    }
+    impl Drop for ReloadRoot<'_> {
+        fn drop(&mut self) {
+            *self.local = self.saved.get();
+        }
+    }
+    let root = ReloadRoot {
+        saved: shadow_stack::OwnerRootGuard::new(*p),
+        local: p,
+    };
+    let mut i = -1;
+    while can_move(root.saved.get()) {
+        if i > 6 {
+            return Err("can't make object non-movable!");
+        }
+        collect_generation(i);
+        i += 1;
+    }
+    Ok(true)
+}
+
 /// x86/assembler.py:1971-1974 codegen-time bounds lookup shim used by
 /// the interpretive `GuardSubclass`. Returns
 /// `(subclassrange_min, subclassrange_max)` for the class whose vtable

--- a/majit/majit-gc/tests/make_sure_does_not_move.rs
+++ b/majit/majit-gc/tests/make_sure_does_not_move.rs
@@ -1,0 +1,135 @@
+//! `rpython/rlib/rgc.py` `_make_sure_does_not_move` through the public hooks.
+//! A separate integration-test process isolates the active-collector hooks.
+
+use majit_gc::{
+    _make_sure_does_not_move, ActiveGcGuardHooks, GcAllocator, TypeInfo, collector::MiniMarkGC,
+    gc_sync, set_active_collect_generation, set_active_gc_guard_hooks, shadow_stack,
+};
+use majit_ir::GcRef;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static GENERATIONS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+static STOP_AT: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+fn record_collection(generation: i64) {
+    GENERATIONS.lock().unwrap().push(generation);
+    // A moving collector rewrites roots, not the caller's unregistered copy.
+    shadow_stack::walk_roots(|p| p.0 += 16);
+}
+
+fn can_still_move(p: GcRef) -> bool {
+    p.0 < STOP_AT.load(Ordering::Relaxed)
+}
+
+fn root_count() -> usize {
+    let mut count = 0;
+    shadow_stack::walk_roots(|_| count += 1);
+    count
+}
+
+#[test]
+fn rgc_make_sure_does_not_move_preserves_the_collection_and_root_contract() {
+    let mut null = GcRef::NULL;
+    assert!(std::panic::catch_unwind(move || _make_sure_does_not_move(&mut null)).is_err());
+
+    // No active collector is non-moving, matching can_move's public fallback.
+    let mut stable = GcRef(0x1000);
+    assert_eq!(_make_sure_does_not_move(&mut stable), Ok(true));
+    assert_eq!(stable, GcRef(0x1000));
+    assert_eq!(root_count(), 0);
+
+    set_active_collect_generation(Some(record_collection));
+    set_active_gc_guard_hooks(ActiveGcGuardHooks {
+        can_move: Some(can_still_move),
+        is_pinned: Some(|_| true),
+        ..Default::default()
+    });
+    assert_eq!(_make_sure_does_not_move(&mut stable), Ok(false));
+    assert!(GENERATIONS.lock().unwrap().is_empty());
+    assert_eq!(root_count(), 0);
+
+    set_active_gc_guard_hooks(ActiveGcGuardHooks {
+        can_move: Some(can_still_move),
+        ..Default::default()
+    });
+    STOP_AT.store(0x1030, Ordering::Relaxed);
+    assert_eq!(_make_sure_does_not_move(&mut stable), Ok(true));
+    assert_eq!(stable, GcRef(0x1030));
+    assert_eq!(*GENERATIONS.lock().unwrap(), [-1, 0, 1]);
+    assert_eq!(root_count(), 0);
+
+    // A collector that always moves tries exactly -1..=6 before failing.
+    GENERATIONS.lock().unwrap().clear();
+    STOP_AT.store(usize::MAX, Ordering::Relaxed);
+    assert_eq!(
+        _make_sure_does_not_move(&mut stable),
+        Err("can't make object non-movable!")
+    );
+    assert_eq!(*GENERATIONS.lock().unwrap(), [-1, 0, 1, 2, 3, 4, 5, 6]);
+    assert_eq!(stable, GcRef(0x10b0));
+    assert_eq!(root_count(), 0);
+
+    set_active_collect_generation(Some(|generation| {
+        record_collection(generation);
+        panic!("collection failed after moving the object");
+    }));
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            _make_sure_does_not_move(&mut stable)
+        }))
+        .is_err()
+    );
+    assert_eq!(
+        stable,
+        GcRef(0x10c0),
+        "unwinding must reload the moved value"
+    );
+    assert_eq!(root_count(), 0, "unwinding must release the live root");
+
+    // Exercise real promotion, not only mocked movement: the value is live
+    // solely through the helper's root while the bare minor evacuates it.
+    let mut gc = MiniMarkGC::new();
+    let tid = gc.register_type(TypeInfo::simple(16));
+    gc_sync::store_singleton(Box::new(gc));
+    shadow_stack::register_mutator();
+    gc_sync::register_thread();
+    set_active_gc_guard_hooks(ActiveGcGuardHooks {
+        can_move: Some(|p| gc_sync::gc_op(|gc| gc.can_move(p))),
+        is_pinned: Some(|p| gc_sync::gc_op(|gc| gc.is_pinned(p))),
+        ..Default::default()
+    });
+    set_active_collect_generation(Some(|generation| {
+        gc_sync::gc_op(|gc| gc.collect_generation(generation));
+    }));
+    let mut p = gc_sync::gc_op(|gc| gc.alloc_with_type(tid, 16));
+    unsafe { *(p.0 as *mut usize) = 0xabcdef };
+    let original = p;
+    let before = gc_sync::gc_op(|gc| gc.collection_counts());
+    assert_eq!(_make_sure_does_not_move(&mut p), Ok(true));
+    assert_ne!(p, original);
+    assert!(!majit_gc::can_move(p));
+    assert_eq!(unsafe { *(p.0 as *const usize) }, 0xabcdef);
+    let after = gc_sync::gc_op(|gc| gc.collection_counts());
+    assert_eq!(after.0, before.0 + 1);
+    assert_eq!(after.1, before.1, "generation -1 must not run a major");
+    assert_eq!(_make_sure_does_not_move(&mut p), Ok(true));
+    assert_eq!(gc_sync::gc_op(|gc| gc.collection_counts()), after);
+    assert_eq!(root_count(), 0);
+
+    let mut pinned = gc_sync::gc_op(|gc| gc.alloc_with_type(tid, 16));
+    assert!(gc_sync::gc_op(|gc| gc.pin(pinned)));
+    let pinned_addr = pinned;
+    assert_eq!(_make_sure_does_not_move(&mut pinned), Ok(false));
+    assert_eq!(pinned, pinned_addr);
+    assert_eq!(gc_sync::gc_op(|gc| gc.collection_counts()), after);
+    gc_sync::gc_op(|gc| gc.unpin(pinned));
+    assert_eq!(_make_sure_does_not_move(&mut pinned), Ok(true));
+    assert_ne!(pinned, pinned_addr);
+    assert_eq!(root_count(), 0);
+
+    set_active_collect_generation(None);
+    set_active_gc_guard_hooks(ActiveGcGuardHooks::default());
+    shadow_stack::unregister_mutator();
+    gc_sync::unregister_thread();
+}


### PR DESCRIPTION
## Summary

- Incremental major progress no longer treats a reservation larger than the remaining credit as already satisfied when nothing was promoted.
- Ports `rgc._make_sure_does_not_move`: collect until the object is permanently non-moving, decline a pin, and reload the caller local after each collection (including on unwind).

## Test plan

- [x] `cargo test -p majit-gc --lib reserving_more_than_credit -- --test-threads=1`
- [x] `cargo test -p majit-gc --test make_sure_does_not_move -- --test-threads=1`