### PR TITLE
jit-trace: pin super receiver class through the heapcache

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10482,6 +10482,59 @@ fn walker_numeric_builtin_class(obj: pyre_object::PyObjectRef) -> pyre_object::P
     }
 }
 
+/// Whether `op` is already the constant `expected`.
+///
+/// A freshly recorded GETFIELD carries the live class as its concrete
+/// snapshot (`field_sanity_load`), so `box_value` matching is not a proof
+/// — that is exactly the case that still needs `GUARD_VALUE`.  After
+/// `implement_guard_value` the heapcache must serve the *constant* box
+/// (`is_constant()`), and only then is a second pin a tautology.
+fn walker_ref_box_is<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    op: OpRef,
+    expected: pyre_object::PyObjectRef,
+) -> bool {
+    op.is_constant()
+        && matches!(
+            ctx.trace_ctx.box_value(op),
+            Some(majit_ir::Value::Ref(r)) if r.0 == expected as usize
+        )
+}
+
+/// Read `obj.w_class` through the heapcache and pin it to `expected_typeobj`.
+///
+/// `pyjitpl.py` `_opimpl_getfield_gc_any_pureornot` records the load once
+/// (`upd.getfield_now_known`), then `implement_guard_value` makes that box
+/// the constant.  A later reader of the same field must reuse the cached
+/// box and emit no second GETFIELD / GUARD_VALUE.  The uncached
+/// `GETFIELD_GC_R` spelling used to skip that cache, so
+/// `walker_emit_super_proxy` and `walker_emit_super_attr_lookup_guards`
+/// each recorded the same receiver-class proof — the name-bound
+/// `s = super(C, self); s.val` spelling paid it twice per iteration.
+fn walker_pin_instance_w_class<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    expected_typeobj: pyre_object::PyObjectRef,
+) -> Result<OpRef, DispatchError> {
+    let descr = crate::descr::w_class_descr();
+    let field_index = descr.index();
+    let actual = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, descr);
+    let expected = ctx.trace_ctx.const_ref(expected_typeobj as i64);
+    if walker_ref_box_is(ctx, actual, expected_typeobj) {
+        return Ok(expected);
+    }
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[actual, expected])?;
+    // `pyjitpl.py` `MIFrame.implement_guard_value`'s second half: the guard
+    // has proved the read equals the constant, so later GETFIELDs of this
+    // slot must return that constant, not the GETFIELD box whose concrete
+    // snapshot merely happened to match at record time.
+    ctx.trace_ctx.heap_cache_mut().replace_box(actual, expected);
+    ctx.trace_ctx
+        .heapcache_getfield_now_known(obj, field_index, expected);
+    Ok(expected)
+}
+
 /// Walker-native mirror of the trait `trace_guard_exact_w_class`
 /// (`trace_opcode.rs`): emit `getfield_gc_r(w_class)` →
 /// `guard_value(expected)` so the spec_ii fast path only stays live for an
@@ -10523,14 +10576,7 @@ fn walker_guard_exact_w_class<Sym: WalkSym>(
         }),
         "guard_exact_w_class at pc={op_pc} would pin a `w_class` its recorded operand does not carry",
     );
-    let actual =
-        crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, crate::descr::w_class_descr());
-    let expected = ctx.trace_ctx.const_ref(expected_typeobj as i64);
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[actual, expected])?;
-    // `pyjitpl.py` `MIFrame.implement_guard_value`'s second half: the guard
-    // has proved the read equals the constant, so the heapcache serves the
-    // constant to every later reader of the same box.
-    ctx.trace_ctx.heap_cache_mut().replace_box(actual, expected);
+    walker_pin_instance_w_class(ctx, op_pc, obj, expected_typeobj)?;
     Ok(())
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5538,7 +5538,7 @@ fn walker_emit_apparent_super_attr_result<Sym: WalkSym>(
     binding: SuperAttrBinding,
 ) -> Result<OpRef, DispatchError> {
     let cls_const = ctx.trace_ctx.const_ref(concrete_cls as i64);
-    if !cls.is_constant() {
+    if !walker_ref_box_is(ctx, cls, concrete_cls) {
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[cls, cls_const])?;
         ctx.trace_ctx.heap_cache_mut().replace_box(cls, cls_const);
     }
@@ -5571,8 +5571,10 @@ pub(crate) fn walker_emit_super_attr_lookup_guards<Sym: WalkSym>(
     class_mode: bool,
 ) -> Result<OpRef, DispatchError> {
     // The class the walk starts after is baked into the emitted body.
+    // A virtual proxy's `super_type` field is already that constant; a
+    // second GUARD_VALUE of the GETFIELD box is a tautology.
     let cls_const = ctx.trace_ctx.const_ref(concrete_cls as i64);
-    if !cls.is_constant() {
+    if !walker_ref_box_is(ctx, cls, concrete_cls) {
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[cls, cls_const])?;
         ctx.trace_ctx.heap_cache_mut().replace_box(cls, cls_const);
     }
@@ -5621,20 +5623,12 @@ pub(crate) fn walker_emit_super_attr_lookup_guards<Sym: WalkSym>(
         // anything else -- there this guard is what proves the class the walk
         // used.  A proxy proves that from its own `w_objtype` field instead,
         // and its receiver's class may be unrelated.
-        let self_class_const = ctx
-            .trace_ctx
-            .const_ref(unsafe { (*concrete_self).w_class } as i64);
-        let w_class_op =
-            walker_record_getfield_gc_r_uncached(ctx, self_obj, crate::descr::w_class_descr());
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op_pc,
-            OpCode::GuardValue,
-            &[w_class_op, self_class_const],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(w_class_op, self_class_const);
+        //
+        // The cached pin: `two_arg_super_call` / `bare_super_virtual` already
+        // ran this on the same receiver when they emitted the virtual proxy,
+        // and a second uncached GETFIELD + GUARD_VALUE was the extra name-bound
+        // cost.  `walker_pin_instance_w_class` reuses the heapcache box.
+        walker_pin_instance_w_class(ctx, op_pc, self_obj, unsafe { (*concrete_self).w_class })?;
     }
 
     // typeobject.py `promote(self.version_tag())`.  Every class the suffix
@@ -5788,7 +5782,11 @@ pub(crate) fn walker_guard_and_read_super_proxy<Sym: WalkSym>(
         crate::descr::super_obj_type_descr(),
         concrete_objtype,
     );
-    if !objtype_op.is_constant() {
+    // A virtual proxy answers this field from its own SetfieldGc cache as
+    // the constant `emit_super_proxy` stored.  A second GUARD_VALUE of that
+    // word is a tautology; `walker_ref_box_is` sees the forwarded constant
+    // even when the opref itself is still the GETFIELD box.
+    if !walker_ref_box_is(ctx, objtype_op, concrete_objtype) {
         let objtype_const = ctx.trace_ctx.const_ref(concrete_objtype as i64);
         walker_emit_fold_guard_with_snapshot(
             ctx,
@@ -5991,7 +5989,7 @@ fn walker_emit_super_proxy<Sym: WalkSym>(
     class_mode: bool,
 ) -> Result<OpRef, DispatchError> {
     let cls_const = ctx.trace_ctx.const_ref(concrete_cls as i64);
-    if !cls_op.is_constant() {
+    if !walker_ref_box_is(ctx, cls_op, concrete_cls) {
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[cls_op, cls_const])?;
         ctx.trace_ctx
             .heap_cache_mut()
@@ -6033,17 +6031,10 @@ fn walker_emit_super_proxy<Sym: WalkSym>(
         // `_super_check`'s answer is baked, so pin the receiver's exact Python
         // class.  An exception instance carrying the generic stub may resolve
         // its class through the kind registry instead and was declined above.
-        let w_class_op =
-            walker_record_getfield_gc_r_uncached(ctx, obj_op, crate::descr::w_class_descr());
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op_pc,
-            OpCode::GuardValue,
-            &[w_class_op, objtype_const],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(w_class_op, objtype_const);
+        // Cached: the following `load_attr_on_super` lookup re-reads this
+        // slot, and an uncached GETFIELD made that a second per-iteration
+        // GUARD_VALUE of the same word.
+        walker_pin_instance_w_class(ctx, op_pc, obj_op, objtype)?;
     }
     // A `__bases__` reassignment anywhere in the selected class's ancestry
     // bumps this tag and can make `issubtype_w(objtype, cls)` stop holding.
@@ -6074,7 +6065,7 @@ fn walker_emit_apparent_super_proxy<Sym: WalkSym>(
     apparent: ApparentSuperClass,
 ) -> Result<OpRef, DispatchError> {
     let cls_const = ctx.trace_ctx.const_ref(concrete_cls as i64);
-    if !cls_op.is_constant() {
+    if !walker_ref_box_is(ctx, cls_op, concrete_cls) {
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[cls_op, cls_const])?;
         ctx.trace_ctx
             .heap_cache_mut()


### PR DESCRIPTION
## Summary

`two_arg_super_call` / `bare_super_virtual` and the following `load_attr_on_super` each recorded an uncached `GETFIELD_GC_R` + `GUARD_VALUE` of the same receiver `w_class`. That is the extra cost of `s = super(C, self); s.val` versus fused `LOAD_SUPER_ATTR`.

`walker_pin_instance_w_class` now reads through `opimpl_getfield_gc_r` (heapcache) and, after the first guard, stores the constant so the second pin is a tautology and is skipped. A freshly recorded GETFIELD still guards: a matching `box_value` is only the record-time snapshot, not a proof.

Local dynasm `pyre/check.py --synthetic-only --synthetic-pattern '*super*'`: 9/9 PASS. Name-bound ratios on this host: `name_bound_super_attr` 1.4x, `zero_arg_name_bound_super_attr` 1.3x, `super_attr_inlined_callee` 1.4x (CI ubuntu dynasm on #1689 was 1.6 / 1.7 / 1.8x).

`ForceToken`, `ec.w_tracefunc`, and the eval-breaker are unchanged: folds already run before the token publish, the tracefunc guard already heapcache-collapses, and the breaker matches `jump_absolute`.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved JIT tracing for superclass specialization by reusing cached class information and avoiding redundant runtime guards.
  * Streamlined field handling during specialization, reducing duplicate cache updates and guard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->