### PR TITLE
blackhole: restore code[position-1] return setup

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -922,12 +922,18 @@ impl BlackholeInterpreter {
     }
 
     /// Set a reference register value.
+    ///
+    /// Same constant-table bound as [`Self::setarg_i`]: a write at or past
+    /// `num_regs_r` replaces a jitcode constant the instruction stream still
+    /// reads as one.
     pub fn setarg_r(&mut self, index: usize, value: i64) {
+        debug_assert_constant_slot_untouched(index, self.jitcode.num_regs_r(), "setarg_r");
         self.registers_r[index] = value;
     }
 
     /// Set a float register value.
     pub fn setarg_f(&mut self, index: usize, value: i64) {
+        debug_assert_constant_slot_untouched(index, self.jitcode.num_regs_f(), "setarg_f");
         self.registers_f[index] = value;
     }
 
@@ -1020,68 +1026,14 @@ impl BlackholeInterpreter {
 
     /// Result register of the call this frame is resuming after.
     ///
-    /// `_setup_return_value_*` connects a returning callee's value to the
-    /// caller's `xxx_call_yyy` result register, read as `code[position-1]`
-    /// (the byte right before the resume position).  The portal codewriter
-    /// emits a per-push valuestackdepth sync (`setfield_vable_i` of the
-    /// valuestackdepth field) immediately after a call result push, so in
-    /// portal jitcode that 5-byte sync lands between the call's result
-    /// register byte and the next opcode's `-live-` resume anchor that
-    /// `position` points at.  When such a sync precedes the anchor, step
-    /// back over it to reach the result register; otherwise `position-1`
-    /// holds it directly.
-    ///
-    /// `BC_INLINE_CALL` is the one caller shape that does NOT end in a single
-    /// result register: `JitCodeBuilder::inline_call_typed` closes every
-    /// variant with three typed return slots.  Resolve that instruction with
-    /// [`JitCode::inline_call_ending_at`] rather than guessing from a sentinel
-    /// byte: the parser checks the opcode start, payload width and recorded
-    /// result type, so an unrelated operand byte cannot be mistaken for a
-    /// return layout.
-    fn call_result_reg(&self, kind: BhReturnType) -> usize {
-        // setfield_vable_i: op + struct_reg + value_reg + descr(2 bytes).
-        const VSD_SYNC_LEN: usize = 5;
-        // valuestackdepth static-field index (codewriter
-        // VABLE_VALUESTACKDEPTH_FIELD_IDX).
-        const VSD_FIELD_IDX: usize = 2;
-        let code = &self.jitcode.code;
-        let pos = self.position;
-
-        let inline_result = |end_pc: usize| {
-            self.jitcode.inline_call_ending_at(end_pc).map(|site| {
-                let slot = match kind {
-                    BhReturnType::Int => site.return_i,
-                    BhReturnType::Ref => site.return_r,
-                    BhReturnType::Float => site.return_f,
-                    BhReturnType::Void => None,
-                };
-                slot.unwrap_or_else(|| {
-                    panic!(
-                        "call_result_reg: inline call ending at {end_pc} has no {kind:?} result slot"
-                    )
-                })
-            })
-        };
-
-        if let Some(slot) = inline_result(pos) {
-            return slot;
-        }
-
-        if pos > VSD_SYNC_LEN
-            && self
-                .jitcode
-                .startpoints
-                .as_ref()
-                .is_some_and(|starts| starts.contains(&(pos - VSD_SYNC_LEN)))
-            && code[pos - VSD_SYNC_LEN] == majit_translate::insns::BC_SETFIELD_VABLE_I
-            && let Some(descr_idx) = self.peek_u16_at(pos - 2)
-            && let Some(BhDescr::VableField { index }) = self.runtime_bh_descr(descr_idx as usize)
-            && *index == VSD_FIELD_IDX
-        {
-            let call_end = pos - VSD_SYNC_LEN;
-            return inline_result(call_end).unwrap_or(code[call_end - 1] as usize);
-        }
-        code[pos - 1] as usize
+    /// `blackhole.py _setup_return_value_*` reads `code[position-1]`, the
+    /// result operand of the `xxx_call_yyy` that the resume `-live-`
+    /// follows.  Flatten emits that `-live-` immediately after every
+    /// `inline_call` and every can-raise `residual_call`
+    /// (`jtransform.py handle_regular_call` / `handle_residual_call`),
+    /// and `inline_call_typed` closes on the destination byte.
+    fn call_result_reg(&self, _kind: BhReturnType) -> usize {
+        self.jitcode.code[self.position - 1] as usize
     }
 
     /// blackhole.py _setup_return_value_i
@@ -2506,10 +2458,9 @@ impl BlackholeInterpBuilder {
     ///     self.op_rvmprof_code = insns.get('rvmprof_code/ii', -1)
     /// ```
     ///
-    /// Builds the reverse opcode table and dispatch function table from the
-    /// assembler's `insns` dict. For now, all dispatch table entries are
-    /// placeholder handlers — real `bhimpl_*` methods are wired in
-    /// incrementally as Phase D progresses.
+    /// Builds the reverse opcode table and a same-sized dispatch table of
+    /// placeholders. [`wire_bhimpl_handlers`] then binds each key to its
+    /// handler, the two-phase split of RPython `setup_insns` + `_get_method`.
     pub fn setup_insns(&mut self, insns: &indexmap::IndexMap<String, u8>) {
         assert!(insns.len() <= 256, "too many instructions!");
         // RPython blackhole.py:68-71: build reverse table.
@@ -4277,17 +4228,8 @@ mod tests {
             let _ = convert_and_run_from_pyjitpl(&mut builder, &framestack, 0, false, None, None);
         }
 
-        /// `_setup_return_value_i` must read `BC_INLINE_CALL`'s `return_i` slot,
-        /// not the byte before the resume position.
-        ///
-        /// `JitCodeBuilder::inline_call_typed` closes every inline call with
-        /// three return slots (`return_i`, `return_r`, `return_f`), so a call
-        /// whose result is an int leaves `NO_RETURN_REG` in the last two.
-        /// Reading `code[position - 1]` — RPython's single-slot
-        /// `blackhole.py:1655` convention — picks up that sentinel and indexes
-        /// `registers_i` out of bounds.  Observed as an index-out-of-bounds
-        /// panic when a tracing-abort blackhole chain returned an int into the
-        /// dispatch jitcode that had inlined it.
+        /// `_setup_return_value_i` reads `code[position-1]`, the single
+        /// result register `inline_call_typed` now closes on.
         #[test]
         fn setup_return_value_i_reads_inline_calls_int_return_slot() {
             let mut b = JitCodeBuilder::default();
@@ -4298,8 +4240,8 @@ mod tests {
             let resume_pos = jitcode.code.len();
             assert_eq!(
                 jitcode.code[resume_pos - 1],
-                crate::jitcode::NO_RETURN_REG,
-                "inline call should end on the unused return_f slot",
+                7,
+                "inline call must end on the int result register",
             );
 
             let mut builder = build_test_bh_builder();
@@ -4466,6 +4408,38 @@ mod tests {
             let _ = bh.run();
 
             assert_eq!(bh.registers_i[2], 42);
+        }
+
+        #[test]
+        #[should_panic(expected = "setarg_r: register index")]
+        fn setarg_r_refuses_constant_table_slot() {
+            let mut b = JitCodeBuilder::default();
+            b.load_const_r_value(0, 0);
+            b.add_const_r(0x11);
+            b.ref_return(0);
+            let jitcode = b.finish();
+
+            let mut builder = build_test_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.setposition(std::sync::Arc::new(jitcode), 0);
+            assert_eq!(bh.jitcode.num_regs_r(), 1);
+            bh.setarg_r(1, 0x22);
+        }
+
+        #[test]
+        #[should_panic(expected = "setarg_f: register index")]
+        fn setarg_f_refuses_constant_table_slot() {
+            let mut b = JitCodeBuilder::default();
+            b.load_const_f_value(0, 0);
+            b.add_const_f(0);
+            b.float_return(0);
+            let jitcode = b.finish();
+
+            let mut builder = build_test_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.setposition(std::sync::Arc::new(jitcode), 0);
+            assert_eq!(bh.jitcode.num_regs_f(), 1);
+            bh.setarg_f(1, 0);
         }
 
         #[test]
@@ -11506,9 +11480,8 @@ bhhandler_self_v_r!(handler_last_exc_value, bhimpl_last_exc_value);
 ///     else:
 ///         return target  # mismatch → jump
 /// ```
-/// Uses `cpu.bh_classof` to get the exception's typeptr and compares
-/// against the bounding class vtable. For now uses pointer equality
-/// (correct for exact match; subclass check needs rclass infrastructure).
+/// Uses `cpu.bh_classof` for the exception typeptr and
+/// `cpu.bh_issubclass` for `rclass.ll_issubclass`.
 fn handler_goto_if_exception_mismatch(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -13060,11 +13033,13 @@ fn handler_record_known_result_ref_ext(
 ///
 /// This handler is the pyre nested-bytecode `inline_call` adapter under
 /// the `(bh, code, position) -> Result<usize, _>` signature.  Operand
-/// payload (pyre-only):
+/// payload:
 ///   `sub_idx: u16`, `num_args: u16`,
 ///   `num_args × (kind: u8, caller_src: u8, callee_dst: u8)`,
-///   `return_i: u8`, `return_r: u8`, `return_f: u8`
-/// `NO_RETURN_REG` in any return slot encodes "no caller destination".
+///   `dest: u8`
+/// The last byte is the single result register, matching
+/// `blackhole.py _setup_return_value_*`'s `code[position-1]`.
+/// `NO_RETURN_REG` encodes a void call.
 ///
 /// Registered via the pyre-only opname `inline_call_nested_ext/P`
 /// in `extension_insns()`.  Canonical `inline_call_{r,ir,irf}_*`
@@ -13150,9 +13125,7 @@ fn handler_inline_call_nested_ext(
         }
     }
 
-    let return_i = decode_return_slot_at(code, &mut p);
-    let return_r = decode_return_slot_at(code, &mut p);
-    let return_f = decode_return_slot_at(code, &mut p);
+    let dest = decode_return_slot_at(code, &mut p);
 
     // RPython `bhimpl_inline_call_*` calls `cpu.bh_call_*(jitcode.fnaddr,
     // ...)` directly, so any `JitException` (`ContinueRunningNormally`,
@@ -13220,38 +13193,28 @@ fn handler_inline_call_nested_ext(
 
         let Some((return_kind, callee_src)) = callee.jitcode.trailing_return_info() else {
             // No trailing return opcode means the callee produced no value.
-            // The caller's three slots are all `NO_RETURN_REG` in that case —
-            // `inline_call_typed` emits a real register only for the kind the
-            // callee returns — so a slot that IS a register here names a
-            // destination nothing will write, and the caller goes on to read
-            // whatever the previous occupant of that register left.  Upstream
-            // cannot reach the state: `bhimpl_inline_call_*` gets its value
-            // from `cpu.bh_call_*`, whose result kind is the calldescr's.
+            // The caller emitted `NO_RETURN_REG` as the single dest byte
+            // (`inline_call_*_v`).  A real dest here names a register
+            // nothing will write.
             assert!(
-                return_i.is_none() && return_r.is_none() && return_f.is_none(),
+                dest.is_none(),
                 "inline_call: callee jitcode {:?} index {:?} ends without a \
-                 typed return opcode, but the caller declared result slots \
-                 (i={return_i:?} r={return_r:?} f={return_f:?})",
+                 typed return opcode, but the caller declared dest {dest:?}",
                 callee.jitcode.name,
                 callee.jitcode.try_index(),
             );
             break 'callee Ok(p);
         };
         {
+            let caller_dst = dest.expect("inline return missing caller destination");
             match return_kind {
                 JitArgKind::Int => {
-                    let caller_dst =
-                        return_i.expect("inline int return missing caller destination");
                     bh.registers_i[caller_dst] = callee.registers_i[callee_src as usize];
                 }
                 JitArgKind::Ref => {
-                    let caller_dst =
-                        return_r.expect("inline ref return missing caller destination");
                     bh.registers_r[caller_dst] = callee.registers_r[callee_src as usize];
                 }
                 JitArgKind::Float => {
-                    let caller_dst =
-                        return_f.expect("inline float return missing caller destination");
                     bh.registers_f[caller_dst] = callee.registers_f[callee_src as usize];
                 }
             }
@@ -13338,9 +13301,7 @@ fn inline_call_native(
     args_r.truncate(len_r);
     args_f.truncate(len_f);
 
-    let return_i = decode_return_slot_at(code, &mut p);
-    let return_r = decode_return_slot_at(code, &mut p);
-    let return_f = decode_return_slot_at(code, &mut p);
+    let dest = decode_return_slot_at(code, &mut p);
 
     // A raise inside the callee reaches this side through the cell, exactly as
     // it does for a residual call and for the canonical `inline_call_*`
@@ -13363,7 +13324,7 @@ fn inline_call_native(
             let result = bh.bhimpl_inline_call_irf_i(fnaddr, &args_i, &args_r, &args_f, calldescr);
             let outcome = check_residual_call_exception_after(bh, p);
             if outcome.is_ok() {
-                if let Some(dst) = return_i {
+                if let Some(dst) = dest {
                     bh.registers_i[dst] = result;
                 }
             }
@@ -13373,7 +13334,7 @@ fn inline_call_native(
             let result = bh.bhimpl_inline_call_irf_r(fnaddr, &args_i, &args_r, &args_f, calldescr);
             let outcome = check_residual_call_exception_after(bh, p);
             if outcome.is_ok() {
-                if let Some(dst) = return_r {
+                if let Some(dst) = dest {
                     bh.registers_r[dst] = result.0 as i64;
                 }
             }
@@ -13383,7 +13344,7 @@ fn inline_call_native(
             let result = bh.bhimpl_inline_call_irf_f(fnaddr, &args_i, &args_r, &args_f, calldescr);
             let outcome = check_residual_call_exception_after(bh, p);
             if outcome.is_ok() {
-                if let Some(dst) = return_f {
+                if let Some(dst) = dest {
                     bh.registers_f[dst] = result.to_bits() as i64;
                 }
             }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3794,22 +3794,26 @@ impl JitCodeBuilder {
             self.push_reg_u8(caller_src, "inline_call caller argument");
             self.push_reg_u8(callee_dst, "inline_call callee argument");
         }
-        self.push_return_slot(return_i);
-        self.push_return_slot(return_r);
-        self.push_return_slot(return_f);
-        // RPython `assembler.py:217-219` — record the result kind at
-        // end-of-instruction position.  Inline-call's typed result
-        // (consumed by `MIFrame::make_result_of_lastop` at the caller
-        // frame after the callee's `finishframe_*_return`,
-        // `pyjitpl.rs`) is determined by which
-        // `return_{i,r,f}` slot the helper received.  At most one is
-        // `Some` for a typed variant; all `None` for the void
-        // variant (no record).
+        // One result register as the last operand, the same shape
+        // `rewrite_call` gives `inline_call_*_* >i/>r/>f`.  Void emits
+        // `NO_RETURN_REG` so `_setup_return_value_*` is never asked to
+        // read it; a typed call's last byte is the destination
+        // `blackhole.py _setup_return_value_*` recovers as
+        // `code[position-1]`.
         match (return_i, return_r, return_f) {
-            (Some(_), None, None) => self.record_resulttype('i'),
-            (None, Some(_), None) => self.record_resulttype('r'),
-            (None, None, Some(_)) => self.record_resulttype('f'),
-            (None, None, None) => {} // _v variant — no result
+            (Some(dst), None, None) => {
+                self.push_return_slot(Some(dst));
+                self.record_resulttype('i');
+            }
+            (None, Some(dst), None) => {
+                self.push_return_slot(Some(dst));
+                self.record_resulttype('r');
+            }
+            (None, None, Some(dst)) => {
+                self.push_return_slot(Some(dst));
+                self.record_resulttype('f');
+            }
+            (None, None, None) => self.push_return_slot(None),
             slots => {
                 panic!("inline_call_typed: at most one return slot may be Some, got {slots:?}")
             }
@@ -6922,7 +6926,7 @@ mod tests {
                     "return slot for {args_r:?} args, bank {bank:?}",
                 );
                 // The width formula the search solves for.
-                assert_eq!(end - start, 8 + 3 * args_r.len(), "encoded width");
+                assert_eq!(end - start, 6 + 3 * args_r.len(), "encoded width");
                 // A position one byte off is not the far side of this call,
                 // and answering there would be a wrong frame rebuild rather
                 // than a decline.

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -903,14 +903,15 @@ impl JitCode {
     ///
     /// The instruction cannot be decoded backwards, so it is decoded forwards
     /// from the only start position that can produce it.  Its width is
-    /// `1 + 2 + 2 + 3 * num_args + 3` — opcode, sub-JitCode index, argument
+    /// `1 + 2 + 2 + 3 * num_args + 1` — opcode, sub-JitCode index, argument
     /// count, one `(kind, caller_src, callee_dst)` triple per argument, then
-    /// the three optional return slots — so each candidate `num_args` names
-    /// exactly one start, and that start is the real one only when the opcode
-    /// byte is there AND the count it encodes is the count that was assumed.
-    /// A position satisfying both while still ending at `end_pc` has decoded
-    /// itself; requiring the match to be unique is what turns a coincidence
-    /// into a decline rather than into a wrong answer.
+    /// the single result-register byte (`NO_RETURN_REG` when the call is
+    /// void).  Each candidate `num_args` names exactly one start, and that
+    /// start is the real one only when the opcode byte is there AND the
+    /// count it encodes is the count that was assumed.  A position
+    /// satisfying both while still ending at `end_pc` has decoded itself;
+    /// requiring the match to be unique is what turns a coincidence into a
+    /// decline rather than into a wrong answer.
     ///
     /// `None` means `end_pc` is not the far side of a `BC_INLINE_CALL` in this
     /// jitcode — including when it is one of the typed `BC_INLINE_CALL_*`
@@ -936,25 +937,48 @@ impl JitCode {
                 continue;
             }
             cursor += 3 * num_args;
-            let return_slot = |cursor: &mut usize| match read_reg(code, cursor) {
+            let dest = match read_reg(code, &mut cursor) {
                 NO_RETURN_REG => None,
                 reg => Some(reg as usize),
-            };
-            let site = InlineCallSite {
-                sub_idx,
-                return_i: return_slot(&mut cursor),
-                return_r: return_slot(&mut cursor),
-                return_f: return_slot(&mut cursor),
             };
             debug_assert_eq!(
                 cursor, end_pc,
                 "the inline-call width formula disagrees with the decode",
             );
-            // `inline_call_typed` refuses to emit more than one filled slot,
-            // so a decode holding two has not landed on a real instruction.
-            if site.filled_return_slots() > 1 {
-                continue;
-            }
+            // The last operand is the single result register;
+            // `_resulttypes[end_pc]` says which bank, the same witness
+            // `make_result_of_lastop` reads.
+            let kind = body
+                .resulttypes
+                .as_ref()
+                .and_then(|types| types.get(&end_pc).copied());
+            let site = match (kind, dest) {
+                (Some('i'), dest) => InlineCallSite {
+                    sub_idx,
+                    return_i: dest,
+                    return_r: None,
+                    return_f: None,
+                },
+                (Some('r'), dest) => InlineCallSite {
+                    sub_idx,
+                    return_i: None,
+                    return_r: dest,
+                    return_f: None,
+                },
+                (Some('f'), dest) => InlineCallSite {
+                    sub_idx,
+                    return_i: None,
+                    return_r: None,
+                    return_f: dest,
+                },
+                (None, None) => InlineCallSite {
+                    sub_idx,
+                    return_i: None,
+                    return_r: None,
+                    return_f: None,
+                },
+                _ => continue,
+            };
             if found.replace(site).is_some() {
                 // Two start positions both decode into an instruction ending
                 // here, so the bytes do not name one call.
@@ -962,6 +986,7 @@ impl JitCode {
             }
         }
         let site = found?;
+        debug_assert!(site.filled_return_slots() <= 1);
         // `pyjitpl.py make_result_of_lastop`'s own check, in its own place:
         //
         //     assert typeof[self.jitcode._resulttypes[self.pc]] == got_type
@@ -969,7 +994,12 @@ impl JitCode {
         // The writer records the kind at end-of-instruction position
         // (`record_resulttype`, `assembler.py`), which makes it an independent
         // witness of which return slot this call filled.
-        if body.resulttypes.as_ref()?.get(&end_pc).copied() != site.recorded_resulttype() {
+        if body
+            .resulttypes
+            .as_ref()
+            .and_then(|types| types.get(&end_pc).copied())
+            != site.recorded_resulttype()
+        {
             return None;
         }
         Some(site)
@@ -977,10 +1007,10 @@ impl JitCode {
 }
 
 /// The encoded width of a `BC_INLINE_CALL` that passes no arguments: the
-/// opcode byte, the `u16` sub-JitCode index, the `u16` argument count, and the
-/// three return-slot register bytes.  Each argument adds a
+/// opcode byte, the `u16` sub-JitCode index, the `u16` argument count, and
+/// the single result-register byte.  Each argument adds a
 /// `(kind, caller_src, callee_dst)` triple of one byte each.
-const INLINE_CALL_FIXED_WIDTH: usize = 1 + 2 + 2 + 3;
+const INLINE_CALL_FIXED_WIDTH: usize = 1 + 2 + 2 + 1;
 
 /// The operands of one `BC_INLINE_CALL`, as [`JitCode::inline_call_ending_at`]
 /// recovers them from the instruction's far side.
@@ -1001,7 +1031,7 @@ impl InlineCallSite {
     /// The caller-side result register and the bank it lands in.
     ///
     /// `None` for a call whose result is discarded, which is the `_v` shape:
-    /// all three slots hold [`NO_RETURN_REG`].
+    /// the dest operand is [`NO_RETURN_REG`].
     pub fn result_slot(&self) -> Option<(JitArgKind, usize)> {
         match (self.return_i, self.return_r, self.return_f) {
             (Some(dst), None, None) => Some((JitArgKind::Int, dst)),
@@ -1011,7 +1041,7 @@ impl InlineCallSite {
         }
     }
 
-    /// How many of the three return slots name a register.  A real
+    /// How many of the typed return banks name a register.  A real
     /// `BC_INLINE_CALL` has at most one.
     fn filled_return_slots(&self) -> usize {
         [self.return_i, self.return_r, self.return_f]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7147,42 +7147,30 @@ where
                         let callee_dst = frame.next_reg() as usize;
                         arg_triples.push((kind, caller_src, callee_dst));
                     }
-                    let decode_return_slot = |f: &mut MIFrame| {
-                        let dst = f.next_reg() as usize;
+                    let dest = {
+                        let dst = frame.next_reg() as usize;
                         if dst == crate::jitcode::NO_RETURN_REG as usize {
                             None
                         } else {
                             Some(dst)
                         }
                     };
-                    let return_i = decode_return_slot(frame);
-                    let return_r = decode_return_slot(frame);
-                    let return_f = decode_return_slot(frame);
-                    let mut result_slots = 0usize;
-                    let mut result_argcode = b'v';
-                    let mut result_arg_index = None;
-                    if let Some(dst) = return_i {
-                        result_slots += 1;
-                        result_argcode = b'i';
-                        result_arg_index = Some(dst);
-                    }
-                    if let Some(dst) = return_r {
-                        result_slots += 1;
-                        result_argcode = b'r';
-                        result_arg_index = Some(dst);
-                    }
-                    if let Some(dst) = return_f {
-                        result_slots += 1;
-                        result_argcode = b'f';
-                        result_arg_index = Some(dst);
-                    }
-                    assert!(
-                        result_slots <= 1,
-                        "BC_INLINE_CALL encodes more than one return slot; RPython call snapshots support one result"
-                    );
-                    frame._result_argcode = result_argcode;
-                    frame.result_arg_index = result_arg_index;
                     frame.pc = frame.code_cursor;
+                    let resulttype = frame
+                        .jitcode
+                        .core()
+                        .body()
+                        .resulttypes
+                        .as_ref()
+                        .and_then(|types| types.get(&frame.pc).copied());
+                    let (return_i, return_r, return_f, result_argcode) = match resulttype {
+                        Some('i') => (dest, None, None, b'i'),
+                        Some('r') => (None, dest, None, b'r'),
+                        Some('f') => (None, None, dest, b'f'),
+                        _ => (None, None, None, b'v'),
+                    };
+                    frame._result_argcode = result_argcode;
+                    frame.result_arg_index = dest;
                     (sub_idx, arg_triples, return_i, return_r, return_f)
                 };
                 let pc = self.frames.current_mut().pc;
@@ -10314,9 +10302,9 @@ where
 /// suffix and the callee's terminator are ONE decision taken once, from the
 /// callee's own result type.
 ///
-/// Pyre encodes the three destinations explicitly (`NO_RETURN_REG` sentinel,
-/// decoded at the `BC_INLINE_CALL`) instead of re-reading the caller's operand
-/// at return time, which is what makes the disagreement representable here.
+/// Pyre records the destination as the last operand of `BC_INLINE_CALL`
+/// (`NO_RETURN_REG` for void) and recovers its kind from `_resulttypes`.
+/// Reaching a typed return with `NO_RETURN_REG` is the disagreement.
 /// Reaching this means an encoder minted `inline_call_*_v` for a callee that
 /// ends in a typed return: the value has nowhere to go, and continuing would
 /// drop it in silence and leave the caller reading a stale register — the same

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -127,7 +127,7 @@ pub struct MIFrame {
     /// RPython encodes the result register as the last byte before the
     /// post-call LIVE marker, so `get_list_of_active_boxes(in_a_call=True)`
     /// can recover it from `self.pc - 1`.  pyre's grouped inline-call
-    /// encoding stores three optional return slots (`i/r/f`) as u16 values,
+    /// encoding stores one result register as the last operand,
     /// so the exact result index is carried here while preserving
     /// `_result_argcode` for the line-by-line clear logic.
     pub result_arg_index: Option<usize>,
@@ -1370,6 +1370,27 @@ mod tests {
         let mut jitcode = builder.finish();
         jitcode.body_mut().resulttypes = Some([(0, 'i'), (1, 'r'), (2, 'f')].into_iter().collect());
         Arc::new(jitcode)
+    }
+
+    #[test]
+    fn ref_value_for_blackhole_prefers_forwarded_constptr_over_stale_mirror() {
+        let jitcode = make_jitcode_with_regs(0, 2, 0);
+        let mut frame = MIFrame::new(jitcode, 0);
+        frame.ref_regs[0] = Some(OpRef::const_ptr(majit_ir::GcRef(0xBEEF)));
+        frame.ref_values[0] = Some(0xDEAD);
+        frame.ref_regs[1] = Some(OpRef::ref_op(7));
+        frame.ref_values[1] = Some(0xCAFE);
+
+        assert_eq!(frame.ref_value_for_blackhole(0), Some(0xBEEF));
+        assert_eq!(frame.ref_value_for_blackhole(1), Some(0xCAFE));
+
+        frame.set_forwarded_ref_value(0, 0xF00D);
+        assert_eq!(frame.ref_values[0], Some(0xF00D));
+        assert_eq!(
+            frame.ref_regs[0],
+            Some(OpRef::const_ptr(majit_ir::GcRef(0xF00D)))
+        );
+        assert_eq!(frame.ref_value_for_blackhole(0), Some(0xF00D));
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/ctor_continuation.rs
+++ b/pyre/pyre-jit-trace/src/ctor_continuation.rs
@@ -73,10 +73,10 @@
 //! `blackhole_from_resumedata` sets each level's `position` from its resume
 //! section, and `run_this_frame` dispatches forward from there.  The
 //! `inline_call` before the anchor therefore never decodes — it exists because
-//! `call_result_reg` resolves the `BC_INLINE_CALL` ending at `position` to find
-//! where a returning callee's value goes. Its callee operand is a placeholder
-//! for the same reason: the instruction is never executed, and the real callee
-//! varies per class while this jitcode is shared.
+//! `_setup_return_value_r` reads `code[position-1]`, the call's result
+//! register. Its callee operand is a placeholder for the same reason: the
+//! instruction is never executed, and the real callee varies per class while
+//! this jitcode is shared.
 
 use crate::PyJitCode;
 use majit_metainterp::jitcode::{JitCallArg, JitCodeBuilder};
@@ -92,8 +92,8 @@ pub(crate) const INSTANCE_REG: u16 = 0;
 /// register is exactly that slot.
 pub(crate) const INIT_RESULT_REG: u16 = 1;
 
-/// Callee operand of the never-decoded `inline_call`.  See the module doc: the
-/// byte is only ever stepped over backwards by `call_result_reg`.
+/// Callee operand of the never-decoded `inline_call`.  See the module doc:
+/// `_setup_return_value_r` only reads the last operand as the dest register.
 const PLACEHOLDER_CALLEE: u16 = 0;
 
 /// `typeobject.py descr_call`: `if not space.is_w(w_result, space.w_None):
@@ -153,8 +153,8 @@ fn build() -> Option<(i32, usize)> {
     let mut builder = JitCodeBuilder::new();
     builder.set_name("descr_call_tail");
 
-    // Never decoded; present so `call_result_reg` finds the complete
-    // `BC_INLINE_CALL` ending at the anchor. See the module doc.
+    // Never decoded; present so `_setup_return_value_r` can read
+    // `code[position-1]` as the dest register. See the module doc.
     builder.inline_call_r_r(
         PLACEHOLDER_CALLEE,
         &[(INSTANCE_REG, INSTANCE_REG)],
@@ -211,7 +211,7 @@ mod tests {
     use super::*;
 
     /// The anchor must sit immediately behind the complete `inline_call`, so
-    /// `call_result_reg` can resolve the exact instruction ending there.
+    /// `_setup_return_value_r` can read `code[position-1]` as the dest.
     #[test]
     fn resume_anchor_sits_behind_the_inline_call_return_tail() {
         let Some((index, resume_pc)) = level() else {
@@ -221,18 +221,13 @@ mod tests {
             .expect("the tail was just installed at this index");
         let code = payload.jitcode.code.as_slice();
         assert!(
-            resume_pc >= 5,
-            "no room for the call header and its return tail"
+            resume_pc >= 3,
+            "no room for the call header and its return register"
         );
         assert_eq!(
-            code[resume_pc - 1],
-            majit_metainterp::jitcode::NO_RETURN_REG,
-            "the synthetic Ref-returning call has no float return slot",
-        );
-        assert_eq!(
-            code[resume_pc - 2] as u16,
+            code[resume_pc - 1] as u16,
             INIT_RESULT_REG,
-            "the ref return slot must name the register the None check reads",
+            "the last operand is the ref result register",
         );
         assert_eq!(
             code[resume_pc],

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1455,22 +1455,14 @@ impl<'a> GraphFlattener<'a> {
         //   handle_residual_call: `op1 = [op1, ('-live-', [], None)]`
         //     emitted iff `may_call_jitcodes or calldescr_canraise(...)`.
         //   handle_regular_call:  `[op0, ('-live-', [], None)]` — always.
-        // The walker covers this point incidentally via its per-PC `-live-`;
-        // the canonical driver must emit it explicitly so the encoder's
-        // FALLTHROUGH_pc read (`handle_possible_exception` ->
-        // `guard_no_exception`, trace_opcode.rs) and the resume reader
-        // find a marker at the post-call position.  Gated on `lowering_ctx`
-        // so the production walker stream is untouched.  `may_call_jitcodes`
-        // has no analogue at this site: the canonical lowering emits only
-        // direct `residual_call_*` to fixed helper indices for the retired
-        // HLOp families, never the indirect call that is upstream's sole
-        // `may_call_jitcodes=True` caller — so the residual gate reduces to
-        // `calldescr_canraise`, read off each Insn's `CallDescrStub` operand
-        // (`insn_needs_trailing_live`).  Most retired families carry
-        // `EF_CAN_RAISE` / `EF_FORCES_*` so they keep the marker; the
-        // `get_current_exception` helper (`EF_CANNOT_RAISE`) does not, so it
-        // gets no trailing `-live-` — matching upstream's per-call gate.
-        let trailing_live = self.lowering_ctx.is_some() && insn_needs_trailing_live(&insn);
+        // Both drivers emit it here so `_setup_return_value_*` can read
+        // `code[position-1]` as the call's result register.  The walker
+        // also records a Live SpaceOp via `record_graph_op`; an adjacent
+        // pair folds in `remove_repeated_live`.  `may_call_jitcodes` has
+        // no analogue at this site: residual calls are direct helpers,
+        // so the residual gate is `calldescr_canraise`
+        // (`insn_needs_trailing_live`).
+        let trailing_live = insn_needs_trailing_live(&insn);
         self.emitline(insn);
         if trailing_live {
             self.emitline(Insn::live(Vec::new()));
@@ -8942,11 +8934,9 @@ mod tests {
         // `jtransform.py handle_residual_call` pairs a
         // `residual_call_*` with a trailing `('-live-', [], None)` so the
         // metainterp can snapshot the post-call `guard_no_exception`
-        // resume state.  The canonical driver (`serialize_op` under
-        // `lowering_ctx`) must emit that marker immediately AFTER the
-        // lowered call; the production walker covers the same point via
-        // its per-PC `-live-`.  A single `add` HLOp lowers to one
-        // `residual_call_ir_r` that must be followed by a `-live-`.
+        // resume state.  `serialize_op` emits that marker immediately
+        // AFTER the call on both drivers.  A single `add` HLOp lowers
+        // to one `residual_call_ir_r` that must be followed by a `-live-`.
         use crate::jit::flow::{Block, FunctionGraph};
         let lhs = Variable::new(VariableId(0), Kind::Ref);
         let rhs = Variable::new(VariableId(1), Kind::Ref);
@@ -8987,6 +8977,45 @@ mod tests {
         assert!(
             ssarepr.insns[call_pos + 1].is_live(),
             "residual_call must be followed by a `-live-` marker, got {:?}",
+            &ssarepr.insns[call_pos..]
+        );
+    }
+
+    #[test]
+    fn walker_path_emits_trailing_live_after_inline_call() {
+        // `jtransform.py handle_regular_call` always appends `-live-`
+        // after `inline_call`.  The walker flatten (no `lowering_ctx`)
+        // must do the same so `_setup_return_value_*` can read
+        // `code[position-1]`.
+        use crate::jit::flow::{Block, FunctionGraph};
+        let arg = Variable::new(VariableId(0), Kind::Ref);
+        let result = Variable::new(VariableId(1), Kind::Ref);
+        let start = Block::shared(vec![arg.into()]);
+        let graph = FunctionGraph::new("walker_inline_live", start.clone(), None);
+        super::super::flow::push_op(
+            &start,
+            SpaceOperation::new("inline_call_r_r", vec![arg.into()], Some(result.into()), 0),
+        );
+        start.closeblock(vec![
+            super::super::flow::Link::new(
+                vec![result.into()],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        let mut ssarepr = SSARepr::new("walker_inline_live");
+        flatten_graph_for_test(&graph, &mut ssarepr);
+
+        let call_pos = ssarepr
+            .insns
+            .iter()
+            .position(|insn| matches!(insn, Insn::Op { opname, .. } if opname == "inline_call_r_r"))
+            .unwrap_or_else(|| panic!("expected inline_call_r_r: {:?}", ssarepr.insns));
+        assert!(
+            ssarepr.insns[call_pos + 1].is_live(),
+            "walker inline_call must be followed by a `-live-` marker, got {:?}",
             &ssarepr.insns[call_pos..]
         );
     }


### PR DESCRIPTION
## Summary

- close `BC_INLINE_CALL` on one dest byte and recover it from `_resulttypes`
- emit `-live-` immediately after `inline_call_*` and can-raise `residual_call_*`, matching `handle_regular_call` / `handle_residual_call`
- let `_setup_return_value_*` read `code[position-1]` and drop the valuestackdepth skip in `call_result_reg`
- refuse `setarg_r` / `setarg_f` writes into the constant table

## Validation

- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py`: dynasm 548/548, cranelift 548/548, wasm 541/541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of typed and void inline calls across interpreted and compiled execution paths.
  - Corrected result-register tracking for inline calls and resume points.
  - Prevented writes to protected constant-table slots for additional value types.
  - Improved forwarding of reference values to ensure current values are used consistently.

- **Performance**
  - Reduced encoded inline-call metadata, lowering instruction payload size.
  - Preserved liveness information for residual and inline calls during trace serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->