### PR TITLE
wasm: batch nursery allocations and fold raw-load addresses

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3249,6 +3249,100 @@ pub struct NurseryAllocParams {
     pub plain_tids: std::collections::HashSet<u32>,
 }
 
+/// `GcRewriterAssembler.round_up_for_allocation`: raise to the nursery
+/// minimum, then 8-align. Shared by the inline `New*` bump and by
+/// `collect_nursery_batches` so a batched total uses the same size the
+/// per-object arm would have asked for.
+fn aligned_nursery_size(payload: i64) -> Option<usize> {
+    let payload = usize::try_from(payload).ok()?;
+    Some(((GcHeader::SIZE + payload).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7) & !7)
+}
+
+/// One member of a rewrite.py `gen_malloc_nursery` run: consecutive
+/// inline-eligible `New`/`NewWithVtable` ops share one bump of `batch_total`.
+/// Followers are `NURSERY_PTR_INCREMENT` — `prev + prev_size` — on the
+/// fast path. The slow path still allocates each object through the
+/// collecting helper, because a follower's frame home is only written at
+/// its own op.
+#[derive(Clone, Copy)]
+enum NurseryBatchRole {
+    Leader { batch_total: usize },
+    Follower { prev_result: u32, prev_size: usize },
+}
+
+/// `New`/`NewWithVtable` that the inline nursery arm would accept.
+/// Constant results are excluded: a follower needs the previous payload
+/// pointer in a local.
+fn new_inline_nursery_member(op: &Op, na: &NurseryAllocParams) -> Option<(usize, u32)> {
+    if !matches!(op.opcode, OpCode::New | OpCode::NewWithVtable) {
+        return None;
+    }
+    let result_id = op.pos.get().raw();
+    if OpRef::raw_is_constant(result_id) {
+        return None;
+    }
+    let descr = op.getdescr()?;
+    let sd = descr.as_size_descr()?;
+    if sd.non_moving() {
+        return None;
+    }
+    if !na.plain_tids.contains(&sd.type_id()) {
+        return None;
+    }
+    let total = aligned_nursery_size(sd.size() as i64)?;
+    (total < na.large_threshold).then_some((total, result_id))
+}
+
+/// rewrite.py `gen_malloc_nursery` merge window: keep extending a run
+/// across ops that cannot collect (`SETFIELD_GC` and friends). `LABEL`
+/// and any other `can_malloc` op flush, matching
+/// `emitting_an_operation_that_can_collect`. Combined size stays strictly
+/// below `large_threshold`, the same exclusive bound as
+/// `can_use_nursery`.
+fn collect_nursery_batches(
+    ops: &[Op],
+    nursery: Option<&NurseryAllocParams>,
+) -> Vec<Option<NurseryBatchRole>> {
+    let mut out = vec![None; ops.len()];
+    let Some(na) = nursery else {
+        return out;
+    };
+    let mut run: Vec<(usize, usize, u32)> = Vec::new();
+    let mut run_total = 0usize;
+    let flush = |out: &mut [Option<NurseryBatchRole>], run: &mut Vec<(usize, usize, u32)>| {
+        if run.len() >= 2 {
+            let batch_total: usize = run.iter().map(|entry| entry.1).sum();
+            out[run[0].0] = Some(NurseryBatchRole::Leader { batch_total });
+            for window in run.windows(2) {
+                out[window[1].0] = Some(NurseryBatchRole::Follower {
+                    prev_result: window[0].2,
+                    prev_size: window[0].1,
+                });
+            }
+        }
+        run.clear();
+    };
+    for (i, op) in ops.iter().enumerate() {
+        if let Some((total, result_id)) = new_inline_nursery_member(op, na) {
+            if !run.is_empty() && run_total + total < na.large_threshold {
+                run.push((i, total, result_id));
+                run_total += total;
+                continue;
+            }
+            flush(&mut out, &mut run);
+            run.push((i, total, result_id));
+            run_total = total;
+            continue;
+        }
+        if op.opcode == OpCode::Label || op.opcode.can_malloc() {
+            flush(&mut out, &mut run);
+            run_total = 0;
+        }
+    }
+    flush(&mut out, &mut run);
+    out
+}
+
 /// `__indirect_function_table` indices of the allocation helpers a compiled
 /// trace calls for `New*` / `NewArray*`.
 ///
@@ -4594,20 +4688,25 @@ fn build_function(
     // Extra i32 scratches when the inline nursery-bump fast path is armed:
     // one holds the loaded `nursery_free` across the bump/commit sequence;
     // runtime varsize array allocation also needs one for the computed
-    // total/new-free word.
+    // total/new-free word. A third local records whether a batched leader
+    // took the bump so followers can `NURSERY_PTR_INCREMENT` instead of
+    // calling the helper.
+    let nursery_batches = if residual_type_base.is_some() {
+        collect_nursery_batches(ops, nursery)
+    } else {
+        Vec::new()
+    };
+    let has_nursery_batches = nursery_batches.iter().any(Option::is_some);
     let base_i32_locals: u32 = 1 + if ca.emit_ca { 3 } else { 0 };
+    let extra_alloc_i32 =
+        u32::from(nursery.is_some() || ca.inline.is_some()) * 2 + u32::from(has_nursery_batches);
     let alloc_scratch_local = bridge_slot_local + base_i32_locals;
     let alloc_size_local = alloc_scratch_local + 1;
+    let alloc_batch_flag_local = alloc_size_local + 1;
     // A keyed census must preserve the raw dispatch value until `br_table`.
     // Its counter-address scratch cannot share `bridge_slot_local`, because
     // the latter would replace the selector with a guest-memory address.
-    let trace_entry_key_local = bridge_slot_local
-        + base_i32_locals
-        + if nursery.is_some() || ca.inline.is_some() {
-            2
-        } else {
-            0
-        };
+    let trace_entry_key_local = bridge_slot_local + base_i32_locals + extra_alloc_i32;
     let trace_entry_needs_key_local = trace_entry_census.is_some() && is_resumable_peeled(ops);
     // `resume_dispatch` keeps the entry key in a local so a region can rewrite
     // it and branch back into the dispatch; without it the key is consumed
@@ -4669,11 +4768,7 @@ fn build_function(
     }
     locals.push((
         base_i32_locals
-            + if nursery.is_some() || ca.inline.is_some() {
-                2
-            } else {
-                0
-            }
+            + extra_alloc_i32
             + u32::from(trace_entry_needs_key_local)
             + u32::from(resume_dispatch),
         ValType::I32,
@@ -7662,17 +7757,75 @@ fn build_function(
                 // none) inline; otherwise fall to the collecting helper.
                 // Restricted to plain types (no destructor/weakref side-list)
                 // under the large-object threshold, exactly the helper's own
-                // fast path.
-                let total_size = {
-                    use majit_gc::header::GcHeader;
-                    ((GcHeader::SIZE + size as usize).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7) & !7
-                };
+                // fast path. Consecutive eligible `New*` ops share one bump
+                // (`gen_malloc_nursery` / `NURSERY_PTR_INCREMENT`).
+                let total_size = aligned_nursery_size(size).unwrap_or(usize::MAX);
                 let inline_nursery = nursery.filter(|_| !non_moving).filter(|na| {
                     total_size < na.large_threshold
                         && u32::try_from(type_id).is_ok_and(|t| na.plain_tids.contains(&t))
                 });
-                if let (Some(base), Some(na)) = (residual_type_base, inline_nursery) {
-                    // free = *nursery_free; new_free = free + total
+                let batch_role = nursery_batches.get(op_idx).and_then(|role| role.as_ref());
+                if let (
+                    Some(base),
+                    Some(_),
+                    Some(NurseryBatchRole::Follower {
+                        prev_result,
+                        prev_size,
+                    }),
+                ) = (residual_type_base, inline_nursery, batch_role)
+                {
+                    // Fast: NURSERY_PTR_INCREMENT(prev, prev_size). Slow: the
+                    // leader overflowed, so this object was never reserved —
+                    // call the helper. The follower's home is written below.
+                    sink.local_get(alloc_batch_flag_local);
+                    sink.if_(BlockType::Result(ValType::I64));
+                    sink.local_get(value_types.local(*prev_result));
+                    sink.i32_wrap_i64();
+                    sink.i32_const(*prev_size as i32);
+                    sink.i32_add();
+                    sink.local_tee(alloc_scratch_local);
+                    sink.i32_const(GcHeader::SIZE as i32);
+                    sink.i32_sub();
+                    sink.i64_const(type_id);
+                    sink.i64_store(MemArg {
+                        offset: 0,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                    sink.local_get(alloc_scratch_local);
+                    sink.i64_extend_i32_u();
+                    sink.else_();
+                    sink.i64_const(type_id);
+                    sink.i64_const(size);
+                    sink.i32_const(alloc_fn_ptr as i32);
+                    sink.call_indirect(0, base + 2);
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                        frame,
+                    );
+                    sink.end();
+                    if !OpRef::raw_is_constant(vi) {
+                        sink.local_set(value_types.local(vi));
+                    } else {
+                        sink.drop();
+                    }
+                } else if let (Some(base), Some(na)) = (residual_type_base, inline_nursery) {
+                    let bump_size = match batch_role {
+                        Some(NurseryBatchRole::Leader { batch_total }) => *batch_total,
+                        _ => total_size,
+                    };
+                    // free = *nursery_free; new_free = free + bump
                     sink.i32_const(na.free_addr as i32);
                     sink.i32_load(MemArg {
                         offset: 0,
@@ -7680,7 +7833,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.local_tee(alloc_scratch_local);
-                    sink.i32_const(total_size as i32);
+                    sink.i32_const(bump_size as i32);
                     sink.i32_add();
                     // The sum is the committed `nursery_free`, so keep it
                     // rather than adding it again on the arm that takes it.
@@ -7718,8 +7871,12 @@ fn build_function(
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                         frame,
                     );
+                    if matches!(batch_role, Some(NurseryBatchRole::Leader { .. })) {
+                        sink.i32_const(0);
+                        sink.local_set(alloc_batch_flag_local);
+                    }
                     sink.else_();
-                    // Commit: *nursery_free = free + total.
+                    // Commit: *nursery_free = free + bump.
                     sink.i32_const(na.free_addr as i32);
                     sink.local_get(alloc_size_local);
                     sink.i32_store(MemArg {
@@ -7735,6 +7892,10 @@ fn build_function(
                         align: 3,
                         memory_index: 0,
                     });
+                    if matches!(batch_role, Some(NurseryBatchRole::Leader { .. })) {
+                        sink.i32_const(1);
+                        sink.local_set(alloc_batch_flag_local);
+                    }
                     // Result payload pointer = free + header size.
                     sink.local_get(alloc_scratch_local);
                     sink.i32_const(majit_gc::header::GcHeader::SIZE as i32);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3259,38 +3259,63 @@ fn aligned_nursery_size(payload: i64) -> Option<usize> {
 }
 
 /// One member of a rewrite.py `gen_malloc_nursery` run: consecutive
-/// inline-eligible `New`/`NewWithVtable` ops share one bump of `batch_total`.
-/// Followers are `NURSERY_PTR_INCREMENT` — `prev + prev_size` — on the
-/// fast path. The slow path still allocates each object through the
-/// collecting helper, because a follower's frame home is only written at
-/// its own op.
+/// inline-eligible `New`/`NewWithVtable` and constant-size `NewArray*`
+/// ops share one bump of `batch_total`. Followers are
+/// `NURSERY_PTR_INCREMENT` — `prev + prev_size` — on the fast path. The
+/// slow path still allocates each object through the collecting helper,
+/// because a follower's frame home is only written at its own op.
 #[derive(Clone, Copy)]
 enum NurseryBatchRole {
     Leader { batch_total: usize },
     Follower { prev_result: u32, prev_size: usize },
 }
 
-/// `New`/`NewWithVtable` that the inline nursery arm would accept.
-/// Constant results are excluded: a follower needs the previous payload
-/// pointer in a local.
-fn new_inline_nursery_member(op: &Op, na: &NurseryAllocParams) -> Option<(usize, u32)> {
-    if !matches!(op.opcode, OpCode::New | OpCode::NewWithVtable) {
-        return None;
-    }
+/// `New`/`NewWithVtable` or a constant-size `NewArray*` that the inline
+/// nursery arm would accept. Constant results are excluded: a follower
+/// needs the previous payload pointer in a local. A runtime-length
+/// array stays on the varsize path and is not a batch member.
+fn new_inline_nursery_member(
+    op: &Op,
+    na: &NurseryAllocParams,
+    constants: &indexmap::IndexMap<u32, i64>,
+) -> Option<(usize, u32)> {
     let result_id = op.pos.get().raw();
     if OpRef::raw_is_constant(result_id) {
         return None;
     }
-    let descr = op.getdescr()?;
-    let sd = descr.as_size_descr()?;
-    if sd.non_moving() {
-        return None;
+    match op.opcode {
+        OpCode::New | OpCode::NewWithVtable => {
+            let descr = op.getdescr()?;
+            let sd = descr.as_size_descr()?;
+            if sd.non_moving() {
+                return None;
+            }
+            if !na.plain_tids.contains(&sd.type_id()) {
+                return None;
+            }
+            let total = aligned_nursery_size(sd.size() as i64)?;
+            (total < na.large_threshold).then_some((total, result_id))
+        }
+        OpCode::NewArray | OpCode::NewArrayClear => {
+            let descr = op.getdescr()?;
+            let ad = descr.as_array_descr()?;
+            if ad.non_moving() {
+                return None;
+            }
+            if !na.plain_tids.contains(&ad.type_id()) {
+                return None;
+            }
+            let length = const_operand_value(constants, op.arg(0).to_opref())?;
+            if length < 0 {
+                return None;
+            }
+            let payload = (ad.base_size() as i64)
+                .checked_add((ad.item_size() as i64).checked_mul(length)?)?;
+            let total = aligned_nursery_size(payload)?;
+            (total < na.large_threshold).then_some((total, result_id))
+        }
+        _ => None,
     }
-    if !na.plain_tids.contains(&sd.type_id()) {
-        return None;
-    }
-    let total = aligned_nursery_size(sd.size() as i64)?;
-    (total < na.large_threshold).then_some((total, result_id))
 }
 
 /// rewrite.py `gen_malloc_nursery` merge window: keep extending a run
@@ -3302,6 +3327,7 @@ fn new_inline_nursery_member(op: &Op, na: &NurseryAllocParams) -> Option<(usize,
 fn collect_nursery_batches(
     ops: &[Op],
     nursery: Option<&NurseryAllocParams>,
+    constants: &indexmap::IndexMap<u32, i64>,
 ) -> Vec<Option<NurseryBatchRole>> {
     let mut out = vec![None; ops.len()];
     let Some(na) = nursery else {
@@ -3323,7 +3349,7 @@ fn collect_nursery_batches(
         run.clear();
     };
     for (i, op) in ops.iter().enumerate() {
-        if let Some((total, result_id)) = new_inline_nursery_member(op, na) {
+        if let Some((total, result_id)) = new_inline_nursery_member(op, na, constants) {
             if !run.is_empty() && run_total + total < na.large_threshold {
                 run.push((i, total, result_id));
                 run_total += total;
@@ -3341,6 +3367,33 @@ fn collect_nursery_batches(
     }
     flush(&mut out, &mut run);
     out
+}
+
+/// rewrite.py `NURSERY_PTR_INCREMENT(prev, prev_size)` plus the interior
+/// object's tid header. Leaves the payload pointer as i64.
+fn emit_nursery_ptr_increment(
+    sink: &mut PeepSink<'_, '_>,
+    value_types: &ValueLocals,
+    alloc_scratch_local: u32,
+    prev_result: u32,
+    prev_size: usize,
+    type_id: i64,
+) {
+    sink.local_get(value_types.local(prev_result));
+    sink.i32_wrap_i64();
+    sink.i32_const(prev_size as i32);
+    sink.i32_add();
+    sink.local_tee(alloc_scratch_local);
+    sink.i32_const(GcHeader::SIZE as i32);
+    sink.i32_sub();
+    sink.i64_const(type_id);
+    sink.i64_store(MemArg {
+        offset: 0,
+        align: 3,
+        memory_index: 0,
+    });
+    sink.local_get(alloc_scratch_local);
+    sink.i64_extend_i32_u();
 }
 
 /// `__indirect_function_table` indices of the allocation helpers a compiled
@@ -4692,7 +4745,7 @@ fn build_function(
     // took the bump so followers can `NURSERY_PTR_INCREMENT` instead of
     // calling the helper.
     let nursery_batches = if residual_type_base.is_some() {
-        collect_nursery_batches(ops, nursery)
+        collect_nursery_batches(ops, nursery, constants)
     } else {
         Vec::new()
     };
@@ -7779,21 +7832,14 @@ fn build_function(
                     // call the helper. The follower's home is written below.
                     sink.local_get(alloc_batch_flag_local);
                     sink.if_(BlockType::Result(ValType::I64));
-                    sink.local_get(value_types.local(*prev_result));
-                    sink.i32_wrap_i64();
-                    sink.i32_const(*prev_size as i32);
-                    sink.i32_add();
-                    sink.local_tee(alloc_scratch_local);
-                    sink.i32_const(GcHeader::SIZE as i32);
-                    sink.i32_sub();
-                    sink.i64_const(type_id);
-                    sink.i64_store(MemArg {
-                        offset: 0,
-                        align: 3,
-                        memory_index: 0,
-                    });
-                    sink.local_get(alloc_scratch_local);
-                    sink.i64_extend_i32_u();
+                    emit_nursery_ptr_increment(
+                        &mut sink,
+                        value_types,
+                        alloc_scratch_local,
+                        *prev_result,
+                        *prev_size,
+                        type_id,
+                    );
                     sink.else_();
                     sink.i64_const(type_id);
                     sink.i64_const(size);
@@ -8106,10 +8152,73 @@ fn build_function(
                 } else {
                     None
                 };
-                if let (Some(base), Some((total_size, length, na))) =
+                let batch_role = nursery_batches.get(op_idx).and_then(|role| role.as_ref());
+                if let (
+                    Some(base),
+                    Some((length, _)),
+                    Some(NurseryBatchRole::Follower {
+                        prev_result,
+                        prev_size,
+                    }),
+                ) = (
+                    residual_type_base,
+                    inline_nursery_total.map(|(total, length, _na)| (length, total)),
+                    batch_role,
+                ) {
+                    sink.local_get(alloc_batch_flag_local);
+                    sink.if_(BlockType::Result(ValType::I64));
+                    emit_nursery_ptr_increment(
+                        &mut sink,
+                        value_types,
+                        alloc_scratch_local,
+                        *prev_result,
+                        *prev_size,
+                        type_id,
+                    );
+                    sink.local_get(alloc_scratch_local);
+                    sink.i32_const(length as i32);
+                    sink.i32_store(MemArg {
+                        offset: len_offset as u64,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.else_();
+                    sink.i64_const(type_id);
+                    sink.i64_const(base_size);
+                    sink.i64_const(item_size);
+                    sink.i64_const(length as i64);
+                    sink.i64_const(len_offset);
+                    sink.i32_const(alloc_array_fn_ptr as i32);
+                    sink.call_indirect(0, base + 5);
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                        frame,
+                    );
+                    sink.end();
+                    if !OpRef::raw_is_constant(vi) {
+                        sink.local_set(value_types.local(vi));
+                    } else {
+                        sink.drop();
+                    }
+                } else if let (Some(base), Some((total_size, length, na))) =
                     (residual_type_base, inline_nursery_total)
                 {
-                    // free = *nursery_free; new_free = free + total
+                    let bump_size = match batch_role {
+                        Some(NurseryBatchRole::Leader { batch_total }) => *batch_total,
+                        _ => total_size,
+                    };
+                    // free = *nursery_free; new_free = free + bump
                     sink.i32_const(na.free_addr as i32);
                     sink.i32_load(MemArg {
                         offset: 0,
@@ -8117,7 +8226,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.local_tee(alloc_scratch_local);
-                    sink.i32_const(total_size as i32);
+                    sink.i32_const(bump_size as i32);
                     sink.i32_add();
                     // The sum is the committed `nursery_free`, so keep it
                     // rather than adding it again on the arm that takes it.
@@ -8155,8 +8264,12 @@ fn build_function(
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                         frame,
                     );
+                    if matches!(batch_role, Some(NurseryBatchRole::Leader { .. })) {
+                        sink.i32_const(0);
+                        sink.local_set(alloc_batch_flag_local);
+                    }
                     sink.else_();
-                    // Commit: *nursery_free = free + total.
+                    // Commit: *nursery_free = free + bump.
                     sink.i32_const(na.free_addr as i32);
                     sink.local_get(alloc_size_local);
                     sink.i32_store(MemArg {
@@ -8181,6 +8294,10 @@ fn build_function(
                         align: 2,
                         memory_index: 0,
                     });
+                    if matches!(batch_role, Some(NurseryBatchRole::Leader { .. })) {
+                        sink.i32_const(1);
+                        sink.local_set(alloc_batch_flag_local);
+                    }
                     // Result payload pointer = free + header size.
                     sink.local_get(alloc_scratch_local);
                     sink.i32_const(majit_gc::header::GcHeader::SIZE as i32);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -452,6 +452,7 @@ enum PendingInstruction {
     LocalSet(u32),
     I64Const(i64),
     I32Const(i32),
+    I64ExtendI32U,
 }
 
 macro_rules! forward_zero {
@@ -511,6 +512,9 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
                 }
                 PendingInstruction::I32Const(value) => {
                     self.sink.i32_const(value);
+                }
+                PendingInstruction::I64ExtendI32U => {
+                    self.sink.i64_extend_i32_u();
                 }
             }
         }
@@ -648,13 +652,33 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
         // does: `pending` is a lookbehind buffer, not an operand stack, so a
         // tail this fold does not consume still owes its instruction to
         // `flush`.
-        if let Some(PendingInstruction::I64Const(value)) = self.pending.last().copied() {
+        match self.pending.last().copied() {
+            Some(PendingInstruction::I64Const(value)) => {
+                self.pending.pop();
+                self.pending
+                    .push(PendingInstruction::I32Const(value as u64 as u32 as i32));
+            }
+            Some(PendingInstruction::I64ExtendI32U) => {
+                // wrap(extend_u(x)) == x for an i32 address already on the
+                // stack.
+                self.pending.pop();
+            }
+            _ => {
+                self.flush();
+                self.sink.i32_wrap_i64();
+            }
+        }
+        self
+    }
+
+    fn i64_extend_i32_u(&mut self) -> &mut Self {
+        if let Some(PendingInstruction::I32Const(value)) = self.pending.last().copied() {
             self.pending.pop();
             self.pending
-                .push(PendingInstruction::I32Const(value as u64 as u32 as i32));
+                .push(PendingInstruction::I64Const(value as u32 as u64 as i64));
         } else {
             self.flush();
-            self.sink.i32_wrap_i64();
+            self.pending.push(PendingInstruction::I64ExtendI32U);
         }
         self
     }
@@ -798,7 +822,6 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
         i64_eqz,
         i64_extend32_s,
         i64_extend_i32_s,
-        i64_extend_i32_u,
         i64_ge_s,
         i64_ge_u,
         i64_gt_s,
@@ -961,12 +984,14 @@ fn emit_raw_addr(
     constants: &indexmap::IndexMap<u32, i64>,
     value_types: &ValueLocals,
     op: &Op,
-) {
-    emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
-    sink.i32_wrap_i64();
-    emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
-    sink.i32_wrap_i64();
-    sink.i32_add();
+) -> u64 {
+    emit_gc_offset_addr(
+        sink,
+        constants,
+        value_types,
+        op.arg(0).to_opref(),
+        op.arg(1).to_opref(),
+    )
 }
 
 /// Address the GC rewrite's descriptor-free `base + offset` memory form.
@@ -6474,24 +6499,24 @@ fn build_function(
             OpCode::RawLoadI | OpCode::RawLoadF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_raw_addr(&mut sink, constants, value_types, op);
+                    let offset = emit_raw_addr(&mut sink, constants, value_types, op);
                     if op.opcode == OpCode::RawLoadF {
-                        sink.f64_load(mem64(0));
+                        sink.f64_load(mem64(offset));
                     } else {
                         let (item_size, signed) = array_item_size_sign_from_descr(op);
-                        emit_sized_int_load(&mut sink, 0, item_size, signed);
+                        emit_sized_int_load(&mut sink, offset, item_size, signed);
                     }
                     sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::RawStore => {
-                emit_raw_addr(&mut sink, constants, value_types, op);
+                let offset = emit_raw_addr(&mut sink, constants, value_types, op);
                 // `emit_resolve` hands back a Float operand as the `i64` its
                 // bits spell, so the width-sized integer store writes the same
                 // eight bytes an `f64.store` would.
                 emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref());
                 let (item_size, _signed) = array_item_size_sign_from_descr(op);
-                emit_sized_int_store(&mut sink, 0, item_size);
+                emit_sized_int_store(&mut sink, offset, item_size);
             }
 
             // ── Exception handling ──

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -6240,6 +6240,41 @@ fn raw_load_f_loads_a_double() {
     assert_eq!(f64_loads, 1, "the float raw load is an f64.load");
 }
 
+#[test]
+fn raw_load_const_offset_uses_memarg_displacement() {
+    use majit_ir::descr::SimpleArrayDescr;
+    use std::sync::Arc;
+
+    const OFFSET: u64 = 24;
+    let descr = Arc::new(SimpleArrayDescr::new(1, 0, 8, 55, Type::Int));
+    let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
+    let load = make_op(
+        OpCode::RawLoadI,
+        &[OpRef::input_arg_ref(0), OpRef::const_int(OFFSET as i64)],
+        OpRef::int_op(1),
+    );
+    load.setdescr(descr);
+    let ops = vec![load, Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))])];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    let mut adds = 0;
+    let mut displaced = 0;
+    count_operators(&bytes, |op| match op {
+        wasmparser::Operator::I32Add => adds += 1,
+        wasmparser::Operator::I64Load { memarg } | wasmparser::Operator::I64Load32U { memarg }
+            if memarg.offset == OFFSET =>
+        {
+            displaced += 1;
+        }
+        _ => {}
+    });
+    assert_eq!(displaced, 1, "the constant offset rides in MemArg");
+    assert_eq!(
+        adds, 0,
+        "a nonnegative constant offset must not emit i32.add"
+    );
+}
+
 /// resoperation.py `int_between(a, b, c)` is `a <= b < c`, signed.
 #[test]
 fn int_between_is_two_signed_comparisons() {

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -7060,28 +7060,12 @@ fn consecutive_allocations_home_and_reload_before_each_collection() {
     }
 }
 
-#[test]
-fn consecutive_new_ops_keep_their_collecting_boundaries() {
-    use majit_ir::descr::SimpleSizeDescr;
-    use std::sync::Arc;
-
-    let size_descr = || {
-        let descr = SimpleSizeDescr::new(0, 16, 53);
-        descr.set_non_moving(false);
-        Arc::new(descr)
-    };
-    let new1 = make_op(OpCode::New, &[], OpRef::ref_op(1));
-    new1.setdescr(size_descr());
-    let new2 = make_op(OpCode::New, &[], OpRef::ref_op(2));
-    new2.setdescr(size_descr());
-    let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
-    finish.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
-
+fn nursery_new_inputs(ops: Vec<Op>, plain_tid: u32) -> codegen::ModuleBuildInputs {
     let mut plain_tids = std::collections::HashSet::new();
-    plain_tids.insert(53);
-    let inputs = codegen::ModuleBuildInputs {
+    plain_tids.insert(plain_tid);
+    codegen::ModuleBuildInputs {
         inputargs: vec![InputArg::from_type(Type::Int, 0)],
-        ops: vec![new1, new2, finish],
+        ops,
         inlined_bridges: Vec::new(),
         constants: indexmap::IndexMap::new(),
         vtable_offset: Some(0),
@@ -7114,19 +7098,105 @@ fn consecutive_new_ops_keep_their_collecting_boundaries() {
         external_jump_key: 0,
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
-    };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
-    validate_wasm(&bytes);
+    }
+}
 
+fn nursery_top_compare_count(bytes: &[u8]) -> usize {
     let mut nursery_top_compares = 0;
-    count_operators(&bytes, |op| {
+    count_operators(bytes, |op| {
         if matches!(op, wasmparser::Operator::I32GtU) {
             nursery_top_compares += 1;
         }
     });
+    nursery_top_compares
+}
+
+fn finish_int_arg0() -> Op {
+    let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
+    finish.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+    finish
+}
+
+fn plain_new(result: u32, type_id: u32) -> Op {
+    use majit_ir::descr::SimpleSizeDescr;
+    use std::sync::Arc;
+    let descr = SimpleSizeDescr::new(0, 16, type_id);
+    descr.set_non_moving(false);
+    let op = make_op(OpCode::New, &[], OpRef::ref_op(result));
+    op.setdescr(Arc::new(descr));
+    op
+}
+
+#[test]
+fn consecutive_new_ops_share_one_nursery_bump() {
+    let inputs = nursery_new_inputs(
+        vec![plain_new(1, 53), plain_new(2, 53), finish_int_arg0()],
+        53,
+    );
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
     assert_eq!(
-        nursery_top_compares, 2,
-        "typed allocation helpers must run at their original GC boundaries"
+        nursery_top_compare_count(&bytes),
+        1,
+        "gen_malloc_nursery merges consecutive New ops into one bump"
+    );
+}
+
+#[test]
+fn collecting_op_between_news_keeps_separate_nursery_bumps() {
+    use majit_ir::descr::SimpleCallDescr;
+    use std::sync::Arc;
+
+    let call = Op::new(OpCode::CallN, &[rb(OpRef::const_int(0x99))]);
+    call.setdescr(Arc::new(SimpleCallDescr::new(
+        0x5300_0000,
+        Vec::new(),
+        Type::Void,
+        true,
+        0,
+        EffectInfo::default(),
+    )));
+    let inputs = nursery_new_inputs(
+        vec![plain_new(1, 53), call, plain_new(2, 53), finish_int_arg0()],
+        53,
+    );
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        2,
+        "a collecting op flushes the pending nursery batch"
+    );
+}
+
+#[test]
+fn setfield_between_news_keeps_one_nursery_bump() {
+    use majit_ir::descr::SimpleFieldDescr;
+    use std::sync::Arc;
+
+    let store = Op::new(
+        OpCode::SetfieldGc,
+        &[rb(OpRef::ref_op(1)), rb(OpRef::input_arg_ref(0))],
+    );
+    store.setdescr(Arc::new(SimpleFieldDescr::new(0, 8, 8, Type::Ref, false)));
+    let mut inputs = nursery_new_inputs(
+        vec![plain_new(1, 53), store, plain_new(2, 53), finish_int_arg0()],
+        53,
+    );
+    inputs.inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    inputs.frame = codegen::FrameGeometry::compact(5, 2, 0);
+    let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(1))]);
+    finish.setfailargs(smallvec![rb(OpRef::input_arg_int(1))]);
+    inputs.ops[3] = finish;
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        1,
+        "non-collecting stores must not flush gen_malloc_nursery"
     );
 }
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -7127,6 +7127,19 @@ fn plain_new(result: u32, type_id: u32) -> Op {
     op
 }
 
+fn plain_new_array(result: u32, type_id: u32, length: i64) -> Op {
+    use majit_ir::descr::SimpleArrayDescr;
+    use std::sync::Arc;
+    let descr = SimpleArrayDescr::new(1, 16, 8, type_id, Type::Int);
+    let op = make_op(
+        OpCode::NewArray,
+        &[OpRef::const_int(length)],
+        OpRef::ref_op(result),
+    );
+    op.setdescr(Arc::new(descr));
+    op
+}
+
 #[test]
 fn consecutive_new_ops_share_one_nursery_bump() {
     let inputs = nursery_new_inputs(
@@ -7197,6 +7210,80 @@ fn setfield_between_news_keeps_one_nursery_bump() {
         nursery_top_compare_count(&bytes),
         1,
         "non-collecting stores must not flush gen_malloc_nursery"
+    );
+}
+
+#[test]
+fn new_and_const_newarray_share_one_nursery_bump() {
+    let mut inputs = nursery_new_inputs(
+        vec![
+            plain_new(1, 53),
+            plain_new_array(2, 55, 3),
+            finish_int_arg0(),
+        ],
+        53,
+    );
+    if let Some(na) = inputs.nursery.as_mut() {
+        na.plain_tids.insert(55);
+    }
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        1,
+        "constant-size NewArray joins gen_malloc_nursery with New"
+    );
+}
+
+#[test]
+fn consecutive_const_newarrays_share_one_nursery_bump() {
+    let inputs = nursery_new_inputs(
+        vec![
+            plain_new_array(1, 55, 2),
+            plain_new_array(2, 55, 4),
+            finish_int_arg0(),
+        ],
+        55,
+    );
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        1,
+        "consecutive constant-size NewArray ops share one bump"
+    );
+}
+
+#[test]
+fn runtime_newarray_flushes_the_nursery_batch() {
+    use majit_ir::descr::SimpleArrayDescr;
+    use std::sync::Arc;
+
+    let descr = SimpleArrayDescr::new(1, 16, 8, 55, Type::Int);
+    let runtime = make_op(
+        OpCode::NewArray,
+        &[OpRef::input_arg_int(0)],
+        OpRef::ref_op(2),
+    );
+    runtime.setdescr(Arc::new(descr));
+    let mut inputs = nursery_new_inputs(
+        vec![
+            plain_new(1, 53),
+            runtime,
+            plain_new(3, 53),
+            finish_int_arg0(),
+        ],
+        53,
+    );
+    if let Some(na) = inputs.nursery.as_mut() {
+        na.plain_tids.insert(55);
+    }
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        3,
+        "a runtime-length NewArray stays on the varsize path and flushes"
     );
 }
 


### PR DESCRIPTION
## Summary

- Batch consecutive inline-eligible `New`/`NewWithVtable` into one nursery bump, matching rewrite `gen_malloc_nursery`. Non-collecting stores keep the run; `LABEL` and collecting ops flush it.
- Let constant-length `NewArray`/`NewArrayClear` join that same bump. Runtime-length arrays stay on the varsize path and flush the pending batch.
- Overflow still allocates each follower through the helper so its frame home is written at its own op. The write barrier is not seeded after the slow/fast join.
- Fold nonnegative constant raw load/store offsets into `MemArg` displacement. PeepSink now folds `i32.const` through `i64.extend_i32_u` and cancels `wrap(extend_u)`.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

## Verification

- `cargo test -p majit-backend-wasm --test codegen_test`: 112 passed, 6 ignored runtime integration tests.
- Did not rerun `cargo test --all --no-default-features --features dynasm` or `python3 pyre/check.py` for this follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved memory allocation efficiency by batching eligible consecutive nursery allocations.
  * Preserved correct handling across collecting operations and runtime-sized array allocations.
  * Improved constant-offset memory access generation.

* **Bug Fixes**
  * Corrected integer extension and wrapping optimizations.
  * Ensured raw loads and stores use their specified memory offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->