### PR TITLE
metainterp: record live traces into the byte buffer

### DIFF
--- a/majit/examples/regex/Cargo.toml
+++ b/majit/examples/regex/Cargo.toml
@@ -11,7 +11,7 @@ dynasm = ["majit-metainterp/dynasm"]
 # on a busy machine. Off by default: it is process-wide, so its four relaxed
 # atomics per allocation would sit inside the timed rows otherwise.
 alloc-census = []
-# Swap the allocator under the census without changing what the census counts:
+# Select the allocator for both clean timings and the optional census:
 # `pyrex` ships mimalloc as its default global allocator and this example did
 # not, so a per-bridge cost measured here was charged the platform allocator's
 # price rather than the one pyre runs on. The counters are identical across the

--- a/majit/examples/regex/rpython_original/README.md
+++ b/majit/examples/regex/rpython_original/README.md
@@ -446,6 +446,65 @@ gap; bridge construction remains the structural difference.
 
 ### Where majit's share of that gap goes
 
+#### Allocator control corrected 2026-09-05
+
+`fast-alloc` used to select mimalloc only when `alloc-census` was also enabled.
+A clean `--features dynasm,fast-alloc` timing build therefore still used System.
+The feature now selects mimalloc with or without the census; it remains opt-in.
+This fixes the measurement control, not the recorder representation.
+
+Three clean System/mimalloc/mimalloc/System rounds at 262,144 characters,
+`PYRE_REGEX_ROWS=2`, each process running the usual five timed samples, were
+collected with `/usr/bin/time -l`.
+
+The saved pair used the recorder at `bdf4abd130e`, before the accompanying
+GC/byte-materializer repairs, and differed only in allocator selection. This
+is an allocator-only control, not a timing of the completed recorder migration.
+
+| allocator | whole-process retired instructions, median of six processes | range |
+|---|---:|---:|
+| System | 51,391,087,211 | 51,301,743,543–51,465,158,457 |
+| mimalloc | 47,970,429,131 | 47,916,263,321–48,018,761,845 |
+
+These are `/usr/bin/time -l` process totals, including setup and warm-up,
+**not** allocations or JIT-only instruction counts. The reduction is 6.7%.
+Both arms retained the 150-op body and the `0 / 24 / 93 / 2` structural counts.
+All twelve processes reported 3,612 bridges and 293,782 compiled bridge ops.
+Concurrent builds made wall time unusable: the six process medians ranged
+125,163–275,993 chars/s for System and 131,786–284,267 for mimalloc. No wall-clock
+speedup or RPython parity is established by this experiment. The live recorder
+still uses `Rc<Op>` and structured snapshots; switching allocators does not
+close that structural gap.
+
+To reproduce the controls, build and save each executable separately:
+
+```sh
+cargo build -p regex --release --no-default-features --features dynasm
+cargo build -p regex --release --no-default-features --features dynasm,fast-alloc
+# Run each saved executable in alternating forward/reverse order:
+PYRE_REGEX_LENGTHS=262144 PYRE_REGEX_ROWS=2 /usr/bin/time -l <saved-executable>
+```
+
+The subsequent GC/materializer repairs and direct live-frame guard capture
+were measured against that saved mimalloc executable with the same clean
+build flags, length and three ABBA rounds. Both arms used mimalloc; neither
+enabled `alloc-census`. This comparison includes all those repairs, so it
+does not isolate the removal of the old full-state failarg-list builder.
+
+| mimalloc build | whole-process retired instructions, median of six processes | range |
+|---|---:|---:|
+| saved allocator control | 47,941,578,060 | 47,899,039,519–48,055,675,906 |
+| GC/materializer repairs + direct guard capture | 47,906,746,857 | 47,880,392,131–47,942,807,794 |
+
+The median difference is only 0.073%, with overlapping ranges: **no meaningful
+performance improvement is established**. The process-median throughput ranges
+were 227,697–294,767 and 255,293–289,188 chars/s respectively. All twelve
+processes again had the same 150-op body, four structural counts, 3,612 bridges
+and 293,782 bridge ops. Removing the redundant list API is a structural repair,
+not evidence that the live byte-recorder migration or the `and/or` gap is done.
+
+#### Recorder and resume costs
+
 Three theories about that gap were measured and two of them were wrong, so the
 numbers matter more than the reasoning:
 

--- a/majit/examples/regex/src/main.rs
+++ b/majit/examples/regex/src/main.rs
@@ -38,6 +38,20 @@ pub mod shortcircuit;
 #[global_allocator]
 static ALLOC: alloc_census::Counting = alloc_census::Counting;
 
+// The census wraps this same allocator. Selecting `fast-alloc` must not
+// silently select System when the timing build leaves the counters out.
+#[cfg(all(feature = "fast-alloc", not(feature = "alloc-census")))]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[test]
+#[cfg(all(feature = "fast-alloc", not(feature = "alloc-census")))]
+fn fast_allocator_is_selected_without_the_census() {
+    // A dependency feature alone does not replace Rust's global allocator.
+    // Pin the actual global's type in the clean timing configuration.
+    let _: &mimalloc::MiMalloc = &ALLOC;
+}
+
 use regex::{NodeRec, bench_regex, bench_regex_left, count, depth, lower, nonmatching, vectors};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3758,7 +3758,12 @@ pub struct QuasiImmutDescr {
     struct_ptr: u64,
     qmut: std::sync::Arc<dyn QuasiImmutHandle>,
     /// `quasiimmut.py self.constantfieldbox`.
-    constantfieldbox: Option<crate::Value>,
+    ///
+    /// RPython stores a `Const*` box on the descr; the translated GC
+    /// traces `ConstPtr.value` through the Python object. This descr
+    /// lives in an `Arc` outside that graph, so the captured `Value::Ref`
+    /// is forwarded explicitly by `walk_const_ptr_refs`.
+    constantfieldbox: Mutex<Option<crate::Value>>,
 }
 
 impl QuasiImmutDescr {
@@ -3773,7 +3778,7 @@ impl QuasiImmutDescr {
             fielddescr,
             struct_ptr,
             qmut,
-            constantfieldbox,
+            constantfieldbox: Mutex::new(constantfieldbox),
         }
     }
 
@@ -3794,7 +3799,17 @@ impl QuasiImmutDescr {
 
     /// `quasiimmut.py self.constantfieldbox`.
     pub fn constantfieldbox(&self) -> Option<crate::Value> {
-        self.constantfieldbox
+        *self.constantfieldbox.lock()
+    }
+
+    /// Forward a `Value::Ref` captured on this descr after a moving
+    /// collection. `MetaInterp::walk_active_trace_refs` calls this
+    /// through the recorder's slot descrs.
+    pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut crate::GcRef)) {
+        let mut slot = self.constantfieldbox.lock();
+        if let Some(crate::Value::Ref(gcref)) = slot.as_mut() {
+            visitor(gcref);
+        }
     }
 }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3748,29 +3748,32 @@ pub trait QuasiImmutHandle: Send + Sync + std::fmt::Debug {
 /// field descr directly — including `index()`, which the heap cache and the
 /// tracer key on.
 ///
-/// `constantfieldbox` (`quasiimmut.py:125`) is the one member that stays off
-/// this descr: it is a Box, and pyre records it as the op's second operand
-/// instead.
+/// `constantfieldbox` (`quasiimmut.py QuasiImmutDescr.__init__`) is
+/// captured on the descr, matching `record1(QUASIIMMUT_FIELD, box,
+/// descr=qmutdescr)`.
 #[derive(Debug)]
 pub struct QuasiImmutDescr {
     fielddescr: DescrRef,
     /// `quasiimmut.py self.struct = struct` — compared, never dereferenced.
     struct_ptr: u64,
     qmut: std::sync::Arc<dyn QuasiImmutHandle>,
+    /// `quasiimmut.py self.constantfieldbox`.
+    constantfieldbox: Option<crate::Value>,
 }
 
 impl QuasiImmutDescr {
-    /// `quasiimmut.py QuasiImmutDescr.__init__`, minus the field read
-    /// the caller keeps as an operand.
+    /// `quasiimmut.py QuasiImmutDescr.__init__`.
     pub fn new(
         fielddescr: DescrRef,
         struct_ptr: u64,
         qmut: std::sync::Arc<dyn QuasiImmutHandle>,
+        constantfieldbox: Option<crate::Value>,
     ) -> Self {
         Self {
             fielddescr,
             struct_ptr,
             qmut,
+            constantfieldbox,
         }
     }
 
@@ -3787,6 +3790,11 @@ impl QuasiImmutDescr {
     /// `quasiimmut.py self.qmut = get_current_qmut_instance(...)`.
     pub fn qmut(&self) -> &std::sync::Arc<dyn QuasiImmutHandle> {
         &self.qmut
+    }
+
+    /// `quasiimmut.py self.constantfieldbox`.
+    pub fn constantfieldbox(&self) -> Option<crate::Value> {
+        self.constantfieldbox
     }
 }
 

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -584,27 +584,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         })
         .collect();
 
-    // ── fail_args ──
-    let fail_scalar_parts: Vec<TokenStream> = scalars
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! { args.push(self.#fname); }
-        })
-        .collect();
-    let fail_array_parts: Vec<TokenStream> = arrays
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! { args.extend_from_slice(&self.#fname); }
-        })
-        .collect();
-    let fail_vable_identity_part: TokenStream = if has_vable_identity {
-        quote! { args.push(self.__vable_identity); }
-    } else {
-        quote! {}
-    };
-
     // ── build_meta: capture flattened array lengths ──
     let build_meta_fields: Vec<TokenStream> = arrays
         .iter()
@@ -1452,13 +1431,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     } else {
         quote! {}
     };
-    let fail_ref_scalar_parts: Vec<TokenStream> = ref_scalars
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! { args.push(self.#fname); }
-        })
-        .collect();
     let state_ref_field_ref_arms: Vec<TokenStream> = ref_scalars
         .iter()
         .enumerate()
@@ -1634,13 +1606,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .map(|(_, f)| {
             let fname = &f.name;
             quote! { args.push(sym.#fname); }
-        })
-        .collect();
-    let fail_float_scalar_parts: Vec<TokenStream> = float_scalars
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! { args.push(self.#fname); }
         })
         .collect();
     let collect_float_scalar_values_parts: Vec<TokenStream> = float_scalars
@@ -2760,16 +2725,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     #(#set_state_array_value_arms)*
                     _ => {}
                 }
-            }
-
-            fn fail_args(&self) -> Option<Vec<majit_ir::OpRef>> {
-                let mut args = Vec::new();
-                #(#fail_scalar_parts)*
-                #(#fail_array_parts)*
-                #fail_vable_identity_part
-                #(#fail_ref_scalar_parts)*
-                #(#fail_float_scalar_parts)*
-                Some(args)
             }
 
             #[allow(unused_assignments, unused_variables)]

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2605,7 +2605,11 @@ impl TraceCtx {
     /// full opencoder.py:567-568 5-tuple.
     pub fn get_trace_position(&self) -> TracePosition {
         let mut pos = self.recorder.get_position();
-        pos.snapshot_data_len = self.snapshots.len();
+        pos.snapshot_data_len = if self.recorder.has_byte_buffer() {
+            self.recorder.snapshot_offset_count()
+        } else {
+            self.snapshots.len()
+        };
         pos
     }
 
@@ -2628,7 +2632,13 @@ impl TraceCtx {
     /// optimizer remaps every published snapshot.
     pub fn cut_trace_with_snapshots(&mut self, pos: TracePosition) {
         self.recorder.cut(pos);
-        self.snapshots.truncate(pos.snapshot_data_len);
+        if self.recorder.has_byte_buffer() {
+            self.recorder
+                .truncate_snapshot_offsets(pos.snapshot_data_len);
+            self.snapshots.clear();
+        } else {
+            self.snapshots.truncate(pos.snapshot_data_len);
+        }
     }
 
     /// pyjitpl.py `MetaInterp.replace_box(oldbox, newbox)` —
@@ -2725,6 +2735,9 @@ impl TraceCtx {
     /// opencoder.py:819 parity: capture a snapshot of the interpreter
     /// frame state. Returns a snapshot_id for use as rd_resume_position.
     pub fn capture_resumedata(&mut self, snapshot: crate::recorder::Snapshot) -> i32 {
+        if self.recorder.has_byte_buffer() {
+            return self.recorder.encode_captured_snapshot(&snapshot);
+        }
         let id = self.snapshots.len() as i32;
         self.snapshots.push(snapshot);
         id
@@ -2737,6 +2750,23 @@ impl TraceCtx {
         } else {
             None
         }
+    }
+
+    /// Decode `_snapshot_data` into `self.snapshots` when the live
+    /// recorder wrote bytes instead of retaining `Vec<Snapshot>`.
+    pub fn ensure_snapshots_materialized(&mut self) {
+        if !self.snapshots.is_empty() {
+            return;
+        }
+        if let Some(decoded) = self.recorder.decode_captured_snapshots() {
+            self.snapshots = decoded;
+        }
+    }
+
+    /// Materialize then take the snapshot side table.
+    pub fn take_snapshots(&mut self) -> Vec<crate::recorder::Snapshot> {
+        self.ensure_snapshots_materialized();
+        std::mem::take(&mut self.snapshots)
     }
 
     /// Set rd_resume_position on the last recorded guard.
@@ -3206,16 +3236,18 @@ impl TraceCtx {
     /// the loop as `TreeLoop { inputargs, ops, snapshots }`. Snapshots
     /// come from the TraceCtx-owned side table (moved them off
     /// `recorder::Trace`); the recorder contributes only inputargs + ops.
-    pub fn into_tree_loop(self) -> crate::history::TreeLoop {
+    pub fn into_tree_loop(mut self) -> crate::history::TreeLoop {
         // `ops` is already `Vec<OpRc>`; `from_oprc` preserves the recorder's
         // shared `Rc<Op>` identity.
+        self.ensure_snapshots_materialized();
         let (inputargs, ops) = self.recorder.into_parts();
         crate::history::TreeLoop::from_oprc(inputargs, ops, self.snapshots)
     }
 
     /// Snapshot slice accessor — Pyre-level parity with
     /// `MetaInterp.history.trace.snapshots()`.
-    pub fn snapshots(&self) -> &[crate::recorder::Snapshot] {
+    pub fn snapshots(&mut self) -> &[crate::recorder::Snapshot] {
+        self.ensure_snapshots_materialized();
         &self.snapshots
     }
 
@@ -3508,8 +3540,8 @@ impl TraceCtx {
         args: &[OpRef],
         num_live: usize,
     ) -> OpRef {
-        let snapshot_idx = self.snapshots.len() as i32;
-        self.snapshots.push(crate::recorder::Snapshot {
+        let opref = self.record_guard(opcode, args, num_live);
+        let snapshot_idx = self.capture_resumedata(crate::recorder::Snapshot {
             frames: vec![crate::recorder::SnapshotFrame {
                 jitcode_index: crate::recorder::UNSTAMPED_JITCODE_INDEX,
                 pc: self.last_traced_pc as u32,
@@ -3519,7 +3551,6 @@ impl TraceCtx {
             vable_boxes: Vec::new(),
             vref_boxes: Vec::new(),
         });
-        let opref = self.record_guard(opcode, args, num_live);
         self.recorder.set_last_op_resume_position(snapshot_idx);
         opref
     }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -3221,9 +3221,21 @@ impl TraceCtx {
 
     /// Op slice accessor — returns the raw recorded operations. After the
     /// `TraceRecordBuffer` swap this materializes via `ByteTraceIter::next`
-    /// walking the byte stream.
+    /// walking the byte stream. Call [`Self::ensure_ops_materialized`] first
+    /// when the live recorder is still in byte form.
     pub fn ops(&self) -> &[majit_ir::OpRc] {
         self.recorder.ops()
+    }
+
+    /// Materialize `opencoder.Trace.get_iter` into `ops` so [`Self::ops`]
+    /// can be read during an in-progress trace.
+    pub fn ensure_ops_materialized(&mut self) {
+        self.recorder.materialize_into_ops();
+    }
+
+    /// Opcode at recorded-op index `i` without materializing the `Op` graph.
+    pub fn opcode_at(&self, i: usize) -> Option<majit_ir::OpCode> {
+        self.recorder.opcode_at(i)
     }
 
     /// `num_inputargs()` — alias for `num_inputs()` keeping RPython

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4905,10 +4905,8 @@ impl<S: JitState> JitDriver<S> {
                         (current_ops == start_ops && current_total == start_total)
                             || (current_ops == start_ops + 1
                                 && current_total == start_total + 1
-                                && ctx
-                                    .ops()
-                                    .get(start_ops)
-                                    .is_some_and(|op| op.opcode == majit_ir::OpCode::GetfieldRawI))
+                                && ctx.opcode_at(start_ops)
+                                    == Some(majit_ir::OpCode::GetfieldRawI))
                     }) {
                         self.meta
                             .bridge_info_cloned()

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -3,7 +3,7 @@
 //! the meta-interpreter.
 use indexmap::IndexMap;
 use majit_ir::operand::Operand;
-use majit_ir::{InputArg, OPCODE_COUNT, Op, OpCode, OpRef, Type, Value};
+use majit_ir::{InputArg, OPCODE_COUNT, OpCode, OpRc, OpRef, Type, Value};
 
 #[allow(dead_code)]
 fn u16_to_opcode(v: u16) -> OpCode {
@@ -600,11 +600,11 @@ where
 /// inputarg list for the op stream between `start` and
 /// `trace._pos`.
 ///
-/// `CutTrace` borrows its parent trace shared-read; the bridge
-/// compilation path produces one per guard failure that triggers a
-/// sub-trace retrace.
+/// `CutTrace.cut_at` mutates the parent, so the view owns an exclusive
+/// borrow. Each iterator reborrows it for its own lifetime; the parent
+/// cannot be cut while a byte-stream reader is still using it.
 pub struct CutTrace<'a> {
-    pub trace: *mut TraceRecordBuffer,
+    pub trace: &'a mut TraceRecordBuffer,
     pub start: usize,
     pub count: u32,
     pub index: u32,
@@ -617,7 +617,6 @@ pub struct CutTrace<'a> {
     /// carries `Box.type` (`history.py:182 AbstractValue.type`) which
     /// pyre encodes as the typed `OpRef` variant tag.
     pub inputargs: Vec<OpRef>,
-    _marker: std::marker::PhantomData<&'a TraceRecordBuffer>,
 }
 
 impl BaseTrace for CutTrace<'_> {}
@@ -626,9 +625,9 @@ impl<'a> CutTrace<'a> {
     /// opencoder.py `CutTrace.cut_at(cut)` — delegate to the
     /// parent trace after asserting the cut lies beyond this cut-trace's
     /// starting count.
-    pub fn cut_at(&self, cut: crate::recorder::TracePosition) {
+    pub fn cut_at(&mut self, cut: crate::recorder::TracePosition) {
         assert!(cut._count > self.count, "cut must lie after CutTrace start");
-        unsafe { (&mut *self.trace).cut_at(cut) };
+        self.trace.cut_at(cut);
     }
 
     /// opencoder.py `CutTrace.get_iter` — build a
@@ -636,8 +635,8 @@ impl<'a> CutTrace<'a> {
     /// `trace._pos`, with `_cache` / `inputargs` seeded from the cut's
     /// inputarg templates.
     #[allow(dead_code)]
-    pub(crate) fn get_iter(&self) -> ByteTraceIter<'a> {
-        let trace = unsafe { &*self.trace };
+    pub(crate) fn get_iter(&self) -> ByteTraceIter<'_> {
+        let trace = &*self.trace;
         ByteTraceIter::new_for_cut(
             trace,
             self.start,
@@ -1440,21 +1439,18 @@ pub struct Trace {
     pub _descrs: Vec<Option<majit_ir::DescrRef>>,
     /// opencoder.py:482 self._refs — `_refs[0]` is always nullptr (index
     /// 0 reserved for the 0-length snapshot array). Non-null GC refs
-    /// append; Rust adaptation roots them on the shadow stack via
-    /// `rooted_ref_indices` so a moving GC can update the pointers
+    /// append; Rust adaptation roots them through `rooted_refs`
+    /// so a moving GC can update the pointers
     /// in-place (gcreftracer.py parity).
     pub _refs: Vec<u64>,
-    /// Rust adaptation: `(_refs index, shadow stack index)` for each
-    /// non-null entry pushed through `_encode_ptr`. RPython's `_refs` is
-    /// a Python list tracked by the host GC; `Vec<u64>` is not, so we
-    /// register each pointer with `majit_gc::shadow_stack` and copy
-    /// updated values back via `refresh_from_gc`. Dropped via
-    /// `release_roots` on `Drop` so the shadow stack returns to its
-    /// creation-time depth.
-    rooted_ref_indices: Vec<(usize, usize)>,
-    /// Shadow-stack depth captured at `Trace::new` — `release_roots`
-    /// pops back to this level.
-    shadow_stack_base: usize,
+    /// `opencoder.py Trace._refs` is a GC-traced list. Rust's raw-word
+    /// vector needs explicit roots, one per non-null entry (slot i roots
+    /// `_refs[i + 1]`). Use independently owned slots: a Trace can outlive
+    /// a lexical root scope or be dropped before roots registered later,
+    /// so it must never truncate somebody else's shadow-stack frame.
+    /// The guards also keep this owner thread-bound. Copy forwarded values
+    /// back at the tracing GC boundary with `refresh_from_gc`.
+    rooted_refs: Vec<majit_gc::shadow_stack::OwnerRootGuard>,
     /// opencoder.py:483 self._refs_dict — caches addr → index into
     /// `_refs`. Cleared by `tracing_done`.
     pub _refs_dict: indexmap::IndexMap<u64, u32>,
@@ -1537,8 +1533,7 @@ impl Trace {
             // opencoder.py:482 — `_refs = [lltype.nullptr(GCREF.TO)]` so
             // index 0 is the null reference / empty-array sentinel.
             _refs: vec![0u64],
-            rooted_ref_indices: Vec::new(),
-            shadow_stack_base: majit_gc::shadow_stack::depth(),
+            rooted_refs: Vec::new(),
             _refs_dict: indexmap::IndexMap::new(),
             _bigints: Vec::new(),
             _bigints_dict: indexmap::IndexMap::new(),
@@ -1636,51 +1631,23 @@ impl Trace {
     // same call shapes; each helper is a single ByteTraceIter walk.
 
     /// Materialize every recorded op in order. O(n) byte walk.
-    pub fn ops(&self) -> Vec<Op> {
-        let mut iter = ByteTraceIter::new(
-            self,
-            self._start as usize,
-            self._pos,
-            self.max_num_inputargs,
-        );
-        let mut ops = Vec::new();
-        for op in iter {
-            ops.push((*op).clone());
-        }
-        ops
+    /// `opencoder.py TraceIterator.next` returns the same ResOperation
+    /// installed in `_cache`: cloning the payload here would split a
+    /// returned producer from the object its consumers' arguments reference.
+    pub fn ops(&self) -> Vec<OpRc> {
+        self.get_byte_iter().collect()
     }
 
     /// Return the first materialized op whose `.pos == pos`. O(n) byte
     /// walk; `None` if no op claims that position.
-    pub fn get_op_by_pos(&self, pos: OpRef) -> Option<Op> {
-        let mut iter = ByteTraceIter::new(
-            self,
-            self._start as usize,
-            self._pos,
-            self.max_num_inputargs,
-        );
-        for op in iter {
-            if op.pos.get() == pos {
-                return Some((*op).clone());
-            }
-        }
-        None
+    pub fn get_op_by_pos(&self, pos: OpRef) -> Option<OpRc> {
+        self.get_byte_iter().find(|op| op.pos.get() == pos)
     }
 
     /// Return the last recorded op, or `None` if the trace is empty.
     /// O(n) byte walk — opencoder's byte layout has no back-pointer.
-    pub fn last_op(&self) -> Option<Op> {
-        let mut iter = ByteTraceIter::new(
-            self,
-            self._start as usize,
-            self._pos,
-            self.max_num_inputargs,
-        );
-        let mut last = None;
-        for op in iter {
-            last = Some((*op).clone());
-        }
-        last
+    pub fn last_op(&self) -> Option<OpRc> {
+        self.get_byte_iter().last()
     }
 
     /// opencoder.py _double_ops — double the byte buffer when
@@ -1798,17 +1765,16 @@ impl Trace {
     /// guard's fail_args (which reference ops recorded before the cut)
     /// acting as fresh inputargs for the resumed trace.
     pub fn cut_trace_from(
-        &self,
+        &mut self,
         cut: crate::recorder::TracePosition,
         inputargs: Vec<OpRef>,
     ) -> CutTrace<'_> {
         CutTrace {
-            trace: self as *const _ as *mut _,
+            trace: self,
             start: cut._pos,
             count: cut._count,
             index: cut._index,
             inputargs,
-            _marker: std::marker::PhantomData,
         }
     }
 
@@ -1895,8 +1861,8 @@ impl Trace {
     /// return `tag(TAGCONSTPTR, idx)`. Index 0 is reserved for nullptr
     /// (seeded by the constructor).
     ///
-    /// Rust adaptation: non-null `addr` is registered on the shadow
-    /// stack so a moving GC can update the entry in-place. RPython's
+    /// Rust adaptation: non-null `addr` gets an independently owned root
+    /// so a moving GC can update the entry in-place. RPython's
     /// `_refs` list is natively GC-tracked; `Vec<u64>` is not.
     pub fn _encode_ptr(&mut self, addr: u64) -> i64 {
         self._consts_ptr += 1;
@@ -1908,8 +1874,10 @@ impl Trace {
         } else {
             let idx = self._refs.len() as u32;
             self._refs.push(addr);
-            let ss_idx = majit_gc::shadow_stack::push(majit_ir::GcRef(addr as usize));
-            self.rooted_ref_indices.push((idx as usize, ss_idx));
+            self.rooted_refs
+                .push(majit_gc::shadow_stack::OwnerRootGuard::new(
+                    majit_ir::GcRef(addr as usize),
+                ));
             self._refs_dict.insert(addr, idx);
             idx
         };
@@ -2878,7 +2846,7 @@ impl Trace {
     }
 
     /// Rust adaptation: mirror pointer moves performed by the GC back
-    /// into `_refs`. The shadow stack holds the authoritative post-move
+    /// into `_refs`. The owner roots hold the authoritative post-move
     /// pointer for each entry pushed by `_encode_ptr`; copy those
     /// values into `_refs` so TAGCONSTPTR decodes land on the current
     /// address. This helper is the required write-back point for the
@@ -2887,24 +2855,23 @@ impl Trace {
     /// (`MetaInterp::walk_active_trace_refs`).
     #[allow(dead_code)]
     pub(crate) fn refresh_from_gc(&mut self) {
-        for &(ref_idx, ss_idx) in &self.rooted_ref_indices {
-            self._refs[ref_idx] = majit_gc::shadow_stack::get(ss_idx).0 as u64;
+        let mut moved = false;
+        for (reference, root) in self._refs[1..].iter_mut().zip(&self.rooted_refs) {
+            let current = root.get().0 as u64;
+            moved |= *reference != current;
+            *reference = current;
         }
-    }
-
-    /// Pop the shadow stack back to the depth captured at construction
-    /// and forget the rooted-index table. Idempotent.
-    fn release_roots(&mut self) {
-        if !self.rooted_ref_indices.is_empty() {
-            majit_gc::shadow_stack::pop_to(self.shadow_stack_base);
-            self.rooted_ref_indices.clear();
+        // `history.py new_ref_dict/rd_hash` hashes stable object identities.
+        // Our address keys need rehashing after movement. Rebuild only after
+        // updating ALL entries (new addresses can overlap old keys), preserving
+        // pool indexes already written into the byte stream. A dictionary
+        // cleared by `tracing_done` must remain cleared.
+        if moved && !self._refs_dict.is_empty() {
+            self._refs_dict.clear();
+            for (index, &reference) in self._refs.iter().enumerate().skip(1) {
+                self._refs_dict.insert(reference, index as u32);
+            }
         }
-    }
-}
-
-impl Drop for Trace {
-    fn drop(&mut self) {
-        self.release_roots();
     }
 }
 
@@ -2919,6 +2886,68 @@ mod tests {
     /// hold in `self.metainterp_sd`.
     fn empty_sd() -> Arc<crate::MetaInterpStaticData> {
         Arc::new(crate::MetaInterpStaticData::new())
+    }
+
+    #[test]
+    fn trace_drop_preserves_later_lexical_roots() {
+        let base = majit_gc::shadow_stack::depth();
+        let mut trace = TraceRecordBuffer::new(0, empty_sd());
+        trace._encode_ptr(0x1000);
+        let lexical = majit_gc::shadow_stack::push(majit_ir::GcRef(0x2000));
+        drop(trace);
+        let remaining = (majit_gc::shadow_stack::depth() > lexical)
+            .then(|| majit_gc::shadow_stack::get(lexical));
+        majit_gc::shadow_stack::pop_to(base);
+        assert_eq!(remaining, Some(majit_ir::GcRef(0x2000)));
+    }
+
+    #[test]
+    fn trace_refresh_rekeys_moved_constants_without_changing_encoded_indexes() {
+        let mut trace = TraceRecordBuffer::new(0, empty_sd());
+        let first = trace._encode_ptr(0x1000);
+        let second = trace._encode_ptr(0x2000);
+        majit_gc::shadow_stack::walk_roots(|reference| reference.0 += 0x1000);
+        trace.refresh_from_gc();
+        assert_eq!(trace._refs, vec![0, 0x2000, 0x3000]);
+        assert_eq!(trace._encode_ptr(0x2000), first);
+        assert_eq!(trace._encode_ptr(0x3000), second);
+        assert_eq!(trace._refs.len(), 3);
+        assert!(!trace._refs_dict.contains_key(&0x1000));
+    }
+
+    #[test]
+    fn trace_roots_outlive_lexical_scopes_and_other_traces() {
+        let base = majit_gc::shadow_stack::depth();
+        majit_gc::shadow_stack::push(majit_ir::GcRef(0x1000));
+        let mut first = TraceRecordBuffer::new(0, empty_sd());
+        first._encode_ptr(0x2000);
+        let mut second = TraceRecordBuffer::new(0, empty_sd());
+        second._encode_ptr(0x3000);
+        majit_gc::shadow_stack::pop_to(base);
+        drop(first);
+        let mut roots = Vec::new();
+        majit_gc::shadow_stack::walk_roots(|reference| roots.push(*reference));
+        assert_eq!(roots, vec![majit_ir::GcRef(0x3000)]);
+        drop(second);
+        roots.clear();
+        majit_gc::shadow_stack::walk_roots(|reference| roots.push(*reference));
+        assert!(roots.is_empty());
+        assert_eq!(majit_gc::shadow_stack::depth(), base);
+    }
+
+    #[test]
+    fn trace_refresh_after_tracing_done_does_not_retain_a_lookup_dictionary() {
+        let mut trace = TraceRecordBuffer::new(0, empty_sd());
+        trace.record_op1(OpCode::SameAsR, Box::ConstPtr(0x1000), None);
+        trace.tracing_done().unwrap();
+        majit_gc::shadow_stack::walk_roots(|reference| reference.0 += 0x1000);
+        trace.refresh_from_gc();
+        assert!(trace._refs_dict.is_empty());
+        let op = trace.get_byte_iter().next().unwrap();
+        assert_eq!(
+            op.arg(0).to_opref().as_const_ptr(),
+            Some(majit_ir::GcRef(0x2000))
+        );
     }
 
     #[test]
@@ -4193,6 +4222,18 @@ mod tests {
         assert_eq!(ops[1].opcode, OpCode::IntMul);
     }
 
+    #[test]
+    fn ops_materializer_returns_the_decoder_producer_identity() {
+        let mut trace = TraceRecordBuffer::new(1, empty_sd());
+        trace.record_input_arg(Type::Int);
+        let position = trace.record_op2(OpCode::IntAdd, Box::ResOp(0), Box::ConstInt(1), None);
+        trace.record_op2(OpCode::IntMul, Box::ResOp(position), Box::ConstInt(2), None);
+        let ops = trace.ops();
+        let producer = ops[1].arg(0).bound_op().unwrap();
+        let first: &majit_ir::Op = std::borrow::Borrow::borrow(&ops[0]);
+        assert!(std::ptr::eq(first, producer.as_ref()));
+    }
+
     /// `get_op_by_pos` returns the Op whose `.pos` equals the
     /// requested OpRef. `ByteTraceIter` seeds `_fresh` at
     /// `max_num_inputargs` and then bumps it once per inputarg before
@@ -4677,6 +4718,27 @@ mod tests {
         // Second op is the guard; third is the INT_SUB tail.
         assert_eq!(ops[1].opcode, OpCode::GuardTrue);
         assert_eq!(ops[2].opcode, OpCode::IntSub);
+    }
+
+    #[test]
+    fn cut_trace_reborrows_for_each_walk_and_delegates_the_rewind() {
+        let mut trace = TraceRecordBuffer::new(1, empty_sd());
+        let input = trace.record_input_arg(Type::Int);
+        let start = trace.cut_point();
+        let first = trace.record_op2(OpCode::IntAdd, Box::ResOp(0), Box::ConstInt(1), None);
+        let end = trace.cut_point();
+        trace.record_op2(OpCode::IntMul, Box::ResOp(first), Box::ConstInt(2), None);
+        {
+            let mut cut = trace.cut_trace_from(start, vec![input]);
+            assert_eq!(cut.get_iter().count(), 2);
+            // `opencoder.py CutTrace.cut_at` delegates to the same parent
+            // that the next get_iter reads, after the old reader has ended.
+            cut.cut_at(end);
+            assert_eq!(cut.get_iter().count(), 1);
+        }
+        assert_eq!(trace.cut_point(), end);
+        trace.record_op2(OpCode::IntSub, Box::ResOp(first), Box::ConstInt(3), None);
+        assert_eq!(trace.ops().last().unwrap().opcode, OpCode::IntSub);
     }
 
     /// test_opencoder.py `TestOpencoder.test_virtualizable_virtualref` —

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -2876,7 +2876,6 @@ impl Trace {
     /// `_refs` shadow-stack adaptation; callers must wire it at the same
     /// GC boundaries as the op-graph Ref-walker
     /// (`MetaInterp::walk_active_trace_refs`).
-    #[allow(dead_code)]
     pub(crate) fn refresh_from_gc(&mut self) {
         let mut moved = false;
         for (reference, root) in self._refs[1..].iter_mut().zip(&self.rooted_refs) {

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -818,9 +818,27 @@ impl<'a> ByteTraceIter<'a> {
 
     /// opencoder.py `_get`.
     fn _get(&self, i: usize) -> Operand {
-        self._cache[i]
-            .clone()
-            .expect("ByteTraceIter._get: cache miss")
+        match self._cache.get(i).cloned().flatten() {
+            Some(res) => res,
+            None => panic!(
+                "ByteTraceIter._get: cache miss at {i} \
+                 (cache_len={}, filled={}, pos={}, start={}, end={}, \
+                 index={}, start_index={}, fresh={}, \
+                 max_in={}, trb_index={}, trb_count={}, n_in={})",
+                self._cache.len(),
+                self._cache.iter().filter(|s| s.is_some()).count(),
+                self.pos,
+                self.start,
+                self.end,
+                self._index,
+                self.start_index,
+                self._fresh,
+                self.trace.max_num_inputargs,
+                self.trace._index,
+                self.trace._count,
+                self.trace.inputargs.len(),
+            ),
+        }
     }
 
     /// opencoder.py `_untag` — full dispatch.
@@ -1519,9 +1537,12 @@ impl Trace {
         // `max_num_inputargs` bytes of `_ops` are reserved as placeholder
         // territory that `TraceIterator.pos = start` walks past —
         // iteration and all write positions operate in a unified
-        // [max_num_inputargs, _pos) range.
+        // [max_num_inputargs, _pos) range. Size the buffer to hold that
+        // prefix: `INIT_SIZE` alone is 4096, and a virtualizable array
+        // can reserve more inputargs than that
+        // (`create_empty_history` after `initialize_virtualizable`).
         let mut t = Trace {
-            _ops: vec![0u8; INIT_SIZE],
+            _ops: vec![0u8; INIT_SIZE.max(max_num_inputargs as usize)],
             _pos: max_num_inputargs as usize,
             _count: max_num_inputargs,
             _index: max_num_inputargs,
@@ -1660,7 +1681,7 @@ impl Trace {
     /// opencoder.py append_byte(c) — write a single byte and
     /// advance `_pos`. Doubles the buffer if needed.
     pub fn append_byte(&mut self, c: u8) {
-        if self._pos >= self._ops.len() {
+        while self._pos >= self._ops.len() {
             self._double_ops();
         }
         self._ops[self._pos] = c;
@@ -1670,15 +1691,17 @@ impl Trace {
     /// opencoder.py append_int(i). Writes a signed varint into
     /// `_ops` at `_pos` using the same 2-or-4 byte layout as
     /// `encode_varint_signed`, but inlined so the buffer-doubling check
-    /// happens once (RPython checks `_pos + 4 > len(_ops)` then writes in
-    /// place). Out-of-range values trip `tag_overflow` and encode 0.
+    /// happens before the write (RPython checks `_pos + 4 > len(_ops)`
+    /// then writes in place). Doubling loops until the reserved
+    /// `_pos = max_num_inputargs` prefix fits. Out-of-range values trip
+    /// `tag_overflow` and encode 0.
     pub fn append_int(&mut self, i: i64) {
         let mut v = i;
         if !(MIN_VALUE..=MAX_VALUE).contains(&v) {
             self.tag_overflow = true;
             v = 0;
         }
-        if self._pos + 4 > self._ops.len() {
+        while self._pos + 4 > self._ops.len() {
             self._double_ops();
         }
         let flag: u8 = if !(-(1 << 14)..(1 << 14)).contains(&v) {

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -958,11 +958,11 @@ impl OptHeap {
     /// struct to the hidden `mutate_*` slot.
     ///
     /// The value comparison is upstream's closing assert: the recording
-    /// captured the field on `arg(1)` (`state::current_quasiimmut_field_value`)
-    /// and a live re-read through `get_runtime_field` is
-    /// `get_current_constant_fieldvalue`. It is answered as a verdict rather
-    /// than an assert, and skipped for an op that carries no captured value —
-    /// the namespace twin, which records a slot index there instead.
+    /// captured the field on `QuasiImmutDescr.constantfieldbox`
+    /// (`quasiimmut.py QuasiImmutDescr.__init__`) and a live re-read
+    /// through `get_runtime_field` is `get_current_constant_fieldvalue`.
+    /// It is answered as a verdict rather than an assert, and skipped
+    /// when the descr carries no captured value.
     ///
     /// ⚠️Answering it as a verdict is LOAD-BEARING here and must not be
     /// demoted to the `debug_assert!` upstream has (gh#964 proposes exactly
@@ -978,7 +978,7 @@ impl OptHeap {
     /// test cannot see. Modelling that chain, or installing the watcher along
     /// it, is what has to come first.
     fn quasiimmut_field_still_valid(
-        op: &Op,
+        _op: &Op,
         obj: OpRef,
         struct_ptr: u64,
         qmutdescr: &majit_ir::QuasiImmutDescr,
@@ -990,10 +990,7 @@ impl OptHeap {
         if !qmutdescr.qmut().is_current() {
             return false;
         }
-        if op.num_args() < 2 {
-            return true;
-        }
-        let Some(constantfieldbox) = op.arg(1).const_value() else {
+        let Some(constantfieldbox) = qmutdescr.constantfieldbox() else {
             return true;
         };
         let Some(currentbox) = ctx

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1050,6 +1050,11 @@ pub struct OptContext {
     /// `OptimizationResult::Remove`, reset on every successful
     /// `emit_operation` (see `Optimizer::emit_operation`).
     pub last_op_removed: bool,
+    /// `history.py Const*` object identity. `get_box_replacement` on a
+    /// Const box returns that same box; minting a fresh `Operand::Const`
+    /// on every `resolve_to_operand` lookup is a lookup-time allocation
+    /// RPython never pays.
+    const_operands: std::cell::RefCell<crate::FxIndexMap<OpRef, Operand>>,
     /// Deferred `InvalidLoop` signal.  RPython `raise InvalidLoop`
     /// abandons the trace; pyre carries the same signal as a
     /// `Result<_, InvalidLoop>` threaded through the optimizer driver so
@@ -1882,6 +1887,7 @@ impl OptContext {
             remove_gctypeptr: true,
             last_op_removed: false,
             pending_invalid_loop: std::cell::Cell::new(None),
+            const_operands: std::cell::RefCell::new(crate::FxIndexMap::default()),
         }
     }
 
@@ -2284,12 +2290,19 @@ impl OptContext {
             return None;
         }
         if opref.is_constant() {
-            return match opref {
+            if let Some(cached) = self.const_operands.borrow().get(&opref).cloned() {
+                return Some(cached);
+            }
+            let minted = match opref {
                 OpRef::ConstInt(v) => Some(Operand::const_from_value(Value::Int(v))),
                 OpRef::ConstFloat(v) => Some(Operand::const_from_value(Value::Float(v))),
                 OpRef::ConstPtr(v) => Some(Operand::const_from_value(Value::Ref(v))),
                 _ => None,
             };
+            if let Some(ref op) = minted {
+                self.const_operands.borrow_mut().insert(opref, op.clone());
+            }
+            return minted;
         }
         if let Some(op) = self.find_producer_op(opref) {
             return Some(Operand::from_bound_op(&op));
@@ -2501,6 +2514,7 @@ impl OptContext {
             remove_gctypeptr: true,
             last_op_removed: false,
             pending_invalid_loop: std::cell::Cell::new(None),
+            const_operands: std::cell::RefCell::new(crate::FxIndexMap::default()),
         }
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -970,31 +970,7 @@ fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::operand::O
                 cache.len(),
             )
         });
-    // `_cache` is indexed by `OpRef::raw()`, which drops the variant tag, so
-    // an Int-bank position and a Ref-bank position carrying the same payload
-    // share one slot. That is sound only while `InputArg*(pos)` positions are
-    // flat across banks — `OpRef::inputarg_refs` states the contract:
-    // position IS the slot index. When two numbering authorities issue into
-    // that one namespace the contract breaks, the lookup SUCCEEDS on the
-    // other bank's operand instead of missing, and the caller receives a
-    // well-formed box for an unrelated value. A ref reaching an int register
-    // this way is decoded as an integer and used as an array index.
-    //
-    // A cross-namespace hit is indistinguishable from a correct translation
-    // at this call site, so compare the banks and fail here rather than
-    // letting the wrong box travel into a snapshot.
-    if let (Some(from), Some(to)) = (opref.ty(), translated.ty())
-        && from != to
-    {
-        panic!(
-            "translate_trace_iter_opref bank mismatch: {opref:?} ({from:?}) resolved \
-             to {translated:?} ({to:?}) through shared raw slot {}. The trace-iterator \
-             cache is keyed by position alone, so two OpRef variants with the same \
-             payload collide; one of them was minted by a numbering authority that \
-             does not share this trace's inputarg space.",
-            opref.raw(),
-        );
-    }
+    assert_prepared_cache_bank("translate_trace_iter_opref", opref, translated.ty());
     translated
 }
 
@@ -1153,7 +1129,7 @@ fn untag_prepared_cache(
     if opref.is_none() || opref.is_constant() {
         return majit_ir::operand::Operand::from_opref(opref);
     }
-    cache
+    let found = cache
         .get(opref.raw() as usize)
         .and_then(|slot| slot.clone())
         .unwrap_or_else(|| {
@@ -1161,7 +1137,33 @@ fn untag_prepared_cache(
                 "prepare_bridge in-place cache miss for {opref:?} (cache_len={})",
                 cache.len()
             )
-        })
+        });
+    assert_prepared_cache_bank("untag_prepared_cache", opref, found.to_opref().ty());
+    found
+}
+
+/// `_cache` is indexed by `OpRef::raw()`, which drops the variant tag, so
+/// an Int-bank position and a Ref-bank position carrying the same payload
+/// share one slot. That is sound only while `InputArg*(pos)` positions are
+/// flat across banks — `OpRef::inputarg_refs` states the contract:
+/// position IS the slot index. When two numbering authorities issue into
+/// that one namespace the contract breaks, the lookup SUCCEEDS on the
+/// other bank's operand instead of missing, and the caller receives a
+/// well-formed box for an unrelated value. A ref reaching an int register
+/// this way is decoded as an integer and used as an array index.
+fn assert_prepared_cache_bank(where_: &str, opref: OpRef, found_ty: Option<Type>) {
+    if let (Some(from), Some(to)) = (opref.ty(), found_ty)
+        && from != to
+    {
+        panic!(
+            "{where_} bank mismatch: {opref:?} ({from:?}) resolved \
+             to {to:?} through shared raw slot {}. The trace-iterator \
+             cache is keyed by position alone, so two OpRef variants with the same \
+             payload collide; one of them was minted by a numbering authority that \
+             does not share this trace's inputarg space.",
+            opref.raw(),
+        );
+    }
 }
 
 fn finish_prepared_bridge(
@@ -7168,9 +7170,10 @@ impl<M: Clone> MetaInterp<M> {
         // prefix from the guard to the header must be cut off — otherwise
         // the root entry contract pairs the guard's fail-arg inputargs
         // with the merge point's full-shape JUMP and aborts on arity.
+        let n_inputargs = ctx.num_inputargs();
         let cut_merge_point = ctx
             .get_merge_point_at(green_key, ctx.header_pc)
-            .filter(|mp| mp.position._pos > 0);
+            .filter(|mp| mp.position.has_prefix_ops(n_inputargs));
         // Resolve while `ctx` is still whole (before `ctx.constants` is moved
         // out below) so `patch_new_loop_to_load_virtualizable_fields` can
         // read the heap object via `vinfo.get_array_length(vable, i)`
@@ -7180,7 +7183,9 @@ impl<M: Clone> MetaInterp<M> {
         let cross_loop_cut = cut_merge_point.map(|mp| {
             (
                 mp.green_boxes.clone(),
-                crate::history::TreeLoopCutPosition::new(mp.position._pos),
+                crate::history::TreeLoopCutPosition::new(
+                    mp.position.tree_loop_op_index(n_inputargs),
+                ),
             )
         });
 
@@ -9146,10 +9151,13 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 return false;
             }
+            let n_inputargs = ctx.num_inputargs();
             let retrace_cut = retrace_merge_point.map(|mp| {
                 (
                     mp.green_boxes.clone(),
-                    crate::history::TreeLoopCutPosition::new(mp.position._pos),
+                    crate::history::TreeLoopCutPosition::new(
+                        mp.position.tree_loop_op_index(n_inputargs),
+                    ),
                 )
             });
             let orig_vable_ptr_retrace =

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -21269,9 +21269,6 @@ mod metainterp_static_data_tests {
             fn loop_header_pc(&self) -> usize {
                 0
             }
-            fn fail_args(&self) -> Option<Vec<OpRef>> {
-                None
-            }
         }
         let mut sym = NoopSym;
         let runtime = crate::ClosureRuntime::new(|_| 0);

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7192,6 +7192,7 @@ impl<M: Clone> MetaInterp<M> {
         // compile.py:221: call_pure_results = metainterp.call_pure_results
         let call_pure_results = ctx.take_call_pure_results();
 
+        let snapshots = ctx.take_snapshots();
         let mut recorder = ctx.recorder;
         // RPython heapcache.py:176: every trace gets at least one
         // GUARD_NOT_INVALIDATED. This allows external invalidation
@@ -7209,7 +7210,7 @@ impl<M: Clone> MetaInterp<M> {
         // captured resumedata. `recorder.get_trace()` on its own returns
         // a snapshot-less TreeLoop.
         let mut trace = recorder.get_trace();
-        trace.snapshots = std::mem::take(&mut ctx.snapshots);
+        trace.snapshots = snapshots;
 
         // compile.py:269-270: cut trace at cross-loop merge point.
         // When the trace was retargeted to a different loop header, record
@@ -10299,9 +10300,10 @@ impl<M: Clone> MetaInterp<M> {
         // walk_active_trace_refs coverage; `compile_snapshot_refs` picks
         // up the snapshot ConstPtrs a few lines below.
         let mut ctx = self.compile_tracing.take().unwrap();
+        let snapshots = ctx.take_snapshots();
         let recorder = ctx.recorder;
         let mut trace = recorder.get_trace();
-        trace.snapshots = std::mem::take(&mut ctx.snapshots);
+        trace.snapshots = snapshots;
         let SimpleCompileViews {
             data: simple_data,
             trace_snapshots,
@@ -10783,13 +10785,14 @@ impl<M: Clone> MetaInterp<M> {
             self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
 
         let call_pure_results = ctx.take_call_pure_results();
+        let snapshots = ctx.take_snapshots();
         let recorder = ctx.recorder;
         // Snapshots live on TraceCtx; rebuild the TreeLoop with them so
         // downstream consumers (`trace.snapshots`) still observe the
         // captured resumedata. `recorder.get_trace()` on its own returns
         // a snapshot-less TreeLoop.
         let mut trace = recorder.get_trace();
-        trace.snapshots = std::mem::take(&mut ctx.snapshots);
+        trace.snapshots = snapshots;
         let SimpleCompileViews {
             data: simple_data,
             trace_snapshots,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5342,7 +5342,6 @@ impl<M: Clone> MetaInterp<M> {
                 }
 
                 let mut ctx = TraceCtx::new(recorder, green_key, self.staticdata.clone());
-                ctx.attach_live_byte_recorder();
                 ctx.set_root_green_key_raw(green_key_raw);
                 // pyjitpl.py:2789 warmrunnerstate.trace_limit snapshot.
                 ctx.set_trace_limit(self.warm_state.trace_limit() as usize);
@@ -5364,6 +5363,11 @@ impl<M: Clone> MetaInterp<M> {
                 self.active_jitdriver_sd = self.elect_active_jitdriver_sd(ctx.driver_descriptor());
                 // pyjitpl.py initialize_virtualizable parity.
                 self.initialize_virtualizable(&mut ctx, live_values);
+                // pyjitpl.py `_compile_and_run_once`: `create_empty_history`
+                // runs after `initialize_state_from_start`, which has already
+                // appended `virtualizable_boxes` onto `original_boxes`. Attach
+                // here so `Trace(max_num_inputargs)` sees the full cap.
+                ctx.attach_live_byte_recorder();
                 // warmstate.py:439 `force_finish_trace=bool(cell.flags &
                 // JC_FORCE_FINISH)`.  Read-only — JC_FORCE_FINISH is sticky
                 // upstream (no clear in rpython/jit/metainterp/).
@@ -5650,7 +5654,6 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             TraceCtx::new(recorder, green_key, self.staticdata.clone())
         };
-        ctx.attach_live_byte_recorder();
         ctx.set_root_green_key_raw(green_key_raw);
         // pyjitpl.py:2789 warmrunnerstate.trace_limit — snapshot onto the
         // per-trace context so `is_too_long` can consult it without needing
@@ -5675,6 +5678,11 @@ impl<M: Clone> MetaInterp<M> {
         self.active_jitdriver_sd = self.elect_active_jitdriver_sd(ctx.driver_descriptor());
         // pyjitpl.py initialize_virtualizable parity.
         self.initialize_virtualizable(&mut ctx, live_values);
+        // pyjitpl.py `_compile_and_run_once`: `create_empty_history`
+        // runs after `initialize_state_from_start`, which has already
+        // appended `virtualizable_boxes` onto `original_boxes`. Attach
+        // here so `Trace(max_num_inputargs)` sees the full cap.
+        ctx.attach_live_byte_recorder();
 
         // warmstate.py:439 `force_finish_trace=bool(cell.flags &
         // JC_FORCE_FINISH)`.  Read-only — JC_FORCE_FINISH is sticky upstream.
@@ -17746,7 +17754,7 @@ impl<M: Clone> MetaInterp<M> {
         let tracelength = self
             .tracing
             .as_ref()
-            .map(|ctx| ctx.ops().len() as i32)
+            .map(|ctx| ctx.num_ops() as i32)
             .unwrap_or(0);
         if tracelength == self.trace_length_at_last_tco {
             // pyjitpl.py:1318-1319: emit SAME_AS_I(ConstInt(tracelength))

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1024,6 +1024,186 @@ fn translate_trace_iter_box_map(
 /// fresh OpRefs in `[bridge_inputarg_base..)`, and rewrites every
 /// reference (op args, fail_args, snapshot boxes, vable boxes,
 /// `pending_bridge_rd.liveboxes`) through the iterator's `_cache`.
+/// `unroll.py UnrollOptimizer.optimize_bridge` `trace.get_iter()` when the caller already uniquely
+/// owns the `ByteTraceIter` / recorder `OpRc`s. RPython's iterator
+/// `cls()` is the one materialization; cloning those objects again
+/// just to rewrite `pos` is a second `cls()`. Rewrite args and
+/// positions in place when `strong_count == 1`.
+fn prepare_bridge_trace_from_owned(
+    mut bridge_ops: Vec<majit_ir::OpRc>,
+    bridge_inputargs: &[InputArg],
+    snapshot_boxes: SnapshotBoxes,
+    snapshot_frame_sizes: SnapshotFrameSizes,
+    snapshot_vable_boxes: SnapshotBoxes,
+    snapshot_vref_boxes: SnapshotBoxes,
+    snapshot_frame_pcs: SnapshotFramePcs,
+    pending_bridge_rd: Option<PendingBridgeRd>,
+    runtime_boxes: Vec<OpRef>,
+    bridge_inputarg_base: u32,
+) -> PreparedBridgeTrace {
+    if !bridge_ops
+        .iter()
+        .all(|op| std::rc::Rc::strong_count(op) == 1)
+    {
+        return prepare_bridge_trace_for_optimizer(
+            &bridge_ops,
+            bridge_inputargs,
+            snapshot_boxes,
+            snapshot_frame_sizes,
+            snapshot_vable_boxes,
+            snapshot_vref_boxes,
+            snapshot_frame_pcs,
+            pending_bridge_rd,
+            runtime_boxes,
+            bridge_inputarg_base,
+        );
+    }
+    #[cfg(feature = "jit-audits")]
+    next_audit_prepare_generation();
+    let max_pos = bridge_ops
+        .iter()
+        .flat_map(|op| {
+            std::iter::once(op.pos.get())
+                .chain(op.getarglist_copy().into_iter().map(|a| a.to_opref()))
+                .chain(op.getfailargs().into_iter().flatten().map(|a| a.to_opref()))
+        })
+        .filter(|opref| !opref.is_none() && !opref.is_constant())
+        .map(|opref| opref.raw())
+        .max()
+        .unwrap_or(0);
+    let cache_size = ((max_pos as usize) + 1).max(bridge_inputargs.len());
+    let mut cache: Vec<Option<majit_ir::operand::Operand>> = vec![None; cache_size];
+    let mut fresh = bridge_inputarg_base;
+    let reminted_inputargs: Vec<InputArg> = bridge_inputargs
+        .iter()
+        .map(|arg| {
+            let reminted = InputArg::from_type(arg.tp, fresh);
+            fresh += 1;
+            if let Some(value) = arg.get_value() {
+                reminted.set_value(value);
+            }
+            reminted
+        })
+        .collect();
+    for (i, arg) in bridge_inputargs.iter().enumerate() {
+        let p = arg.opref().raw() as usize;
+        if p >= cache.len() {
+            cache.resize(p + 1, None);
+        }
+        let ia = InputArg::from_type_rc(arg.tp, reminted_inputargs[i].index);
+        if let Some(value) = reminted_inputargs[i].get_value() {
+            ia.set_value(value);
+        }
+        cache[p] = Some(majit_ir::operand::Operand::from_bound_inputarg(&ia));
+    }
+    for i in 0..bridge_ops.len() {
+        let orig;
+        let is_void;
+        {
+            let op = std::rc::Rc::get_mut(&mut bridge_ops[i]).expect("strong_count checked above");
+            for ai in 0..op.num_args() {
+                let arg = op.arg(ai);
+                if !arg.is_constant() {
+                    op.setarg(ai, untag_prepared_cache(arg.to_opref(), &cache));
+                }
+            }
+            if let Some(fa) = op.fail_args_mut() {
+                for arg in fa.iter_mut() {
+                    if !arg.is_constant() {
+                        *arg = untag_prepared_cache(arg.to_opref(), &cache);
+                    }
+                }
+            }
+            orig = op.pos.get();
+            is_void = orig.is_none() || op.opcode.result_type() == Type::Void;
+            if !is_void {
+                op.pos.set(OpRef::op_typed(fresh, op.opcode.result_type()));
+                fresh += 1;
+            } else if !orig.is_none() {
+                op.pos.set(OpRef::void_op(fresh));
+                fresh += 1;
+            }
+        }
+        if !is_void {
+            let slot = orig.raw() as usize;
+            if slot >= cache.len() {
+                cache.resize(slot + 1, None);
+            }
+            cache[slot] = Some(majit_ir::operand::Operand::from_bound_op(&bridge_ops[i]));
+        }
+    }
+    finish_prepared_bridge(
+        bridge_ops,
+        reminted_inputargs,
+        cache,
+        snapshot_boxes,
+        snapshot_frame_sizes,
+        snapshot_vable_boxes,
+        snapshot_vref_boxes,
+        snapshot_frame_pcs,
+        pending_bridge_rd,
+        runtime_boxes,
+    )
+}
+
+fn untag_prepared_cache(
+    opref: OpRef,
+    cache: &[Option<majit_ir::operand::Operand>],
+) -> majit_ir::operand::Operand {
+    if opref.is_none() || opref.is_constant() {
+        return majit_ir::operand::Operand::from_opref(opref);
+    }
+    cache
+        .get(opref.raw() as usize)
+        .and_then(|slot| slot.clone())
+        .unwrap_or_else(|| {
+            panic!(
+                "prepare_bridge in-place cache miss for {opref:?} (cache_len={})",
+                cache.len()
+            )
+        })
+}
+
+fn finish_prepared_bridge(
+    ops: Vec<majit_ir::OpRc>,
+    inputargs: Vec<InputArg>,
+    cache: Vec<Option<majit_ir::operand::Operand>>,
+    snapshot_boxes: SnapshotBoxes,
+    snapshot_frame_sizes: SnapshotFrameSizes,
+    snapshot_vable_boxes: SnapshotBoxes,
+    snapshot_vref_boxes: SnapshotBoxes,
+    snapshot_frame_pcs: SnapshotFramePcs,
+    pending_bridge_rd: Option<PendingBridgeRd>,
+    runtime_boxes: Vec<OpRef>,
+) -> PreparedBridgeTrace {
+    let snapshot_boxes = translate_trace_iter_box_map(snapshot_boxes, &cache);
+    let snapshot_vable_boxes = translate_trace_iter_box_map(snapshot_vable_boxes, &cache);
+    let snapshot_vref_boxes = translate_trace_iter_box_map(snapshot_vref_boxes, &cache);
+    let pending_bridge_rd = pending_bridge_rd.map(|mut prd| {
+        prd.liveboxes = prd
+            .liveboxes
+            .into_iter()
+            .map(|opref| translate_trace_iter_opref(opref, &cache))
+            .collect();
+        prd
+    });
+    let runtime_boxes = runtime_boxes
+        .into_iter()
+        .map(|opref| translate_trace_iter_opref(opref, &cache))
+        .collect();
+    PreparedBridgeTrace {
+        ops,
+        inputargs,
+        snapshot_boxes,
+        snapshot_frame_sizes,
+        snapshot_vable_boxes,
+        snapshot_vref_boxes,
+        snapshot_frame_pcs,
+        pending_bridge_rd,
+        runtime_boxes,
+    }
+}
+
 fn prepare_bridge_trace_for_optimizer<T>(
     bridge_ops: &[T],
     bridge_inputargs: &[InputArg],
@@ -5162,6 +5342,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
 
                 let mut ctx = TraceCtx::new(recorder, green_key, self.staticdata.clone());
+                ctx.attach_live_byte_recorder();
                 ctx.set_root_green_key_raw(green_key_raw);
                 // pyjitpl.py:2789 warmrunnerstate.trace_limit snapshot.
                 ctx.set_trace_limit(self.warm_state.trace_limit() as usize);
@@ -5469,6 +5650,7 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             TraceCtx::new(recorder, green_key, self.staticdata.clone())
         };
+        ctx.attach_live_byte_recorder();
         ctx.set_root_green_key_raw(green_key_raw);
         // pyjitpl.py:2789 warmrunnerstate.trace_limit — snapshot onto the
         // per-trace context so `is_too_long` can consult it without needing
@@ -8594,6 +8776,7 @@ impl<M: Clone> MetaInterp<M> {
         // canonical `Rc<Op>` handles preserves the same live trace identity
         // and lets `prepare_bridge_trace_for_optimizer` perform the sole fresh
         // materialization, as upstream does.
+        ctx.recorder.materialize_into_ops();
         let bridge_ops: Vec<majit_ir::OpRc> = ctx.ops().to_vec();
         // Carry the history's live input boxes, WITHOUT carrying the values
         // the recorder's own inputargs hold.
@@ -8751,7 +8934,7 @@ impl<M: Clone> MetaInterp<M> {
                     green_key,
                     fail_index,
                     fail_descr,
-                    &bridge_ops,
+                    bridge_ops,
                     &bridge_inputargs,
                     bridge_constants,
                     snapshot_boxes,
@@ -14187,7 +14370,7 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    pub fn compile_bridge<T>(
+    pub fn compile_bridge(
         &mut self,
         green_key: u64,
         // The jitcell the closing JUMP enters (`bridge_cell_token_key`).
@@ -14204,7 +14387,7 @@ impl<M: Clone> MetaInterp<M> {
         jump_target_key: u64,
         fail_index: u32,
         fail_descr: &dyn majit_ir::FailDescr,
-        bridge_ops: &[T],
+        bridge_ops: Vec<majit_ir::OpRc>,
         bridge_inputargs: &[majit_ir::InputArg],
         bridge_constants: majit_ir::ConstMap<majit_ir::Const>,
         snapshot_boxes: SnapshotBoxes,
@@ -14213,10 +14396,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
-    ) -> bool
-    where
-        T: std::borrow::Borrow<majit_ir::Op>,
-    {
+    ) -> bool {
         self.remember_compiled_graph_write();
         self.last_compiled_artifact_token = None;
         crate::mc_diag_bump(8); // compile_bridge entered
@@ -14425,12 +14605,12 @@ impl<M: Clone> MetaInterp<M> {
         // for every recorded operation, immediately before TraceIterator
         // allocated the real fresh objects consumed by the optimizer.
         let bridge_runtime_boxes: Vec<OpRef> =
-            Self::closing_jump_runtime_boxes(bridge_ops, bridge_inputargs);
+            Self::closing_jump_runtime_boxes(&bridge_ops, bridge_inputargs);
         // `UnrollOptimizer.optimize_bridge`'s `trace = trace.get_iter()`: mint
         // fresh InputArg / ResOperation objects in a disjoint OpRef namespace
         // (`TraceIterator.__init__`, `opencoder.py`:
         // `self.inputargs = [rop.inputarg_from_tp(arg.type) for ...]`).
-        let prepared = prepare_bridge_trace_for_optimizer(
+        let prepared = prepare_bridge_trace_from_owned(
             bridge_ops,
             bridge_inputargs,
             snapshot_boxes,
@@ -15060,6 +15240,7 @@ impl<M: Clone> MetaInterp<M> {
                 .expect("bridge source token must name a registered jitdriver");
             ctx.set_driver_descriptor(descriptor.clone());
         }
+        ctx.attach_live_byte_recorder();
         ctx.set_force_finish(self.force_finish_trace);
         // pyjitpl.py:929-947 `self.metainterp.cpu` analog — see
         // `setup_tracing` for the contract on raw-pointer lifetime

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -680,21 +680,6 @@ pub trait JitCodeSym {
     fn abort_portal_op(&mut self) {}
     fn total_slots(&self) -> usize;
     fn loop_header_pc(&self) -> usize;
-    /// Full interpreter-visible state to materialize on guard failure.
-    ///
-    /// When `None`, guards fall back to the legacy auto-generated fail args.
-    fn fail_args(&self) -> Option<Vec<OpRef>>;
-
-    /// Guard-failure state materialization that may record extra IR.
-    fn fail_args_with_ctx(&mut self, _ctx: &mut TraceCtx) -> Option<Vec<OpRef>> {
-        self.fail_args()
-    }
-
-    /// Types of fail_args values. When Some, used instead of default all-Int.
-    fn fail_args_types(&self) -> Option<Vec<majit_ir::Type>> {
-        None
-    }
-
     /// pyjitpl.py:2981-2989 `live_arg_boxes` — this merge point's
     /// loop-carried boxes, in the exact order the closing JUMP emits them.
     ///
@@ -1683,43 +1668,21 @@ where
         {
             return first;
         }
-        if let Some(fail_args) = sym.fail_args_with_ctx(ctx) {
-            let fail_types = sym.fail_args_types();
-            // The snapshot is the source of truth — the
-            // optimizer's `store_final_boxes_in_guard`
-            // (`optimizeopt/mod.rs`) overwrites `op.fail_args` from
-            // the snapshot built below, so the inline `fail_args` copy
-            // that the legacy
-            // `record_guard_typed_with_fail_args` /
-            // `record_guard_with_fail_args` paths used to write is
-            // redundant.  Mirrors RPython's
-            // `pyjitpl.MetaInterp.generate_guard`
-            // (`pyjitpl.py:2558-2602`) which records the guard with no
-            // inline fail_args and lets `capture_resumedata` +
-            // `_number_boxes` populate them from the snapshot chain.
-            let guard_op = if let Some(types) = fail_types {
-                ctx.record_guard_typed(opcode, args, types)
-            } else {
-                ctx.record_guard(opcode, args, fail_args.len())
-            };
-            // framestack-lift 3b: capture a
-            // matching snapshot and patch the guard's
-            // rd_resume_position so the optimizer's
-            // store_final_boxes_in_guard derives fail_args from the
-            // snapshot (RPython parity, opencoder.py:819 +
-            // resume.py:396-397).
-            self.publish_last_guard_resume_snapshot(
-                ctx,
-                sym,
-                resume_pc,
-                after_residual_call,
-                GuardStampTarget::LastOp,
-                Some((opcode, fail_args.len())),
-            );
-            guard_op
-        } else {
-            ctx.record_guard(opcode, args, sym.total_slots())
-        }
+        // `pyjitpl.py MetaInterp.generate_guard` records the guard and then
+        // captures its live MIFrames. It does not construct a second failarg
+        // list (or type list) to decide whether the frame snapshot exists.
+        // `resume.py ResumeDataVirtualAdder.finish` derives the final failargs
+        // from that snapshot after optimization.
+        let guard_op = ctx.record_guard(opcode, args, 0);
+        self.publish_last_guard_resume_snapshot(
+            ctx,
+            sym,
+            resume_pc,
+            after_residual_call,
+            GuardStampTarget::LastOp,
+            Some(opcode),
+        );
+        guard_op
     }
 
     fn apply_pending_box_replace(&mut self, ctx: &mut TraceCtx) {
@@ -1783,12 +1746,6 @@ where
         if minted == 0 {
             return;
         }
-        if sym.fail_args_with_ctx(ctx).is_none() {
-            // The sym cannot name the live set, so no snapshot is buildable —
-            // the same condition under which `record_state_guard` records a
-            // guard without one.
-            return;
-        }
         let restored = write.and_then(|w| {
             ctx.swap_virtualizable_entry(w.index, w.prev_box, w.prev_value)
                 .map(|current| (w.index, current))
@@ -1826,7 +1783,7 @@ where
     /// top of the vable promote, so that caller needs the guard form or the
     /// position lands on the COND_CALL.
     ///
-    /// `diag` carries the guard opcode and its fail-arg count for the
+    /// `diag` carries the guard opcode for the
     /// `callee_rca` trace only; callers re-stamping a guard `TraceCtx`
     /// recorded internally pass `None`.
     fn publish_last_guard_resume_snapshot(
@@ -1836,7 +1793,7 @@ where
         resume_pc: usize,
         after_residual_call: bool,
         target: GuardStampTarget,
-        diag: Option<(OpCode, usize)>,
+        diag: Option<OpCode>,
     ) {
         let top_idx = self
             .frames
@@ -1933,12 +1890,11 @@ where
                 .collect();
             eprintln!(
                 "[callee-rca][record-guard] opcode={:?} resume_pc={} \
-                 vable_boxes={} vref_boxes={} fail_args={:?}",
-                diag.map(|(opcode, _)| opcode),
+                 vable_boxes={} vref_boxes={}",
+                diag,
                 resume_pc,
                 virtualizable_snapshot.len(),
                 virtualref_snapshot.len(),
-                diag.map(|(_, n)| n),
             );
             eprintln!("[callee-rca][record-guard-vable] {:?}", vable_payload);
         }
@@ -12085,10 +12041,6 @@ mod tests {
         fn loop_header_pc(&self) -> usize {
             0
         }
-
-        fn fail_args(&self) -> Option<Vec<OpRef>> {
-            None
-        }
     }
 
     #[test]
@@ -12364,10 +12316,6 @@ mod tests {
             0
         }
 
-        fn fail_args(&self) -> Option<Vec<OpRef>> {
-            None
-        }
-
         fn recursive_fresh_entry_reds(&self) -> Option<(Vec<Value>, Box<dyn std::any::Any>)> {
             let fresh: Box<Vec<i64>> = Box::new(vec![0i64; 12]);
             let base = &*fresh as *const Vec<i64> as usize;
@@ -12400,19 +12348,21 @@ mod tests {
     #[test]
     fn recursive_call_assembler_records_fresh_frame_and_returns_result() {
         RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
 
         // Caller jitcode: recurse (decision = CallAssembler), result into reg
         // 0, then return reg 0.  The callee runs with a fresh frame, so no
         // caller reds flow in (the arg-triple is ignored).
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_int(0, 0, &[], &[]);
+        caller_builder.live(&mut asm, &[0], &[], &[]);
         caller_builder.int_return(0);
         let caller = caller_builder.finish();
 
         let runtime = RecursiveAssemblerRuntime {
             token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
         };
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = RecursiveFreshSym;
         let action =
             trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
@@ -12544,16 +12494,18 @@ mod tests {
     #[test]
     fn a_residual_decision_still_reaches_call_assembler_through_the_token_seam() {
         RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
 
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_int(0, 0, &[], &[]);
+        caller_builder.live(&mut asm, &[0], &[], &[]);
         caller_builder.int_return(0);
         let caller = caller_builder.finish();
 
         let runtime = RecursiveResidualDecisionRuntime {
             token: Some(std::sync::Arc::new(majit_backend::JitCellToken::new(7))),
         };
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = RecursiveFreshSym;
         let action =
             trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
@@ -12615,16 +12567,18 @@ mod tests {
     #[test]
     fn recursive_call_assembler_ref_records_and_returns_result() {
         RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
 
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_ref(0, 0, &[], &[]);
+        caller_builder.live(&mut asm, &[], &[0], &[]);
         caller_builder.ref_return(0);
         let caller = caller_builder.finish();
 
         let runtime = RecursiveAssemblerRuntime {
             token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
         };
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = RecursiveFreshSym;
         let action =
             trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
@@ -12680,16 +12634,18 @@ mod tests {
     #[test]
     fn recursive_call_assembler_float_records_and_returns_result() {
         RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
 
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_float(0, 0, &[], &[]);
+        caller_builder.live(&mut asm, &[], &[], &[0]);
         caller_builder.float_return(0);
         let caller = caller_builder.finish();
 
         let runtime = RecursiveAssemblerRuntime {
             token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
         };
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = RecursiveFreshSym;
         let action =
             trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
@@ -12745,16 +12701,18 @@ mod tests {
     #[test]
     fn recursive_call_assembler_void_records_and_runs_side_effect() {
         RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
 
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_void(0, &[], &[]);
+        caller_builder.live(&mut asm, &[], &[], &[]);
         caller_builder.void_return();
         let caller = caller_builder.finish();
 
         let runtime = RecursiveAssemblerRuntime {
             token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
         };
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = RecursiveFreshSym;
         let action =
             trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
@@ -12874,6 +12832,7 @@ mod tests {
 
     #[test]
     fn recursive_portal_merge_point_cuts_to_call_assembler() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         // Portal body: a merge point THEN a return.  The merge point is
         // reached at portal_call_depth > 0 (inlined), triggering the
         // else-branch cut; the trailing `int_return` must NOT be traced (the
@@ -12887,6 +12846,7 @@ mod tests {
         // reg 0, then return reg 0.
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.recursive_call_int(0, 0, &[], &[]);
+        caller_builder.live(&mut asm, &[0], &[], &[]);
         caller_builder.int_return(0);
         let caller = caller_builder.finish();
 
@@ -12894,6 +12854,8 @@ mod tests {
         // merge point auto-stamps `seen_loop_header_for_jdindex` (>= 0),
         // bypassing the EDIT-A seen<0 skip and flowing into the depth>0 cut.
         let mut staticdata = crate::MetaInterpStaticData::new();
+        staticdata.op_live = crate::jitcode::insns::BC_LIVE as i32;
+        staticdata.liveness_info = asm.all_liveness().to_vec();
         let mut jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![("frame", Type::Int)]);
         jd.index = Some(0);
         jd.result_type = Type::Int;
@@ -13131,23 +13093,18 @@ mod tests {
         assert_eq!(recorder.num_ops(), 0);
     }
 
-    /// A `JitCodeSym` that names a live set, so guard capture is reachable.
-    /// `DummySym` answers `None` and skips it entirely.
-    struct FailArgsSym {
-        fail_args: Vec<OpRef>,
+    /// A symbol whose two state slots already reside in the live MIFrame.
+    struct LiveSlotsSym {
+        num_slots: usize,
     }
 
-    impl JitCodeSym for FailArgsSym {
+    impl JitCodeSym for LiveSlotsSym {
         fn total_slots(&self) -> usize {
-            self.fail_args.len()
+            self.num_slots
         }
 
         fn loop_header_pc(&self) -> usize {
             0
-        }
-
-        fn fail_args(&self) -> Option<Vec<OpRef>> {
-            Some(self.fail_args.clone())
         }
     }
 
@@ -13196,9 +13153,7 @@ mod tests {
             Some(array_box)
         );
 
-        let mut sym = FailArgsSym {
-            fail_args: vec![OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
-        };
+        let mut sym = LiveSlotsSym { num_slots: 2 };
         let action = trace_jitcode_with_args(
             &mut ctx,
             &mut sym,
@@ -13295,9 +13250,7 @@ mod tests {
         // the standard path instead of falling back to the heap.
         ctx.set_opref_concrete(vable_arg, Value::Ref(majit_ir::GcRef(999)));
 
-        let mut sym = FailArgsSym {
-            fail_args: vec![OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
-        };
+        let mut sym = LiveSlotsSym { num_slots: 2 };
         let action = trace_jitcode_with_args(
             &mut ctx,
             &mut sym,
@@ -13724,15 +13677,17 @@ mod tests {
 
     #[test]
     fn jitcode_call_may_force_marks_standard_virtualizable_token_and_guards() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut obj = ResidualVable { token: 0 };
         let obj_ptr = (&mut obj as *mut ResidualVable) as usize as i64;
 
         let mut builder = JitCodeBuilder::new();
         let fn_idx = builder.add_fn_ptr(residual_no_force as *const ());
         builder.call_may_force_void_canonical_via_target(fn_idx, &[JitCallArg::reference(0)]);
+        builder.live(&mut asm, &[], &[0], &[]);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut info = VirtualizableInfo::new(0);
         info.set_parent_descr(majit_ir::descr::make_size_descr(64));
         let vable_ref = ctx.const_ref(obj_ptr);
@@ -13944,6 +13899,7 @@ mod tests {
 
     #[test]
     fn residual_call_can_raise_records_guard_no_exception_on_success() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let fn_idx = builder.add_fn_ptr(residual_void_no_args as *const ());
         builder.residual_call_void_canonical_via_target_with_effect_info(
@@ -13951,9 +13907,10 @@ mod tests {
             &[],
             residual_effect(majit_ir::descr::ExtraEffect::CanRaise),
         );
+        builder.live(&mut asm, &[], &[], &[]);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = DummySym;
         let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
         crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -13970,6 +13927,7 @@ mod tests {
 
     #[test]
     fn residual_call_exception_records_guard_exception_and_routes_to_handler() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let handler = builder.new_label();
         let fn_idx = builder.add_fn_ptr(residual_void_raises as *const ());
@@ -13978,13 +13936,15 @@ mod tests {
             &[],
             residual_effect(majit_ir::descr::ExtraEffect::CanRaise),
         );
+        builder.live(&mut asm, &[], &[], &[]);
         builder.catch_exception(handler);
         builder.mark_label(handler);
         builder.last_exc_value(0);
+        builder.live(&mut asm, &[], &[0], &[]);
         builder.ref_guard_value(0);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut sym = DummySym;
         let action = trace_jitcode(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0);
         crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -14205,9 +14165,6 @@ mod tests {
             fn loop_header_pc(&self) -> usize {
                 0
             }
-            fn fail_args(&self) -> Option<Vec<OpRef>> {
-                Some(vec![OpRef::int_op(50)])
-            }
             fn populate_frame_int_regs(&self, frame: &mut MIFrame) {
                 frame.int_regs[0] = Some(OpRef::int_op(50));
                 frame.int_values[0] = Some(500);
@@ -14286,15 +14243,17 @@ mod tests {
 
     #[test]
     fn jitcode_residual_call_int_may_force_marks_standard_virtualizable_token_and_guards() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut obj = ResidualVable { token: 0 };
         let obj_ptr = (&mut obj as *mut ResidualVable) as usize as i64;
 
         let mut builder = JitCodeBuilder::new();
         let fn_idx = builder.add_fn_ptr(residual_int_no_force as *const ());
         builder.call_may_force_int_canonical_via_target(fn_idx, &[JitCallArg::reference(0)], 1);
+        builder.live(&mut asm, &[1], &[0], &[]);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut info = VirtualizableInfo::new(0);
         info.set_parent_descr(majit_ir::descr::make_size_descr(64));
         let vable_ref = ctx.const_ref(obj_ptr);
@@ -14345,15 +14304,17 @@ mod tests {
 
     #[test]
     fn jitcode_residual_call_ref_may_force_marks_standard_virtualizable_token_and_guards() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut obj = ResidualVable { token: 0 };
         let obj_ptr = (&mut obj as *mut ResidualVable) as usize as i64;
 
         let mut builder = JitCodeBuilder::new();
         let fn_idx = builder.add_fn_ptr(residual_ref_no_force as *const ());
         builder.call_may_force_ref_canonical_via_target(fn_idx, &[JitCallArg::reference(0)], 1);
+        builder.live(&mut asm, &[], &[0, 1], &[]);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut info = VirtualizableInfo::new(0);
         info.set_parent_descr(majit_ir::descr::make_size_descr(64));
         let vable_ref = ctx.const_ref(obj_ptr);
@@ -14404,15 +14365,17 @@ mod tests {
 
     #[test]
     fn jitcode_residual_call_float_may_force_marks_standard_virtualizable_token_and_guards() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut obj = ResidualVable { token: 0 };
         let obj_ptr = (&mut obj as *mut ResidualVable) as usize as i64;
 
         let mut builder = JitCodeBuilder::new();
         let fn_idx = builder.add_fn_ptr(residual_float_no_force as *const ());
         builder.call_may_force_float_canonical_via_target(fn_idx, &[JitCallArg::reference(0)], 1);
+        builder.live(&mut asm, &[], &[0], &[1]);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(0);
+        let mut ctx = context_with_liveness(&[], &asm);
         let mut info = VirtualizableInfo::new(0);
         info.set_parent_descr(majit_ir::descr::make_size_descr(64));
         let vable_ref = ctx.const_ref(obj_ptr);
@@ -14499,13 +14462,15 @@ mod tests {
 
         // Non-constant operands (input args 5 < 3 = false): the compare and
         // the GuardFalse are materialised.
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[0, 1], &[], &[]);
         builder.goto_if_not_int_lt(0, 1, target);
         builder.mark_label(target);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(2);
+        let mut ctx = context_with_liveness(&[Type::Int, Type::Int], &asm);
         let mut sym = DummySym;
         let action = trace_jitcode_with_args(
             &mut ctx,
@@ -14545,7 +14510,30 @@ mod tests {
         jitcode: &JitCode,
         argboxes: &[(JitArgKind, OpRef, i64)],
     ) -> Vec<OpCode> {
-        let mut ctx = TraceCtx::for_test_types(types);
+        traced_opcodes_with_liveness(types, jitcode, argboxes, &Default::default())
+    }
+
+    fn context_with_liveness(
+        types: &[majit_ir::Type],
+        asm: &majit_translate::codewriter::assembler::Assembler,
+    ) -> TraceCtx {
+        let mut staticdata = crate::MetaInterpStaticData::new();
+        staticdata.op_live = crate::jitcode::insns::BC_LIVE as i32;
+        staticdata.liveness_info = asm.all_liveness().to_vec();
+        TraceCtx::new(
+            crate::recorder::Trace::with_input_types(types),
+            0,
+            std::sync::Arc::new(staticdata),
+        )
+    }
+
+    fn traced_opcodes_with_liveness(
+        types: &[majit_ir::Type],
+        jitcode: &JitCode,
+        argboxes: &[(JitArgKind, OpRef, i64)],
+        asm: &majit_translate::codewriter::assembler::Assembler,
+    ) -> Vec<OpCode> {
+        let mut ctx = context_with_liveness(types, asm);
         let mut sym = DummySym;
         let action = trace_jitcode_with_args(&mut ctx, &mut sym, jitcode, 0, |_pc| 0, argboxes);
         assert!(matches!(action, TraceAction::Continue));
@@ -14586,14 +14574,17 @@ mod tests {
             ),
         ];
         for (emit, ptr, want) in cases {
+            let mut asm = majit_translate::codewriter::assembler::Assembler::new();
             let mut builder = JitCodeBuilder::new();
             let target = builder.new_label();
+            builder.live(&mut asm, &[], &[0], &[]);
             emit(&mut builder, target);
             builder.mark_label(target);
-            let recorded = traced_opcodes(
+            let recorded = traced_opcodes_with_liveness(
                 &[majit_ir::Type::Ref],
                 &builder.finish(),
                 &[(JitArgKind::Ref, OpRef::input_arg_ref(0), ptr)],
+                &asm,
             );
             assert_eq!(recorded, vec![want], "ptr={ptr:#x}");
         }
@@ -14604,17 +14595,21 @@ mod tests {
     /// short-circuit and guards nothing.
     #[test]
     fn a_second_nullity_branch_on_one_box_is_answered_by_the_heapcache() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let first = builder.new_label();
+        builder.live(&mut asm, &[], &[0], &[]);
         builder.goto_if_not_ptr_nonzero(0, first);
         builder.mark_label(first);
         let second = builder.new_label();
+        builder.live(&mut asm, &[], &[0], &[]);
         builder.goto_if_not_ptr_nonzero(0, second);
         builder.mark_label(second);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Ref],
             &builder.finish(),
             &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0x40)],
+            &asm,
         );
         assert_eq!(recorded, vec![OpCode::GuardNonnull], "{recorded:?}");
     }
@@ -14628,15 +14623,18 @@ mod tests {
     /// through `FASTPATHS_SAME_BOXES` and would answer the same either way.
     #[test]
     fn a_null_ptr_nullity_branch_rebinds_its_source_register() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[], &[0], &[]);
         builder.goto_if_not_ptr_iszero(0, target);
         builder.ptr_nonzero(1, 0);
         builder.mark_label(target);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Ref],
             &builder.finish(),
             &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0)],
+            &asm,
         );
         assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
     }
@@ -14668,17 +14666,20 @@ mod tests {
     /// through the alias folds.
     #[test]
     fn a_null_ptr_nullity_branch_replaces_the_box_in_an_aliasing_register() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[], &[0, 1], &[]);
         builder.goto_if_not_ptr_iszero(0, target);
         // Read the ALIAS, not the register the branch resolved.
         builder.ptr_nonzero(0, 1);
         builder.mark_label(target);
         let aliased = OpRef::input_arg_ref(0);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Ref, majit_ir::Type::Ref],
             &builder.finish(),
             &[(JitArgKind::Ref, aliased, 0), (JitArgKind::Ref, aliased, 0)],
+            &asm,
         );
         assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
     }
@@ -14689,15 +14690,18 @@ mod tests {
     /// recording arithmetic against a box already pinned to a value.
     #[test]
     fn a_guard_value_promote_replaces_the_box_in_an_aliasing_register() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
+        builder.live(&mut asm, &[0, 1], &[], &[]);
         builder.int_guard_value(0);
         // Read the ALIAS, not the register the guard named.
         builder.record_binop_i(2, OpCode::IntAdd, 1, 1);
         let aliased = OpRef::input_arg_int(0);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Int, majit_ir::Type::Int],
             &builder.finish(),
             &[(JitArgKind::Int, aliased, 3), (JitArgKind::Int, aliased, 3)],
+            &asm,
         );
         assert_eq!(recorded, vec![OpCode::GuardValue], "{recorded:?}");
     }
@@ -14709,17 +14713,20 @@ mod tests {
     fn goto_if_not_rebinds_its_condition_register_to_the_proved_constant() {
         // `cond` is an input arg, so the guard cannot be elided; reading it
         // again after the branch is what shows the rebind.
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[0], &[], &[]);
         builder.goto_if_not(0, target);
         builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
         builder.mark_label(target);
         let jitcode = builder.finish();
 
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Int],
             &jitcode,
             &[(JitArgKind::Int, OpRef::input_arg_int(0), 1)],
+            &asm,
         );
         assert!(recorded.contains(&OpCode::GuardTrue), "{recorded:?}");
         assert!(
@@ -14733,17 +14740,20 @@ mod tests {
     /// then branches with `replace=False`.
     #[test]
     fn goto_if_not_int_is_true_records_the_folded_int_is_true() {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[0], &[], &[]);
         builder.goto_if_not_int_is_true(0, target);
         builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
         builder.mark_label(target);
         let jitcode = builder.finish();
 
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Int],
             &jitcode,
             &[(JitArgKind::Int, OpRef::input_arg_int(0), 7)],
+            &asm,
         );
         assert!(recorded.contains(&OpCode::IntIsTrue), "{recorded:?}");
         assert!(recorded.contains(&OpCode::GuardTrue), "{recorded:?}");
@@ -15036,14 +15046,17 @@ mod tests {
         assert!(!folded.contains(&OpCode::IntIsZero));
         assert!(!folded.contains(&OpCode::GuardFalse));
 
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[0], &[], &[]);
         builder.goto_if_not_int_is_zero(0, target);
         builder.mark_label(target);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Int],
             &builder.finish(),
             &[(JitArgKind::Int, OpRef::input_arg_int(0), 5)],
+            &asm,
         );
         assert!(recorded.contains(&OpCode::IntIsZero));
         assert!(recorded.contains(&OpCode::GuardFalse));
@@ -15064,16 +15077,19 @@ mod tests {
         assert!(!folded.contains(&OpCode::IntEq));
         assert!(!folded.contains(&OpCode::GuardFalse));
 
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let case_a = builder.new_label();
         let case_b = builder.new_label();
+        builder.live(&mut asm, &[0], &[], &[]);
         builder.switch(0, &[(-3, case_a), (7, case_b)]);
         builder.mark_label(case_a);
         builder.mark_label(case_b);
-        let recorded = traced_opcodes(
+        let recorded = traced_opcodes_with_liveness(
             &[majit_ir::Type::Int],
             &builder.finish(),
             &[(JitArgKind::Int, OpRef::input_arg_int(0), 99)],
+            &asm,
         );
         assert_eq!(
             recorded.iter().filter(|&&o| o == OpCode::IntEq).count(),
@@ -15137,11 +15153,13 @@ mod tests {
         assert!(ops.contains(&OpCode::GetfieldGcI));
     }
 
-    fn switch_return_jitcode() -> JitCode {
+    fn switch_return_jitcode() -> (JitCode, majit_translate::codewriter::assembler::Assembler) {
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let case_a = builder.new_label();
         let case_b = builder.new_label();
         let case_c = builder.new_label();
+        builder.live(&mut asm, &[0], &[], &[]);
         builder.switch(0, &[(-3, case_a), (7, case_b), (42, case_c)]);
         builder.load_const_i_value(1, 10);
         builder.int_return(1);
@@ -15154,7 +15172,7 @@ mod tests {
         builder.mark_label(case_c);
         builder.load_const_i_value(1, 40);
         builder.int_return(1);
-        builder.finish()
+        (builder.finish(), asm)
     }
 
     #[test]
@@ -15162,8 +15180,8 @@ mod tests {
         // RPython `pyjitpl.py opimpl_switch` hit path:
         // promote the switched value with GUARD_VALUE, then jump to the
         // target from SwitchDictDescr.dict.
-        let jitcode = switch_return_jitcode();
-        let mut ctx = TraceCtx::for_test(1);
+        let (jitcode, asm) = switch_return_jitcode();
+        let mut ctx = context_with_liveness(&[Type::Int], &asm);
         let mut sym = DummySym;
         let action = trace_jitcode_with_args(
             &mut ctx,
@@ -15197,8 +15215,8 @@ mod tests {
         // RPython `pyjitpl.py opimpl_switch` miss path:
         // for each `const_keys_in_order`, emit INT_EQ plus GUARD_FALSE,
         // then leave pc at the fall-through default path.
-        let jitcode = switch_return_jitcode();
-        let mut ctx = TraceCtx::for_test(1);
+        let (jitcode, asm) = switch_return_jitcode();
+        let mut ctx = context_with_liveness(&[Type::Int], &asm);
         let mut sym = DummySym;
         let action = trace_jitcode_with_args(
             &mut ctx,
@@ -15511,9 +15529,6 @@ mod tests {
             fn loop_header_pc(&self) -> usize {
                 0
             }
-            fn fail_args(&self) -> Option<Vec<OpRef>> {
-                None
-            }
             fn populate_frame_int_regs(&self, frame: &mut MIFrame) {
                 let mut slot = 0;
                 // scalars
@@ -15555,10 +15570,10 @@ mod tests {
     }
 
     #[test]
-    fn record_state_guard_attaches_snapshot_when_sym_supplies_fail_args() {
-        // When a JitCodeSym implementation returns `Some(_)` from
-        // `fail_args_with_ctx` and overrides `populate_frame_int_regs`
-        // (the macro-emitted state-field-JIT shape), every guard
+    fn record_state_guard_captures_frames_without_building_legacy_fail_args() {
+        // `pyjitpl.py MetaInterp.generate_guard` captures the live frames,
+        // without first constructing a second full list of guard failargs.
+        // With the macro-emitted state-field-JIT shape, every guard
         // recorded via `record_state_guard` must
         //   (a) push a snapshot through `TraceCtx::capture_resumedata`,
         //   (b) patch the just-recorded guard's `rd_resume_position`
@@ -15571,7 +15586,6 @@ mod tests {
         // call) is caught at the unit level rather than only via the
         // macro-example end-to-end suites.
         struct StateFieldLikeSym {
-            fail_args: Vec<OpRef>,
             populated: Vec<(usize, OpRef, i64)>,
         }
         impl JitCodeSym for StateFieldLikeSym {
@@ -15580,9 +15594,6 @@ mod tests {
             }
             fn loop_header_pc(&self) -> usize {
                 0
-            }
-            fn fail_args(&self) -> Option<Vec<OpRef>> {
-                Some(self.fail_args.clone())
             }
             fn populate_frame_int_regs(&self, frame: &mut MIFrame) {
                 for &(slot, opref, value) in &self.populated {
@@ -15616,7 +15627,6 @@ mod tests {
         // — the actual values are arbitrary; the snapshot must mirror
         // them slot-for-slot post-`populate_frame_int_regs`.
         let mut sym = StateFieldLikeSym {
-            fail_args: vec![OpRef::int_op(50), OpRef::int_op(51), OpRef::int_op(52)],
             populated: vec![
                 (0, OpRef::int_op(50), 500),
                 (1, OpRef::int_op(51), 510),
@@ -15673,24 +15683,26 @@ mod tests {
     }
 
     #[test]
-    fn record_state_guard_skips_snapshot_when_sym_returns_none_fail_args() {
-        // Inverse of the above: when a JitCodeSym returns `None` from
-        // `fail_args_with_ctx` (legacy / non-state-field path), the
-        // else branch of `record_state_guard` keeps the original
-        // `record_guard` semantics — no snapshot capture, no
-        // `set_last_guard_resume_position` patch.  Locks the negative
-        // contract so the wire-up does not bleed into call sites that
-        // did not opt in.
+    fn record_state_guard_uses_live_frames_without_legacy_fail_args() {
+        // `MetaInterp.generate_guard` always captures the current frame.
+        // A symbol without a legacy failarg list still has live registers;
+        // it must not leave the guard with an unusable -1 resume position.
         // Non-constant input-arg operands (regs 0, 1) so the fused compare is
         // recorded rather than folded; 5 < 3 is false → GuardFalse.
+        let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
         let target = builder.new_label();
+        builder.live(&mut asm, &[0, 1], &[], &[]);
         builder.goto_if_not_int_lt(0, 1, target);
         builder.mark_label(target);
         let jitcode = builder.finish();
 
-        let mut ctx = TraceCtx::for_test(2);
-        let mut sym = DummySym; // fail_args() = None
+        let mut staticdata = crate::MetaInterpStaticData::new();
+        staticdata.op_live = crate::jitcode::insns::BC_LIVE as i32;
+        staticdata.liveness_info = asm.all_liveness().to_vec();
+        let recorder = crate::recorder::Trace::with_num_inputs(2);
+        let mut ctx = TraceCtx::new(recorder, 0, std::sync::Arc::new(staticdata));
+        let mut sym = DummySym;
         let action = trace_jitcode_with_args(
             &mut ctx,
             &mut sym,
@@ -15706,8 +15718,8 @@ mod tests {
 
         assert_eq!(
             ctx.snapshots().len(),
-            0,
-            "DummySym fail_args() = None must skip the snapshot wire-up",
+            1,
+            "live MIFrame registers must supply a snapshot without legacy failargs",
         );
         let recorder = ctx.into_recorder();
         let guard = recorder
@@ -15718,8 +15730,8 @@ mod tests {
             .expect("guard recorded");
         assert_eq!(
             guard.rd_resume_position.get(),
-            -1,
-            "non-state-field guard keeps the -1 sentinel",
+            0,
+            "non-state-field guard must carry its frame snapshot",
         );
     }
 

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -11,8 +11,29 @@
 /// `history.rs` as `impl TraceCtx`.  Pyre callers reach the recorder via
 /// `MetaInterp.history.record*` mirroring
 /// `pyjitpl.py:2455+ self.history.record2(...)`.
+use crate::opencoder::{Box as OcBox, TraceRecordBuffer};
 use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, GcRef, InputArg, InputArgRc, Op, OpCode, OpRc, OpRef, Type, Value};
+use std::cell::Cell;
+
+/// Compact stand-in for `history.py *FrontendOp` while the live recorder
+/// writes `TraceRecordBuffer` bytes. The 240-byte `Op` is materialized
+/// once, at `into_parts` / `get_iter`, matching `opencoder.py TraceIterator.next`
+/// (`cls()`). `unique` is the pyre-legacy all-ops `OpRef` callers already
+/// store; `box_index` is the opencoder.py `_index` TAGBOX coordinate.
+#[derive(Clone, Debug)]
+struct FrontendSlot {
+    unique: u32,
+    #[allow(dead_code)]
+    box_index: u32,
+    opcode: OpCode,
+    descr: Option<DescrRef>,
+    resume: Cell<i32>,
+    fail_args: Option<Vec<OpRef>>,
+    fail_arg_types: Option<Vec<Type>>,
+    concrete: Cell<Option<Value>>,
+    args: Vec<OpRef>,
+}
 
 /// opencoder.py `cut_point()` — RPython 5-tuple
 /// `(_pos, _count, _index, len(_snapshot_data), len(_snapshot_array_data))`.
@@ -237,6 +258,17 @@ pub struct Trace {
     /// out, and prevents every repeated ConstPtr operand from allocating a
     /// fresh `Rc<Cell<Value>>` in the meantime.
     const_ptrs: crate::FxIndexMap<GcRef, Operand>,
+    /// Live JIT path: `History.trace` is `opencoder.Trace`. When present,
+    /// `record_*` appends bytes and a [`FrontendSlot`] instead of a 240-byte
+    /// `Op`. `into_parts` materializes through `ByteTraceIter`, the
+    /// `cls()` step. Tests that construct `Trace::new()` keep the `Vec<Op>`
+    /// path so they do not need `metainterp_sd`.
+    trb: Option<Box<TraceRecordBuffer>>,
+    slots: Vec<FrontendSlot>,
+    /// unique `OpRef.raw()` → opencoder `_index` for TAGBOX. Inputargs
+    /// occupy `[0, n)` as themselves. Void ops store `u32::MAX` and are
+    /// never encoded as a value box.
+    unique_to_box: Vec<u32>,
 }
 
 impl Trace {
@@ -255,6 +287,9 @@ impl Trace {
             box_count: 0,
             recorded_ops_total: 0,
             const_ptrs: crate::FxIndexMap::default(),
+            trb: None,
+            slots: Vec::new(),
+            unique_to_box: Vec::new(),
         }
     }
 
@@ -285,6 +320,183 @@ impl Trace {
         recorder
     }
 
+    /// Attach `opencoder.Trace` as the live storage. `History.__init__`
+    /// (`history.py`) builds that buffer with `metainterp_sd` once the
+    /// inputarg cap is known. Called from `TraceCtx::new` after
+    /// `record_input_arg` has reserved the frontend boxes, so existing
+    /// inputargs are replayed into the buffer and later `record_*` calls
+    /// write bytes instead of `Rc<Op>`.
+    pub fn attach_byte_buffer(
+        &mut self,
+        metainterp_sd: std::sync::Arc<crate::MetaInterpStaticData>,
+    ) {
+        if self.trb.is_some() || !self.ops.is_empty() || !self.slots.is_empty() {
+            return;
+        }
+        let n = self.inputargs.len() as u32;
+        let mut trb = TraceRecordBuffer::new(n, metainterp_sd);
+        for ia in &self.inputargs {
+            trb.record_input_arg(ia.tp);
+        }
+        self.unique_to_box = (0..n).collect();
+        self.trb = Some(Box::new(trb));
+    }
+
+    fn byte_mode(&self) -> bool {
+        self.trb.is_some()
+    }
+
+    fn arg_to_box(&self, r: OpRef) -> OcBox {
+        if r.is_constant() {
+            let value = r
+                .inline_const_to_value()
+                .unwrap_or_else(|| panic!("arg_to_box: constant {r:?} not inline-resolvable"));
+            return match value {
+                Value::Int(v) => OcBox::ConstInt(v),
+                Value::Float(f) => OcBox::ConstFloat(f.to_bits()),
+                Value::Ref(g) => OcBox::ConstPtr(g.as_usize() as u64),
+                Value::Void => panic!("arg_to_box: constant {r:?} has Void type"),
+            };
+        }
+        let raw = r.raw();
+        if (raw as usize) < self.inputargs.len() {
+            return OcBox::ResOp(raw);
+        }
+        let mapped = *self
+            .unique_to_box
+            .get(raw as usize)
+            .unwrap_or_else(|| panic!("arg_to_box: OpRef {r:?} has no TAGBOX index"));
+        assert!(
+            mapped != u32::MAX,
+            "arg_to_box: void op {r:?} used as a value box"
+        );
+        OcBox::ResOp(mapped)
+    }
+
+    fn record_bytes(
+        &mut self,
+        opcode: OpCode,
+        args: &[OpRef],
+        descr: Option<DescrRef>,
+        fail_args: Option<&[OpRef]>,
+    ) -> OpRef {
+        let unique = self.op_count;
+        let opref = OpRef::op_typed(unique, opcode.result_type());
+        let boxes: Vec<OcBox> = args.iter().copied().map(|a| self.arg_to_box(a)).collect();
+        let trb = self
+            .trb
+            .as_mut()
+            .expect("record_bytes requires attach_byte_buffer");
+        let box_index = trb.record_op(opcode, &boxes, descr.as_ref());
+        if opcode.result_type() != Type::Void {
+            if self.unique_to_box.len() <= unique as usize {
+                self.unique_to_box.resize(unique as usize + 1, u32::MAX);
+            }
+            self.unique_to_box[unique as usize] = box_index;
+            self.box_count += 1;
+        } else if self.unique_to_box.len() <= unique as usize {
+            self.unique_to_box.resize(unique as usize + 1, u32::MAX);
+        }
+        if opcode.is_guard() {
+            self.guard_count += 1;
+        }
+        self.slots.push(FrontendSlot {
+            unique,
+            box_index,
+            opcode,
+            descr,
+            resume: Cell::new(-1),
+            fail_args: fail_args.map(|a| a.to_vec()),
+            fail_arg_types: None,
+            concrete: Cell::new(None),
+            args: args.to_vec(),
+        });
+        self.recorded_ops_total += 1;
+        self.op_count += 1;
+        opref
+    }
+
+    fn slot_by_unique(&self, raw: u32) -> Option<&FrontendSlot> {
+        let n = self.inputargs.len() as u32;
+        raw.checked_sub(n).and_then(|i| self.slots.get(i as usize))
+    }
+
+    fn last_slot_mut(&mut self) -> Option<&mut FrontendSlot> {
+        self.slots.last_mut()
+    }
+
+    fn materialize_ops(&self) -> Vec<OpRc> {
+        let Some(trb) = self.trb.as_ref() else {
+            return self.ops.clone();
+        };
+        // start_fresh=0 so inputargs occupy `[0, n)` and recorded ops
+        // occupy `[n, …)` — the same unique numbering `record_*` handed
+        // to snapshots. `get_byte_iter` seeds `_fresh` at
+        // `max_num_inputargs`, which would shift every box by `n`.
+        let ops: Vec<OpRc> =
+            crate::opencoder::ByteTraceIter::new(trb, trb._start as usize, trb._pos, 0).collect();
+        let n = self.inputargs.len() as u32;
+        for op in &ops {
+            for i in 0..op.num_args() {
+                let arg = op.arg(i);
+                if arg.is_inputarg() {
+                    if let Some(idx) = arg.position() {
+                        if let Some(ours) = self.inputargs.get(idx as usize) {
+                            op.setarg(i, Operand::from_bound_inputarg(ours));
+                        }
+                    }
+                }
+            }
+        }
+        for (i, op) in ops.iter().enumerate() {
+            let unique = n + i as u32;
+            op.pos.set(OpRef::op_typed(unique, op.opcode.result_type()));
+            if let Some(slot) = self.slots.get(i) {
+                if let Some(v) = slot.concrete.get() {
+                    op.set_value(v);
+                }
+                if let Some(d) = slot.descr.clone() {
+                    op.setdescr(d);
+                }
+                op.rd_resume_position.set(slot.resume.get());
+                if let Some(ref types) = slot.fail_arg_types {
+                    op.set_fail_arg_types(types.clone());
+                }
+            }
+        }
+        for (i, op) in ops.iter().enumerate() {
+            let Some(slot) = self.slots.get(i) else {
+                continue;
+            };
+            let Some(ref fail) = slot.fail_args else {
+                continue;
+            };
+            let boxed: Vec<Operand> = fail
+                .iter()
+                .copied()
+                .map(|r| self.operand_from_materialized(r, &ops))
+                .collect();
+            op.setfailargs(boxed.into());
+        }
+        ops
+    }
+
+    fn operand_from_materialized(&self, r: OpRef, ops: &[OpRc]) -> Operand {
+        if r.is_constant() {
+            return Operand::from_opref(r);
+        }
+        let raw = r.raw() as usize;
+        let n = self.inputargs.len();
+        if raw < n {
+            return Operand::from_bound_inputarg(&self.inputargs[raw]);
+        }
+        let idx = raw - n;
+        if let Some(op) = ops.get(idx) {
+            return Operand::from_bound_op(op);
+        }
+        Operand::from_opref(r)
+    }
+
     /// Register an input argument of the given type.
     /// Returns an OpRef that can be used as an argument to subsequent operations.
     /// Input arguments are numbered starting from 0; the OpRef index matches
@@ -294,7 +506,7 @@ impl Trace {
     /// each pin `type = 'i'/'f'/'r'` at construction.
     pub fn record_input_arg(&mut self, tp: Type) -> OpRef {
         assert!(
-            self.ops.is_empty(),
+            self.ops.is_empty() && self.slots.is_empty(),
             "input args must be registered before any operations"
         );
         let index = self.inputargs.len() as u32;
@@ -380,6 +592,12 @@ impl Trace {
         {
             return Operand::from_bound_op(op);
         }
+        // Byte-mode recording has no `Op` yet (`FrontendSlot` only).
+        // RPython's FrontendOp *is* the box; `from_opref` is that
+        // position-only stand-in until `ByteTraceIter` materializes.
+        if self.byte_mode() && self.slot_by_unique(r.raw()).is_some() {
+            return Operand::from_opref(r);
+        }
         // S3/#124: a ResOp operand always has a dense producer in `ops`
         // (positions are op_count order; opencoder.py:640 asserts).
         #[cfg(not(test))]
@@ -400,6 +618,9 @@ impl Trace {
     /// `AbstractResOp.type = 'v'` default (resoperation.py).
     pub fn record_op(&mut self, opcode: OpCode, args: &[OpRef]) -> OpRef {
         assert!(!opcode.is_guard(), "use record_guard for guard operations");
+        if self.byte_mode() {
+            return self.record_bytes(opcode, args, None, None);
+        }
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
         let op = Op::new(opcode, &self.box_args(args));
         op.pos.set(opref);
@@ -421,6 +642,9 @@ impl Trace {
         descr: DescrRef,
     ) -> OpRef {
         assert!(!opcode.is_guard(), "use record_guard for guard operations");
+        if self.byte_mode() {
+            return self.record_bytes(opcode, args, Some(descr), None);
+        }
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
         let op = Op::with_descr(opcode, &self.box_args(args), descr);
         op.pos.set(opref);
@@ -447,6 +671,9 @@ impl Trace {
         descr: Option<DescrRef>,
     ) -> OpRef {
         assert!(opcode.is_guard(), "opcode {:?} is not a guard", opcode);
+        if self.byte_mode() {
+            return self.record_bytes(opcode, args, descr, None);
+        }
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
         self.guard_count += 1;
         let op = match descr {
@@ -474,6 +701,9 @@ impl Trace {
         fail_args: &[OpRef],
     ) -> OpRef {
         assert!(opcode.is_guard(), "opcode {:?} is not a guard", opcode);
+        if self.byte_mode() {
+            return self.record_bytes(opcode, args, descr, Some(fail_args));
+        }
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
         self.guard_count += 1;
         let op = match descr {
@@ -494,6 +724,10 @@ impl Trace {
     /// Set rd_resume_position on the last recorded op.
     /// Called after record_guard* to associate a snapshot.
     pub fn set_last_op_resume_position(&mut self, snapshot_id: i32) {
+        if let Some(slot) = self.last_slot_mut() {
+            slot.resume.set(snapshot_id);
+            return;
+        }
         if let Some(op) = self.ops.last() {
             op.rd_resume_position.set(snapshot_id);
         }
@@ -524,6 +758,16 @@ impl Trace {
     /// that only reaches the guards after the helper returns walks back over
     /// them with this.
     pub fn set_guard_op_resume_position_from_end(&mut self, from_end: usize, snapshot_id: i32) {
+        if let Some(slot) = self
+            .slots
+            .iter()
+            .rev()
+            .filter(|s| s.opcode.is_guard())
+            .nth(from_end)
+        {
+            slot.resume.set(snapshot_id);
+            return;
+        }
         if let Some(op) = self
             .ops
             .iter()
@@ -537,6 +781,10 @@ impl Trace {
 
     /// Replace the descriptor on the last recorded operation.
     pub fn set_last_op_descr(&mut self, descr: DescrRef) {
+        if let Some(slot) = self.last_slot_mut() {
+            slot.descr = Some(descr);
+            return;
+        }
         if let Some(op) = self.ops.last() {
             op.setdescr(descr);
         }
@@ -546,6 +794,9 @@ impl Trace {
     /// stamp, for a caller that has to mint the descr subtype the opcode
     /// requires.
     pub fn last_op_opcode(&self) -> Option<OpCode> {
+        if let Some(slot) = self.slots.last() {
+            return Some(slot.opcode);
+        }
         self.ops.last().map(|op| op.opcode)
     }
 
@@ -553,6 +804,15 @@ impl Trace {
     /// [`set_guard_op_descr_from_end`](Self::set_guard_op_descr_from_end)
     /// would stamp, selected by the same walk.
     pub fn guard_op_opcode_from_end(&self, from_end: usize) -> Option<OpCode> {
+        if let Some(slot) = self
+            .slots
+            .iter()
+            .rev()
+            .filter(|s| s.opcode.is_guard())
+            .nth(from_end)
+        {
+            return Some(slot.opcode);
+        }
         self.ops
             .iter()
             .rev()
@@ -564,6 +824,16 @@ impl Trace {
     /// Replace the descriptor on the guard `from_end` guards back from the
     /// most recently recorded one.
     pub fn set_guard_op_descr_from_end(&mut self, from_end: usize, descr: DescrRef) {
+        if let Some(slot) = self
+            .slots
+            .iter_mut()
+            .rev()
+            .filter(|s| s.opcode.is_guard())
+            .nth(from_end)
+        {
+            slot.descr = Some(descr);
+            return;
+        }
         if let Some(op) = self
             .ops
             .iter()
@@ -579,6 +849,9 @@ impl Trace {
     /// capture keys `after_residual_call` on the guard opcode itself
     /// (`pyjitpl.py generate_guard`).
     pub fn last_guard_opcode(&self) -> Option<OpCode> {
+        if let Some(slot) = self.slots.iter().rev().find(|s| s.opcode.is_guard()) {
+            return Some(slot.opcode);
+        }
         self.ops
             .iter()
             .rev()
@@ -597,6 +870,15 @@ impl Trace {
     /// from the snapshot via `op.store_final_boxes(liveboxes)` in the
     /// optimizer's `store_final_boxes_in_guard`.
     pub fn set_op_fail_args(&mut self, opref: OpRef, fail_args: &[OpRef]) {
+        if let Some(slot) = self
+            .slots
+            .iter_mut()
+            .rev()
+            .find(|s| s.unique == opref.raw())
+        {
+            slot.fail_args = Some(fail_args.to_vec());
+            return;
+        }
         let boxed_fail_args = self.box_args(fail_args).iter().cloned().collect();
         let op = self
             .ops
@@ -612,6 +894,10 @@ impl Trace {
     /// without stamping a tracer-stage descr (codex #3 /
     /// pyjitpl.py generate_guard parity).
     pub fn set_last_op_fail_arg_types(&mut self, types: Vec<Type>) {
+        if let Some(slot) = self.last_slot_mut() {
+            slot.fail_arg_types = Some(types);
+            return;
+        }
         if let Some(op) = self.ops.last() {
             op.set_fail_arg_types(types);
         }
@@ -629,6 +915,10 @@ impl Trace {
     /// `descr=ptoken` before compile_trace(). Plain loop recording keeps
     /// `descr=None` until optimization rewrites it.
     pub fn close_loop_with_descr(&mut self, jump_args: &[OpRef], descr: Option<DescrRef>) {
+        if self.byte_mode() {
+            self.record_bytes(OpCode::Jump, jump_args, descr, None);
+            return;
+        }
         // RPython parity: Jump args may differ from InputArgs count when
         // virtualizable arrays change depth. The optimizer (OptUnroll preamble
         // peeling) bridges the gap by creating a Label with the extended count.
@@ -649,6 +939,10 @@ impl Trace {
     /// Finish the trace (non-looping): add a FINISH operation.
     /// `finish_args` are the values returned from the trace.
     pub fn finish(&mut self, finish_args: &[OpRef], descr: DescrRef) {
+        if self.byte_mode() {
+            self.record_bytes(OpCode::Finish, finish_args, Some(descr), None);
+            return;
+        }
         let opref = OpRef::op_typed(self.op_count, OpCode::Finish.result_type());
         let op = Op::with_descr(OpCode::Finish, &self.box_args(finish_args), descr);
         op.pos.set(opref);
@@ -666,13 +960,18 @@ impl Trace {
     /// to the optimizer as a `TreeLoop`. See `TraceCtx::into_tree_loop` for
     /// the snapshot-bearing path.
     pub fn into_parts(self) -> (Vec<InputArgRc>, Vec<OpRc>) {
+        let ops = if self.trb.is_some() {
+            self.materialize_ops()
+        } else {
+            self.ops
+        };
         let inputargs = self
             .inputargs
             .into_iter()
             .zip(self.inputarg_live)
             .filter_map(|(arg, live)| live.then_some(arg))
             .collect();
-        (inputargs, self.ops)
+        (inputargs, ops)
     }
 
     /// Materialize the history's live input box list without consuming it.
@@ -706,6 +1005,16 @@ impl Trace {
     /// table); callers should use `TraceCtx::get_trace_position` for a
     /// fully-populated position.
     pub fn get_position(&self) -> TracePosition {
+        if let Some(trb) = self.trb.as_ref() {
+            return TracePosition {
+                _pos: trb._pos,
+                _count: self.op_count,
+                _index: self.box_count,
+                snapshot_data_len: 0,
+                snapshot_array_data_len: 0,
+                guard_count: Some(self.guard_count),
+            };
+        }
         TracePosition {
             _pos: self.ops.len(),
             _count: self.op_count,
@@ -723,6 +1032,27 @@ impl Trace {
     /// tentative JUMP after compile_trace succeeds or fails
     /// (pyjitpl.py finally: `self.history.cut(cut_at)`).
     pub fn cut(&mut self, pos: TracePosition) {
+        if let Some(trb) = self.trb.as_mut() {
+            let n = self.inputargs.len() as u32;
+            trb.cut_at(crate::recorder::TracePosition {
+                _pos: pos._pos,
+                _count: n + (pos._count.saturating_sub(n)),
+                _index: pos._index,
+                snapshot_data_len: 0,
+                snapshot_array_data_len: 0,
+                guard_count: pos.guard_count,
+            });
+            let nops = pos._count.saturating_sub(n) as usize;
+            self.slots.truncate(nops);
+            self.unique_to_box.truncate(pos._count as usize);
+            self.op_count = pos._count;
+            self.box_count = pos._index;
+            self.guard_count = pos
+                .guard_count
+                .unwrap_or_else(|| self.slots.iter().filter(|s| s.opcode.is_guard()).count());
+            self.ops.clear();
+            return;
+        }
         self.ops.truncate(pos._pos);
         self.op_count = pos._count;
         self.box_count = pos._index;
@@ -738,6 +1068,9 @@ impl Trace {
     /// Compared against `warmstate.trace_limit` by
     /// `MetaInterp.blackhole_if_trace_too_long` (pyjitpl.py).
     pub fn num_ops(&self) -> usize {
+        if self.byte_mode() {
+            return self.slots.len();
+        }
         self.ops.len()
     }
 
@@ -804,6 +1137,12 @@ impl Trace {
                 .get(&gcref)
                 .is_some_and(|cached| cached == arg)
         };
+        for slot in &self.slots {
+            if let Some(Value::Ref(mut gcref)) = slot.concrete.get() {
+                visitor(&mut gcref);
+                slot.concrete.set(Some(Value::Ref(gcref)));
+            }
+        }
         for op in &self.ops {
             for arg in op.args.borrow().iter() {
                 if !is_pooled_const_ptr(arg) {
@@ -849,6 +1188,28 @@ impl Trace {
             .map(|op| &**op)
     }
 
+    /// Byte-mode stand-in for `get_op_by_raw_pos` on a `GetfieldGcR`
+    /// recorded as a [`FrontendSlot`]. Used by `recover_ref_value` while
+    /// the 240-byte `Op` does not yet exist.
+    pub(crate) fn getfield_gc_r_at(&self, raw: u32) -> Option<(DescrRef, OpRef)> {
+        let slot = self.slot_by_unique(raw)?;
+        if slot.opcode != OpCode::GetfieldGcR {
+            return None;
+        }
+        let descr = slot.descr.clone()?;
+        let obj = slot.args.first().copied()?;
+        Some((descr, obj))
+    }
+
+    /// Fill `self.ops` from the byte buffer so `&[Op]` readers
+    /// (`get_op_by_raw_pos`, tests after `into_recorder`) see the
+    /// materialized trace. No-op on the `Vec<Op>` path or if already filled.
+    pub fn materialize_into_ops(&mut self) {
+        if self.trb.is_some() && self.ops.is_empty() && !self.slots.is_empty() {
+            self.ops = self.materialize_ops();
+        }
+    }
+
     /// Get an operation by its raw u32 position, ignoring the variant
     /// tag. Use this when iterating a numeric position range without
     /// knowing each op's RPython `box.type` upfront — the typed lookup
@@ -872,6 +1233,9 @@ impl Trace {
         if pos < n {
             self.inputargs[pos].set_value(value);
             true
+        } else if let Some(slot) = self.slots.get(pos - n) {
+            slot.concrete.set(Some(value));
+            true
         } else if let Some(op) = self.ops.get(pos - n) {
             op.set_value(value);
             true
@@ -888,6 +1252,8 @@ impl Trace {
         let n = self.inputargs.len();
         if pos < n {
             self.inputargs[pos].get_value()
+        } else if let Some(slot) = self.slots.get(pos - n) {
+            slot.concrete.get()
         } else {
             self.ops.get(pos - n).and_then(|op| op.get_value())
         }
@@ -1167,6 +1533,31 @@ mod tests {
         assert_eq!(trace.ops[1].pos.get(), vop(3)); // GuardTrue
         assert_eq!(trace.ops[2].pos.get(), iop(4)); // IntSub
         assert_eq!(trace.ops[3].pos.get(), vop(5)); // Jump
+    }
+
+    #[test]
+    fn byte_buffer_materialize_keeps_unique_positions() {
+        // history.py record + opencoder.py get_iter: bytes during
+        // record, ResOp objects only at iterate. Unique OpRefs (void
+        // and non-void) must survive materialize so snapshots still match.
+        let mut rec = Trace::new();
+        let i0 = rec.record_input_arg(Type::Int);
+        let i1 = rec.record_input_arg(Type::Int);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        let i2 = rec.record_op(OpCode::IntAdd, &[i0, i1]);
+        let g0 = rec.record_guard(OpCode::GuardTrue, &[i2], None);
+        rec.set_last_op_resume_position(7);
+        rec.close_loop(&[i2, i1]);
+        assert_eq!(rec.num_ops(), 3);
+        let (inputs, ops) = rec.into_parts();
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(ops.len(), 3);
+        assert_eq!(ops[0].opcode, OpCode::IntAdd);
+        assert_eq!(ops[0].pos.get(), i2);
+        assert_eq!(ops[1].opcode, OpCode::GuardTrue);
+        assert_eq!(ops[1].pos.get(), g0);
+        assert_eq!(ops[1].rd_resume_position.get(), 7);
+        assert_eq!(ops[2].opcode, OpCode::Jump);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -773,12 +773,19 @@ impl Trace {
     /// explicit adaptation. Constants inserted by test-only direct-op helpers
     /// are not in the pool and are visited from their operation instead.
     pub(crate) fn walk_const_ptr_refs(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        let cached_len = self.const_ptrs.len();
-        for _ in 0..cached_len {
-            let (_, operand) = self
-                .const_ptrs
-                .swap_remove_index(0)
-                .expect("cached ConstPtr length changed during GC walk");
+        // `history.py new_ref_dict` uses `rd_hash` / `lltype.identityhash`,
+        // which survives movement. Our address-keyed map must remove ALL old
+        // keys before inserting any new ones: a destination can equal another
+        // object's old address. Removing index zero and immediately reinserting
+        // also changes which object swap_remove brings into index zero, so a
+        // fixed-count loop can repeatedly visit the same box and skip others.
+        // Drain the identities, retaining the map's capacity, then re-key once.
+        let operands: smallvec::SmallVec<[Operand; 8]> = self
+            .const_ptrs
+            .drain(..)
+            .map(|(_, operand)| operand)
+            .collect();
+        for operand in operands {
             operand.walk_const_ptr_refs(visitor);
             let Value::Ref(gcref) = operand
                 .const_value()
@@ -1025,6 +1032,37 @@ mod tests {
 
         let stale = rec.box_for_operand(OpRef::const_ptr(old));
         assert_ne!(stale, moved, "the pre-move key must no longer be cached");
+    }
+
+    #[test]
+    fn ref_pool_gc_visits_each_box_once_and_rekeys_overlapping_addresses() {
+        let mut rec = Trace::new();
+        let boxes: Vec<_> = (1..=4)
+            .map(|i| rec.box_for_operand(OpRef::const_ptr(GcRef(i * 0x1000))))
+            .collect();
+        let constants: Vec<_> = boxes.iter().map(Operand::to_opref).collect();
+        for &constant in &constants {
+            rec.record_op(OpCode::SameAsR, &[constant]);
+        }
+        rec.record_guard_with_fail_args(
+            OpCode::GuardTrue,
+            &[OpRef::const_int(1)],
+            None,
+            &constants,
+        );
+        let mut visited = Vec::new();
+        rec.walk_const_ptr_refs(&mut |reference| {
+            visited.push(reference.0);
+            reference.0 += 0x1000;
+        });
+        visited.sort_unstable();
+        assert_eq!(visited, vec![0x1000, 0x2000, 0x3000, 0x4000]);
+        assert_eq!(rec.const_ptrs.len(), 4);
+        for (index, original) in boxes.iter().enumerate() {
+            let address = GcRef((index + 2) * 0x1000);
+            assert_eq!(original.const_value(), Some(Value::Ref(address)));
+            assert_eq!(*original, rec.box_for_operand(OpRef::const_ptr(address)));
+        }
     }
 
     #[test]

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -32,7 +32,10 @@ struct FrontendSlot {
     fail_args: Option<Vec<OpRef>>,
     fail_arg_types: Option<Vec<Type>>,
     concrete: Cell<Option<Value>>,
-    args: Vec<OpRef>,
+    /// First operand, only for `GetfieldGcR` recovery while the `Op`
+    /// does not yet exist. `history.py FrontendOp` does not store args;
+    /// they live in the byte stream.
+    first_arg: Option<OpRef>,
 }
 
 /// opencoder.py `cut_point()` — RPython 5-tuple
@@ -382,7 +385,12 @@ impl Trace {
     ) -> OpRef {
         let unique = self.op_count;
         let opref = OpRef::op_typed(unique, opcode.result_type());
-        let boxes: Vec<OcBox> = args.iter().copied().map(|a| self.arg_to_box(a)).collect();
+        let first_arg = args.first().copied();
+        // history.py record0/1/2/3 take the boxes inline. A heap `Vec`
+        // here would be one allocation per recorded op; arity ≤ 4 is
+        // the fixed-op surface (`resoperation.py oparity`).
+        let boxes: smallvec::SmallVec<[OcBox; 4]> =
+            args.iter().copied().map(|a| self.arg_to_box(a)).collect();
         let trb = self
             .trb
             .as_mut()
@@ -409,7 +417,7 @@ impl Trace {
             fail_args: fail_args.map(|a| a.to_vec()),
             fail_arg_types: None,
             concrete: Cell::new(None),
-            args: args.to_vec(),
+            first_arg,
         });
         self.recorded_ops_total += 1;
         self.op_count += 1;
@@ -1217,7 +1225,7 @@ impl Trace {
             return None;
         }
         let descr = slot.descr.clone()?;
-        let obj = slot.args.first().copied()?;
+        let obj = slot.first_arg?;
         Some((descr, obj))
     }
 

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -322,10 +322,10 @@ impl Trace {
 
     /// Attach `opencoder.Trace` as the live storage. `History.__init__`
     /// (`history.py`) builds that buffer with `metainterp_sd` once the
-    /// inputarg cap is known. Called from `TraceCtx::new` after
-    /// `record_input_arg` has reserved the frontend boxes, so existing
-    /// inputargs are replayed into the buffer and later `record_*` calls
-    /// write bytes instead of `Rc<Op>`.
+    /// inputarg cap is known — after `initialize_virtualizable` has
+    /// appended every vable box (`pyjitpl.py create_empty_history`).
+    /// Existing inputargs are replayed into the buffer and later
+    /// `record_*` calls write bytes instead of `Rc<Op>`.
     pub fn attach_byte_buffer(
         &mut self,
         metainterp_sd: std::sync::Arc<crate::MetaInterpStaticData>,
@@ -508,6 +508,18 @@ impl Trace {
         assert!(
             self.ops.is_empty() && self.slots.is_empty(),
             "input args must be registered before any operations"
+        );
+        // opencoder.py `Trace.__init__(max_num_inputargs)` freezes the
+        // reserved prefix. `create_empty_history` therefore runs after
+        // `initialize_virtualizable` has appended every vable box
+        // (`pyjitpl.py _compile_and_run_once`). Growing the cap after
+        // `attach_byte_buffer` would shift `_start`/`_pos` under already-
+        // written ops.
+        assert!(
+            self.trb.is_none(),
+            "record_input_arg after attach_byte_buffer: History is created \
+             after every inputarg exists (pyjitpl.py create_empty_history \
+             after initialize_virtualizable)"
         );
         let index = self.inputargs.len() as u32;
         self.inputargs.push(InputArg::from_type_rc(tp, index));
@@ -1100,6 +1112,14 @@ impl Trace {
         &self.ops
     }
 
+    /// Opcode at recorded-op index `i` (`slots` in byte mode, `ops` otherwise).
+    pub fn opcode_at(&self, i: usize) -> Option<OpCode> {
+        if let Some(slot) = self.slots.get(i) {
+            return Some(slot.opcode);
+        }
+        self.ops.get(i).map(|op| op.opcode)
+    }
+
     /// Visit each `ConstPtr` box once and re-key `_refs_dict` after a moving
     /// collection. RPython's `new_ref_dict` follows moved keys as part of the
     /// translated GC; Rust's `IndexMap` does not, so the re-key is the minimal
@@ -1558,6 +1578,35 @@ mod tests {
         assert_eq!(ops[1].pos.get(), g0);
         assert_eq!(ops[1].rd_resume_position.get(), 7);
         assert_eq!(ops[2].opcode, OpCode::Jump);
+    }
+
+    #[test]
+    fn byte_buffer_materialize_jump_over_extra_inputargs() {
+        // pyjitpl.py `initialize_virtualizable` appends vable boxes onto
+        // `original_boxes` before `create_empty_history`. The byte buffer
+        // must be sized to that full cap so JUMP TAGBOX args past the
+        // portal reds resolve.
+        let mut rec = Trace::new();
+        let portal = rec.record_input_arg(Type::Int);
+        let extras: Vec<OpRef> = (0..8).map(|_| rec.record_input_arg(Type::Int)).collect();
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        let mut jump_args = vec![portal];
+        jump_args.extend(extras.iter().copied());
+        rec.close_loop(&jump_args);
+        let (inputs, ops) = rec.into_parts();
+        assert_eq!(inputs.len(), 9);
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].opcode, OpCode::Jump);
+        assert_eq!(ops[0].num_args(), 9);
+    }
+
+    #[test]
+    #[should_panic(expected = "record_input_arg after attach_byte_buffer")]
+    fn record_input_arg_after_attach_is_rejected() {
+        let mut rec = Trace::new();
+        rec.record_input_arg(Type::Int);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        rec.record_input_arg(Type::Int);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -96,9 +96,9 @@ impl TracePosition {
 /// frame state, encoded as tagged references to boxes.
 ///
 /// RPython stores snapshots inline in the trace byte stream
-/// (`_snapshot_data` / `_snapshot_array_data`).  Pyre owns them on
-/// `TraceCtx` as a `Vec<Snapshot>` side-table (the pending migration moves
-/// this to the byte-stream form already carried by `TraceRecordBuffer`).
+/// (`_snapshot_data` / `_snapshot_array_data`).  The live recorder writes
+/// that stream; `Vec<Snapshot>` is rebuilt at compile (`into_tree_loop`)
+/// so TreeLoop / resume keep the same index-by-`rd_resume_position` surface.
 /// Each snapshot captures the live variables of each frame in the call
 /// stack at the guard point.
 #[derive(Clone, Debug)]
@@ -292,6 +292,14 @@ pub struct Trace {
     /// occupy `[0, n)` as themselves. Void ops store `u32::MAX` and are
     /// never encoded as a value box.
     unique_to_box: Vec<u32>,
+    /// Byte offsets of each `create_top_snapshot` in `_snapshot_data`,
+    /// in capture order. Sequential `rd_resume_position` indexes this
+    /// list; `into_tree_loop` decodes it back to `Vec<Snapshot>`.
+    snapshot_offsets: Vec<usize>,
+    /// Per-snapshot `py_pc` words, outermost-first. RPython's
+    /// `_encode_snapshot` has no twin; resume still reads this pyre
+    /// extra after decode.
+    snapshot_py_pcs: Vec<Vec<u32>>,
 }
 
 impl Trace {
@@ -313,6 +321,8 @@ impl Trace {
             trb: None,
             slots: Vec::new(),
             unique_to_box: Vec::new(),
+            snapshot_offsets: Vec::new(),
+            snapshot_py_pcs: Vec::new(),
         }
     }
 
@@ -367,6 +377,233 @@ impl Trace {
 
     fn byte_mode(&self) -> bool {
         self.trb.is_some()
+    }
+
+    pub fn has_byte_buffer(&self) -> bool {
+        self.trb.is_some()
+    }
+
+    pub fn snapshot_offset_count(&self) -> usize {
+        self.snapshot_offsets.len()
+    }
+
+    pub fn truncate_snapshot_offsets(&mut self, len: usize) {
+        self.snapshot_offsets.truncate(len);
+        self.snapshot_py_pcs.truncate(len);
+    }
+
+    fn encode_jitcode_index(idx: u32) -> i64 {
+        if idx == UNSTAMPED_JITCODE_INDEX {
+            -2
+        } else {
+            i64::from(idx)
+        }
+    }
+
+    fn decode_jitcode_index(idx: i64) -> u32 {
+        if idx == -2 {
+            UNSTAMPED_JITCODE_INDEX
+        } else {
+            idx as u32
+        }
+    }
+
+    fn snapshot_tagged_to_box(&self, tagged: SnapshotTagged) -> OcBox {
+        match tagged {
+            SnapshotTagged::Const(v, Type::Int) => OcBox::ConstInt(v),
+            SnapshotTagged::Const(v, Type::Float) => OcBox::ConstFloat(v as u64),
+            SnapshotTagged::Const(v, Type::Ref) => OcBox::ConstPtr(v as u64),
+            SnapshotTagged::Const(_, Type::Void) => {
+                panic!("encode snapshot: Const Void is not a tagged value")
+            }
+            SnapshotTagged::Box(r, _) => self.arg_to_box(r),
+        }
+    }
+
+    fn box_index_to_opref(&self, box_index: u32) -> OpRef {
+        let n = self.inputargs.len() as u32;
+        if box_index < n {
+            return OpRef::input_arg_typed(box_index, self.inputargs[box_index as usize].tp);
+        }
+        for (unique, &mapped) in self.unique_to_box.iter().enumerate() {
+            if mapped != box_index {
+                continue;
+            }
+            let unique = unique as u32;
+            if unique < n {
+                return OpRef::input_arg_typed(unique, self.inputargs[unique as usize].tp);
+            }
+            let slot = &self.slots[(unique - n) as usize];
+            return OpRef::op_typed(unique, slot.opcode.result_type());
+        }
+        panic!("decode snapshot: TAGBOX({box_index}) has no unique OpRef")
+    }
+
+    fn untag_snapshot(&self, tagged: i64) -> SnapshotTagged {
+        use crate::opencoder::{TAG_MASK, TAG_SHIFT, TAGBOX, TAGCONSTOTHER, TAGCONSTPTR, TAGINT};
+        let tag = (tagged & TAG_MASK as i64) as u8;
+        let v = tagged >> TAG_SHIFT;
+        match tag {
+            TAGBOX => {
+                debug_assert!(v >= 0, "TAGBOX value must be non-negative, got {v}");
+                let opref = self.box_index_to_opref(v as u32);
+                SnapshotTagged::Box(opref, opref.ty().unwrap_or(Type::Int))
+            }
+            TAGINT => SnapshotTagged::Const(v, Type::Int),
+            TAGCONSTPTR => {
+                let trb = self.trb.as_ref().expect("untag_snapshot requires TRB");
+                let addr = trb._refs[v as usize];
+                SnapshotTagged::Const(addr as i64, Type::Ref)
+            }
+            TAGCONSTOTHER => {
+                let trb = self.trb.as_ref().expect("untag_snapshot requires TRB");
+                let pool_idx = (v >> 1) as usize;
+                if v & 1 != 0 {
+                    SnapshotTagged::Const(trb._floats[pool_idx] as i64, Type::Float)
+                } else {
+                    SnapshotTagged::Const(trb._bigints[pool_idx], Type::Int)
+                }
+            }
+            other => panic!("decode snapshot: unknown tag {other}"),
+        }
+    }
+
+    /// `opencoder.py create_top_snapshot` / `create_snapshot` from a
+    /// structured `Snapshot`. Sequential id is the live
+    /// `rd_resume_position`; the byte offset lives in `snapshot_offsets`.
+    pub fn encode_captured_snapshot(&mut self, snapshot: &Snapshot) -> i32 {
+        let id = self.snapshot_offsets.len() as i32;
+        let py_pcs: Vec<u32> = snapshot.frames.iter().map(|f| f.py_pc).collect();
+        let vable: Vec<OcBox> = snapshot
+            .vable_boxes
+            .iter()
+            .copied()
+            .map(|t| self.snapshot_tagged_to_box(t))
+            .collect();
+        let vref: Vec<OcBox> = snapshot
+            .vref_boxes
+            .iter()
+            .copied()
+            .map(|t| self.snapshot_tagged_to_box(t))
+            .collect();
+        let frame_boxes: Vec<Vec<OcBox>> = snapshot
+            .frames
+            .iter()
+            .map(|f| {
+                f.boxes
+                    .iter()
+                    .copied()
+                    .map(|t| self.snapshot_tagged_to_box(t))
+                    .collect()
+            })
+            .collect();
+        let frame_meta: Vec<(i64, i64)> = snapshot
+            .frames
+            .iter()
+            .map(|f| (Self::encode_jitcode_index(f.jitcode_index), i64::from(f.pc)))
+            .collect();
+
+        let trb = self
+            .trb
+            .as_mut()
+            .expect("encode_captured_snapshot requires attach_byte_buffer");
+        let encode_boxes = |trb: &mut TraceRecordBuffer, boxes: &[OcBox]| -> Vec<i64> {
+            boxes.iter().copied().map(|b| trb._encode(b)).collect()
+        };
+
+        // Write `_snapshot_data` only. `create_top_snapshot` also patches
+        // the last op's descr slot (`opencoder.py`); that slot is the
+        // RPython resume position. Live pyre keeps the sequential id on
+        // `FrontendSlot.resume` and must not rewrite a later non-guard's
+        // trailing bytes as if they were the placeholder.
+        let offset = if frame_meta.is_empty() {
+            let vable_t = encode_boxes(trb, &vable);
+            let vref_t = encode_boxes(trb, &vref);
+            trb._total_snapshots += 1;
+            let s = trb._snapshot_data.len() as i64;
+            let empty_array = trb._list_of_boxes(&[]);
+            let vable_array = trb._list_of_boxes_virtualizable(&vable_t);
+            let vref_array = trb._list_of_boxes(&vref_t);
+            trb.append_snapshot_data_int(vable_array);
+            trb.append_snapshot_data_int(vref_array);
+            trb._encode_snapshot(-1, 0, empty_array, true);
+            s
+        } else {
+            let last = frame_meta.len() - 1;
+            let inner = encode_boxes(trb, &frame_boxes[last]);
+            let array = trb._list_of_boxes(&inner);
+            let vable_t = encode_boxes(trb, &vable);
+            let vref_t = encode_boxes(trb, &vref);
+            trb._total_snapshots += 1;
+            let s = trb._snapshot_data.len() as i64;
+            let vable_array = trb._list_of_boxes(&vable_t);
+            let vref_array = trb._list_of_boxes(&vref_t);
+            trb.append_snapshot_data_int(vable_array);
+            trb.append_snapshot_data_int(vref_array);
+            trb._encode_snapshot(
+                frame_meta[last].0,
+                frame_meta[last].1,
+                array,
+                frame_meta.len() == 1,
+            );
+            for i in (0..last).rev() {
+                let tagged = encode_boxes(trb, &frame_boxes[i]);
+                let array = trb._list_of_boxes(&tagged);
+                trb.create_snapshot(frame_meta[i].0, frame_meta[i].1, array, i == 0);
+            }
+            s
+        };
+        self.snapshot_offsets.push(offset as usize);
+        self.snapshot_py_pcs.push(py_pcs);
+        id
+    }
+
+    /// Rebuild `Vec<Snapshot>` from `_snapshot_data` in capture order.
+    pub fn decode_captured_snapshots(&self) -> Option<Vec<Snapshot>> {
+        let trb = self.trb.as_ref()?;
+        let mut out = Vec::with_capacity(self.snapshot_offsets.len());
+        for (i, &offset) in self.snapshot_offsets.iter().enumerate() {
+            let (vable_t, vref_t, frames_t) = {
+                let it = trb.get_snapshot_iter(offset);
+                let vable_t: Vec<i64> = it.iter_vable_array().collect();
+                let vref_t: Vec<i64> = it.iter_vref_array().collect();
+                let frames_t: Vec<(i64, i64, Vec<i64>)> = it
+                    .framestack
+                    .iter()
+                    .copied()
+                    .map(|snap_idx| {
+                        let (jc, pc) = it.unpack_jitcode_pc(snap_idx);
+                        let boxes: Vec<i64> = it.iter_array(snap_idx).collect();
+                        (jc, pc, boxes)
+                    })
+                    .collect();
+                (vable_t, vref_t, frames_t)
+            };
+            let py_pcs = self
+                .snapshot_py_pcs
+                .get(i)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let frames = frames_t
+                .into_iter()
+                .enumerate()
+                .map(|(fi, (jc, pc, boxes))| SnapshotFrame {
+                    jitcode_index: Self::decode_jitcode_index(jc),
+                    pc: pc as u32,
+                    py_pc: py_pcs.get(fi).copied().unwrap_or(pc as u32),
+                    boxes: boxes.into_iter().map(|t| self.untag_snapshot(t)).collect(),
+                })
+                .collect();
+            out.push(Snapshot {
+                frames,
+                vable_boxes: vable_t
+                    .into_iter()
+                    .map(|t| self.untag_snapshot(t))
+                    .collect(),
+                vref_boxes: vref_t.into_iter().map(|t| self.untag_snapshot(t)).collect(),
+            });
+        }
+        Some(out)
     }
 
     fn arg_to_box(&self, r: OpRef) -> OcBox {
@@ -1625,6 +1862,41 @@ mod tests {
         assert_eq!(ops[1].pos.get(), g0);
         assert_eq!(ops[1].rd_resume_position.get(), 7);
         assert_eq!(ops[2].opcode, OpCode::Jump);
+    }
+
+    #[test]
+    fn byte_buffer_snapshot_roundtrip_keeps_boxes_and_py_pc() {
+        let mut rec = Trace::new();
+        let i0 = rec.record_input_arg(Type::Int);
+        let i1 = rec.record_input_arg(Type::Int);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        let add = rec.record_op(OpCode::IntAdd, &[i0, i1]);
+        let _g = rec.record_guard(OpCode::GuardTrue, &[add], None);
+        let snapshot = Snapshot {
+            frames: vec![SnapshotFrame {
+                jitcode_index: 3,
+                pc: 11,
+                py_pc: 22,
+                boxes: vec![
+                    SnapshotTagged::Box(i0, Type::Int),
+                    SnapshotTagged::Box(add, Type::Int),
+                    SnapshotTagged::Const(7, Type::Int),
+                ],
+            }],
+            vable_boxes: vec![SnapshotTagged::Box(i1, Type::Int)],
+            vref_boxes: Vec::new(),
+        };
+        let id = rec.encode_captured_snapshot(&snapshot);
+        assert_eq!(id, 0);
+        let decoded = rec.decode_captured_snapshots().expect("byte mode");
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].frames.len(), 1);
+        assert_eq!(decoded[0].frames[0].jitcode_index, 3);
+        assert_eq!(decoded[0].frames[0].pc, 11);
+        assert_eq!(decoded[0].frames[0].py_pc, 22);
+        assert_eq!(decoded[0].frames[0].boxes, snapshot.frames[0].boxes);
+        assert_eq!(decoded[0].vable_boxes, snapshot.vable_boxes);
+        assert!(decoded[0].vref_boxes.is_empty());
     }
 
     #[test]

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -72,6 +72,26 @@ pub struct TracePosition {
     pub guard_count: Option<usize>,
 }
 
+impl TracePosition {
+    /// Recorded-op index into a materialized `TreeLoop.ops`.
+    ///
+    /// `opencoder.py cut_point` `_count` is inputargs + recorded ops;
+    /// `TreeLoop.ops` is recorded ops only. `_pos` is the byte cursor
+    /// in byte mode and must not be used as this index.
+    pub fn tree_loop_op_index(&self, num_inputargs: usize) -> usize {
+        (self._count as usize).saturating_sub(num_inputargs)
+    }
+
+    /// True when this cut point sits after at least one recorded op.
+    ///
+    /// `compile.py compile_loop` compares `start != (0, 0, 0, 0, 0)`.
+    /// The zero tuple is a sentinel, not "byte offset 0": after
+    /// `Trace.__init__` the live `_pos` is already `max_num_inputargs`.
+    pub fn has_prefix_ops(&self, num_inputargs: usize) -> bool {
+        (self._count as usize) > num_inputargs
+    }
+}
+
 /// opencoder.py Snapshot parity: per-guard snapshot of the interpreter
 /// frame state, encoded as tagged references to boxes.
 ///
@@ -980,7 +1000,7 @@ impl Trace {
     /// to the optimizer as a `TreeLoop`. See `TraceCtx::into_tree_loop` for
     /// the snapshot-bearing path.
     pub fn into_parts(self) -> (Vec<InputArgRc>, Vec<OpRc>) {
-        let ops = if self.trb.is_some() {
+        let ops = if self.trb.is_some() && self.ops.is_empty() {
             self.materialize_ops()
         } else {
             self.ops
@@ -1165,10 +1185,24 @@ impl Trace {
                 .get(&gcref)
                 .is_some_and(|cached| cached == arg)
         };
-        for slot in &self.slots {
+        if let Some(trb) = self.trb.as_mut() {
+            trb.refresh_from_gc();
+        }
+        for slot in &mut self.slots {
             if let Some(Value::Ref(mut gcref)) = slot.concrete.get() {
                 visitor(&mut gcref);
                 slot.concrete.set(Some(Value::Ref(gcref)));
+            }
+            if let Some(r) = slot.first_arg.as_mut() {
+                r.walk_const_ptr_refs_mut(visitor);
+            }
+            if let Some(fail) = slot.fail_args.as_mut() {
+                for r in fail.iter_mut() {
+                    r.walk_const_ptr_refs_mut(visitor);
+                }
+            }
+            if let Some(qd) = slot.descr.as_ref().and_then(|d| d.as_quasi_immut_descr()) {
+                qd.walk_const_ptr_refs(visitor);
             }
         }
         for op in &self.ops {
@@ -1187,6 +1221,11 @@ impl Trace {
             if let Some(Value::Ref(mut gcref)) = op.get_value() {
                 visitor(&mut gcref);
                 op.set_value(Value::Ref(gcref));
+            }
+            if let Some(descr) = op.getdescr() {
+                if let Some(qd) = descr.as_quasi_immut_descr() {
+                    qd.walk_const_ptr_refs(visitor);
+                }
             }
         }
     }
@@ -1615,6 +1654,101 @@ mod tests {
         rec.record_input_arg(Type::Int);
         rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
         rec.record_input_arg(Type::Int);
+    }
+
+    #[test]
+    fn tree_loop_cut_uses_op_count_not_byte_cursor() {
+        let pos = TracePosition {
+            _pos: 80,
+            _count: 5,
+            _index: 5,
+            snapshot_data_len: 0,
+            snapshot_array_data_len: 0,
+            guard_count: None,
+        };
+        assert!(pos.has_prefix_ops(2));
+        assert_eq!(pos.tree_loop_op_index(2), 3);
+        assert!(
+            !TracePosition {
+                _pos: 2,
+                _count: 2,
+                _index: 2,
+                snapshot_data_len: 0,
+                snapshot_array_data_len: 0,
+                guard_count: None,
+            }
+            .has_prefix_ops(2)
+        );
+    }
+
+    #[test]
+    fn into_parts_reuses_materialized_ops() {
+        let mut rec = Trace::new();
+        let i0 = rec.record_input_arg(Type::Int);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        rec.record_op(OpCode::IntAdd, &[i0, i0]);
+        rec.materialize_into_ops();
+        let first = rec.ops()[0].clone();
+        let (_, ops) = rec.into_parts();
+        assert!(std::rc::Rc::ptr_eq(&first, &ops[0]));
+    }
+
+    #[test]
+    fn byte_mode_walk_forwards_slot_const_ptrs() {
+        let mut rec = Trace::new();
+        let i0 = rec.record_input_arg(Type::Ref);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        let cptr = OpRef::const_ptr(GcRef(0x1000));
+        rec.record_op(OpCode::GetfieldGcR, &[cptr]);
+        rec.record_guard_with_fail_args(OpCode::GuardTrue, &[i0], None, &[cptr]);
+        rec.walk_const_ptr_refs(&mut |gcref| gcref.0 += 0x1000);
+        assert_eq!(
+            rec.slots[0].first_arg,
+            Some(OpRef::const_ptr(GcRef(0x2000)))
+        );
+        assert_eq!(
+            rec.slots[1].fail_args.as_ref().map(|a| a.as_slice()),
+            Some(&[OpRef::const_ptr(GcRef(0x2000))][..])
+        );
+        rec.materialize_into_ops();
+        let fail = rec.ops()[1].getfailargs().expect("guard fail_args");
+        assert_eq!(fail[0].to_opref(), OpRef::const_ptr(GcRef(0x2000)));
+    }
+
+    #[test]
+    fn walk_forwards_quasiimmut_constantfieldbox() {
+        #[derive(Debug)]
+        struct Handle;
+        impl majit_ir::QuasiImmutHandle for Handle {
+            fn is_current(&self) -> bool {
+                true
+            }
+            fn register_loop_token(
+                &self,
+                _token: &std::sync::Arc<dyn majit_ir::QuasiImmutLoopToken>,
+            ) {
+            }
+            fn instance_identity(&self) -> usize {
+                1
+            }
+        }
+        let field = std::sync::Arc::new(majit_ir::SimpleFieldDescr::new(0, 8, 8, Type::Ref, false))
+            as DescrRef;
+        let descr = std::sync::Arc::new(majit_ir::QuasiImmutDescr::new(
+            field,
+            0,
+            std::sync::Arc::new(Handle),
+            Some(Value::Ref(GcRef(0x1000))),
+        )) as DescrRef;
+        let mut rec = Trace::new();
+        let obj = rec.record_input_arg(Type::Ref);
+        rec.attach_byte_buffer(std::sync::Arc::new(crate::MetaInterpStaticData::new()));
+        rec.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr.clone());
+        rec.walk_const_ptr_refs(&mut |gcref| gcref.0 += 0x1000);
+        assert_eq!(
+            descr.as_quasi_immut_descr().unwrap().constantfieldbox(),
+            Some(Value::Ref(GcRef(0x2000)))
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1765,9 +1765,30 @@ impl TraceCtx {
         )
     }
 
+    /// history.py `History.__init__` — bind `opencoder.Trace` once the
+    /// live JIT has `metainterp_sd` and the inputarg cap. Tests that
+    /// construct a `TraceCtx` without going through `setup_tracing` /
+    /// `start_retrace` keep the `Vec<Op>` recorder so they can emit
+    /// synthetic arities the byte encoder rejects.
+    pub fn attach_live_byte_recorder(&mut self) {
+        // `cfg(test)` here is the metainterp crate's own test build.
+        // Those fixtures emit synthetic 0-arg `PtrEq` ops the byte
+        // encoder rejects (`opencoder.py _op_start` arity). The regex
+        // / pyre-jit crates compile this lib without `cfg(test)` and
+        // take the live path. The unit test
+        // `byte_buffer_materialize_keeps_unique_positions` attaches
+        // explicitly.
+        #[cfg(not(test))]
+        self.recorder.attach_byte_buffer(self.metainterp_sd.clone());
+        #[cfg(test)]
+        let _ = self;
+    }
+
     /// Take the recorder out of this context (consumes self).
     pub fn into_recorder(self) -> Trace {
-        self.recorder
+        let mut recorder = self.recorder;
+        recorder.materialize_into_ops();
+        recorder
     }
 
     pub(crate) fn new(
@@ -3666,12 +3687,17 @@ impl TraceCtx {
         if depth == 0 {
             return None;
         }
-        let op = self.recorder.get_op_by_raw_pos(opref.raw())?;
-        if !matches!(op.opcode, OpCode::GetfieldGcR) {
-            return None;
-        }
-        let descr = op.descr.borrow().clone()?;
-        let obj = op.args.borrow().first()?.to_opref();
+        let (descr, obj) = if let Some(pair) = self.recorder.getfield_gc_r_at(opref.raw()) {
+            pair
+        } else {
+            let op = self.recorder.get_op_by_raw_pos(opref.raw())?;
+            if !matches!(op.opcode, OpCode::GetfieldGcR) {
+                return None;
+            }
+            let descr = op.descr.borrow().clone()?;
+            let obj = op.args.borrow().first()?.to_opref();
+            (descr, obj)
+        };
         let Value::Ref(obj_ref) = self.recover_ref_value(obj, depth - 1)? else {
             return None;
         };

--- a/majit/majit-metainterp/tests/elidable_canary_test.rs
+++ b/majit/majit-metainterp/tests/elidable_canary_test.rs
@@ -103,6 +103,7 @@ fn elidable_canary_traces_to_call_pure_i_when_args_not_all_const() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
 
     // pyjitpl.py:3577-3579 — original CallI cut, CallPureI re-recorded.
@@ -161,6 +162,7 @@ fn elidable_canary_all_const_args_fold_to_const_and_cut_call() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     // Neither CallI nor CallPureI may remain in the trace.
     assert!(

--- a/majit/majit-metainterp/tests/elidable_ref_canary_test.rs
+++ b/majit/majit-metainterp/tests/elidable_ref_canary_test.rs
@@ -121,6 +121,7 @@ fn elidable_ref_canary_traces_to_call_pure_r_when_args_not_all_const() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     let opcodes: Vec<_> = ops.iter().map(|op| op.opcode).collect();
 
@@ -179,6 +180,7 @@ fn elidable_ref_canary_all_const_args_fold_to_const_ptr_not_const_int() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     let opcodes: Vec<_> = ops.iter().map(|op| op.opcode).collect();
 

--- a/majit/majit-metainterp/tests/vable_array_promote_order.rs
+++ b/majit/majit-metainterp/tests/vable_array_promote_order.rs
@@ -47,7 +47,7 @@ use majit_ir::{OpRef, Type, Value};
 use majit_metainterp::jitcode::JitCodeBuilder;
 use majit_metainterp::virtualizable::VirtualizableInfo;
 use majit_metainterp::{
-    ClosureRuntime, JitCode, JitCodeMachine, JitCodeSym, MIFrame, MIFrameStack, TraceCtx,
+    ClosureRuntime, JitCode, JitCodeMachine, JitCodeSym, MIFrame, MIFrameStack,
 };
 
 /// The minimum a `JitCodeSym` has to answer for the dispatcher to run one
@@ -61,10 +61,6 @@ impl JitCodeSym for MinimalSym {
 
     fn loop_header_pc(&self) -> usize {
         0
-    }
-
-    fn fail_args(&self) -> Option<Vec<OpRef>> {
-        None
     }
 }
 
@@ -128,8 +124,17 @@ const VALUE_REG: u16 = 1;
 const DEST_REG: u16 = 1;
 const ARRAY_IDX: u16 = 0;
 
-fn build_jitcode(arm: Arm) -> (Arc<JitCode>, usize) {
+fn build_jitcode(
+    arm: Arm,
+) -> (
+    Arc<JitCode>,
+    usize,
+    majit_translate::codewriter::assembler::Assembler,
+) {
+    let mut asm = majit_translate::codewriter::assembler::Assembler::new();
     let mut builder = JitCodeBuilder::new();
+    let live_ints: &[u8] = if arm == Arm::Set { &[0, 1] } else { &[0] };
+    builder.live(&mut asm, live_ints, &[0], &[]);
     let pc = builder.current_pos();
     match arm {
         Arm::Get => {
@@ -141,7 +146,7 @@ fn build_jitcode(arm: Arm) -> (Arc<JitCode>, usize) {
     }
     let jitcode = Arc::new(builder.finish());
     jitcode.set_index(0);
-    (jitcode, pc)
+    (jitcode, pc, asm)
 }
 
 /// Whether the vable register holds a recorded box or a prebuilt constant.
@@ -158,7 +163,18 @@ enum VableBox {
 /// names the index box, whether Step 4's PTR_EQ was recorded)`.
 fn run_arm(arm: Arm, vable: VableBox) -> (usize, bool, bool) {
     let info = one_int_array_vinfo();
-    let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
+    let (jitcode, pc, asm) = build_jitcode(arm);
+    let mut staticdata = majit_metainterp::MetaInterpStaticData::new();
+    staticdata.op_live = majit_metainterp::jitcode::insns::BC_LIVE as i32;
+    staticdata.liveness_info = asm.all_liveness().to_vec();
+    let mut meta = majit_metainterp::MetaInterp::<()>::new(200);
+    meta.staticdata = Arc::new(staticdata);
+    meta.finish_setup_descrs_for_jitdrivers();
+    meta.force_start_tracing(0, (0, 0), None, &[Value::Ref(majit_ir::GcRef(2))]);
+    let ctx = meta.trace_ctx().expect("force-started fixture trace");
+    // This is an IR-shape fixture with symbolic pointer sentinels, as with
+    // TraceCtx::for_test_types; do not ask a native CPU to dereference them.
+    ctx.set_cpu(None);
 
     // The STANDARD virtualizable, i.e. `virtualizable_boxes[-1]`
     // (`pyjitpl.py:1195 virtualizable_boxes[-1]`).
@@ -207,8 +223,10 @@ fn run_arm(arm: Arm, vable: VableBox) -> (usize, bool, bool) {
     );
     let stored = ctx.const_int(7);
 
-    let (jitcode, pc) = build_jitcode(arm);
     let mut frame = MIFrame::new(jitcode, pc);
+    // This fixture executes the array opcode once, not its preceding LIVE.
+    // MIFrame::new initializes the bytecode cursor independently of `pc`.
+    frame.code_cursor = pc;
     frame.ref_regs[VABLE_REG as usize] = Some(other_vable);
     frame.ref_values[VABLE_REG as usize] = Some(2);
     frame.int_regs[INDEX_REG as usize] = Some(index);
@@ -224,7 +242,7 @@ fn run_arm(arm: Arm, vable: VableBox) -> (usize, bool, bool) {
     let runtime = ClosureRuntime::new(|pc: usize| pc);
     let mut sym = MinimalSym;
     let mut machine = JitCodeMachine::<MinimalSym, _>::with_framestack(&mut frames, &[], &[]);
-    machine.run_one_step(&mut ctx, &mut sym, &runtime);
+    machine.run_one_step(ctx, &mut sym, &runtime);
     drop(machine);
 
     let promoted_index = ctx.ops().iter().any(|recorded| {

--- a/majit/majit-metainterp/tests/vable_array_promote_order.rs
+++ b/majit/majit-metainterp/tests/vable_array_promote_order.rs
@@ -245,6 +245,7 @@ fn run_arm(arm: Arm, vable: VableBox) -> (usize, bool, bool) {
     machine.run_one_step(ctx, &mut sym, &runtime);
     drop(machine);
 
+    ctx.ensure_ops_materialized();
     let promoted_index = ctx.ops().iter().any(|recorded| {
         recorded.opcode == majit_ir::OpCode::GuardValue
             && recorded

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -17003,18 +17003,22 @@ pub(crate) fn subwalk_guard_follows_store(
     trace_ctx: &TraceCtx,
     start: majit_metainterp::recorder::TracePosition,
 ) -> bool {
-    let ops = trace_ctx.ops();
-    let Some(recorded) = ops.get(start._pos..) else {
+    // Byte-mode `_pos` is the opencoder cursor, not an `ops` index.
+    // `opcode_at` reads `FrontendSlot` without materializing `Rc<Op>`.
+    let start_i = start.tree_loop_op_index(trace_ctx.num_inputargs());
+    let end = trace_ctx.num_ops();
+    if start_i > end {
         return true;
-    };
+    }
     let mut stored = false;
-    for op in recorded {
-        if op.opcode.is_guard() && stored {
+    for i in start_i..end {
+        let Some(opcode) = trace_ctx.opcode_at(i) else {
+            return true;
+        };
+        if opcode.is_guard() && stored {
             return true;
         }
-        stored |= op.opcode.is_setfield()
-            || op.opcode.is_setarrayitem()
-            || op.opcode.is_setinteriorfield();
+        stored |= opcode.is_setfield() || opcode.is_setarrayitem() || opcode.is_setinteriorfield();
     }
     false
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -37,10 +37,6 @@ impl JitCodeSym for StaticRefusalSym {
     fn loop_header_pc(&self) -> usize {
         0
     }
-
-    fn fail_args(&self) -> Option<Vec<OpRef>> {
-        Some(Vec::new())
-    }
 }
 
 /// The generated dispatch loop re-runs its source arm when a trace start

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -14535,7 +14535,7 @@ fn a_guard_after_the_subwalks_store_is_what_declines_the_pop_fold() {
     // there must not pass for "no guard after a store".
     let tc = TraceCtx::for_test_types(&[Type::Ref]);
     let mut past_end = tc.get_trace_position();
-    past_end._pos = tc.ops().len() + 1;
+    past_end._count = (tc.num_inputargs() + tc.num_ops() + 1) as u32;
     assert!(
         subwalk_guard_follows_store(&tc, past_end),
         "an unreadable window declines"

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5384,21 +5384,22 @@ pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: Des
     // and the trace keeps a value that is already stale.  Without a GIL that
     // window is a real interleaving, not a theoretical one.
     let qmutdescr = quasi_immut_descr(ctx, obj, &descr);
-    // quasiimmut.py:125 `self.constantfieldbox =
-    // self.get_current_constant_fieldvalue()` — the field's value at the moment
-    // the trace baked it.  `heap.py OptHeap.optimize_QUASIIMMUT_FIELD is_still_valid_for` compares it against
-    // the live value and abandons the loop when they disagree, so it has to be
-    // captured here; by the time the optimizer runs, the change it is looking
-    // for has already happened.
+    // `quasiimmut.py QuasiImmutDescr.__init__` captures
+    // `constantfieldbox` on the descr; `pyjitpl.py
+    // opimpl_record_quasiimmut_field` then `record1(QUASIIMMUT_FIELD,
+    // box, descr=qmutdescr)`.
     let constantfieldbox = current_quasiimmut_field_value(ctx, obj, &descr);
     ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
-    // The captured value is the one `QuasiImmutDescr` member that stays off the
-    // descr: it is a Box, so it rides as the op's second operand.
-    let descr = qmutdescr.unwrap_or(descr);
-    match constantfieldbox {
-        Some(value) => ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj, value], descr),
-        None => ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr),
+    let descr = match qmutdescr.as_ref().and_then(|d| d.as_quasi_immut_descr()) {
+        Some(qd) => std::sync::Arc::new(majit_ir::QuasiImmutDescr::new(
+            qd.fielddescr().clone(),
+            qd.struct_ptr(),
+            qd.qmut().clone(),
+            constantfieldbox.and_then(|r| r.inline_const_to_value()),
+        )) as majit_ir::DescrRef,
+        None => descr,
     };
+    ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr);
     if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
         ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
     }
@@ -5533,6 +5534,7 @@ fn quasi_immut_descr(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) -> Option
         descr.clone(),
         struct_ptr as u64,
         std::sync::Arc::new(RecordedQuasiImmut(qmut)),
+        None,
     )))
 }
 

--- a/pyre/pyre-jit-trace/src/unpack_state.rs
+++ b/pyre/pyre-jit-trace/src/unpack_state.rs
@@ -61,14 +61,6 @@ impl JitCodeSym for UnpackSym {
             .expect("jd1 drain body must contain a jit_merge_point")
             .pc
     }
-
-    fn fail_args(&self) -> Option<Vec<OpRef>> {
-        Some(vec![self.w_iterator, self.items])
-    }
-
-    fn fail_args_types(&self) -> Option<Vec<Type>> {
-        Some(vec![Type::Ref, Type::Ref])
-    }
 }
 
 /// jd1 `JitState`: reuses [`PyreMeta`] (the "shape of the traced code") and the

--- a/pyre/pyre-jit-trace/tests/elidable_helper_canary_test.rs
+++ b/pyre/pyre-jit-trace/tests/elidable_helper_canary_test.rs
@@ -87,6 +87,7 @@ fn elidable_helper_traces_to_call_pure_i_when_args_not_all_const() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
 
     assert!(
@@ -135,6 +136,7 @@ fn emit_trace_call_int_typed_elidable_cannot_raise_routes_to_call_pure_i() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     assert!(
         ops.iter().any(|op| op.opcode == OpCode::CallPureI),
@@ -189,6 +191,7 @@ fn elidable_int_bit_count_macro_advertises_extern_c_trampoline_and_traces_call_p
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     assert!(
         ops.iter().any(|op| op.opcode == OpCode::CallPureI),
@@ -231,6 +234,7 @@ fn elidable_helper_all_const_args_fold_to_const_and_cut_call() {
     );
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     assert!(
         ops.iter()
@@ -314,6 +318,7 @@ fn emit_ref_lookup_shape_routes_to_call_pure_r_when_type_not_const() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     let opcodes: Vec<_> = ops.iter().map(|op| op.opcode).collect();
     assert!(
@@ -376,6 +381,7 @@ fn emit_ref_lookup_shape_all_const_folds_to_const_ptr() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     assert!(
         ops.iter()
@@ -455,6 +461,7 @@ fn real_lookup_wrapper_records_call_pure_r_when_type_not_const() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     let opcodes: Vec<_> = ops.iter().map(|op| op.opcode).collect();
     assert!(
@@ -514,6 +521,7 @@ fn real_lookup_wrapper_all_const_folds_to_const_ptr() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     assert!(
         ops.iter()
@@ -585,6 +593,7 @@ fn instance_getdictvalue_records_residual_call_r_not_pure() {
     };
 
     let ctx = meta.trace_ctx().expect("active trace");
+    ctx.ensure_ops_materialized();
     let ops = ctx.ops();
     let opcodes: Vec<_> = ops.iter().map(|op| op.opcode).collect();
     assert!(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7284,10 +7284,6 @@ impl majit_metainterp::JitCodeSym for PortalMetatraceSym {
     fn loop_header_pc(&self) -> usize {
         self.header_pc
     }
-
-    fn fail_args(&self) -> Option<Vec<majit_ir::OpRef>> {
-        None
-    }
 }
 
 /// Stage-0 diagnostic drive of the build-time jd0 portal jitcode. Set


### PR DESCRIPTION
## Summary

Live JIT recording now writes `opencoder.Trace` bytes plus a compact `FrontendSlot`, matching `History.record` / `TraceIterator.next`. `ByteTraceIter` materializes `Op`s once at compile. Owned bridge traces remap positions in place instead of cloning each `Op`.

The `and`/`or` regex census moves from about 10 allocs / 1.6KB per character to **4.4 / 725B**. Peeled body stays `0 / 24 / 93 / 2`. Wall-clock vs translated RPython is still about 2.2x; remaining cost is snapshot side-tables and `optimize_bridge` itself.

## Test plan

- [x] `cargo test -p regex --no-default-features --features dynasm`
- [x] `cargo test -p majit-metainterp --no-default-features --features dynasm --lib`
- [x] `cargo run -p regex --release --no-default-features --features dynasm,alloc-census` (1MiB and/or row: 4.4 allocs / 725B)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added memory-efficient trace recording with on-demand operation and snapshot materialization.
  - Improved bridge compilation by reusing recorded operations and preserving operation identity.
  - Added mimalloc selection for clean performance measurements.

- **Bug Fixes**
  - Corrected quasi-immutable field tracking by retaining captured values with descriptors.
  - Improved garbage-collection reference handling during trace recording.
  - Improved guard snapshot capture from live execution frames.
  - Improved trace inspection without unnecessary full materialization.

- **Documentation**
  - Clarified allocator behavior and added performance measurement guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->