### PR TITLE
wasm: lower CallMallocNursery and fix nursery batch boundaries

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3394,15 +3394,26 @@ fn new_inline_nursery_member(
 /// `emitting_an_operation_that_can_collect`. Combined size stays strictly
 /// below `large_threshold`, the same exclusive bound as
 /// `can_use_nursery`.
+///
+/// `region_starts` are the first op indices of inlined-bridge regions in
+/// the merged stream. Those regions are alternative control-flow paths,
+/// so a region's allocation must not follow an owner-side leader.
 fn collect_nursery_batches(
     ops: &[Op],
     nursery: Option<&NurseryAllocParams>,
     constants: &indexmap::IndexMap<u32, i64>,
+    region_starts: &[usize],
 ) -> Vec<Option<NurseryBatchRole>> {
     let mut out = vec![None; ops.len()];
     let Some(na) = nursery else {
         return out;
     };
+    let mut at_region_start = vec![false; ops.len()];
+    for &start in region_starts {
+        if let Some(slot) = at_region_start.get_mut(start) {
+            *slot = true;
+        }
+    }
     let mut run: Vec<(usize, usize, u32)> = Vec::new();
     let mut run_total = 0usize;
     let flush = |out: &mut [Option<NurseryBatchRole>], run: &mut Vec<(usize, usize, u32)>| {
@@ -3419,6 +3430,10 @@ fn collect_nursery_batches(
         run.clear();
     };
     for (i, op) in ops.iter().enumerate() {
+        if at_region_start[i] {
+            flush(&mut out, &mut run);
+            run_total = 0;
+        }
         if let Some((total, result_id)) = new_inline_nursery_member(op, na, constants) {
             if !run.is_empty() && run_total + total < na.large_threshold {
                 run.push((i, total, result_id));
@@ -3430,7 +3445,11 @@ fn collect_nursery_batches(
             run_total = total;
             continue;
         }
-        if op.opcode == OpCode::Label || op.opcode.can_malloc() {
+        if op.opcode == OpCode::Label
+            || op.opcode == OpCode::Jump
+            || op.opcode == OpCode::Finish
+            || op.opcode.can_malloc()
+        {
             flush(&mut out, &mut run);
             run_total = 0;
         }
@@ -4855,7 +4874,11 @@ fn build_function(
     // took the bump so followers can `NURSERY_PTR_INCREMENT` instead of
     // calling the helper.
     let nursery_batches = if residual_type_base.is_some() {
-        collect_nursery_batches(ops, nursery, constants)
+        let region_starts: Vec<usize> = InlinedRegionSpan::collect(ops.len(), inlined_bridges)
+            .iter()
+            .map(|span| span.ops_start)
+            .collect();
+        collect_nursery_batches(ops, nursery, constants, &region_starts)
     } else {
         Vec::new()
     };

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2958,7 +2958,7 @@ fn direct_helper_i64_arity(
     }
     match op.opcode {
         // wasm_jit_alloc(type_id, size)
-        OpCode::New | OpCode::NewWithVtable => Some(2),
+        OpCode::New | OpCode::NewWithVtable | OpCode::CallMallocNursery => Some(2),
         // wasm_jit_alloc_array(type_id, base_size, item_size, length, len_offset)
         OpCode::NewArray | OpCode::NewArrayClear => Some(5),
         // wasm_jit_write_barrier(base)
@@ -7014,6 +7014,135 @@ fn build_function(
                     sink.i64_add();
                     sink.local_set(value_types.local(vi));
                 }
+            }
+            // rewrite.py `CALL_MALLOC_NURSERY(ConstInt(size))`: size is the
+            // already-rounded header+payload total. Fast path is malloc_cond
+            // (bump, zero the header word, return free+HDR). Slow path is
+            // `wasm_jit_alloc(0, payload)` — tid is written afterwards by
+            // `gen_initialize_tid`.
+            OpCode::CallMallocNursery => {
+                let vi = op.pos.get().raw();
+                let size_const = const_operand_value(constants, op.arg(0).to_opref());
+                let bump_size = size_const.and_then(|size| u32::try_from(size).ok());
+                let payload =
+                    bump_size.map(|size| i64::from(size.saturating_sub(GcHeader::SIZE as u32)));
+                let Some(base) = residual_type_base else {
+                    return Err(BackendError::Unsupported(
+                        "wasm codegen: CallMallocNursery needs a residual alloc helper".into(),
+                    ));
+                };
+                let inlined = matches!((nursery, bump_size, payload), (Some(_), Some(_), Some(_)));
+                if let (Some(na), Some(bump_size), Some(payload)) = (nursery, bump_size, payload) {
+                    sink.i32_const(na.free_addr as i32);
+                    sink.i32_load(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.local_tee(alloc_scratch_local);
+                    sink.i32_const(bump_size as i32);
+                    sink.i32_add();
+                    sink.local_tee(alloc_size_local);
+                    sink.i32_const(na.top_addr as i32);
+                    sink.i32_load(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.i32_gt_u();
+                    sink.if_(BlockType::Result(ValType::I64));
+                    sink.i64_const(0);
+                    sink.i64_const(payload);
+                    sink.i32_const(alloc.new_fn_ptr as i32);
+                    sink.call_indirect(0, base + 2);
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        (!OpRef::raw_is_constant(vi)).then_some(vi),
+                        frame,
+                    );
+                    sink.else_();
+                    sink.i32_const(na.free_addr as i32);
+                    sink.local_get(alloc_size_local);
+                    sink.i32_store(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    // Fast path clears the header word; rewrite then stores tid.
+                    sink.local_get(alloc_scratch_local);
+                    sink.i64_const(0);
+                    sink.i64_store(MemArg {
+                        offset: 0,
+                        align: 3,
+                        memory_index: 0,
+                    });
+                    sink.local_get(alloc_scratch_local);
+                    sink.i32_const(GcHeader::SIZE as i32);
+                    sink.i32_add();
+                    sink.i64_extend_i32_u();
+                    sink.end();
+                } else {
+                    sink.i64_const(0);
+                    if let Some(payload) = payload {
+                        sink.i64_const(payload);
+                    } else {
+                        emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                        sink.i64_const(GcHeader::SIZE as i64);
+                        sink.i64_sub();
+                    }
+                    sink.i32_const(alloc.new_fn_ptr as i32);
+                    sink.call_indirect(0, base + 2);
+                }
+                if !OpRef::raw_is_constant(vi) {
+                    sink.local_set(value_types.local(vi));
+                } else {
+                    sink.drop();
+                }
+                emit_memory_error_check(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    op.pos.get(),
+                    residual_type_base,
+                    ca.ca_reload_fn_ptr,
+                    ca.jf_top_addr,
+                );
+                if !inlined {
+                    let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        skip,
+                        frame,
+                    );
+                }
+            }
+            OpCode::CallMallocNurseryHeaderless
+            | OpCode::CallMallocNurseryVarsize
+            | OpCode::CallMallocNurseryVarsizeFrame => {
+                return Err(BackendError::Unsupported(format!(
+                    "wasm codegen: {:?} is not lowered yet",
+                    op.opcode
+                )));
             }
             // `GcRewriterImpl::_gen_call_malloc_gc` emits this after a residual
             // malloc. Use the same propagate-exception exit as the wasm

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -7164,6 +7164,68 @@ fn consecutive_new_ops_keep_their_collecting_boundaries() {
     );
 }
 
+fn call_malloc_nursery(result: u32, size: i64) -> Op {
+    make_op(
+        OpCode::CallMallocNursery,
+        &[OpRef::const_int(size)],
+        OpRef::ref_op(result),
+    )
+}
+
+#[test]
+fn call_malloc_nursery_uses_one_inline_bump() {
+    let inputs = nursery_new_inputs(vec![call_malloc_nursery(1, 32), finish_int_arg0()], 53);
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(nursery_top_compare_count(&bytes), 1);
+}
+
+#[test]
+fn call_malloc_nursery_and_ptr_increment_share_one_bump() {
+    let incr = make_op(
+        OpCode::NurseryPtrIncrement,
+        &[OpRef::ref_op(1), OpRef::const_int(32)],
+        OpRef::ref_op(2),
+    );
+    let inputs = nursery_new_inputs(
+        vec![call_malloc_nursery(1, 72), incr, finish_int_arg0()],
+        53,
+    );
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        1,
+        "rewrite already combined the batch; increment is pointer math"
+    );
+    let mut adds = 0;
+    count_operators(&bytes, |op| {
+        if matches!(op, wasmparser::Operator::I64Add) {
+            adds += 1;
+        }
+    });
+    assert!(adds >= 1, "NURSERY_PTR_INCREMENT is an i64 add");
+}
+
+#[test]
+fn unlowered_call_malloc_nursery_variants_decline() {
+    for opcode in [
+        OpCode::CallMallocNurseryHeaderless,
+        OpCode::CallMallocNurseryVarsize,
+        OpCode::CallMallocNurseryVarsizeFrame,
+    ] {
+        let op = make_op(opcode, &[OpRef::const_int(32)], OpRef::ref_op(1));
+        let inputs = nursery_new_inputs(vec![op, finish_int_arg0()], 53);
+        assert!(
+            matches!(
+                codegen::build_wasm_module(&inputs),
+                Err(majit_backend::BackendError::Unsupported(_))
+            ),
+            "{opcode:?} must decline until it has a malloc_cond arm"
+        );
+    }
+}
+
 #[test]
 fn inline_nursery_new_keeps_the_barrier_at_the_slow_path_join() {
     use majit_ir::descr::{SimpleFieldDescr, SimpleSizeDescr};

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -7187,9 +7187,13 @@ fn finish_int_arg0() -> Op {
 }
 
 fn plain_new(result: u32, type_id: u32) -> Op {
+    sized_new(result, type_id, 16)
+}
+
+fn sized_new(result: u32, type_id: u32, size: usize) -> Op {
     use majit_ir::descr::SimpleSizeDescr;
     use std::sync::Arc;
-    let descr = SimpleSizeDescr::new(0, 16, type_id);
+    let descr = SimpleSizeDescr::new(0, size, type_id);
     descr.set_non_moving(false);
     let op = make_op(OpCode::New, &[], OpRef::ref_op(result));
     op.setdescr(Arc::new(descr));
@@ -7221,6 +7225,59 @@ fn consecutive_new_ops_share_one_nursery_bump() {
         nursery_top_compare_count(&bytes),
         1,
         "gen_malloc_nursery merges consecutive New ops into one bump"
+    );
+}
+
+#[test]
+fn news_that_fill_the_nursery_threshold_keep_separate_bumps() {
+    let inputs = nursery_new_inputs(
+        vec![
+            sized_new(1, 53, 2048),
+            sized_new(2, 53, 2048),
+            finish_int_arg0(),
+        ],
+        53,
+    );
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        2,
+        "combined aligned size must stay strictly below large_threshold"
+    );
+}
+
+#[test]
+fn inlined_region_new_does_not_join_the_owners_nursery_batch() {
+    let descr = majit_ir::make_loop_target_descr(10, false);
+    let label = Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]);
+    label.setdescr(descr.clone());
+    let guard = make_guard(
+        OpCode::GuardTrue,
+        &[OpRef::input_arg_int(0)],
+        &[OpRef::input_arg_int(0)],
+    );
+    let jump = Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]);
+    jump.setdescr(descr);
+    let region_finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(10))]);
+    region_finish.setfailargs(smallvec![rb(OpRef::input_arg_int(10))]);
+    let mut inputs = nursery_new_inputs(vec![label, plain_new(2, 53), guard, jump], 53);
+    inputs.inlined_bridges = vec![codegen::InlinedBridge {
+        external_jump: None,
+        source_fail_index: 0,
+        outside_loop: false,
+        trace_id: 1,
+        inputargs: vec![InputArg::from_type(Type::Int, 10)],
+        ops: vec![plain_new(11, 53), region_finish],
+        gc_table_base: 0,
+        constants: indexmap::IndexMap::new(),
+    }];
+    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(
+        nursery_top_compare_count(&bytes),
+        2,
+        "an inlined region must not follow an owner-side nursery leader"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1717.

- Lower rewrite `CALL_MALLOC_NURSERY` through the same `malloc_cond` bump `New` already uses. `NURSERY_PTR_INCREMENT` stays pointer math. Headerless and varsize twins still decline.
- Flush the nursery batch at each inlined-region start and at `Jump`/`Finish`, so a region's allocation cannot follow an owner-side leader. That was the P1 from the #1717 review: a stale `alloc_batch_flag_local` could make a follower write a header at an unrelated pointer.
- Add tests for the `large_threshold` restart and for a region `New` that must not join the owner's bump.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

The #1717 comments addressed here:

- Codex/CodeRabbit: reset nursery batches at inlined-region boundaries.
- CodeRabbit: witness the `large_threshold` batch restart.

## Verification

- `cargo test -p majit-backend-wasm --test codegen_test`: 118 passed, 6 ignored runtime integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved WebAssembly memory allocation with a faster path for eligible nursery allocations.
  - Improved batching behavior to preserve efficient allocation boundaries across larger allocations and inlined execution regions.
  - Added fallback handling for allocations requiring collection.

- **Bug Fixes**
  - Improved allocation behavior at control-flow boundaries, including jumps and completed execution paths.

- **Tests**
  - Expanded coverage for nursery allocation, batching thresholds, and unsupported allocation variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->