### PR TITLE
gc: arm failed-attr collect only for registered finalizers

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6263,6 +6263,13 @@ impl MiniMarkGC {
         crate::shadow_stack::walk_extra_roots(|gcref| {
             self.seed_major_root(*gcref, "rescan_extra_root");
         });
+        // TLS exception cells live on the per-mutator frame area for the
+        // first pass. Upstream's second `collect_nonstack_roots` still
+        // repeats the non-stack carriers that can be written after the
+        // snapshot; the rescan-only walkers are those three cells.
+        crate::shadow_stack::walk_rescan_roots(|gcref| {
+            self.seed_major_root(*gcref, "rescan_tls_exception");
+        });
         let pending: Vec<usize> = self
             .finalizer_handlers
             .iter()

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1550,6 +1550,48 @@ pub fn register_extra_root_walker(walker: ExtraRootWalkerFn) {
     );
 }
 
+/// Walkers that `rescan_major_nonstack_roots_and_drain` must repeat and that
+/// `walk_extra_roots` must not. Per-mutator `PyFrameRootArea` already walks
+/// the collecting thread's TLS exception cells on the first pass; repeating
+/// those three cells here is what incminimark's second `collect_nonstack_roots`
+/// does for values that can appear after the initial snapshot. Putting them
+/// in [`EXTRA_ROOT_WALKERS`] would double-walk them on every nursery/major
+/// seed.
+static RESCAN_ROOT_WALKERS: parking_lot::RwLock<
+    [Option<ExtraRootWalkerFn>; MAX_EXTRA_ROOT_WALKERS],
+> = parking_lot::RwLock::new([None; MAX_EXTRA_ROOT_WALKERS]);
+
+/// Register a walker that only the mid-major non-stack rescan invokes.
+pub fn register_rescan_root_walker(walker: ExtraRootWalkerFn) {
+    let mut guard = RESCAN_ROOT_WALKERS.write();
+    for slot in guard.iter_mut() {
+        match slot {
+            Some(existing) if std::ptr::fn_addr_eq(*existing, walker) => return,
+            None => {
+                *slot = Some(walker);
+                return;
+            }
+            _ => {}
+        }
+    }
+    panic!(
+        "register_rescan_root_walker: capacity exceeded ({} walkers already registered)",
+        MAX_EXTRA_ROOT_WALKERS
+    );
+}
+
+/// Invoke every rescan-only walker. Called from
+/// `MiniMarkGC::rescan_major_nonstack_roots_and_drain`.
+pub fn walk_rescan_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    let walkers = {
+        let guard = RESCAN_ROOT_WALKERS.read();
+        *guard
+    };
+    for walker in walkers.iter().flatten() {
+        walker(&mut visitor);
+    }
+}
+
 /// Invoke every registered extra root walker with the given visitor.
 ///
 /// Called by `MiniMarkGC::do_collect_nursery` (Phase 1e).

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1674,6 +1674,11 @@ pub struct MetaInterp<M: Clone> {
     /// interpreter-origin entry bridge at that key.
     pub(crate) speculative_cut_owned_key: Option<u64>,
     pub(crate) tracing: Option<TraceCtx>,
+    /// Taken recorder parked for the compile window. `walk_active_trace_refs`
+    /// still forwards its ConstPtrs until intern / drop; `tracing.take()`
+    /// alone would leave those ops unrooted for the whole optimize/compile
+    /// allocation storm.
+    pub(crate) compile_tracing: Option<TraceCtx>,
     /// Single-pass tracing: the `(walk_final_pc, walk_final_reds)` snapshot
     /// copied off the active `TraceCtx` at the CloseLoop point BEFORE
     /// `compile_loop` drains the ctx, so the merge-point hook can read it
@@ -2786,7 +2791,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
             }
         }
-        let Some(trace_ctx) = self.tracing.as_mut() else {
+        let Some(trace_ctx) = self.tracing.as_mut().or(self.compile_tracing.as_mut()) else {
             return;
         };
         trace_ctx.recorder.walk_const_ptr_refs(&mut visitor);
@@ -3524,6 +3529,7 @@ impl<M: Clone> MetaInterp<M> {
             cut_compiled_keys: indexmap::IndexSet::new(),
             speculative_cut_owned_key: None,
             tracing: None,
+            compile_tracing: None,
             single_pass_outcome: None,
             single_pass_finish: false,
             single_pass_finish_values: None,
@@ -10022,24 +10028,44 @@ impl<M: Clone> MetaInterp<M> {
             .and_then(|ctx| ctx.driver_descriptor())
             .cloned();
         self.force_finish_trace = false;
-        let mut ctx = self.tracing.take().unwrap();
+        // Park the recorder here so `walk_active_trace_refs` still forwards
+        // its ConstPtrs while `finish` (and any collection it triggers) runs.
+        // Taking it out of `tracing` stops a re-entrant record; dropping it
+        // before compile intern would reopen the nursery-ConstPtr window.
+        self.compile_tracing = self.tracing.take();
+        let compile_tracing_slot = &raw mut self.compile_tracing;
+        struct CompileTracingGuard(*mut Option<TraceCtx>);
+        impl Drop for CompileTracingGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    *self.0 = None;
+                }
+            }
+        }
+        let _compile_tracing_guard = CompileTracingGuard(compile_tracing_slot);
         // compile.py:510 `vable = orig_inpargs[index_of_virtualizable].getref_base()`.
         // Resolve the constant Ref that the tracer stashed for the
         // virtualizable inputarg at trace-start so
         // `patch_new_loop_to_load_virtualizable_fields` below can read the
         // heap object via `vinfo.get_array_length(vable, i)` without
         // consulting a separate trace-start cache.
-        let orig_vable_ptr = self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
+        let orig_vable_ptr = {
+            let ctx = self.compile_tracing.as_ref().unwrap();
+            self.orig_vable_ptr_from_trace_ctx(ctx, driver_descriptor.as_ref())
+        };
         // pyjitpl.py compile_done_with_this_frame parity:
         // `store_token_in_vable` (SetfieldGc on vable_token + the
         // accompanying GUARD_NOT_FORCED_2) is recorded by the pyre
         // frontend right before TraceAction::Finish is emitted, so the
         // guard captures fresh resumedata via the proper
         // `MIFrame::generate_guard` path.
-        let green_key = ctx.green_key;
+        let green_key = self.compile_tracing.as_ref().unwrap().green_key;
 
-        let call_pure_results = ctx.take_call_pure_results();
-        let mut recorder = ctx.recorder;
+        let call_pure_results = self
+            .compile_tracing
+            .as_mut()
+            .unwrap()
+            .take_call_pure_results();
         // `pyjitpl.py:3216-3217` / `pyjitpl.py:3241`:
         //   `token = sd.done_with_this_frame_descr_<type>` (normal) or
         //   `token = sd.exit_frame_with_exception_descr_ref` (raising),
@@ -10062,11 +10088,19 @@ impl<M: Clone> MetaInterp<M> {
                     crate::make_finish_fail_descr_typed(finish_arg_types.clone(), false)
                 })
         };
-        recorder.finish(finish_args, finish_descr);
+        self.compile_tracing
+            .as_mut()
+            .unwrap()
+            .recorder
+            .finish(finish_args, finish_descr);
         // Snapshots live on TraceCtx; rebuild the TreeLoop with them so
         // downstream consumers (`trace.snapshots`) still observe the
         // captured resumedata. `recorder.get_trace()` on its own returns
-        // a snapshot-less TreeLoop.
+        // a snapshot-less TreeLoop. Taking the parked ctx here ends the
+        // walk_active_trace_refs coverage; `compile_snapshot_refs` picks
+        // up the snapshot ConstPtrs a few lines below.
+        let mut ctx = self.compile_tracing.take().unwrap();
+        let recorder = ctx.recorder;
         let mut trace = recorder.get_trace();
         trace.snapshots = std::mem::take(&mut ctx.snapshots);
         let SimpleCompileViews {

--- a/pyre/extra_tests/snippets/gc_failed_attr_finalizes_only_a_dead_receiver.py
+++ b/pyre/extra_tests/snippets/gc_failed_attr_finalizes_only_a_dead_receiver.py
@@ -1,0 +1,36 @@
+# pyre-check: gate=1
+"""A failed LOAD_ATTR runs a user finalizer only for a dead temporary.
+
+CPython drops the popped receiver immediately.  pyre approximates that with a
+collect after POP_EXCEPT, the same boundary `test_io.test_error_through_destructor`
+uses via `assertRaises`.  Arm only when this object is registered for a
+finalizer.  A live `f.missing` stays reachable through the local, so its
+`__del__` must not run; `C().missing` must.
+"""
+
+import unittest
+
+seen = []
+
+
+class Watched:
+    def __init__(self, name):
+        self.name = name
+
+    def __del__(self):
+        seen.append(self.name)
+
+
+class FailedAttrFinalizer(unittest.TestCase):
+    def test_only_the_dead_receiver_is_finalized(self):
+        live = Watched("live")
+        with self.assertRaises(AttributeError):
+            live.missing
+        self.assertEqual(seen, [])
+        with self.assertRaises(AttributeError):
+            Watched("temp").missing
+        self.assertEqual(seen, ["temp"])
+        self.assertEqual(live.name, "live")
+
+
+FailedAttrFinalizer().test_only_the_dead_receiver_is_finalized()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2628,13 +2628,18 @@ fn eval_loop(frame: &mut PyFrame, ec: *mut crate::PyExecutionContext) -> PyResul
 /// popped a finalizable receiver, an otherwise-unreferenced temporary runs its
 /// finalizer before the surrounding exception handler continues. This is
 /// observable in `test_io.test_error_through_destructor` for both native and
-/// `_pyio` streams. A reachability pass, rather than an IO/type shortcut,
-/// decides whether the receiver is actually dead.
+/// `_pyio` streams.
+///
+/// PyPy's `UserDelAction` only drains the queue; the collect that discovers a
+/// just-popped temporary is the 3.14 adaptation. Arm only when this object is
+/// itself registered for a finalizer. An MRO `__del__` lookup is the wrong
+/// predicate: many types expose `__del__` without `register_finalizer` ever
+/// seeing the instance, and a collect then finds nothing to run. A live
+/// registered receiver (`f.xyzzy`) still triggers the collect, but stays
+/// reachable so its finalizer does not run.
 #[majit_macros::dont_look_inside]
 pub(crate) fn finalize_failed_attr_receiver_now(obj: PyObjectRef) -> bool {
-    crate::typedef::r#type(obj).is_some_and(|w_type| unsafe {
-        crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__del__").is_some()
-    })
+    !obj.is_null() && majit_gc::gc_object_finalizer_pending(obj as usize)
 }
 
 impl SharedOpcodeHandler for PyFrame {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5057,6 +5057,19 @@ fn walk_rbigint_parts_cache(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     });
 }
 
+/// Collecting-thread TLS exception cells that mid-major rescan must repeat.
+///
+/// The per-mutator `PyFrameRootArea` already walks these on the first pass
+/// (every thread, including this one). They are *not* extra-root walkers:
+/// that list is also the first-pass seed, and repeating them there would
+/// double-walk the collecting thread. `rescan_major_nonstack_roots_and_drain`
+/// is the only caller.
+fn walk_rescan_tls_exception_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    walk_bh_last_exc_value(visitor);
+    walk_guard_exc_value(visitor);
+    pyre_interpreter::stack_check::walk_jit_pending_exception(visitor);
+}
+
 /// Every exception parked outside GC discipline, as one root source.
 ///
 /// Each carrier below holds a `W_BaseException` in a cell the precise collector
@@ -5068,18 +5081,12 @@ fn walk_rbigint_parts_cache(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// each enumerating its own population.
 fn walk_parked_exception_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     walk_jit_exc_value(visitor);
-    walk_bh_last_exc_value(visitor);
-    walk_guard_exc_value(visitor);
     // Children of the off-GC exception singletons, which no carrier and no
     // collection phase reaches on its own.
     walk_immortal_exception_singleton_roots(visitor);
     // Stored `PyError` carrier whose GC refs the precise collector cannot
     // reach through its raw TLS cell. Mirrors `walk_pending_call_error`.
     crate::call_jit::walk_last_ca_exception(visitor);
-    // Exception parked for the next interpreter call boundary (JIT prologue
-    // overflow, or a jd1 drain error handed back to the caller loop): live in
-    // a raw TLS cell across the collecting code that runs before the drain.
-    pyre_interpreter::stack_check::walk_jit_pending_exception(visitor);
     // Trace-time exception carriers held only in the active `PyreSym`
     // (`trace_built_exc` / `last_exc_value` / `current_exc_value`): a
     // trace-built exception is unreachable to the precise collector between its
@@ -5116,6 +5123,7 @@ fn install_gc_root_walkers() {
     pyre_interpreter::eval::register_interpreter_global_root_walker();
     majit_gc::shadow_stack::register_extra_root_walker(walk_parked_exception_roots);
     majit_gc::shadow_stack::register_extra_root_walker(walk_immortal_store_roots);
+    majit_gc::shadow_stack::register_rescan_root_walker(walk_rescan_tls_exception_roots);
     // The mapdict side tables are keyed by owner address. Their values are
     // conditional edges, matching the instance-dict and weakref fields PyPy
     // stores on the owner itself, so major marking keeps a value only after


### PR DESCRIPTION
## Summary

- Arm `run_failed_attr_finalizers`' old-gen collect only when the popped receiver is itself `gc_object_finalizer_pending`, not when its type merely has `__del__` in the MRO.
- Park the `finish_and_compile` recorder on `compile_tracing` so `walk_active_trace_refs` still forwards ConstPtrs across `recorder.finish`.
- Move the collecting-thread TLS exception cells (`BH_LAST_EXC_VALUE`, `GUARD_EXC_VALUE`, `TL_JIT_PENDING_EXCEPTION`) off the first-pass extra-root walker and onto a mid-major rescan-only walker.

Closes #1506. Related: #581 compile-window, #528 terminator still open.

## Test plan

- [x] `cargo test -p majit-gc --lib -- shadow_stack`
- [x] `cargo test -p majit-metainterp --features dynasm --lib walk_active_trace_refs`
- [x] `pyre/extra_tests/snippets/gc_failed_attr_finalizes_only_a_dead_receiver.py` on dynasm and CPython
- [x] `test_io.test_error_through_destructor` shape (`assertRaises` + temporary stream) still reports the OSError unraisable
- [ ] `python3 pyre/check.py` on CI backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed garbage collection handling for exception-related references held during execution, reducing the risk of prematurely collected objects.
  - Corrected object finalization after failed attribute lookups: temporary receivers can now be finalized promptly, while live objects remain protected.
  - Improved tracing and compilation reference handling to prevent objects from becoming unreachable during JIT compilation.
- **Tests**
  - Added coverage for finalization behavior when attribute access fails on live and temporary objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->