### PR TITLE
codewriter, macros: align lowerer rewrites with jtransform.py

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -456,6 +456,46 @@ pub(super) fn expr_is_unsigned_int(expr: &Expr) -> bool {
     }
 }
 
+fn type_is_raw_pointer(ty: &Type) -> bool {
+    matches!(ty, Type::Ptr(_))
+}
+
+/// `jtransform.py` `_rewrite_equality`'s `not arg.value` test for a
+/// pointer: the operand is still a source expression, so the null
+/// spellings RPython would have as `Constant(nullptr)` are recognised
+/// here. `ptr::null` / `ptr::null_mut` (any path prefix, optional
+/// turbofish) and `0 as *mut T` / `0 as *const T`.
+pub(super) fn expr_is_null_ptr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Paren(paren) => expr_is_null_ptr(&paren.expr),
+        Expr::Group(group) => expr_is_null_ptr(&group.expr),
+        Expr::Call(call) if call.args.is_empty() => {
+            match &*call.func {
+                Expr::Path(path) => path.path.segments.last().is_some_and(|seg| {
+                    matches!(seg.ident.to_string().as_str(), "null" | "null_mut")
+                }),
+                _ => false,
+            }
+        }
+        Expr::Cast(cast) => {
+            int_literal_value(&cast.expr) == Some(0) && type_is_raw_pointer(&cast.ty)
+        }
+        _ => false,
+    }
+}
+
+/// `x.is_null()` — the Rust spelling of RPython `ptr_iszero`.
+pub(super) fn expr_is_ptr_is_null_method(expr: &Expr) -> Option<&Expr> {
+    match expr {
+        Expr::Paren(paren) => expr_is_ptr_is_null_method(&paren.expr),
+        Expr::Group(group) => expr_is_ptr_is_null_method(&group.expr),
+        Expr::MethodCall(call) if call.method == "is_null" && call.args.is_empty() => {
+            Some(&call.receiver)
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn is_supported_float_type(ty: &Type) -> bool {
     match ty {
         Type::Path(type_path) => type_path.path.is_ident("f64"),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -47,7 +47,7 @@ impl<'c> Lowerer<'c> {
         // RPython `jtransform.py` `optimize_goto_if_not`: when the boolean
         // comparison result is used only as this block's exitswitch, remove
         // the value-producing op and carry its operands in the exitswitch.
-        // Flatten then emits `goto_if_not_<opname>/{ii,ff}L`.
+        // Flatten then emits `goto_if_not_<opname>/{ii,ff,rr}L`.
         //
         // Do not fuse through `!`: `!(a < b)` is not `a >= b` for NaNs.
         if !negated {
@@ -64,30 +64,94 @@ impl<'c> Lowerer<'c> {
                     BinOp::Ge(_) => "ge",
                     _ => return None,
                 };
-                let lhs = s.lower_value_expr(&binary.left)?;
-                let rhs = s.lower_value_expr(&binary.right)?;
-                if lhs.kind != rhs.kind
-                    || !matches!(lhs.kind, BindingKind::Int | BindingKind::Float)
-                {
-                    return None;
-                }
-                // `_rewrite_equality` then `optimize_goto_if_not`:
-                // `int_eq(x, 0)` → `int_is_zero` → `goto_if_not_int_is_zero`.
-                if matches!(lhs.kind, BindingKind::Int)
-                    && matches!(binary.op, BinOp::Eq(_) | BinOp::Ne(_))
-                {
-                    let left_zero = int_literal_value(&binary.left) == Some(0);
-                    let right_zero = int_literal_value(&binary.right) == Some(0);
-                    if left_zero || right_zero {
-                        let value = if right_zero { lhs } else { rhs };
+                // `_rewrite_equality` on `ptr_eq` / `ptr_ne`: a comparison
+                // against null is `ptr_iszero` / `ptr_nonzero`. Detect the
+                // null spelling on the source tree — `null_mut()` does not
+                // lower as a value, so waiting until both sides are bound
+                // would refuse the condition.
+                if matches!(binary.op, BinOp::Eq(_) | BinOp::Ne(_)) {
+                    let left_null = expr_is_null_ptr(&binary.left);
+                    let right_null = expr_is_null_ptr(&binary.right);
+                    if left_null || right_null {
+                        if left_null && right_null {
+                            return None;
+                        }
+                        let other = if right_null {
+                            &binary.left
+                        } else {
+                            &binary.right
+                        };
+                        let value = s.lower_value_expr(other)?;
+                        if !matches!(value.kind, BindingKind::Ref) {
+                            return None;
+                        }
                         let negated = matches!(binary.op, BinOp::Eq(_));
                         return Some(LoweredCondition::Value {
                             binding: value,
                             negated,
-                            int_is_true: true,
+                            int_is_true: false,
                         });
                     }
                 }
+                let lhs = s.lower_value_expr(&binary.left)?;
+                let rhs = s.lower_value_expr(&binary.right)?;
+                if lhs.kind != rhs.kind {
+                    return None;
+                }
+                match lhs.kind {
+                    BindingKind::Int => {
+                        // `_rewrite_equality` then `optimize_goto_if_not`:
+                        // `int_eq(x, 0)` → `int_is_zero` → `goto_if_not_int_is_zero`.
+                        if matches!(binary.op, BinOp::Eq(_) | BinOp::Ne(_)) {
+                            let left_zero = int_literal_value(&binary.left) == Some(0);
+                            let right_zero = int_literal_value(&binary.right) == Some(0);
+                            if left_zero || right_zero {
+                                let value = if right_zero { lhs } else { rhs };
+                                let negated = matches!(binary.op, BinOp::Eq(_));
+                                return Some(LoweredCondition::Value {
+                                    binding: value,
+                                    negated,
+                                    int_is_true: true,
+                                });
+                            }
+                        }
+                    }
+                    BindingKind::Float => {}
+                    BindingKind::Ref => {
+                        // `optimize_goto_if_not` lists `ptr_eq` / `ptr_ne`.
+                        // Ordered pointer compares do not exist upstream.
+                        if !matches!(binary.op, BinOp::Eq(_) | BinOp::Ne(_)) {
+                            return None;
+                        }
+                        return Some(LoweredCondition::Compare {
+                            lhs,
+                            rhs,
+                            branch: format_ident!("goto_if_not_ptr_{suffix}"),
+                        });
+                    }
+                }
+                if !matches!(lhs.kind, BindingKind::Int | BindingKind::Float) {
+                    return None;
+                }
+                // `_rewrite_symmetric` before `optimize_goto_if_not`:
+                // `c1 < v2` → `v2 > c1` so flatten sees one bytecode form.
+                let swap = binop_is_symmetric(&binary.op)
+                    && int_literal_value(&binary.left).is_some()
+                    && int_literal_value(&binary.right).is_none();
+                let (op, lhs, rhs) = if swap {
+                    (mirrored_compare_binop(&binary.op), rhs, lhs)
+                } else {
+                    (binary.op, lhs, rhs)
+                };
+                let suffix = match &op {
+                    BinOp::Lt(_) => "lt",
+                    BinOp::Le(_) => "le",
+                    BinOp::Eq(_) => "eq",
+                    BinOp::Ne(_) => "ne",
+                    BinOp::Gt(_) => "gt",
+                    BinOp::Ge(_) => "ge",
+                    _ => return None,
+                };
                 let prefix = match lhs.kind {
                     BindingKind::Int => "goto_if_not_int_",
                     BindingKind::Float => "goto_if_not_float_",
@@ -102,6 +166,21 @@ impl<'c> Lowerer<'c> {
             if fused.is_some() {
                 return fused;
             }
+        }
+
+        // `x.is_null()` is `ptr_iszero`. Combined with a peeled `!` it
+        // is `ptr_nonzero` — the same pair `_rewrite_equality` produces
+        // for `ptr == NULL` / `ptr != NULL`.
+        if let Some(receiver) = expr_is_ptr_is_null_method(expr) {
+            let binding = self.lower_value_expr(receiver)?;
+            if !matches!(binding.kind, BindingKind::Ref) {
+                return None;
+            }
+            return Some(LoweredCondition::Value {
+                binding,
+                negated: !negated,
+                int_is_true: false,
+            });
         }
 
         let binding = self.lower_value_expr(expr)?;
@@ -214,26 +293,10 @@ impl<'c> Lowerer<'c> {
             self.emit_aux(quote! { let #next_label = __builder.new_label(); });
 
             if value_tokens.len() == 1 {
-                let value_tok = &value_tokens[0];
-                let const_reg = self.alloc_reg();
-                let eq_reg = self.alloc_reg();
-                self.emit_op(
-                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
-                    quote! { __builder.load_const_i_value(#const_reg, #value_tok); },
-                );
-                self.emit_op(
-                    OpMeta::linear(
-                        OpKind::BinopI,
-                        Register::ints(&[disc_reg, const_reg]),
-                        vec![Register::int(eq_reg)],
-                    ),
-                    quote! { __builder.record_binop_i(#eq_reg, majit_ir::OpCode::IntEq, #disc_reg, #const_reg); },
-                );
-                self.emit_op(
-                    OpMeta::live_marker(),
-                    quote! { let _ = __builder.live_placeholder(); },
-                );
-                self.emit_conditional_guard(eq_reg, &next_label);
+                // `optimize_goto_if_not` fuses `int_eq` + exitswitch into
+                // `goto_if_not_int_eq`. A compare against zero is
+                // `_rewrite_equality` → `goto_if_not_int_is_zero`.
+                self.emit_fused_int_eq_miss(disc_reg, &value_tokens[0], &next_label);
             } else {
                 let first_tok = &value_tokens[0];
                 let first_const_reg = self.alloc_reg();
@@ -693,26 +756,7 @@ impl<'c> Lowerer<'c> {
             self.emit_aux(quote! { let #next_label = __builder.new_label(); });
 
             if values.len() == 1 {
-                let value = &values[0];
-                let const_reg = self.alloc_reg();
-                let eq_reg = self.alloc_reg();
-                self.emit_op(
-                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
-                    quote! { __builder.load_const_i_value(#const_reg, #value); },
-                );
-                self.emit_op(
-                    OpMeta::linear(
-                        OpKind::BinopI,
-                        Register::ints(&[disc_reg, const_reg]),
-                        vec![Register::int(eq_reg)],
-                    ),
-                    quote! { __builder.record_binop_i(#eq_reg, majit_ir::OpCode::IntEq, #disc_reg, #const_reg); },
-                );
-                self.emit_op(
-                    OpMeta::live_marker(),
-                    quote! { let _ = __builder.live_placeholder(); },
-                );
-                self.emit_conditional_guard(eq_reg, &next_label);
+                self.emit_fused_int_eq_miss(disc_reg, &values[0], &next_label);
             } else {
                 let first_val = &values[0];
                 let first_const_reg = self.alloc_reg();
@@ -828,8 +872,19 @@ impl<'c> Lowerer<'c> {
     }
 
     fn emit_checked_ovf_match(&mut self, parsed: CheckedOvfMatch<'_>) -> Option<Binding> {
-        let lhs = self.lower_value_expr(parsed.recv)?;
-        let rhs = self.lower_value_expr(parsed.arg)?;
+        // `rewrite_op_int_add_ovf` / `rewrite_op_int_mul_ovf` run
+        // `_rewrite_symmetric` before emitting `-live-` + the ovf op.
+        // `int_sub_ovf` is not symmetric.
+        let swap = parsed.builder_method != "int_sub_jump_if_ovf"
+            && int_literal_value(parsed.recv).is_some()
+            && int_literal_value(parsed.arg).is_none();
+        let (lhs_expr, rhs_expr) = if swap {
+            (parsed.arg, parsed.recv)
+        } else {
+            (parsed.recv, parsed.arg)
+        };
+        let lhs = self.lower_value_expr(lhs_expr)?;
+        let rhs = self.lower_value_expr(rhs_expr)?;
         if !matches!(lhs.kind, BindingKind::Int) || !matches!(rhs.kind, BindingKind::Int) {
             return None;
         }
@@ -1277,6 +1332,61 @@ mod unroll_binding_tests {
     }
 
     #[test]
+    fn if_const_lt_var_mirrors_to_goto_if_not_int_gt() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "n".to_string(),
+            Binding {
+                reg: 4,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr_if: syn::ExprIf = syn::parse_quote! { if 0 < n { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_int_gt"),
+            "`if 0 < n` must swap to int_gt, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("goto_if_not_int_lt"),
+            "must not keep the constant-left form:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn match_fuses_to_goto_if_not_int_eq() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "n".to_string(),
+            Binding {
+                reg: 4,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr_match: syn::ExprMatch = syn::parse_quote! {
+            match n {
+                1 => {},
+                _ => {},
+            }
+        };
+        assert!(lowerer.lower_match_stmt(&expr_match).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_int_eq"),
+            "`match n {{ 1 => }}` must fuse to int_eq, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("IntEq"),
+            "must not materialise the compare:\n{emitted}"
+        );
+    }
+
+    #[test]
     fn if_eq_zero_fuses_to_goto_if_not_int_is_zero() {
         let mut lowerer = Lowerer::new(None);
         lowerer.bindings.insert(
@@ -1303,6 +1413,101 @@ mod unroll_binding_tests {
         assert!(
             !emitted.contains("goto_if_not_int_eq"),
             "must not keep the binary compare:\n{emitted}"
+        );
+    }
+
+    fn insert_ref(lowerer: &mut Lowerer, name: &str, reg: u16) {
+        lowerer.bindings.insert(
+            name.to_string(),
+            Binding {
+                reg,
+                kind: BindingKind::Ref,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+    }
+
+    fn emitted_if(lowerer: &Lowerer) -> String {
+        lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn if_ptr_eq_fuses_to_goto_if_not_ptr_eq() {
+        let mut lowerer = Lowerer::new(None);
+        insert_ref(&mut lowerer, "a", 0);
+        insert_ref(&mut lowerer, "b", 1);
+        let expr_if: syn::ExprIf = syn::parse_quote! { if a == b { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_ptr_eq"),
+            "`if a == b` on refs must fuse to ptr_eq, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("ptr_iszero") && !emitted.contains("goto_if_not_int"),
+            "must not fall through to an int branch:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn if_ptr_eq_null_fuses_to_goto_if_not_ptr_iszero() {
+        let mut lowerer = Lowerer::new(None);
+        insert_ref(&mut lowerer, "p", 0);
+        let expr_if: syn::ExprIf = syn::parse_quote! { if p == std::ptr::null_mut() { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_ptr_iszero"),
+            "`if p == null_mut()` must fuse to ptr_iszero, got:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn if_ptr_ne_null_fuses_to_goto_if_not_ptr_nonzero() {
+        let mut lowerer = Lowerer::new(None);
+        insert_ref(&mut lowerer, "p", 0);
+        let expr_if: syn::ExprIf = syn::parse_quote! { if p != std::ptr::null() { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_ptr_nonzero"),
+            "`if p != null()` must fuse to ptr_nonzero, got:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn if_is_null_fuses_to_goto_if_not_ptr_iszero() {
+        let mut lowerer = Lowerer::new(None);
+        insert_ref(&mut lowerer, "p", 0);
+        let expr_if: syn::ExprIf = syn::parse_quote! { if p.is_null() { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_ptr_iszero"),
+            "`if p.is_null()` must fuse to ptr_iszero, got:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn if_not_is_null_fuses_to_goto_if_not_ptr_nonzero() {
+        let mut lowerer = Lowerer::new(None);
+        insert_ref(&mut lowerer, "p", 0);
+        let expr_if: syn::ExprIf = syn::parse_quote! { if !p.is_null() { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+        let emitted = emitted_if(&lowerer);
+        assert!(
+            emitted.contains("goto_if_not_ptr_nonzero"),
+            "`if !p.is_null()` must fuse to ptr_nonzero, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("goto_if_not_ptr_iszero"),
+            "the negation must replace the branch, not add one:\n{emitted}"
         );
     }
 
@@ -1351,6 +1556,47 @@ mod unroll_binding_tests {
         assert!(
             emitted.contains("IntAdd") || emitted.contains("int_add"),
             "Some(v) => v + 1 must emit the increment, got:\n{emitted}"
+        );
+    }
+
+    #[test]
+    fn checked_add_swaps_a_constant_receiver() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.bindings.insert(
+            "x".to_string(),
+            Binding {
+                reg: 3,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            },
+        );
+        let expr: syn::ExprMatch = syn::parse_quote! {
+            match 1.checked_add(x) {
+                Some(v) => v,
+                None => 0,
+            }
+        };
+        assert!(
+            lowerer
+                .lower_checked_ovf_match(&expr)
+                .expect("recognized")
+                .is_some()
+        );
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            emitted.contains("int_add_jump_if_ovf ("),
+            "expected the ovf add, got:\n{emitted}"
+        );
+        // `_rewrite_symmetric` moves the variable to the left: dst, x, 1.
+        assert!(
+            emitted.contains("int_add_jump_if_ovf (") && emitted.contains("3u16"),
+            "the variable must be the left ovf operand, got:\n{emitted}"
         );
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1681,6 +1681,40 @@ impl<'c> Lowerer<'c> {
                 // helper performs leaves the trace with no diagnostic. The
                 // workaround is to bind the result to `let _x = ...`, which is
                 // a source change the declaration does not ask for.
+                crate::jit_interp::CallPolicyKind::InlinePipelineInt
+                | crate::jit_interp::CallPolicyKind::InlinePipelineRef
+                | crate::jit_interp::CallPolicyKind::InlinePipelineFloat => {
+                    let result_kind = binding_kind_for_inline_policy(kind)
+                        .expect("the arm's own patterns are the pipeline result policies");
+                    let throwaway_reg = self.alloc_reg();
+                    let pipeline_name = match &*call.func {
+                        syn::Expr::Path(ep) => ep
+                            .path
+                            .segments
+                            .last()
+                            .map(|segment| segment.ident.to_string()),
+                        _ => None,
+                    }?;
+                    let (inline_call, post_live) = inline_call_tokens(&arg_bindings, throwaway_reg);
+                    let arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
+                    self.inline_liveness_prebuild.push(quote! {
+                        __majit_pipeline_liveness_prebuild(__asm);
+                    });
+                    self.emit_op(
+                        OpMeta::linear(
+                            OpKind::InlineCall,
+                            arg_regs,
+                            vec![Register::new(result_kind, throwaway_reg)],
+                        ),
+                        quote! {
+                            let __sub_jitcode = __majit_pipeline_jitcode(#pipeline_name);
+                            let __sub_idx = __builder.add_sub_jitcode_arc(__sub_jitcode);
+                            #inline_call
+                        },
+                    );
+                    self.emit_op(OpMeta::live_marker(), post_live);
+                }
                 crate::jit_interp::CallPolicyKind::InlineInt
                 | crate::jit_interp::CallPolicyKind::InlineRef
                 | crate::jit_interp::CallPolicyKind::InlineFloat => {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -378,6 +378,9 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_float_bitcast_method_call(call) {
                     return Some(binding);
                 }
+                if let Some(binding) = self.lower_ptr_is_null_method_call(call) {
+                    return Some(binding);
+                }
                 self.lower_method_call_value(call)
             }
             Expr::Struct(s) => self.lower_struct_value(s),
@@ -681,17 +684,36 @@ impl<'c> Lowerer<'c> {
             .iter()
             .map(|(member, value)| {
                 let is_ref = matches!(value.kind, BindingKind::Ref);
-                // A struct literal names no sub-word integer field: the
-                // allocation's own field stores go through the int/ref banks,
-                // so the layout registers `scalar_size`'s default here. A ref
-                // field's width comes from `Type::Ref` and ignores this.
+                // `rewrite_op_malloc` + `rewrite_op_setfield` register
+                // each field through `fielddescrof`, which reads width
+                // and signedness from FIELDTYPE. Use the same
+                // `int_fields` / `ref_fields` witness the getfield path
+                // already consults.
+                let struct_name = struct_path
+                    .segments
+                    .last()
+                    .map(|s| s.ident.to_string())
+                    .unwrap_or_default();
+                let member_name = named_member(member).unwrap_or_default();
+                let key = format!("{struct_name}::{member_name}");
+                let (size, signed, witness) = match self.config {
+                    Some(config) => {
+                        super::lower_vable::field_scalar_tokens(config, &key, struct_path, member)
+                    }
+                    None => (
+                        quote! { ::core::mem::size_of::<i64>() },
+                        quote! { true },
+                        quote! {},
+                    ),
+                };
                 quote! {
+                    #witness
                     (
                         ::core::mem::offset_of!(#struct_path, #member),
                         #is_ref,
                         stringify!(#member),
-                        ::core::mem::size_of::<i64>(),
-                        true,
+                        #size,
+                        #signed,
                     )
                 }
             })
@@ -1952,6 +1974,75 @@ impl<'c> Lowerer<'c> {
         self.lower_call_value(&normalized)
     }
 
+    /// `jtransform.py` `_rewrite_equality` via `rewrite_op_ptr_eq` /
+    /// `rewrite_op_ptr_ne`: a comparison against the null pointer is the
+    /// unary `ptr_iszero` / `ptr_nonzero`. The null operand is recognised
+    /// on the source tree because `null_mut()` is not a lowerable value.
+    fn lower_ptr_equality_against_null(&mut self, expr: &ExprBinary) -> Option<Binding> {
+        let left_null = expr_is_null_ptr(&expr.left);
+        let right_null = expr_is_null_ptr(&expr.right);
+        if !left_null && !right_null {
+            return None;
+        }
+        if left_null && right_null {
+            let value = i64::from(matches!(expr.op, BinOp::Eq(_)));
+            let reg = self.alloc_reg();
+            self.emit_op(
+                OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(reg)]),
+                quote! { __builder.load_const_i_value(#reg, #value); },
+            );
+            return Some(Binding {
+                reg,
+                kind: BindingKind::Int,
+                depends_on_stack: false,
+                struct_type: None,
+            });
+        }
+        let other = if right_null { &expr.left } else { &expr.right };
+        let binding = self.lower_value_expr(other)?;
+        if !matches!(binding.kind, BindingKind::Ref) {
+            return None;
+        }
+        self.emit_ptr_nullity_test(binding, matches!(expr.op, BinOp::Eq(_)))
+    }
+
+    /// `x.is_null()` is RPython `ptr_iszero`.
+    fn lower_ptr_is_null_method_call(&mut self, call: &ExprMethodCall) -> Option<Binding> {
+        if call.method != "is_null" || !call.args.is_empty() {
+            return None;
+        }
+        let recv = self.lower_value_expr(&call.receiver)?;
+        if !matches!(recv.kind, BindingKind::Ref) {
+            return None;
+        }
+        self.emit_ptr_nullity_test(recv, true)
+    }
+
+    /// `ptr_iszero` when `is_zero`, otherwise `ptr_nonzero`.
+    fn emit_ptr_nullity_test(&mut self, binding: Binding, is_zero: bool) -> Option<Binding> {
+        let src_reg = binding.reg;
+        let reg = self.alloc_reg();
+        let emit = if is_zero {
+            quote! { __builder.ptr_iszero(#reg, #src_reg); }
+        } else {
+            quote! { __builder.ptr_nonzero(#reg, #src_reg); }
+        };
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::UnaryI,
+                vec![Register::ref_(src_reg)],
+                vec![Register::int(reg)],
+            ),
+            emit,
+        );
+        Some(Binding {
+            reg,
+            kind: BindingKind::Int,
+            depends_on_stack: binding.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
     fn lower_if_value(&mut self, expr_if: &ExprIf) -> Option<Binding> {
         if let Some(binding) = self.lower_bool_if(expr_if) {
             return Some(binding);
@@ -2031,20 +2122,16 @@ impl<'c> Lowerer<'c> {
         match (then_value, else_value) {
             (1, 0) => Some(cond),
             (0, 1) => {
-                let zero_reg = self.alloc_reg();
-                self.emit_op(
-                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(zero_reg)]),
-                    quote! { __builder.load_const_i_value(#zero_reg, 0); },
-                );
-                let reg = self.alloc_reg();
+                // `_rewrite_equality` / `bool_not` → `int_is_zero`.
                 let cond_reg = cond.reg;
+                let reg = self.alloc_reg();
                 self.emit_op(
                     OpMeta::linear(
-                        OpKind::BinopI,
-                        Register::ints(&[cond_reg, zero_reg]),
+                        OpKind::UnaryI,
+                        Register::ints(&[cond_reg]),
                         vec![Register::int(reg)],
                     ),
-                    quote! { __builder.record_binop_i(#reg, majit_ir::OpCode::IntEq, #cond_reg, #zero_reg); },
+                    quote! { __builder.record_unary_i(#reg, majit_ir::OpCode::IntIsZero, #cond_reg); },
                 );
                 Some(Binding {
                     reg,
@@ -2216,6 +2303,11 @@ impl<'c> Lowerer<'c> {
     }
 
     fn lower_binary(&mut self, expr: &ExprBinary) -> Option<Binding> {
+        if matches!(expr.op, BinOp::Eq(_) | BinOp::Ne(_)) {
+            if let Some(binding) = self.lower_ptr_equality_against_null(expr) {
+                return Some(binding);
+            }
+        }
         let lhs = self.lower_value_expr(&expr.left)?;
         let rhs = self.lower_value_expr(&expr.right)?;
         if matches!(lhs.kind, BindingKind::Float) && matches!(rhs.kind, BindingKind::Float) {
@@ -3149,6 +3241,60 @@ mod tests {
             });
             assert!(out.is_some());
             assert!(emitted(&lowerer).contains("PtrNe"));
+        }
+
+        #[test]
+        fn a_ref_equality_against_null_lowers_to_ptr_iszero() {
+            let (lowerer, out) = lower("p == std::ptr::null_mut()", |l| {
+                l.bindings.insert("p".into(), ref_binding(0, None));
+            });
+            assert!(out.is_some(), "null_mut() must not refuse the compare");
+            let text = emitted(&lowerer);
+            assert!(
+                text.contains("ptr_iszero"),
+                "`p == null_mut()` is `_rewrite_equality` to ptr_iszero, got:\n{text}"
+            );
+            assert!(
+                !text.contains("PtrEq"),
+                "must not keep the binary pointer compare:\n{text}"
+            );
+        }
+
+        #[test]
+        fn a_ref_inequality_against_null_lowers_to_ptr_nonzero() {
+            let (lowerer, out) = lower("p != core::ptr::null()", |l| {
+                l.bindings.insert("p".into(), ref_binding(0, None));
+            });
+            assert!(out.is_some());
+            assert!(
+                emitted(&lowerer).contains("ptr_nonzero"),
+                "`p != null()` is ptr_nonzero"
+            );
+        }
+
+        #[test]
+        fn a_zero_cast_to_raw_pointer_is_the_null_constant() {
+            let (lowerer, out) = lower("p == (0 as *mut u8)", |l| {
+                l.bindings.insert("p".into(), ref_binding(0, None));
+            });
+            assert!(out.is_some());
+            assert!(
+                emitted(&lowerer).contains("ptr_iszero"),
+                "`0 as *mut T` is the same null constant"
+            );
+        }
+
+        #[test]
+        fn is_null_lowers_to_ptr_iszero() {
+            let mut lowerer = Lowerer::new(None);
+            lowerer.bindings.insert("p".into(), ref_binding(0, None));
+            let expr: Expr = syn::parse_str("p.is_null()").expect("parse method call");
+            let out = lowerer.lower_value_expr(&expr);
+            assert!(out.is_some(), "is_null() must not refuse");
+            assert!(
+                emitted(&lowerer).contains("ptr_iszero"),
+                "`p.is_null()` is ptr_iszero"
+            );
         }
 
         #[test]

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -405,7 +405,42 @@ impl<'c> Lowerer<'c> {
     }
 
     pub(super) fn emit_conditional_guard(&mut self, cond_reg: u16, target: &Ident) {
-        self.emit_conditional_guard_negatable(cond_reg, target, false, false);
+        self.emit_conditional_guard_negatable(cond_reg, target, false, false, BindingKind::Int);
+    }
+
+    /// `optimize_goto_if_not` on `int_eq(disc, const)`: fall through when
+    /// they match, jump to `miss` otherwise. Zero is `_rewrite_equality`
+    /// → `goto_if_not_int_is_zero`.
+    pub(super) fn emit_fused_int_eq_miss(
+        &mut self,
+        disc_reg: u16,
+        value_tok: &TokenStream,
+        miss: &Ident,
+    ) {
+        self.emit_op(
+            OpMeta::live_marker(),
+            quote! { let _ = __builder.live_placeholder(); },
+        );
+        if value_tok.to_string().replace(' ', "") == "0" {
+            self.emit_op(
+                OpMeta::conditional_guard(Register::int(disc_reg), miss.clone()),
+                quote! { __builder.goto_if_not_int_is_zero(#disc_reg, #miss); },
+            );
+            return;
+        }
+        let const_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
+            quote! { __builder.load_const_i_value(#const_reg, #value_tok); },
+        );
+        self.emit_op(
+            OpMeta::conditional_guard_compare(
+                Register::int(disc_reg),
+                Register::int(const_reg),
+                miss.clone(),
+            ),
+            quote! { __builder.goto_if_not_int_eq(#disc_reg, #const_reg, #miss); },
+        );
     }
 
     /// The branch RPython writes as `goto_if_not_<opname>`: fall through
@@ -419,26 +454,40 @@ impl<'c> Lowerer<'c> {
     ///
     /// `int_is_true` is the integer `!= 0` rewrite. A Rust `if`/`while`
     /// condition is otherwise `bool`, so flatten emits plain `goto_if_not`.
+    ///
+    /// A Ref binding is the `_rewrite_equality` fold of `ptr_eq` /
+    /// `ptr_ne` against null (`ptr_iszero` / `ptr_nonzero`); flatten
+    /// writes `goto_if_not_ptr_iszero/rL` / `goto_if_not_ptr_nonzero/rL`.
     pub(super) fn emit_conditional_guard_negatable(
         &mut self,
         cond_reg: u16,
         target: &Ident,
         negated: bool,
         int_is_true: bool,
+        kind: BindingKind,
     ) {
-        let branch = if negated {
-            format_ident!("goto_if_not_int_is_zero")
-        } else if int_is_true {
-            format_ident!("goto_if_not_int_is_true")
+        let (branch, register) = if matches!(kind, BindingKind::Ref) {
+            let branch = if negated {
+                format_ident!("goto_if_not_ptr_iszero")
+            } else {
+                format_ident!("goto_if_not_ptr_nonzero")
+            };
+            (branch, Register::ref_(cond_reg))
         } else {
-            format_ident!("goto_if_not")
+            let branch = if negated {
+                format_ident!("goto_if_not_int_is_zero")
+            } else if int_is_true {
+                format_ident!("goto_if_not_int_is_true")
+            } else {
+                format_ident!("goto_if_not")
+            };
+            (branch, Register::int(cond_reg))
         };
-        // Both forms read an int-banked register: `assembler.py write_insn`
-        // takes a `Register` operand's argcode from `x.kind[0]`, which is
-        // `'i'` for the int bank — encode the kind into the metadata
-        // `Register` so the liveness walker keeps it under Int.
+        // `assembler.py write_insn` takes a `Register` operand's argcode
+        // from `x.kind[0]`; encode the bank into the metadata `Register`
+        // so the liveness walker keeps a Ref truth-test under Ref.
         self.emit_op(
-            OpMeta::conditional_guard(Register::int(cond_reg), target.clone()),
+            OpMeta::conditional_guard(register, target.clone()),
             quote! { __builder.#branch(#cond_reg, #target); },
         );
     }
@@ -456,7 +505,13 @@ impl<'c> Lowerer<'c> {
                 negated,
                 int_is_true,
             } => {
-                self.emit_conditional_guard_negatable(binding.reg, target, *negated, *int_is_true);
+                self.emit_conditional_guard_negatable(
+                    binding.reg,
+                    target,
+                    *negated,
+                    *int_is_true,
+                    binding.kind,
+                );
             }
             LoweredCondition::Compare { lhs, rhs, branch } => {
                 let lhs_reg = Register::new(lhs.kind, lhs.reg);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -417,30 +417,39 @@ impl<'c> Lowerer<'c> {
         value_tok: &TokenStream,
         miss: &Ident,
     ) {
+        // `flatten.insert_exits` puts `-live-` immediately before the
+        // fused `goto_if_not_*`. The constant load is not the guard, so
+        // it must land first; otherwise `get_list_of_active_snapshot_boxes`
+        // reads `pc - SIZE_LIVE_OP` as the load opcode.
+        let const_reg = if value_tok.to_string().replace(' ', "") == "0" {
+            None
+        } else {
+            let const_reg = self.alloc_reg();
+            self.emit_op(
+                OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
+                quote! { __builder.load_const_i_value(#const_reg, #value_tok); },
+            );
+            Some(const_reg)
+        };
         self.emit_op(
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        if value_tok.to_string().replace(' ', "") == "0" {
+        if let Some(const_reg) = const_reg {
+            self.emit_op(
+                OpMeta::conditional_guard_compare(
+                    Register::int(disc_reg),
+                    Register::int(const_reg),
+                    miss.clone(),
+                ),
+                quote! { __builder.goto_if_not_int_eq(#disc_reg, #const_reg, #miss); },
+            );
+        } else {
             self.emit_op(
                 OpMeta::conditional_guard(Register::int(disc_reg), miss.clone()),
                 quote! { __builder.goto_if_not_int_is_zero(#disc_reg, #miss); },
             );
-            return;
         }
-        let const_reg = self.alloc_reg();
-        self.emit_op(
-            OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
-            quote! { __builder.load_const_i_value(#const_reg, #value_tok); },
-        );
-        self.emit_op(
-            OpMeta::conditional_guard_compare(
-                Register::int(disc_reg),
-                Register::int(const_reg),
-                miss.clone(),
-            ),
-            quote! { __builder.goto_if_not_int_eq(#disc_reg, #const_reg, #miss); },
-        );
     }
 
     /// The branch RPython writes as `goto_if_not_<opname>`: fall through

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -37,17 +37,17 @@ mod reexports {
     };
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_f_emit_tokens, binop_i_emit_tokens,
-        binop_is_symmetric, block_has_loop_control, expr_has_loop_control, expr_is_unsigned_int,
-        extract_block_tail_int, extract_bool_branch_values, extract_branch_int,
-        extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
-        inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
-        inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, inline_shared_path,
-        int_arg_regs, int_literal_value, is_lowercase_binding_pat, is_supported_float_type,
-        is_supported_int_cast, is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens,
-        mirrored_compare_binop, opcode_for_assign_binop, opcode_for_assign_binop_f,
-        opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control,
-        type_is_unsigned_int, typed_call_arg_tokens, word_result_addr_for_kind,
-        word_result_addr_tokens, word_void_addr_tokens,
+        binop_is_symmetric, block_has_loop_control, expr_has_loop_control, expr_is_null_ptr,
+        expr_is_ptr_is_null_method, expr_is_unsigned_int, extract_block_tail_int,
+        extract_bool_branch_values, extract_branch_int, extract_pat_switch_case_tokens,
+        extract_pat_value_tokens, extract_stmts, inline_call_tokens, inline_call_tokens_void,
+        inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
+        inline_ref_arg_tokens, inline_shared_path, int_arg_regs, int_literal_value,
+        is_lowercase_binding_pat, is_supported_float_type, is_supported_int_cast,
+        is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens, mirrored_compare_binop,
+        opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f,
+        opcode_for_compare_f, stmt_has_loop_control, type_is_unsigned_int, typed_call_arg_tokens,
+        word_result_addr_for_kind, word_result_addr_tokens, word_void_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,
@@ -1658,6 +1658,9 @@ pub(super) enum LoweredCondition {
         /// `true` when this value is an integer `== 0` / `!= 0` compare
         /// rewritten as a truth test. Rust `if`/`while` conditions are
         /// otherwise `bool`, which flatten emits as `goto_if_not`.
+        /// A Ref binding is the `_rewrite_equality` fold of `ptr_eq` /
+        /// `ptr_ne` against null; `negated` then selects
+        /// `goto_if_not_ptr_iszero` / `goto_if_not_ptr_nonzero`.
         int_is_true: bool,
     },
     Compare {

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -751,14 +751,18 @@ fn rewrite_symmetric(graph: &FunctionGraph, op: SpaceOperation) -> SpaceOperatio
 /// `add` / `mul` cover both `int_add` / `int_mul` and `float_add` /
 /// `float_mul`, and the bare comparisons cover the `int_`, `uint_` and
 /// `float_` families at once, because the register kind is not yet part of
-/// the name at this point.  `sub`, the divisions, the shifts and the
-/// `*_assign` spellings are absent for the same reason they are absent
-/// upstream: they are not symmetric.
+/// the name at this point.  `add_ovf` / `mul_ovf` are the same rewrite:
+/// `rewrite_op_int_add_ovf` (aliased to `rewrite_op_int_mul_ovf`) calls
+/// `_rewrite_symmetric` before prepending `-live-`.  `sub`, `sub_ovf`,
+/// the divisions, the shifts and the `*_assign` spellings are absent for
+/// the same reason they are absent upstream: they are not symmetric.
 fn is_symmetric_binop(name: &str) -> bool {
     matches!(
         name,
         "add"
             | "mul"
+            | "add_ovf"
+            | "mul_ovf"
             | "bitand"
             | "bitor"
             | "bitxor"
@@ -3981,6 +3985,20 @@ impl<'a> Transformer<'a> {
         // The structural arm, as on the read side: a write into a
         // non-dereferenced local aggregate is not a virtualizable write.
         let fresh_virtualizable = fresh_virtualizable || field.base_is_local_aggregate();
+        // `is_virtualizable_getset`: writing the array field itself
+        // (not an element) raises `VirtualizableArrayField`. `rewrite_op_setfield`
+        // does not catch it, so translation fails. A fresh virtualizable
+        // is still being initialised and may take a plain `setfield`.
+        if !fresh_virtualizable && self.config.virtualizable_array(field).is_some() {
+            panic!(
+                "A virtualizable array is passed around; it should\n\
+                 only be used immediately after being read.  Note\n\
+                 that a possible cause is writing the array field\n\
+                 itself rather than an element.\n\
+                 This is about: {field:?}\n\
+                 Occurred in: {graph_name}"
+            );
+        }
         if let Some(vable_field) = self
             .config
             .virtualizable_field(field)
@@ -4081,28 +4099,38 @@ impl<'a> Transformer<'a> {
                 },
             ]);
         }
-        if &typed_item_ty != item_ty {
+        let (array_type_id, nolength, source_pure) = match &op.kind {
+            OpKind::ArrayRead {
+                array_type_id,
+                nolength,
+                pure,
+                ..
+            } => (array_type_id.clone(), *nolength, *pure),
+            _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
+        };
+        // `rewrite_op_getarrayitem`: `immut = ARRAY._immutable_field(None)`
+        // → `pure = '_pure'`. The front leaves ordinary reads `pure: false`;
+        // the array type's immutability lives on
+        // `CallControl.immutable_array_types` (`descr.py is_pure`).
+        // `OpHelpers.is_pure_with_descr` does not consult the descr for
+        // `GETARRAYITEM_GC_*`, so the opcode itself must be the `_pure`
+        // form.
+        let immutable = array_type_id.as_deref().is_some_and(|aid| {
+            self.callcontrol
+                .as_deref()
+                .is_some_and(|cc| cc.immutable_array_types.contains(aid))
+        });
+        let pure = source_pure || immutable;
+        if &typed_item_ty != item_ty || pure != source_pure {
             return RewriteResult::Replace(vec![SpaceOperation {
                 result: op.result.clone(),
                 kind: OpKind::ArrayRead {
                     base: base.clone(),
                     index: index.clone(),
                     item_ty: typed_item_ty,
-                    array_type_id: match &op.kind {
-                        OpKind::ArrayRead { array_type_id, .. } => array_type_id.clone(),
-                        _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
-                    },
-                    nolength: match &op.kind {
-                        OpKind::ArrayRead { nolength, .. } => *nolength,
-                        _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
-                    },
-                    // Preserve the source foldable/immutable flag through
-                    // the item_ty re-type — never hardcode it (rlist.py:724
-                    // ll_getitem_foldable_nonneg).
-                    pure: match &op.kind {
-                        OpKind::ArrayRead { pure, .. } => *pure,
-                        _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
-                    },
+                    array_type_id,
+                    nolength,
+                    pure,
                 },
             }]);
         }
@@ -4769,7 +4797,11 @@ impl<'a> Transformer<'a> {
             && segments[2] == "eq"
             && args.len() == 2
         {
-            return RewriteResult::Replace(vec![SpaceOperation {
+            // Finish as `ptr_eq` and then run `rewrite_op_ptr_eq` —
+            // `_rewrite_equality` + `_rewrite_cmp_ptrs` — so
+            // `ptr::eq(p, NULL)` becomes `ptr_iszero` and a two-variable
+            // compare is fusable as `goto_if_not_ptr_eq`.
+            let lowered = SpaceOperation {
                 result: op.result.clone(),
                 kind: OpKind::BinOp {
                     op: "eq".into(),
@@ -4777,7 +4809,8 @@ impl<'a> Transformer<'a> {
                     rhs: args[1].clone(),
                     result_ty: ValueType::Int,
                 },
-            }]);
+            };
+            return self.rewrite_operation(&lowered, graph_name, graph);
         }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
         if self.callcontrol.is_some() {
@@ -6325,7 +6358,7 @@ impl<'a> Transformer<'a> {
 
         // RPython jtransform.py: promote_greens emits guard_value
         // for each non-void green arg before the recursive_call.
-        let mut ops = self.promote_greens(green_args);
+        let mut ops = self.promote_greens(graph, green_args);
 
         // RPython jtransform.py:532-533: recursive_call + -live-
         ops.push(SpaceOperation {
@@ -6350,16 +6383,23 @@ impl<'a> Transformer<'a> {
 
     /// RPython: `Transformer.promote_greens(args, jitdriver)`.
     ///
-    /// Emits `-live-` + `{kind}_guard_value` for each non-void green arg.
-    /// This ensures green values are constant before the recursive call.
+    /// Emits `-live-` + `{kind}_guard_value` for each non-void, non-constant
+    /// green arg. This ensures green values are constant before the recursive
+    /// call.
     ///
-    /// RPython jtransform.py:1646-1656.
+    /// `promote_greens`: skip `Constant` and Void. A source constant is
+    /// an SSA `Const*` Variable here, which `is_source_constant_variable`
+    /// recovers.
     fn promote_greens(
         &self,
+        graph: &FunctionGraph,
         green_args: &[crate::flowspace::model::Variable],
     ) -> Vec<SpaceOperation> {
         let mut ops = Vec::new();
         for var in green_args {
+            if is_source_constant_variable(graph, var) {
+                continue;
+            }
             let kind = self.get_value_kind_var(var);
             if kind == 'v' {
                 continue; // skip void
@@ -6911,7 +6951,7 @@ impl<'a> Transformer<'a> {
                         "Constant specified red in jit_merge_point()"
                     );
                 }
-                let mut ops = self.promote_greens(greens_raw);
+                let mut ops = self.promote_greens(graph, greens_raw);
                 let (greens_i, greens_r, greens_f) = split_args_by_kind(greens_raw);
                 let (reds_i, reds_r, reds_f) = split_args_by_kind(reds_raw);
                 // jtransform.py final shape is `ops + [op3, op1, op2]`.
@@ -10964,6 +11004,41 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "virtualizable array")]
+    fn writing_a_vable_array_field_is_refused() {
+        let mut graph = FunctionGraph::new("vable_array_setfield");
+        let frame = graph.alloc_value_var();
+        let array = graph.alloc_value_var();
+        graph.push_inputarg_var(graph.startblock, frame.clone());
+        graph.push_inputarg_var(graph.startblock, array.clone());
+        graph.push_op_var(
+            graph.startblock,
+            OpKind::FieldWrite {
+                base: frame,
+                field: crate::model::FieldDescriptor::new("locals_stack_w", Some("Frame".into()))
+                    .with_base_is_deref(true),
+                value: crate::model::LinkArg::Value(array),
+                ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph.set_return(graph.startblock, None);
+        let _ = transform_graph(
+            &graph,
+            &GraphTransformConfig {
+                vable_arrays: vec![VirtualizableFieldDescriptor::new_with_arraydescr(
+                    "locals_stack_w",
+                    Some("Frame".into()),
+                    0,
+                    8,
+                    true,
+                )],
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
     fn transform_graph_tags_vable_arrays_with_explicit_base() {
         let mut graph = FunctionGraph::new("test");
         let base_var = graph.alloc_value_var();
@@ -13666,7 +13741,7 @@ mod tests {
         let mut graph = crate::model::FunctionGraph::new("test_promote_greens_fixture");
         let greens: Vec<crate::flowspace::model::Variable> =
             (0..3).map(|_| graph.alloc_value_var()).collect();
-        let ops = transformer.promote_greens(&greens);
+        let ops = transformer.promote_greens(&graph, &greens);
         assert_eq!(ops.len(), 6, "expect 2 ops per green");
         for i in 0..greens.len() {
             assert!(
@@ -13689,7 +13764,28 @@ mod tests {
     fn promote_greens_empty_input_yields_empty_output() {
         let config = GraphTransformConfig::default();
         let transformer = Transformer::new(&config);
-        assert!(transformer.promote_greens(&[]).is_empty());
+        assert!(
+            transformer
+                .promote_greens(&crate::model::FunctionGraph::new("empty"), &[])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn promote_greens_skips_source_constants() {
+        let config = GraphTransformConfig::default();
+        let transformer = Transformer::new(&config);
+        let mut graph = crate::model::FunctionGraph::new("const_green");
+        let live = graph.alloc_value_var();
+        let constant = graph
+            .push_op_var(graph.startblock, OpKind::ConstInt(0), true)
+            .unwrap();
+        let ops = transformer.promote_greens(&graph, &[live.clone(), constant]);
+        assert_eq!(ops.len(), 2, "only the variable green is promoted: {ops:?}");
+        match &ops[1].kind {
+            OpKind::GuardValue { value, .. } => assert_eq!(value, &live),
+            other => panic!("expected GuardValue of the live green, got {other:?}"),
+        }
     }
 
     #[test]
@@ -17829,6 +17925,51 @@ mod tests {
             let (op, lhs, _) = binary_op(&ops).expect("the addition must survive");
             assert_eq!(op, "add", "`add` has no mirror: {ops:?}");
             assert_eq!(lhs, x, "the variable must move to the left: {ops:?}");
+        }
+
+        #[test]
+        fn a_constant_left_operand_of_add_ovf_is_swapped() {
+            let (ops, x) = transform_binop(
+                "add_ovf",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            let (op, lhs, _) = binary_op(&ops).expect("the overflow add must survive");
+            assert_eq!(op, "add_ovf", "`add_ovf` has no mirror: {ops:?}");
+            assert_eq!(
+                lhs, x,
+                "`rewrite_op_int_add_ovf` runs `_rewrite_symmetric`: {ops:?}"
+            );
+            assert!(
+                ops.iter().any(|o| matches!(o.kind, OpKind::Live)),
+                "the swapped ovf op must still be led by -live-: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn a_constant_left_operand_of_sub_ovf_keeps_its_operand_order() {
+            let (ops, _x) = transform_binop(
+                "sub_ovf",
+                OpKind::ConstInt(5),
+                ConcreteType::Signed,
+                ConcreteType::Signed,
+                ValueType::Int,
+                true,
+            );
+            let (op, lhs, _) = binary_op(&ops).expect("the overflow sub must survive");
+            assert_eq!(op, "sub_ovf");
+            assert!(
+                matches!(
+                    ops.iter()
+                        .find(|o| o.result.as_ref() == Some(&lhs))
+                        .map(|o| &o.kind),
+                    Some(OpKind::ConstInt(5))
+                ),
+                "`5 -ovf x` must keep the constant on the left: {ops:?}"
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

PyPy `jtransform.py`와 매크로 lowerer / `jtransform.rs`를 대조해, 근거가 있는 rewrite를 맞췄습니다.

- `ptr == NULL` / `is_null()` → `ptr_iszero` / `ptr_nonzero` (`rewrite_op_ptr_eq` + `_rewrite_equality`)
- 조건의 포인터 비교 → `goto_if_not_ptr_{eq,ne,iszero,nonzero}` (`optimize_goto_if_not`)
- `if 0 < n` → `_rewrite_symmetric` 후 `goto_if_not_int_gt`
- `match` 단일 리터럴 암 → `goto_if_not_int_eq` (`-live-`는 가드 바로 앞)
- `if cond { 0 } else { 1 }` → `int_is_zero`
- `add_ovf` / `mul_ovf` 상수 좌항 스왑 (`rewrite_op_int_add_ovf`)
- 불변 배열 읽기 `pure` (`ARRAY._immutable_field`)
- fresh가 아닌 vable 배열 필드 통째 쓰기 거절 (`VirtualizableArrayField`)
- `new` 필드 폭을 `int_fields` 증인으로 등록
- discarded `inline_pipeline_{int,ref,float}` 유지 (`handle_regular_call`)
- 상수 green은 `promote_greens`에서 skip
- `core::ptr::eq`는 `rewrite_operation`을 다시 탐

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

테스트: `majit-macros --lib` 180, `majit-metainterp --test jit_interp_*`, `majit-translate` `codewriter::jtransform` 195 통과.
전체 `cargo test --workspace --features dynasm`는 이 패치와 무관한 `pyre-jit-trace` LLBC STALE로 이 환경에서 막혔습니다.