### PR TITLE
blackhole: emit recursive_call as iIRFIRF dest-last

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3274,177 +3274,141 @@ impl JitCodeBuilder {
         self.push_u8(src as u8);
     }
 
-    /// Emit a recursive portal call returning an int (pyjitpl.py:1376
-    /// `opimpl_recursive_call`).  The payload is consumed by
-    /// `JitCodeMachine::exec_recursive_call`:
-    ///   jd_index:u16, result_dst:u8, num_green:u16,
-    ///   (green_kind:u8, green_src:u8) × num_green, num_args:u16,
-    ///   (kind:u8, caller_src:u8, callee_dst:u8) × num_args.
-    /// The portal is self-recursive, so the opcode carries the jitdriver
-    /// index rather than a compiled target.  `greens` are the caller
-    /// registers holding the portal green key, in the jitdriver's green
-    /// declaration order so they hash against `green_args_spec`; each
-    /// carries its own `JitArgKind` so the dispatcher reads it from the
-    /// matching register bank (an int `pc` green from the int bank, a ref
-    /// `program` green from the ref bank).  The first green seeds the
-    /// portal entry pc.  Each arg moves caller register `caller_src` into
-    /// portal register `callee_dst`.
+    /// Emit a recursive portal call returning an int.
+    ///
+    /// `jtransform.py handle_recursive_call` + `assembler.py` encode
+    /// `recursive_call_i/iIRFIRF>i`: jdindex as an `i` register (constant
+    /// pool), then the six kind lists, then the dest byte so
+    /// `blackhole.py _setup_return_value_i` can read `code[position-1]`.
     pub fn recursive_call_int(
         &mut self,
         jd_index: u16,
         result_dst: u16,
         greens: &[(JitArgKind, u16)],
-        args: &[(JitArgKind, u16, u16)],
+        reds: &[(JitArgKind, u16)],
     ) {
         self.touch_reg(result_dst);
-        for &(kind, src) in greens {
-            match kind {
-                JitArgKind::Ref => self.touch_ref_reg(src),
-                JitArgKind::Int => self.touch_reg(src),
-                JitArgKind::Float => self.touch_float_reg(src),
-            }
-        }
-        for &(kind, caller_src, _callee_dst) in args {
-            self.touch_call_arg(JitCallArg {
-                kind,
-                reg: caller_src,
-            });
-        }
-        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_INT);
-        self.push_u16(jd_index);
-        self.push_reg_u8(result_dst, "recursive_call_int result");
-        self.push_u16(greens.len() as u16);
-        for &(kind, src) in greens {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(src, "recursive_call_int green");
-        }
-        self.push_u16(args.len() as u16);
-        for &(kind, caller_src, callee_dst) in args {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(caller_src, "recursive_call_int caller argument");
-            self.push_reg_u8(callee_dst, "recursive_call_int callee argument");
-        }
-        self.record_resulttype('i');
+        self.emit_recursive_call(
+            jitcode::insns::BC_RECURSIVE_CALL_INT,
+            jd_index,
+            Some(result_dst),
+            greens,
+            reds,
+            Some('i'),
+        );
     }
 
     /// Ref-result sibling of [`Self::recursive_call_int`]
-    /// (`opimpl_recursive_call_r`).  Same payload shape; the result lands in
-    /// the ref register `result_dst`.
+    /// (`blackhole.py bhimpl_recursive_call_r`).
     pub fn recursive_call_ref(
         &mut self,
         jd_index: u16,
         result_dst: u16,
         greens: &[(JitArgKind, u16)],
-        args: &[(JitArgKind, u16, u16)],
+        reds: &[(JitArgKind, u16)],
     ) {
         self.touch_ref_reg(result_dst);
-        for &(kind, src) in greens {
-            match kind {
-                JitArgKind::Ref => self.touch_ref_reg(src),
-                JitArgKind::Int => self.touch_reg(src),
-                JitArgKind::Float => self.touch_float_reg(src),
-            }
-        }
-        for &(kind, caller_src, _callee_dst) in args {
-            self.touch_call_arg(JitCallArg {
-                kind,
-                reg: caller_src,
-            });
-        }
-        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_REF);
-        self.push_u16(jd_index);
-        self.push_reg_u8(result_dst, "recursive_call_ref result");
-        self.push_u16(greens.len() as u16);
-        for &(kind, src) in greens {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(src, "recursive_call_ref green");
-        }
-        self.push_u16(args.len() as u16);
-        for &(kind, caller_src, callee_dst) in args {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(caller_src, "recursive_call_ref caller argument");
-            self.push_reg_u8(callee_dst, "recursive_call_ref callee argument");
-        }
-        self.record_resulttype('r');
+        self.emit_recursive_call(
+            jitcode::insns::BC_RECURSIVE_CALL_REF,
+            jd_index,
+            Some(result_dst),
+            greens,
+            reds,
+            Some('r'),
+        );
     }
 
     /// Float-result sibling of [`Self::recursive_call_int`]
-    /// (`opimpl_recursive_call_f`).  Same payload shape; the result lands in
-    /// the float register `result_dst`.
+    /// (`blackhole.py bhimpl_recursive_call_f`).
     pub fn recursive_call_float(
         &mut self,
         jd_index: u16,
         result_dst: u16,
         greens: &[(JitArgKind, u16)],
-        args: &[(JitArgKind, u16, u16)],
+        reds: &[(JitArgKind, u16)],
     ) {
         self.touch_float_reg(result_dst);
-        for &(kind, src) in greens {
-            match kind {
-                JitArgKind::Ref => self.touch_ref_reg(src),
-                JitArgKind::Int => self.touch_reg(src),
-                JitArgKind::Float => self.touch_float_reg(src),
-            }
-        }
-        for &(kind, caller_src, _callee_dst) in args {
-            self.touch_call_arg(JitCallArg {
-                kind,
-                reg: caller_src,
-            });
-        }
-        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_FLOAT);
-        self.push_u16(jd_index);
-        self.push_reg_u8(result_dst, "recursive_call_float result");
-        self.push_u16(greens.len() as u16);
-        for &(kind, src) in greens {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(src, "recursive_call_float green");
-        }
-        self.push_u16(args.len() as u16);
-        for &(kind, caller_src, callee_dst) in args {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(caller_src, "recursive_call_float caller argument");
-            self.push_reg_u8(callee_dst, "recursive_call_float callee argument");
-        }
-        self.record_resulttype('f');
+        self.emit_recursive_call(
+            jitcode::insns::BC_RECURSIVE_CALL_FLOAT,
+            jd_index,
+            Some(result_dst),
+            greens,
+            reds,
+            Some('f'),
+        );
     }
 
     /// Void-result sibling of [`Self::recursive_call_int`]
-    /// (`opimpl_recursive_call_v`).  Carries no result register — the
-    /// `result_dst` slot is emitted as the `jitcode::NO_RETURN_REG` "no
-    /// result" sentinel the dispatcher decodes to `None`.
+    /// (`blackhole.py bhimpl_recursive_call_v`).  No dest byte: the
+    /// assembler omits `emit_call_result_arg` when the result is void.
     pub fn recursive_call_void(
         &mut self,
         jd_index: u16,
         greens: &[(JitArgKind, u16)],
-        args: &[(JitArgKind, u16, u16)],
+        reds: &[(JitArgKind, u16)],
     ) {
-        for &(kind, src) in greens {
-            match kind {
-                JitArgKind::Ref => self.touch_ref_reg(src),
-                JitArgKind::Int => self.touch_reg(src),
-                JitArgKind::Float => self.touch_float_reg(src),
-            }
+        self.emit_recursive_call(
+            jitcode::insns::BC_RECURSIVE_CALL_VOID,
+            jd_index,
+            None,
+            greens,
+            reds,
+            None,
+        );
+    }
+
+    /// `jtransform.py handle_recursive_call` payload:
+    /// `recursive_call_{kind}(jd_index, G_I, G_R, G_F, R_I, R_R, R_F)`
+    /// then the dest register for a typed result.
+    fn emit_recursive_call(
+        &mut self,
+        opcode: u8,
+        jd_index: u16,
+        result_dst: Option<u16>,
+        greens: &[(JitArgKind, u16)],
+        reds: &[(JitArgKind, u16)],
+        resulttype: Option<char>,
+    ) {
+        for &(kind, src) in greens.iter().chain(reds.iter()) {
+            self.touch_call_arg(JitCallArg { kind, reg: src });
         }
-        for &(kind, caller_src, _callee_dst) in args {
-            self.touch_call_arg(JitCallArg {
-                kind,
-                reg: caller_src,
-            });
+        self.start_instr(opcode);
+        // `blackhole.py bhimpl_recursive_call_*` takes jdindex as
+        // `@arguments("self", "i", ...)` — a register, not a literal u16.
+        // Same const-pool patch `jit_merge_point/iIRFIRF` uses.
+        let jdindex_const = self.add_const_i(i64::from(jd_index));
+        let jdindex_offset = self.code.len();
+        self.push_u8(0);
+        self.const_patches_u8
+            .push((jdindex_offset, ConstKind::Int, jdindex_const));
+        self.emit_kind_reg_list(greens, JitArgKind::Int);
+        self.emit_kind_reg_list(greens, JitArgKind::Ref);
+        self.emit_kind_reg_list(greens, JitArgKind::Float);
+        self.emit_kind_reg_list(reds, JitArgKind::Int);
+        self.emit_kind_reg_list(reds, JitArgKind::Ref);
+        self.emit_kind_reg_list(reds, JitArgKind::Float);
+        if let Some(dst) = result_dst {
+            self.push_reg_u8(dst, "recursive_call result");
         }
-        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_VOID);
-        self.push_u16(jd_index);
-        self.push_u8(jitcode::NO_RETURN_REG);
-        self.push_u16(greens.len() as u16);
-        for &(kind, src) in greens {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(src, "recursive_call_void green");
+        if let Some(kind) = resulttype {
+            self.record_resulttype(kind);
         }
-        self.push_u16(args.len() as u16);
-        for &(kind, caller_src, callee_dst) in args {
-            self.push_u8(kind.encode());
-            self.push_reg_u8(caller_src, "recursive_call_void caller argument");
-            self.push_reg_u8(callee_dst, "recursive_call_void callee argument");
+    }
+
+    fn emit_kind_reg_list(&mut self, regs: &[(JitArgKind, u16)], want: JitArgKind) {
+        let selected: Vec<u16> = regs
+            .iter()
+            .filter(|(kind, _)| *kind == want)
+            .map(|(_, src)| *src)
+            .collect();
+        assert!(
+            selected.len() < 256,
+            "recursive_call list length {} exceeds u8 byte encoding",
+            selected.len()
+        );
+        self.push_u8(selected.len() as u8);
+        for src in selected {
+            self.push_u8(src as u8);
         }
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3238,11 +3238,10 @@ where
     /// Execute a `BC_RECURSIVE_CALL_*` opcode (pyjitpl.py:1376
     /// `opimpl_recursive_call`).
     ///
-    /// Payload (little-endian, emitted by
-    /// `JitCodeBuilder::recursive_call_int` and siblings):
-    ///   jd_index:u16, result_dst:u8 (`NO_RETURN_REG` = no result / void),
-    ///   num_green:u16, (green_kind:u8, green_src:u8) × num_green,
-    ///   num_args:u16, (kind:u8, caller_src:u8, callee_dst:u8) × num_args.
+    /// Payload matches `jtransform.py handle_recursive_call` /
+    /// `blackhole.py bhimpl_recursive_call_*`:
+    ///   jdindex `i` (const-pool register), then `I R F I R F` lists,
+    ///   then the dest byte for a typed result (`recursive_call_v` has none).
     ///
     /// `result_kind` is `Some(Int/Ref/Float)` for the typed opcodes and
     /// `None` for the void opcode.  The green register sources carry the
@@ -3273,30 +3272,32 @@ where
         // `pc` is set to `code_cursor` so a later `make_result_of_lastop`
         // (driven by the portal's typed return) keys `resulttypes[pc]` at
         // the post-operand offset the emitter recorded.
-        let (jd_index, result_dst, green_srcs, arg_triples) = {
+        let (jd_index, result_dst, greens_i, greens_r, greens_f, reds_i, reds_r, reds_f) = {
             let frame = self.frames.current_mut();
-            let jd_index = frame.next_u16() as usize;
-            let result_dst_raw = frame.next_reg() as usize;
-            let result_dst = if result_dst_raw == crate::jitcode::NO_RETURN_REG as usize {
-                None
-            } else {
-                Some(result_dst_raw)
+            let jd_reg = frame.next_reg() as usize;
+            let read_list = |frame: &mut crate::pyjitpl::frame::MIFrame| {
+                let n = frame.next_u8() as usize;
+                (0..n)
+                    .map(|_| frame.next_reg() as usize)
+                    .collect::<Vec<_>>()
             };
-            let num_green = frame.next_u16() as usize;
-            let mut green_srcs = Vec::with_capacity(num_green);
-            for _ in 0..num_green {
-                let kind = JitArgKind::decode(frame.next_u8());
-                let src = frame.next_reg() as usize;
-                green_srcs.push((kind, src));
-            }
-            let num_args = frame.next_u16() as usize;
-            let mut arg_triples = Vec::with_capacity(num_args);
-            for _ in 0..num_args {
-                let kind = JitArgKind::decode(frame.next_u8());
-                let caller_src = frame.next_reg() as usize;
-                let callee_dst = frame.next_reg() as usize;
-                arg_triples.push((kind, caller_src, callee_dst));
-            }
+            let greens_i = read_list(frame);
+            let greens_r = read_list(frame);
+            let greens_f = read_list(frame);
+            let reds_i = read_list(frame);
+            let reds_r = read_list(frame);
+            let reds_f = read_list(frame);
+            let result_dst = match result_kind {
+                Some(_) => {
+                    let dest = frame.next_reg() as usize;
+                    if dest == crate::jitcode::NO_RETURN_REG as usize {
+                        None
+                    } else {
+                        Some(dest)
+                    }
+                }
+                None => None,
+            };
             // Caller-side result-slot bookkeeping (BC_INLINE_CALL:3298-3300).
             frame._result_argcode = match (result_kind, result_dst) {
                 (Some(JitArgKind::Int), Some(_)) => b'i',
@@ -3306,26 +3307,28 @@ where
             };
             frame.result_arg_index = result_dst;
             frame.pc = frame.code_cursor;
-            (jd_index, result_dst, green_srcs, arg_triples)
+            (
+                jd_reg, result_dst, greens_i, greens_r, greens_f, reds_i, reds_r, reds_f,
+            )
         };
+        let jd_index = self.read_int_reg(jd_index).1 as usize;
 
-        // Read each green from the register bank its `JitArgKind` names: a
-        // ref green (e.g. tl's `program`) from the ref bank, an int green
-        // (e.g. `pc`) from the int bank, a float green from the float bank
-        // (its raw i64 bits feed the green-key hash — `prepare_list_of_boxes`
-        // decodes `argcode == 'f'` from `registers_f`).  The values are
-        // collected in green declaration order so they hash against
-        // `green_args_spec`.  `green_pc` is the first green (the int portal
-        // entry pc), or 0 when the call carries no greens.
-        let green_values: Vec<i64> = green_srcs
-            .iter()
-            .map(|&(kind, src)| match kind {
-                JitArgKind::Ref => self.read_ref_reg(src).1,
-                JitArgKind::Int => self.read_int_reg(src).1,
-                JitArgKind::Float => self.read_float_reg(src).1,
-            })
-            .collect();
-        let green_pc = green_values.first().copied().unwrap_or(0) as usize;
+        // `pyjitpl.py` `boxes3` concatenates the three kind lists (I then R
+        // then F).  `green_pc` is the first int green — the portal entry pc.
+        let mut green_values = Vec::with_capacity(greens_i.len() + greens_r.len() + greens_f.len());
+        for &src in &greens_i {
+            green_values.push(self.read_int_reg(src).1);
+        }
+        for &src in &greens_r {
+            green_values.push(self.read_ref_reg(src).1);
+        }
+        for &src in &greens_f {
+            green_values.push(self.read_float_reg(src).1);
+        }
+        let green_pc = greens_i
+            .first()
+            .map(|&src| self.read_int_reg(src).1 as usize)
+            .unwrap_or(0);
 
         let recursive_depth = ctx.recursive_depth((jd_index, green_pc));
         let inline_depth = ctx.inline_depth();
@@ -3380,7 +3383,6 @@ where
                 jd_index,
                 result_dst,
                 &green_values,
-                &arg_triples,
             );
         }
         // pc-aligned portal runtimes (dispatch.rs test fixtures) wire
@@ -3435,30 +3437,28 @@ where
             // auto-LEAVE pops.
             portal_frame.portal_entered = true;
             portal_frame.portal_jd = jd_index;
-            for (kind, caller_src, callee_dst) in arg_triples {
-                match kind {
-                    JitArgKind::Int => {
-                        let (value, concrete) = self.read_int_reg(caller_src);
-                        #[cfg(feature = "jit-audits")]
-                        majit_ir::reg_write_audit::note_int_write(
-                            portal_frame.int_regs.as_ptr() as usize,
-                            callee_dst,
-                            Some(value),
-                        );
-                        portal_frame.int_regs[callee_dst] = Some(value);
-                        portal_frame.int_values[callee_dst] = Some(concrete);
-                    }
-                    JitArgKind::Ref => {
-                        let (value, concrete) = self.read_ref_reg(caller_src);
-                        portal_frame.ref_regs[callee_dst] = Some(value);
-                        portal_frame.ref_values[callee_dst] = Some(concrete);
-                    }
-                    JitArgKind::Float => {
-                        let (value, concrete) = self.read_float_reg(caller_src);
-                        portal_frame.float_regs[callee_dst] = Some(value);
-                        portal_frame.float_values[callee_dst] = Some(concrete);
-                    }
-                }
+            // Portal args are greens+reds per kind, the same concatenation
+            // `bhimpl_recursive_call_*` passes to `cpu.bh_call_*`.
+            for (dst, &src) in greens_i.iter().chain(reds_i.iter()).enumerate() {
+                let (value, concrete) = self.read_int_reg(src);
+                #[cfg(feature = "jit-audits")]
+                majit_ir::reg_write_audit::note_int_write(
+                    portal_frame.int_regs.as_ptr() as usize,
+                    dst,
+                    Some(value),
+                );
+                portal_frame.int_regs[dst] = Some(value);
+                portal_frame.int_values[dst] = Some(concrete);
+            }
+            for (dst, &src) in greens_r.iter().chain(reds_r.iter()).enumerate() {
+                let (value, concrete) = self.read_ref_reg(src);
+                portal_frame.ref_regs[dst] = Some(value);
+                portal_frame.ref_values[dst] = Some(concrete);
+            }
+            for (dst, &src) in greens_f.iter().chain(reds_f.iter()).enumerate() {
+                let (value, concrete) = self.read_float_reg(src);
+                portal_frame.float_regs[dst] = Some(value);
+                portal_frame.float_values[dst] = Some(concrete);
             }
             match result_kind {
                 Some(JitArgKind::Int) => portal_frame.return_i = result_dst,
@@ -3531,10 +3531,6 @@ where
         jd_index: usize,
         result_dst: Option<usize>,
         green_values: &[i64],
-        // A recursive portal call runs the callee with a FRESH frame, so the
-        // caller's red-arg mapping does not flow into the callee's reds (the
-        // fresh state supersedes it); kept for the opcode's decode shape.
-        _arg_triples: &[(JitArgKind, usize, usize)],
     ) -> TraceAction {
         // Validate the (result_kind, result_dst) pairing: the three typed
         // kinds carry a destination register, `Void` carries none.  Any
@@ -6683,7 +6679,6 @@ where
                             jdindex,
                             result_dst,
                             &green_values,
-                            &[],
                         ) {
                             TraceAction::Continue => {}
                             // Abort propagates (missing fresh-reds / target).
@@ -12177,7 +12172,7 @@ mod tests {
         // then return reg 0.
         let mut caller_builder = JitCodeBuilder::new();
         caller_builder.load_const_i_value(5, 42);
-        caller_builder.recursive_call_int(0, 0, &[], &[(JitArgKind::Int, 5, 0)]);
+        caller_builder.recursive_call_int(0, 0, &[], &[(JitArgKind::Int, 5)]);
         caller_builder.int_return(0);
         let caller = caller_builder.finish();
 


### PR DESCRIPTION
## Summary

- encode helper `recursive_call_*` as `iIRFIRF>X` dest-last: jdindex as an i-register, then the six kind lists, then the dest byte
- match `handle_recursive_call` / `make_three_lists` and `_setup_return_value_*`
- decode the same layout in the tracer so portal greens+reds seed sequentially per kind

## Validation

- `cargo test --all --no-default-features --features dynasm`