### PR TITLE
Reload forced virtualizables and fix list-pop residual ABI

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4313,6 +4313,19 @@ impl<M: Clone> MetaInterp<M> {
             if !self.vable_ptr.is_null() {
                 self.vable_ptr = virtualizable_ptr;
             }
+            // `initial_inputarg_consts` was copied from `live_values` before
+            // this force. `ctx` is not in `self.tracing` yet, so
+            // `walk_active_trace_refs` cannot forward those ConstPtrs.
+            // `orig_vable_ptr_from_trace_ctx` reads that slot first.
+            let vable_const_index = ctx
+                .driver_descriptor()
+                .and_then(|driver| driver.virtualizable_arg_index())
+                .unwrap_or(index_of_virtualizable);
+            if let Some(OpRef::ConstPtr(gcref)) =
+                ctx.initial_inputarg_consts.get_mut(vable_const_index)
+            {
+                *gcref = majit_ir::GcRef(virtualizable_ptr as usize);
+            }
         }
 
         let num_static = info.num_static_extra_boxes;
@@ -26253,7 +26266,12 @@ mod tests {
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         assert_eq!(obj.token, 0);
         assert_ne!(meta.vable_ptr as usize, old as usize);
+        let forwarded = meta.vable_ptr as usize;
         let ctx = meta.trace_ctx().expect("expected active trace context");
+        assert_eq!(
+            ctx.initial_inputarg_consts.first().copied(),
+            Some(OpRef::ConstPtr(majit_ir::GcRef(forwarded)))
+        );
         assert_eq!(
             ctx.virtualizable_entry_at(0),
             Some((OpRef::input_arg_int(1), Value::Int(41)))

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4220,7 +4220,7 @@ impl<M: Clone> MetaInterp<M> {
     /// The local `original_boxes = greens ++ reds` shape is restored
     /// (greens prepended as positional placeholders), matching RPython's
     /// `original_boxes[num_green_args + index_of_virtualizable]` read.
-    fn initialize_virtualizable(&self, ctx: &mut TraceCtx, live_values: &[Value]) {
+    fn initialize_virtualizable(&mut self, ctx: &mut TraceCtx, live_values: &[Value]) {
         // pyjitpl.py:3315: vinfo = self.jitdriver_sd.virtualizable_info
         // Prefer the trace-bound `active_jitdriver_sd` (RPython
         // `self.jitdriver_sd`); fall back to scanning when an
@@ -4290,7 +4290,7 @@ impl<M: Clone> MetaInterp<M> {
         // token-none precondition.  The blackhole helper implements the same
         // two force_now arms and reaches the host's ResumeGuardForcedDescr
         // force hook for an Active token.
-        let virtualizable_ptr = if !self.vable_ptr.is_null() {
+        let mut virtualizable_ptr = if !self.vable_ptr.is_null() {
             self.vable_ptr as *mut u8
         } else {
             match original_boxes.get(index) {
@@ -4300,8 +4300,18 @@ impl<M: Clone> MetaInterp<M> {
             }
         };
         if !virtualizable_ptr.is_null() {
+            // RPython's `virtualizable` local is a GC pointer: `clear_vable_token`
+            // can allocate in `force_now`, and the collector forwards the local
+            // before `read_boxes`. Root the same way and reload before any heap
+            // read (`initialize_virtualizable` / `clear_vable_token`).
+            let root = majit_gc::shadow_stack::push(majit_ir::GcRef(virtualizable_ptr as usize));
             unsafe {
                 crate::virtualizable::bh_clear_vable_token(info, virtualizable_ptr);
+            }
+            virtualizable_ptr = majit_gc::shadow_stack::get(root).0 as *mut u8;
+            majit_gc::shadow_stack::pop_to(root);
+            if !self.vable_ptr.is_null() {
+                self.vable_ptr = virtualizable_ptr;
             }
         }
 
@@ -26195,6 +26205,54 @@ mod tests {
 
         assert!(matches!(action, BackEdgeAction::StartedTracing));
         assert_eq!(obj.token, 0);
+        let ctx = meta.trace_ctx().expect("expected active trace context");
+        assert_eq!(
+            ctx.virtualizable_entry_at(0),
+            Some((OpRef::input_arg_int(1), Value::Int(41)))
+        );
+    }
+
+    extern "C" fn test_clear_vable_token_forwards(obj: i64) {
+        let old = obj as *mut ResidualCallVableObj;
+        unsafe {
+            (*old).token = 0;
+            let moved = Box::into_raw(Box::new(ResidualCallVableObj::new(0, (*old).pc)));
+            majit_gc::shadow_stack::walk_roots(|root| {
+                if root.0 == old as usize {
+                    *root = majit_ir::GcRef(moved as usize);
+                }
+            });
+        }
+    }
+
+    #[test]
+    fn initialize_virtualizable_reloads_a_forced_forwarded_object() {
+        let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let mut info = VirtualizableInfo::new(0);
+        info.add_field("pc", Type::Int, 8);
+        info.set_parent_descr(majit_ir::descr::make_size_descr(64));
+        info.set_clear_vable(
+            test_clear_vable_token_forwards as *const (),
+            VirtualizableInfo::make_clear_vable_descr(),
+        );
+        meta.set_virtualizable_info(std::sync::Arc::new(info));
+
+        let mut obj = ResidualCallVableObj::new(0x100, 41);
+        let old = &mut obj as *mut ResidualCallVableObj;
+        meta.set_vable_ptr(old.cast());
+        let descriptor = JitDriverStaticData::with_virtualizable(
+            vec![],
+            vec![("frame", Type::Ref)],
+            Some("frame"),
+        );
+        let frame = Value::Ref(majit_ir::GcRef(old as usize));
+
+        let action = meta.force_start_tracing(779, (0, 0), Some(descriptor), &[frame]);
+
+        assert!(matches!(action, BackEdgeAction::StartedTracing));
+        assert_eq!(obj.token, 0);
+        assert_ne!(meta.vable_ptr as usize, old as usize);
         let ctx = meta.trace_ctx().expect("expected active trace context");
         assert_eq!(
             ctx.virtualizable_entry_at(0),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -37,9 +37,7 @@ macro_rules! residual_scalar {
 
 // `f32` is deliberately absent: `return_type_string_to_value_type` maps it to
 // the integer class while the machine ABI returns it in the float bank.
-residual_scalar!(
-    i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool, char, f64
-);
+residual_scalar!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool, char, f64);
 
 /// `OpArg` is `#[repr(transparent)] struct OpArg(u32)` — one word.
 impl ResidualSlot for rustpython_compiler_core::bytecode::OpArg {}
@@ -89,6 +87,29 @@ extern "C" fn shadow_stack_get_word(index: i64) -> i64 {
 
 extern "C" fn shadow_stack_try_pop_to_word(depth: i64) {
     majit_gc::shadow_stack::try_pop_to(depth as usize);
+}
+
+/// One-word residual ABI for `w_list_pop_end`. Empty is NULL; the generated
+/// `descr_pop` graph still owns the IndexError. `Option<PyObjectRef>` is two
+/// words with no pointer niche, so publishing the Rust function would return
+/// the `Some` discriminant instead of the popped object.
+extern "C" fn w_list_pop_end_word(obj: i64) -> i64 {
+    match unsafe {
+        pyre_object::listobject::w_list_pop_end(obj as usize as pyre_object::PyObjectRef)
+    } {
+        Some(item) => item as usize as i64,
+        None => 0,
+    }
+}
+
+/// One-word residual ABI for the descended `w_list_pop_end_inner` body.
+extern "C" fn w_list_pop_end_inner_word(obj: i64) -> i64 {
+    match unsafe {
+        pyre_object::listobject::w_list_pop_end_inner(obj as usize as pyre_object::PyObjectRef)
+    } {
+        Some(item) => item as usize as i64,
+        None => 0,
+    }
 }
 
 /// Word-ABI bridge for the scalar bytecode read used by translated residual
@@ -2835,25 +2856,20 @@ fn build_jit_trace_fnaddrs() -> (Vec<(&'static str, i64)>, Vec<i64>) {
         "pyre_object::w_list_append",
         w_list_append,
     );
-    let w_list_pop_end_inner: unsafe fn(
-        pyre_object::PyObjectRef,
-    ) -> Option<pyre_object::PyObjectRef> = pyre_object::listobject::w_list_pop_end_inner;
-    // ABI-UNSOUND: same two-word Option as `w_list_pop_end` below. The empty
-    // check now lives in this descended body (`W_ListObject.descr_pop`).
-    push_abi_unsound_alias_pair(
+    // The fold descends the Option-returning Rust body. Residual/blackhole
+    // calls use the one-word bridges: `Option<PyObjectRef>` has no pointer
+    // niche, so the raw function would return the Some discriminant.
+    cpa1(
         &mut entries,
         "pyre_object::listobject::w_list_pop_end_inner",
         "pyre_object::w_list_pop_end_inner",
-        w_list_pop_end_inner as *const (),
+        w_list_pop_end_inner_word,
     );
-    let w_list_pop_end: unsafe fn(pyre_object::PyObjectRef) -> Option<pyre_object::PyObjectRef> =
-        pyre_object::listobject::w_list_pop_end;
-    // ABI-UNSOUND: `Option<PyObjectRef>` is two words: a raw pointer has no niche.
-    push_abi_unsound_alias_pair(
+    cpa1(
         &mut entries,
         "pyre_object::listobject::w_list_pop_end",
         "pyre_object::w_list_pop_end",
-        w_list_pop_end as *const (),
+        w_list_pop_end_word,
     );
     let w_list_len: unsafe fn(pyre_object::PyObjectRef) -> usize =
         pyre_object::listobject::w_list_len;
@@ -4864,6 +4880,7 @@ mod tests {
         is_rerunnable_bookkeeping_residual, jit_static_pytype_addrs, jit_static_ref_addrs,
         jit_trace_fnaddrs, pyre_class_pytype_addrs, pyre_class_pytype_by_struct_addrs,
         shadow_stack_get_word, shadow_stack_push_word, shadow_stack_try_pop_to_word,
+        w_list_pop_end_inner_word, w_list_pop_end_word,
     };
     use std::collections::HashMap;
 
@@ -4989,6 +5006,43 @@ mod tests {
         try_pop_to(depth);
         assert_eq!(push(marker), depth, "try_pop_to left the depth unrestored");
         try_pop_to(depth);
+    }
+
+    #[test]
+    fn list_pop_fnaddrs_are_the_one_word_bridges() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        for (path, expected) in [
+            (
+                "pyre_object::listobject::w_list_pop_end",
+                w_list_pop_end_word as *const () as usize as i64,
+            ),
+            (
+                "pyre_object::w_list_pop_end",
+                w_list_pop_end_word as *const () as usize as i64,
+            ),
+            (
+                "pyre_object::listobject::w_list_pop_end_inner",
+                w_list_pop_end_inner_word as *const () as usize as i64,
+            ),
+            (
+                "pyre_object::w_list_pop_end_inner",
+                w_list_pop_end_inner_word as *const () as usize as i64,
+            ),
+        ] {
+            assert_eq!(bindings.get(path), Some(&expected), "missing {path}");
+        }
+        let raw_inner = pyre_object::listobject::w_list_pop_end_inner as *const () as usize as i64;
+        let raw_end = pyre_object::listobject::w_list_pop_end as *const () as usize as i64;
+        assert_ne!(
+            bindings["pyre_object::listobject::w_list_pop_end_inner"],
+            raw_inner,
+            "must not publish the Option-returning Rust item"
+        );
+        assert_ne!(
+            bindings["pyre_object::listobject::w_list_pop_end"],
+            raw_end,
+            "must not publish the Option-returning Rust item"
+        );
     }
 
     /// Two registered functions must never share an address.
@@ -5396,7 +5450,8 @@ mod tests {
         let int_int = crate::objspace::descroperation::jit_bigint_lshift_int_int_result as *const ()
             as usize as i64;
         assert_eq!(
-            bindings["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result"],
+            bindings
+                ["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result"],
             int_int
         );
     }
@@ -5496,7 +5551,8 @@ mod tests {
             crate::executioncontext::ExecutionContext::_get_topmost_exception;
         let get_topmost_exception = get_topmost_exception as *const () as usize as i64;
         assert_eq!(
-            bindings["pyre_interpreter::executioncontext::ExecutionContext::_get_topmost_exception"],
+            bindings
+                ["pyre_interpreter::executioncontext::ExecutionContext::_get_topmost_exception"],
             get_topmost_exception,
         );
         assert_eq!(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -37,7 +37,9 @@ macro_rules! residual_scalar {
 
 // `f32` is deliberately absent: `return_type_string_to_value_type` maps it to
 // the integer class while the machine ABI returns it in the float bank.
-residual_scalar!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool, char, f64);
+residual_scalar!(
+    i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool, char, f64
+);
 
 /// `OpArg` is `#[repr(transparent)] struct OpArg(u32)` — one word.
 impl ResidualSlot for rustpython_compiler_core::bytecode::OpArg {}
@@ -5034,13 +5036,11 @@ mod tests {
         let raw_inner = pyre_object::listobject::w_list_pop_end_inner as *const () as usize as i64;
         let raw_end = pyre_object::listobject::w_list_pop_end as *const () as usize as i64;
         assert_ne!(
-            bindings["pyre_object::listobject::w_list_pop_end_inner"],
-            raw_inner,
+            bindings["pyre_object::listobject::w_list_pop_end_inner"], raw_inner,
             "must not publish the Option-returning Rust item"
         );
         assert_ne!(
-            bindings["pyre_object::listobject::w_list_pop_end"],
-            raw_end,
+            bindings["pyre_object::listobject::w_list_pop_end"], raw_end,
             "must not publish the Option-returning Rust item"
         );
     }
@@ -5450,8 +5450,7 @@ mod tests {
         let int_int = crate::objspace::descroperation::jit_bigint_lshift_int_int_result as *const ()
             as usize as i64;
         assert_eq!(
-            bindings
-                ["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result"],
+            bindings["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result"],
             int_int
         );
     }
@@ -5551,8 +5550,7 @@ mod tests {
             crate::executioncontext::ExecutionContext::_get_topmost_exception;
         let get_topmost_exception = get_topmost_exception as *const () as usize as i64;
         assert_eq!(
-            bindings
-                ["pyre_interpreter::executioncontext::ExecutionContext::_get_topmost_exception"],
+            bindings["pyre_interpreter::executioncontext::ExecutionContext::_get_topmost_exception"],
             get_topmost_exception,
         );
         assert_eq!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -11,17 +11,20 @@
 use super::*;
 
 /// Register-bank half of `pyjitpl.MetaInterp.replace_box`, owned by a live
-/// walker frame. Rust cannot borrow a paused caller's banks while its child
-/// is using the same TraceCtx. Queue the replacement on each frame owner and
-/// apply it before that frame executes again; its resume boxes are rewritten
-/// immediately below, before any descendant can capture a guard.
+/// walker frame. Resume snapshots (`InlineParentFrame.boxes`) are rewritten
+/// immediately, as `replace_box` walks `framestack`. Register banks stay
+/// queued: Rust cannot borrow a paused caller's banks while its child holds
+/// `TraceCtx`. Convergence is one red frame per inlined call (#1731) so
+/// replace can write those banks in place.
+///
+/// Apply the queue before that frame executes again. Delivery must precede
+/// the caller continuation, not the next opcode: trace rollback can reuse
+/// an OpRef id, and a later delivery could rewrite a new value that was
+/// never present in the paused caller.
 ///
 /// Weak registration neither extends a frame's lifetime nor leaks aliases
 /// into a nested trace session. Heap-owned SubWalkFrames keep this owner
 /// across suspension; recursive callers keep it for precisely the child call.
-/// Delivery must precede the caller continuation, not the next opcode: trace
-/// rollback can reuse an OpRef id, and a later delivery could rewrite a new
-/// value that was never present in the paused caller.
 pub(super) struct FrameBoxReplacements(std::rc::Rc<FrameBoxReplacementInbox>);
 
 pub(crate) struct FrameBoxReplacementInbox {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -242,6 +242,7 @@ fn jitframe_layout_descrs() -> majit_gc::rewrite::JitFrameDescrs {
 mod tests {
     use super::jitframe_layout_descrs;
     use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JF_FRAME_OFS};
+    use pyre_interpreter::pyframe::PyFrame;
 
     #[test]
     fn jitframe_layout_descrs_uses_frame_relative_offsets() {
@@ -262,6 +263,56 @@ mod tests {
             super::leave_resumed_blackhole_frame(&bh, false);
             super::leave_resumed_blackhole_frame(&bh, true);
             assert!(ec.topframeref.is_null());
+            pyre_interpreter::call::set_last_exec_ctx(std::ptr::null_mut());
+        })
+        .join()
+        .unwrap();
+    }
+
+    /// Stack `PyFrame` whose Drop-owned pointers stay null.
+    fn stack_pyframe() -> PyFrame {
+        unsafe { std::mem::zeroed::<PyFrame>() }
+    }
+
+    #[test]
+    fn blackhole_leave_marks_an_on_chain_parent_without_rewriting_top() {
+        std::thread::spawn(|| {
+            let mut ec = pyre_interpreter::PyExecutionContext::default();
+            pyre_interpreter::call::set_last_exec_ctx(&mut ec);
+            let mut parent = stack_pyframe();
+            let mut child = stack_pyframe();
+            child.f_backref = &mut parent;
+            ec.topframeref = &mut child;
+            let mut bh = majit_metainterp::blackhole::BlackholeInterpreter::default();
+            bh.virtualizable_ptr = std::ptr::from_mut(&mut parent) as i64;
+            super::leave_resumed_blackhole_frame(&bh, false);
+            assert!(parent.frame_finished_execution());
+            assert!(!child.frame_finished_execution());
+            assert!(std::ptr::eq(ec.topframeref, std::ptr::from_mut(&mut child)));
+            pyre_interpreter::call::set_last_exec_ctx(std::ptr::null_mut());
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn blackhole_leave_closes_the_open_scope() {
+        std::thread::spawn(|| {
+            let mut ec = pyre_interpreter::PyExecutionContext::default();
+            pyre_interpreter::call::set_last_exec_ctx(&mut ec);
+            let mut parent = stack_pyframe();
+            let mut child = stack_pyframe();
+            child.f_backref = &mut parent;
+            ec.topframeref = &mut child;
+            let mut bh = majit_metainterp::blackhole::BlackholeInterpreter::default();
+            bh.virtualizable_ptr = std::ptr::from_mut(&mut child) as i64;
+            super::leave_resumed_blackhole_frame(&bh, false);
+            assert!(child.frame_finished_execution());
+            assert!(!parent.frame_finished_execution());
+            assert!(std::ptr::eq(
+                ec.topframeref,
+                std::ptr::from_mut(&mut parent)
+            ));
             pyre_interpreter::call::set_last_exec_ctx(std::ptr::null_mut());
         })
         .join()
@@ -2420,11 +2471,52 @@ fn leave_resumed_blackhole_frame(
     frame: &majit_metainterp::blackhole::BlackholeInterpreter,
     got_exception: bool,
 ) {
-    let frame_ptr = frame.virtualizable_ptr as *mut PyFrame;
-    if frame_ptr.is_null() {
+    let recovered = frame.virtualizable_ptr as *mut PyFrame;
+    if recovered.is_null() {
         return;
     }
-    leave_compiled_frame_chain(frame_ptr, got_exception);
+    let ec =
+        pyre_interpreter::call::getexecutioncontext() as *mut pyre_interpreter::PyExecutionContext;
+    if ec.is_null() {
+        return;
+    }
+    let open = unsafe { pyre_interpreter::executioncontext::vref_referent((*ec).topframeref) };
+    if std::ptr::eq(open, recovered) {
+        // `leave(frame)` is given the current top. The recovered red is that
+        // frame, so run the chain half in full.
+        leave_compiled_frame_chain(recovered, got_exception);
+        return;
+    }
+    // Not the open scope. `leave` must not rewrite `topframeref` or it
+    // would drop an inlined callee still sitting there. The blackhole's
+    // own frame still needs the `dispatch_bytecode` / `handle_operation_error`
+    // finish mark if it is a live chain member (the portal under that
+    // callee). A garbage red is not on the chain and is not dereferenced.
+    if frame_is_on_unforced_ec_chain(ec, recovered) {
+        unsafe {
+            (*recovered).set_frame_finished_execution(true);
+        }
+    }
+}
+
+/// Walk `topframeref` / `f_backref` without forcing, the way
+/// `executioncontext.py` moves those slots (no parens) rather than
+/// `frame.f_backref()`.
+fn frame_is_on_unforced_ec_chain(
+    ec: *mut pyre_interpreter::PyExecutionContext,
+    frame_ptr: *mut PyFrame,
+) -> bool {
+    let mut cur = unsafe { pyre_interpreter::executioncontext::vref_referent((*ec).topframeref) };
+    for _ in 0..1024 {
+        if cur.is_null() {
+            return false;
+        }
+        if std::ptr::eq(cur, frame_ptr) {
+            return true;
+        }
+        cur = unsafe { pyre_interpreter::executioncontext::vref_referent((*cur).f_backref) };
+    }
+    false
 }
 
 /// `executioncontext.py ExecutionContext.leave`'s frame-chain half for a frame


### PR DESCRIPTION
## Follow-up from #1686

Two Codex P1s from the virtualizable merge:

- Residual/blackhole calls to `w_list_pop_end` / `w_list_pop_end_inner` now go through one-word `extern "C"` bridges. The Option-returning Rust items are no longer published as callable addresses (`Option<PyObjectRef>` has no pointer niche).
- `initialize_virtualizable` roots the virtualizable across `clear_vable_token` and reloads the forwarded address before heap reads, matching RPython's GC-updated local (`pyjitpl.py` `initialize_virtualizable` / `clear_vable_token`).

## Tests

- `cargo test --no-default-features --features dynasm -p majit-metainterp initialize_virtualizable`
- `cargo test -p pyre-interpreter --features dynasm -- list_pop_fnaddrs`

## Remaining #1686 follow-ups (issues, not this PR)

- #1728 cranelift/wasm GUARD_NOT_INVALIDATED still a flag test
- #1729 3.14t invalidation publication order
- #1730 macos `for_iter_nested_method_inline` floor re-measure
- #1731 replace_box mailbox → one red frame per inlined call
- #1732 list.pop fold should descend `descr_pop`
- #1733 blackhole leave vs `ExecutionContext.leave`
- #126 wasm `fib_recursive` CALL_ASSEMBLER residual (CI re-measured 4.7x)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when virtualizable objects are moved during garbage collection, preserving their state correctly.
  - Fixed JIT-compiled list-end removal operations to return results safely and consistently, including empty-list cases.
  - Added coverage for object forwarding and list operation result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->