### PR TITLE
wasm-host: reject replace/free on a wide table slot

### DIFF
--- a/majit/majit-backend-wasm-host/src/lib.rs
+++ b/majit/majit-backend-wasm-host/src/lib.rs
@@ -19,8 +19,12 @@ pub struct TraceState {
     pub memory: Option<Memory>,
     pub table: Option<Table>,
     pub trace_base: u64,
-    // Published wide entries cannot be dropped by a replacement. Sorted slot
-    // membership is sufficient; there is no language-specific registry here.
+    // Pair-base slots whose spare half is a published `trace_wide`.
+    // The table stores a copy of the narrow function in that half when no
+    // wide entry exists, so membership here is what forbids a later replace
+    // from dropping a published wide target. Keys are pair bases, not wide
+    // indices; replace/free must reject a wide index before they rewrite
+    // `slot` and `slot + 1`.
     wide_slots: BTreeSet<u32>,
 }
 
@@ -118,6 +122,7 @@ pub fn replace<T: HostState>(
     wide: Option<Func>,
 ) -> Result<u32> {
     let table = table(caller)?;
+    pair_base(caller, slot)?;
     live_trace(caller, slot)?;
     if wide.is_none() && caller.data().traces().wide_slots.contains(&slot) {
         return Err(Error::msg("replacement would drop a published wide entry"));
@@ -127,6 +132,28 @@ pub fn replace<T: HostState>(
     if let Some(wide) = wide {
         table.set(&mut *caller, slot as u64 + 1, Ref::Func(Some(wide)))?;
         caller.data_mut().traces_mut().wide_slots.insert(slot);
+    }
+    Ok(slot)
+}
+
+/// The published handle is the even index of a reserved pair.
+///
+/// `publish` grows the table by two. `execute` may call `slot + 1` as the
+/// wide entry, so that index is a live function, but `replace`/`free` rewrite
+/// or clear both halves. Treating a wide index as a handle would write past
+/// the last pair or clear the next pair's narrow function. `live_trace`
+/// cannot tell those apart. `execute` does not use this: calling a wide
+/// entry is the point of the spare slot.
+fn pair_base<T: HostState>(caller: &Caller<'_, T>, slot: u32) -> Result<u32> {
+    let traces = caller.data().traces();
+    if (slot as u64) < traces.trace_base {
+        return Err(Error::msg(format!(
+            "slot {slot} belongs to the guest, not a trace"
+        )));
+    }
+    let size = table(caller)?.size(caller);
+    if (slot as u64) + 1 >= size || (slot as u64 - traces.trace_base) % 2 != 0 {
+        return Err(Error::msg(format!("slot {slot} is not a trace pair base")));
     }
     Ok(slot)
 }
@@ -157,6 +184,7 @@ pub fn free<T: HostState>(caller: &mut Caller<'_, T>, slot: u32) -> Result<()> {
     if (slot as u64) < caller.data().traces().trace_base {
         return Ok(());
     }
+    pair_base(caller, slot)?;
     let table = table(caller)?;
     table.set(&mut *caller, slot as u64, Ref::Func(None))?;
     table.set(&mut *caller, slot as u64 + 1, Ref::Func(None))?;

--- a/majit/majit-backend-wasm-host/tests/transport.rs
+++ b/majit/majit-backend-wasm-host/tests/transport.rs
@@ -59,6 +59,30 @@ fn trace_pairs_publish_replace_and_free() {
 }
 
 #[test]
+fn replace_and_free_reject_a_wide_slot_without_touching_the_next_pair() {
+    with_caller(|caller| {
+        let module = Module::new(
+            caller.engine(),
+            r#"(module
+            (func (export "trace") (param i32) (result i32) i32.const 7)
+            (func (export "trace_wide") (param i32) (result i32) i32.const 8))"#,
+        )
+        .unwrap();
+        let (trace, wide, _) = instantiate(caller, &module, |_, _, _| Ok(())).unwrap();
+        let first = publish(caller, trace, wide).unwrap();
+        let second = publish(caller, trace, wide).unwrap();
+        assert_eq!(first, 2);
+        assert_eq!(second, 4);
+        assert!(replace(caller, first + 1, trace, wide).is_err());
+        assert_eq!(execute(caller, first, 0).unwrap(), 7);
+        assert_eq!(execute(caller, second, 0).unwrap(), 7);
+        assert!(free(caller, first + 1).is_err());
+        assert_eq!(execute(caller, first, 0).unwrap(), 7);
+        assert_eq!(execute(caller, second, 0).unwrap(), 7);
+    });
+}
+
+#[test]
 fn reflective_call_uses_declared_width_and_zero_extends_result() {
     with_caller(|caller| {
         let target = Func::wrap(&mut *caller, |value: i32, wide: i64| -> i32 {


### PR DESCRIPTION
`publish` reserves a pair. `replace` and `free` treated any live index
at or above `trace_base` as a pair base, so a wide slot could write past
the table after mutating the first entry, or clear the next pair's
narrow function.

Require `(slot - trace_base)` even and `slot + 1` in range before
touching the table. `execute` is unchanged: calling the wide entry is
what the spare slot is for.

Follow-up to #1713 review.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid wide-slot handles from being used to replace or free trace pairs.
  * Preserved neighboring trace pairs when invalid slot operations are rejected.

* **Tests**
  * Added coverage confirming invalid wide-slot operations are rejected without affecting adjacent pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->