### PR TITLE
thread: rebuild fork tables after fork; size benches instead of raising ceilings

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2404,6 +2404,22 @@ fn emit_word_store(sink: &mut PeepSink<'_, '_>, offset: u64) {
     }
 }
 
+/// assembler.py `_call_footer_shadowstack`: `SUB [rootstacktop], 2*WORD`.
+///
+/// The CA return used to call `wasm_jit_ca_pop_frame` on every level.
+/// That helper is the collecting footer (`finish_gcmap` + write barrier +
+/// pop). The happy path is the same one-instruction decrement x86 emits
+/// after a `CALL_ASSEMBLER` return; overflow/deopt still uses the helper.
+fn emit_ca_pop_footer(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
+    let ss_word = std::mem::size_of::<usize>() as i32;
+    sink.i32_const(top_addr as i32);
+    sink.i32_const(top_addr as i32);
+    sink.i32_load(mem32(0));
+    sink.i32_const(2 * ss_word);
+    sink.i32_sub();
+    sink.i32_store(mem32(0));
+}
+
 /// While a CA callee is pushed, its caller's `jf_ptr` is `top[-3 * WORD]`.
 fn emit_ca_reload_caller(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
     sink.i32_const(top_addr as i32);
@@ -7889,10 +7905,13 @@ fn build_function(
                     }
                 }
                 // Pop the callee frame off the jitframe shadow stack (strict
-                // LIFO) via `wasm_jit_ca_pop_frame` — same direct-vs-trampoline
-                // split as the alloc above (the pop only shrinks the shadow
-                // stack; it never allocates or collects).
-                if let Some(base) = residual_type_base {
+                // LIFO).  `assembler.py` `_call_footer_shadowstack` is
+                // `SUB [rootstacktop], 2*WORD`; keep the helper only when
+                // the inline nursery path is off (it also publishes the
+                // finish gcmap).
+                if let (Some(_base), Some(inline)) = (residual_type_base, ca.inline) {
+                    emit_ca_pop_footer(&mut sink, inline.jf_top_addr);
+                } else if let Some(base) = residual_type_base {
                     sink.local_get(ca_cfp_local);
                     sink.i64_extend_i32_u();
                     sink.i32_const(ca.ca_pop_fn_ptr as i32);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2405,12 +2405,7 @@ fn emit_word_store(sink: &mut PeepSink<'_, '_>, offset: u64) {
 }
 
 /// assembler.py `_call_footer_shadowstack`: `SUB [rootstacktop], 2*WORD`.
-///
-/// The CA return used to call `wasm_jit_ca_pop_frame` on every level.
-/// That helper is the collecting footer (`finish_gcmap` + write barrier +
-/// pop). The happy path is the same one-instruction decrement x86 emits
-/// after a `CALL_ASSEMBLER` return; overflow/deopt still uses the helper.
-fn emit_ca_pop_footer(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
+fn emit_ca_pop_shadowstack(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
     let ss_word = std::mem::size_of::<usize>() as i32;
     sink.i32_const(top_addr as i32);
     sink.i32_const(top_addr as i32);
@@ -2418,6 +2413,59 @@ fn emit_ca_pop_footer(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
     sink.i32_const(2 * ss_word);
     sink.i32_sub();
     sink.i32_store(mem32(0));
+}
+
+/// CA return footer: `execute_token`'s post-FINISH gcmap publish, then
+/// `_call_footer_shadowstack`.
+///
+/// A CA callee's `FINISH` returns inside generated wasm, so it never
+/// reaches `execute_token`'s `install_post_finish_force_gcmap`.  When
+/// `jf_force_descr` is clear the publish is `jf_gcmap = NULL` and the
+/// pop is the x86 `SUB`.  A `GUARD_NOT_FORCED_2` token keeps the frame
+/// reachable after the shadow-stack pop, so that arm keeps
+/// `wasm_jit_ca_pop_frame` (finish map + write barrier + pop).
+fn emit_ca_pop_footer(
+    sink: &mut PeepSink<'_, '_>,
+    inline: CaInlineParams,
+    residual_type_base: u32,
+    ca_pop_fn_ptr: i64,
+    ca_cfp_local: u32,
+    scratch: u32,
+) {
+    use majit_backend::jitframe::{JF_FORCE_DESCR_OFS, JF_GCMAP_OFS, SIZEOFSIGNED};
+    let ss_word = std::mem::size_of::<usize>() as i32;
+    // `assembler.py` `_reload_frame_if_necessary`: `top[-WORD]` is the
+    // jitframe, not the CA items base (which a collection may have moved).
+    sink.i32_const(inline.jf_top_addr as i32);
+    sink.i32_load(mem32(0));
+    sink.i32_const(ss_word);
+    sink.i32_sub();
+    sink.i32_load(mem32(0));
+    sink.local_tee(scratch);
+    if SIZEOFSIGNED == 4 {
+        sink.i32_load(memarg(JF_FORCE_DESCR_OFS as u64, 2));
+        sink.i32_eqz();
+    } else {
+        sink.i64_load(memarg(JF_FORCE_DESCR_OFS as u64, 3));
+        sink.i64_eqz();
+    }
+    sink.if_(BlockType::Empty);
+    sink.local_get(scratch);
+    if SIZEOFSIGNED == 4 {
+        sink.i32_const(0);
+        sink.i32_store(memarg(JF_GCMAP_OFS as u64, 2));
+    } else {
+        sink.i64_const(0);
+        sink.i64_store(memarg(JF_GCMAP_OFS as u64, 3));
+    }
+    emit_ca_pop_shadowstack(sink, inline.jf_top_addr);
+    sink.else_();
+    sink.local_get(ca_cfp_local);
+    sink.i64_extend_i32_u();
+    sink.i32_const(ca_pop_fn_ptr as i32);
+    sink.call_indirect(0, residual_type_base + 1);
+    sink.drop();
+    sink.end();
 }
 
 /// While a CA callee is pushed, its caller's `jf_ptr` is `top[-3 * WORD]`.
@@ -7909,8 +7957,15 @@ fn build_function(
                 // `SUB [rootstacktop], 2*WORD`; keep the helper only when
                 // the inline nursery path is off (it also publishes the
                 // finish gcmap).
-                if let (Some(_base), Some(inline)) = (residual_type_base, ca.inline) {
-                    emit_ca_pop_footer(&mut sink, inline.jf_top_addr);
+                if let (Some(base), Some(inline)) = (residual_type_base, ca.inline) {
+                    emit_ca_pop_footer(
+                        &mut sink,
+                        inline,
+                        base,
+                        ca.ca_pop_fn_ptr,
+                        ca_cfp_local,
+                        alloc_scratch_local,
+                    );
                 } else if let Some(base) = residual_type_base {
                     sink.local_get(ca_cfp_local);
                     sink.i64_extend_i32_u();

--- a/pyre/bench/inline_helper.py
+++ b/pyre/bench/inline_helper.py
@@ -1,3 +1,4 @@
+# 150e6 so leftover pyre startup is a small fraction of the 1.5x pypy budget.
 def add(a, b):
     return a + b
 
@@ -13,7 +14,7 @@ def compute(x):
 def main():
     s = 0
     i = 0
-    while i < 50000000:
+    while i < 150000000:
         s = add(s, compute(i)) % 1000000007
         i = add(i, 1)
     print(s)

--- a/pyre/bench/synth/callee_return_side_effect.py
+++ b/pyre/bench/synth/callee_return_side_effect.py
@@ -5,7 +5,11 @@
 # gh#495 guard: a callee's mutation must not be replayed or dropped, for a
 # constant-int and for a float return value.  Each return kind keeps its own
 # driver so the call stays a direct global call rather than an indirect one.
-N = 61620000
+#
+# N is 3x the previous 61620000 so a 10ms pypy swing cannot flip 2.58x
+# through the 2.6 ceiling (ubuntu cranelift 0.31/0.12 passed on main;
+# 0.30/0.11 failed on PR 1736). The ceiling is unchanged.
+N = 184860000
 
 
 class C:

--- a/pyre/bench/synth/fast_local_swap.py
+++ b/pyre/bench/synth/fast_local_swap.py
@@ -1,11 +1,11 @@
-# pyre-check: max-pypy-ratio=2
+# pyre-check: max-pypy-ratio=4.5
 # The ceiling gates cranelift as well as dynasm, and `perf_gate_floor` derives
-# a floor from it as ceiling/6, so both ends of the reading spread pick it. Run
-# 33384229844 reads 0.5x (macos dynasm, median of 3), 0.6x (macos cranelift),
-# 1.3x and 1.5x (ubuntu) on the four pairs where pypy's baseline was measurable
-# -- wasm is ungated and windows read a clamped baseline. Sizing off the slow
-# end alone lands the floor on the fast end: 3x derives exactly 0.5x. 2x clears
-# both by a third.
+# a floor from it as ceiling/6, so both ends of the reading spread pick it.
+# Fitted over the 38 CI jobs of 2026-09-03: macos reads 1.3x-1.6x, ubuntu
+# 1.6x-2.2x and windows 2.0x-3.1x.  The reading the old ceiling of 2 was sized
+# against -- 0.5x on macos dynasm -- no host produces any more, and windows
+# crossed 2 three times.  4.5 clears the widest by 45% and derives a 0.75x
+# floor the narrowest clears by 73%.
 # pyre-check: skip-cpython
 # cpython 1.33s vs pyre 0.24s (5.5x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/fast_local_swap.py
+++ b/pyre/bench/synth/fast_local_swap.py
@@ -1,17 +1,13 @@
-# pyre-check: max-pypy-ratio=4.5
+# pyre-check: max-pypy-ratio=2
 # The ceiling gates cranelift as well as dynasm, and `perf_gate_floor` derives
 # a floor from it as ceiling/6, so both ends of the reading spread pick it.
-# Fitted over the 38 CI jobs of 2026-09-03: macos reads 1.3x-1.6x, ubuntu
-# 1.6x-2.2x and windows 2.0x-3.1x.  The reading the old ceiling of 2 was sized
-# against -- 0.5x on macos dynasm -- no host produces any more, and windows
-# crossed 2 three times.  4.5 clears the widest by 45% and derives a 0.75x
-# floor the narrowest clears by 73%.
 # pyre-check: skip-cpython
 # cpython 1.33s vs pyre 0.24s (5.5x on the ubuntu runner), and it is not
 # gated on — only pypy is.
-# Sized so pypy's own execution clears the measurement floor: below it the
-# ratio gate divides by the floor and reads startup rather than this loop.
-N = 15162700
+# Sized so pypy's own execution clears Windows `FLOOR_GATE_MIN_BASELINE_S`
+# (~0.16s).  Below that the ceiling divides by a `?` band denominator and
+# the same binary reads 2x on one host and 3x on the next.
+N = 38000000
 
 
 def fib_swap(n):

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.py
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=20
+# pyre-check: max-pypy-ratio=70
 # The function-entry door reading its own cell took this off the 44 it needed
 # while the door read another cell's answer, asked to trace at every call and
 # never entered the compiled loop.
@@ -6,11 +6,12 @@
 # The ceiling is NOT the measured ratio.  pypy's execution-only time here lands
 # either side of EXEC_TIME_FLOOR_S, and check.py gates the ratio whenever it
 # lands above (`?`) and skips it whenever it is clamped to the floor (`~`), so
-# the same binary reads 17.7x on one runner and 27.9x on the next.  Size the
-# ceiling for the worst denominator in the gated band instead: dynasm's
-# execution-only time over `2 * EXEC_TIME_FLOOR_S` -- the floor plus the grace
-# `_compare_buffer` adds for a floor-sized baseline -- which is 0.14s / 0.01s,
-# plus room for the run-to-run spread of that numerator.
+# the same binary reads 14.6x on one runner and 45.3x on the next.  Size the
+# ceiling for the worst denominator in the gated band instead.  Over the 38 CI
+# jobs of 2026-09-03 the gated readings span 7.5x (windows) to 45.3x (ubuntu
+# cranelift); 70 clears the widest by 55%.  Lengthening the loop until pypy is
+# measurable everywhere is not open: pyre runs about 40x slower here, so a
+# baseline over FLOOR_GATE_MIN_BASELINE_S would put this fixture past 6s.
 # gh#495 guard: fbw_abort_nested_unjournaled_residual prevents the ForIterNext exemption double-advance.
 # branch-bearing callee with a SECOND FOR_ITER (nested), not the loop header.
 # Two shared generators; inner FOR_ITER advance is a non-header foriter (Finding #2).

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.py
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.py
@@ -1,21 +1,17 @@
-# pyre-check: max-pypy-ratio=70
+# pyre-check: max-pypy-ratio=20
 # The function-entry door reading its own cell took this off the 44 it needed
 # while the door read another cell's answer, asked to trace at every call and
 # never entered the compiled loop.
 #
-# The ceiling is NOT the measured ratio.  pypy's execution-only time here lands
-# either side of EXEC_TIME_FLOOR_S, and check.py gates the ratio whenever it
-# lands above (`?`) and skips it whenever it is clamped to the floor (`~`), so
-# the same binary reads 14.6x on one runner and 45.3x on the next.  Size the
-# ceiling for the worst denominator in the gated band instead.  Over the 38 CI
-# jobs of 2026-09-03 the gated readings span 7.5x (windows) to 45.3x (ubuntu
-# cranelift); 70 clears the widest by 55%.  Lengthening the loop until pypy is
-# measurable everywhere is not open: pyre runs about 40x slower here, so a
-# baseline over FLOOR_GATE_MIN_BASELINE_S would put this fixture past 6s.
 # gh#495 guard: fbw_abort_nested_unjournaled_residual prevents the ForIterNext exemption double-advance.
 # branch-bearing callee with a SECOND FOR_ITER (nested), not the loop header.
 # Two shared generators; inner FOR_ITER advance is a non-header foriter (Finding #2).
 # Post-inner declining residual forces abort while inner item in-flight.
+# N cannot be raised to clear `FLOOR_GATE_MIN_BASELINE_S`: generator resume
+# has no merge point (`caro_no_merge_entry`), so gouter/ginner stay
+# interpreted and the true ratio is ~100x.  Lengthening only makes that
+# honest.  20000 is the original size; the 20x ceiling is the compiled
+# `run()` loop's budget, not the residual generator path.
 N = 20000
 
 

--- a/pyre/bench/synth/generator_tree_recursion.cranelift.jitstats
+++ b/pyre/bench/synth/generator_tree_recursion.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=33
+bridges_compiled=34
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -12,7 +12,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=4382
+guard_failures=4606
 internal_compile_panics=0
 loops_aborted=1
 loops_compiled=3

--- a/pyre/bench/synth/generator_tree_recursion.dynasm.jitstats
+++ b/pyre/bench/synth/generator_tree_recursion.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=33
+bridges_compiled=34
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -12,7 +12,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=4382
+guard_failures=4606
 internal_compile_panics=0
 loops_aborted=1
 loops_compiled=3

--- a/pyre/bench/synth/generator_tree_recursion.py
+++ b/pyre/bench/synth/generator_tree_recursion.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=14
+# pyre-check: max-pypy-ratio=32
 # pyre-check: jitstats-band=guard_failures=8
 # Successful bridge closure and a pre-trace Decline are not aborts in
 # `MetaInterp._interpret`. Charging both to pyre's local abort ceiling held this
@@ -6,7 +6,10 @@
 # 48 / 7378. The PyPy oracle compiles still more (65 bridges) with forcings=0,
 # virtualizables forced=0 and nvirtuals=721, so the higher count is coverage,
 # not a regression to suppress. Four final-binary cranelift runs measured
-# 12.5x..12.7x; 14x leaves 10% headroom. The recovery target is PyPy's
+# 12.5x..12.7x, and the 14x that left 10% headroom over them was fitted on that
+# host alone; across the 38 CI jobs of 2026-09-03 the same fixture reads
+# 6.4x-22.4x, and macos cranelift crossed 14.  32 clears the widest by 43% and
+# derives a parity floor the narrowest clears sixfold. The recovery target is PyPy's
 # zero-forcing per-`MIFrame` recursive-frame/blackhole path, not restoring the
 # abort-ceiling shortcut.
 # Jitcounter decay is 0.96 every 32 minor collections

--- a/pyre/bench/synth/generator_tree_recursion.py
+++ b/pyre/bench/synth/generator_tree_recursion.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=32
+# pyre-check: max-pypy-ratio=14
 # pyre-check: jitstats-band=guard_failures=8
 # Successful bridge closure and a pre-trace Decline are not aborts in
 # `MetaInterp._interpret`. Charging both to pyre's local abort ceiling held this
@@ -6,19 +6,16 @@
 # 48 / 7378. The PyPy oracle compiles still more (65 bridges) with forcings=0,
 # virtualizables forced=0 and nvirtuals=721, so the higher count is coverage,
 # not a regression to suppress. Four final-binary cranelift runs measured
-# 12.5x..12.7x, and the 14x that left 10% headroom over them was fitted on that
-# host alone; across the 38 CI jobs of 2026-09-03 the same fixture reads
-# 6.4x-22.4x, and macos cranelift crossed 14.  32 clears the widest by 43% and
-# derives a parity floor the narrowest clears sixfold. The recovery target is PyPy's
+# 12.5x..12.7x; 14x leaves 10% headroom. The recovery target is PyPy's
 # zero-forcing per-`MIFrame` recursive-frame/blackhole path, not restoring the
 # abort-ceiling shortcut.
 # Jitcounter decay is 0.96 every 32 minor collections
 # (majit-trace/src/counter.rs), so guard_failures tracks collection count during
 # each guard's warm-up rather than a compile decision. One host measured
 # 3648..3661 across nursery sizes before the lifecycle fix; decay=0 now pins
-# 7378 everywhere, while loops_compiled=3 and bridges_compiled=48 remain
-# gated exactly. The fixture sets decay=0 itself, so the band covers the pinned
-# run, not that 13-wide unpinned spread; width 8 is margin (0.22%). Real
+# 4606 everywhere at this length, while loops_compiled=3 and bridges_compiled=34
+# remain gated exactly. The fixture sets decay=0 itself, so the band covers the pinned
+# run, not that 13-wide unpinned spread; width 8 is margin (0.17%). Real
 # regressions this gate caught moved by hundreds to thousands (828 -> 4923,
 # 404 -> 812, 937 -> 7408).
 # Generator-driven accumulation over recursive tree/linear results. The
@@ -83,7 +80,10 @@ def gen_values(limit):
 def main():
     acc = 0
     cnt = 0
-    for v in gen_values(9000):
+    # Sized so pypy's own execution clears Windows `FLOOR_GATE_MIN_BASELINE_S`
+    # (~0.16s).  At 9000 the baseline sat in the `?` band and macos cranelift
+    # crossed 14.
+    for v in gen_values(280000):
         acc = (acc + v) % MOD
         cnt += 1
         if cnt % 1800 == 0:

--- a/pyre/bench/synth/generator_tree_recursion.wasm.jitstats
+++ b/pyre/bench/synth/generator_tree_recursion.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=33
+bridges_compiled=34
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -12,7 +12,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=4382
+guard_failures=4606
 internal_compile_panics=0
 loops_aborted=1
 loops_compiled=3

--- a/pyre/bench/synth/import_math.py
+++ b/pyre/bench/synth/import_math.py
@@ -1,6 +1,11 @@
-# pyre-check: max-pypy-ratio=2
-# Ubuntu run 33279264115: 0.7-1x; the ceiling is twice the slowest,
-# rounded up to one decimal place.
+# pyre-check: max-pypy-ratio=3
+# The spread across hosts is wider than one number comfortably holds: over the
+# 38 CI jobs of 2026-09-03 ubuntu reads 0.6x-1.2x and windows 0.9x-1.1x, while
+# macos reads 1.7x-2.5x and crossed the old ceiling of 2.  Because
+# `perf_gate_floor` derives the floor as ceiling/6, the two ends are pinned
+# together: 3 leaves 20% over the widest reading and 20% under the narrowest,
+# and no single value does better than that here.  A ceiling of 3.5 would put
+# the floor at 0.583x, inside ubuntu's own band.
 # pyre-check: skip-cpython
 # 56372764 puts pypy at 142ms; a count cpython could finish inside its
 # reference timeout leaves pypy back on the floor, so cpython is dropped

--- a/pyre/bench/synth/import_math.py
+++ b/pyre/bench/synth/import_math.py
@@ -1,21 +1,13 @@
-# pyre-check: max-pypy-ratio=3
-# The spread across hosts is wider than one number comfortably holds: over the
-# 38 CI jobs of 2026-09-03 ubuntu reads 0.6x-1.2x and windows 0.9x-1.1x, while
-# macos reads 1.7x-2.5x and crossed the old ceiling of 2.  Because
-# `perf_gate_floor` derives the floor as ceiling/6, the two ends are pinned
-# together: 3 leaves 20% over the widest reading and 20% under the narrowest,
-# and no single value does better than that here.  A ceiling of 3.5 would put
-# the floor at 0.583x, inside ubuntu's own band.
+# pyre-check: max-pypy-ratio=2
 # pyre-check: skip-cpython
-# 56372764 puts pypy at 142ms; a count cpython could finish inside its
-# reference timeout leaves pypy back on the floor, so cpython is dropped
-# deliberately rather than by spending the whole timeout to discover the same
-# drop.
+# A count cpython could finish inside its reference timeout leaves pypy back
+# on the floor, so cpython is dropped deliberately rather than by spending
+# the whole timeout to discover the same drop.
 import math
 
-# Sized so pypy's own execution clears the measurement floor: below it the
-# ratio gate divides by the floor and reads startup rather than this loop.
-N = 56372764
+# Sized so pypy's own execution clears Windows `FLOOR_GATE_MIN_BASELINE_S`
+# (~0.16s).  Below that macos readings sat in the `?` band and crossed 2.
+N = 152000000
 
 
 def main():

--- a/pyre/bench/synth/pure_tupleload.py
+++ b/pyre/bench/synth/pure_tupleload.py
@@ -1,4 +1,11 @@
-# pyre-check: max-pypy-ratio=6
+# pyre-check: max-pypy-ratio=14
+# pypy's execution-only time here lands between EXEC_TIME_FLOOR_S and
+# FLOOR_GATE_MIN_BASELINE_S on nearly every run, the band check.py marks `?`:
+# the ceiling is applied while the floor gate declines the same denominator as
+# too small to judge, and a denominator that size carries its own magnitude as
+# error.  Over the 38 CI jobs of 2026-09-03 unchanged code read 1.6x-9.5x
+# across the three hosts and both native backends, crossing the old ceiling of
+# 6 seven times.  14 clears the widest by 47%.
 # The ceiling sits between the two measured states: served this runs 2.6x pypy,
 # and with the arity-2 reader off the loop pays the opaque residual (about 198x
 # when the retired `subscr_specialised_pair` fold was the only reader).

--- a/pyre/bench/synth/pure_tupleload.py
+++ b/pyre/bench/synth/pure_tupleload.py
@@ -1,11 +1,4 @@
-# pyre-check: max-pypy-ratio=14
-# pypy's execution-only time here lands between EXEC_TIME_FLOOR_S and
-# FLOOR_GATE_MIN_BASELINE_S on nearly every run, the band check.py marks `?`:
-# the ceiling is applied while the floor gate declines the same denominator as
-# too small to judge, and a denominator that size carries its own magnitude as
-# error.  Over the 38 CI jobs of 2026-09-03 unchanged code read 1.6x-9.5x
-# across the three hosts and both native backends, crossing the old ceiling of
-# 6 seven times.  14 clears the widest by 47%.
+# pyre-check: max-pypy-ratio=6
 # The ceiling sits between the two measured states: served this runs 2.6x pypy,
 # and with the arity-2 reader off the loop pays the opaque residual (about 198x
 # when the retired `subscr_specialised_pair` fold was the only reader).
@@ -29,16 +22,19 @@
 
 def main():
     # Case A: canonical array-backed tuple (arity 5 > 2).
+    # Iteration counts are sized so pypy's own execution clears Windows
+    # `FLOOR_GATE_MIN_BASELINE_S` (~0.16s).  Below that the same binary
+    # read 1.6x-9.5x in the `?` band and crossed the ceiling of 6.
     t = (10, 20, 30, 40, 50)
     s = 0
-    for _ in range(1600000):
+    for _ in range(4300000):
         s += t[0] + t[1] + t[2] + t[3] + t[4]
     print(s)
 
     # Case B: 2-element tuple (specialised-tuple path must be safe + correct).
     t2 = (1, 2)
     s2 = 0
-    for _ in range(1600000):
+    for _ in range(4300000):
         s2 += t2[0] + t2[1]
     print(s2)
 
@@ -57,4 +53,4 @@ def hot_specialised_pair(n):
     return s
 
 
-print(hot_specialised_pair(160000000))
+print(hot_specialised_pair(430000000))

--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -1,4 +1,11 @@
-# pyre-check: max-pypy-ratio=6
+# pyre-check: max-pypy-ratio=17
+# pypy's execution-only time here sits in check.py's `?` band -- above
+# EXEC_TIME_FLOOR_S, under FLOOR_GATE_MIN_BASELINE_S -- so the ceiling is
+# applied to a denominator the floor gate declines as too small to judge.  Over
+# the 38 CI jobs of 2026-09-03 unchanged code read 2.2x-12.0x across the three
+# hosts and both native backends, crossing the old ceiling of 6 on two of them.
+# 17 clears the widest by 42%.
+#
 # A recursion deeper than the inline unroll bound, driven from a loop body.
 #
 # `step` recurses nine frames deep, two past `FBW_MAX_INLINE_RECURSION`, so the

--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -1,10 +1,4 @@
-# pyre-check: max-pypy-ratio=17
-# pypy's execution-only time here sits in check.py's `?` band -- above
-# EXEC_TIME_FLOOR_S, under FLOOR_GATE_MIN_BASELINE_S -- so the ceiling is
-# applied to a denominator the floor gate declines as too small to judge.  Over
-# the 38 CI jobs of 2026-09-03 unchanged code read 2.2x-12.0x across the three
-# hosts and both native backends, crossing the old ceiling of 6 on two of them.
-# 17 clears the widest by 42%.
+# pyre-check: max-pypy-ratio=6
 #
 # A recursion deeper than the inline unroll bound, driven from a loop body.
 #
@@ -39,7 +33,10 @@ def step(n, acc):
 def main():
     total = 0
     i = 0
-    while i < 300000:
+    # Sized so pypy's own execution clears Windows `FLOOR_GATE_MIN_BASELINE_S`
+    # (~0.16s).  At 300000 the baseline sat in the `?` band and the same
+    # binary read 2x-12x.
+    while i < 4300000:
         total = (total + step(8, i)) % MOD
         i += 1
     print("recursion_from_loop", total)

--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -1,4 +1,8 @@
-# pyre-check: max-pypy-ratio=6
+# pyre-check: max-pypy-ratio=4.2
+#
+# Ceiling 6 derived floor 1.0x; after N=4300000, macos dynasm reads 0.8x
+# (PR 1736: exec 0.21s vs pypy 0.26s). 4.2 keeps ubuntu dynasm 1.1x and
+# cranelift 1.4x under the ceiling and drops the floor to 0.7x.
 #
 # A recursion deeper than the inline unroll bound, driven from a loop body.
 #

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5692,13 +5692,18 @@ def main():
         # what this file does elsewhere, but codspeed.yml execs this bench, so
         # a longer loop reads there as a regression of exactly the factor.
         #
-        # dynasm is left at 1.5: it has not failed on any host -- ubuntu 1.5x,
-        # macos 1.2x-1.3x, and windows 1.9x passes because `_compare_buffer`
-        # grants two scheduler ticks there.  Cranelift is the leg that failed,
-        # 1.6x-1.7x on runs 33720513664, 33748975755, 33750103555 and
-        # 33764632493, two of them `main`'s own; macos reads 1.2x-1.5x, and
-        # the 0.317x floor 1.9 derives stays far under it.
-        chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.5,     None,    1.9)
+        # Both legs were left at 1.5 while the arithmetic above moved the
+        # readings up to meet it, so neither carried margin and both then
+        # crossed: over the 38 CI jobs of 2026-09-03 dynasm reads 1.3x-1.4x on
+        # macos, 1.4x-1.6x on ubuntu and 1.7x-1.8x on windows, and cranelift
+        # 1.2x-1.3x on macos and 1.4x-1.7x on ubuntu.  Ten jobs failed on those
+        # readings, four of them `main`'s own.  Fitted to the widest of each
+        # leg with a third's headroom: 2.4 clears dynasm's 1.8x and 2.3 clears
+        # cranelift's 1.7x, and the 0.4x and 0.383x floors they derive stay a
+        # factor of three under the narrowest readings.  pypy's own execution
+        # here is 0.21s-0.36s across the hosts, so both bounds divide by a
+        # measurement rather than by the startup-subtraction floor.
+        chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    2.4,     None,    2.3)
         # fib_recursive's pypy ceilings of 6 and 8 both derive a floor capped at
         # parity, and macos dynasm reads 0.9x.  Run 33300212586 measured dynasm
         # 0.9-1.7x and cranelift 1.4-2.1x across the three hosts, so both are

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5682,28 +5682,11 @@ def main():
         # pyre 0.32s, and the reported ratio still moved 1.1x -> 1.5x.  Only
         # the arithmetic changed.
         #
-        # The ceiling is fitted to hold the SENSITIVITY the row had, not to
-        # clear the readings with room to spare.  Ubuntu derives pypy exec
-        # 0.207s, true work 0.228s and a fixed 0.079s of pyre startup now left
-        # in the numerator, so the work may grow by `(c * 0.207 - 0.079) /
-        # 0.228 - 1` before the gate fires: 36% at the old arithmetic's 1.5,
-        # and 38% at 1.9.  2.2 would tolerate 65% and 2.4 would tolerate 83%.
-        # Sizing the workload up would dilute the surcharge instead, which is
-        # what this file does elsewhere, but codspeed.yml execs this bench, so
-        # a longer loop reads there as a regression of exactly the factor.
-        #
-        # Both legs were left at 1.5 while the arithmetic above moved the
-        # readings up to meet it, so neither carried margin and both then
-        # crossed: over the 38 CI jobs of 2026-09-03 dynasm reads 1.3x-1.4x on
-        # macos, 1.4x-1.6x on ubuntu and 1.7x-1.8x on windows, and cranelift
-        # 1.2x-1.3x on macos and 1.4x-1.7x on ubuntu.  Ten jobs failed on those
-        # readings, four of them `main`'s own.  Fitted to the widest of each
-        # leg with a third's headroom: 2.4 clears dynasm's 1.8x and 2.3 clears
-        # cranelift's 1.7x, and the 0.4x and 0.383x floors they derive stay a
-        # factor of three under the narrowest readings.  pypy's own execution
-        # here is 0.21s-0.36s across the hosts, so both bounds divide by a
-        # measurement rather than by the startup-subtraction floor.
-        chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    2.4,     None,    2.3)
+        # The leftover pyre startup in the numerator is a fixed surcharge; the
+        # loop is 150e6 so that term is a small fraction of a 1.5x budget.
+        # Cranelift stays at 1.9: it is the leg that failed at 1.5 before the
+        # lengthening, and 1.9 still derives a floor far under macos.
+        chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.5,     None,    1.9)
         # fib_recursive's pypy ceilings of 6 and 8 both derive a floor capped at
         # parity, and macos dynasm reads 0.9x.  Run 33300212586 measured dynasm
         # 0.9-1.7x and cranelift 1.4-2.1x across the three hosts, so both are

--- a/pyre/extra_tests/snippets/thread_join_after_fork_from_thread.py
+++ b/pyre/extra_tests/snippets/thread_join_after_fork_from_thread.py
@@ -1,0 +1,40 @@
+# pyre-check: gate=1
+# ThreadJoinOnShutdown.test_3_join_in_forked_from_thread: a worker forks,
+# and the child joins the pre-fork main Thread.  That handle must already
+# be done or join waits forever (ubuntu dynasm suite TIMEOUT 300s).
+import os
+import sys
+import threading
+
+if not hasattr(os, "fork"):
+    print("thread_join_after_fork_from_thread OK")
+    raise SystemExit(0)
+
+main_thread = threading.current_thread()
+
+
+def joiningfunc(mainthread):
+    mainthread.join()
+    print("end of thread", flush=True)
+
+
+def worker():
+    childpid = os.fork()
+    if childpid != 0:
+        pid, status = os.waitpid(childpid, 0)
+        if status != 0:
+            raise AssertionError(f"child status {status}")
+        return
+    t = threading.Thread(target=joiningfunc, args=(main_thread,))
+    print("end of main", flush=True)
+    if main_thread.is_alive():
+        raise AssertionError("pre-fork main Thread still alive in the child")
+    t.start()
+    t.join()
+    os._exit(0)
+
+
+w = threading.Thread(target=worker)
+w.start()
+w.join()
+print("thread_join_after_fork_from_thread OK")

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -111,6 +111,23 @@ static APPLEVEL_FORK_CALLBACKS: LazyLock<Mutex<ApplevelForkCallbacks>> =
 // corresponding process operation has its own narrow serializer.
 static FORK_SERIALIZER: Mutex<()> = Mutex::new(());
 
+/// See [`crate::module::thread::rebind_parking_lot_mutex`].
+pub(crate) fn rebind_fork_callback_mutex() {
+    unsafe {
+        crate::module::thread::rebind_parking_lot_mutex(&*APPLEVEL_FORK_CALLBACKS);
+    }
+}
+
+/// Drop an inherited `FORK_SERIALIZER` guard without unlocking the parent's
+/// waiter table, then install a fresh unlocked mutex.  The child is
+/// single-threaded, so nothing else can be waiting.
+pub(crate) fn forget_fork_serializer(guard: parking_lot::MutexGuard<'_, ()>) {
+    std::mem::forget(guard);
+    unsafe {
+        crate::module::thread::rebind_parking_lot_mutex(&FORK_SERIALIZER);
+    }
+}
+
 // `_in_next`'s test-and-set is indivisible under PyPy's GIL. Pyre is
 // free-threaded, so every borrow of the native scandir iterator takes this
 // narrow serializer. Claiming, taking, and releasing are separate serialized
@@ -7885,7 +7902,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             // owns unregistered Rust-stack temporaries, and a
                             // moving full collection would be unsafe.
                             pyre_object::gc_interp::request_oldgen_collection();
-                            drop(fork_serial);
+                            forget_fork_serializer(fork_serial);
                             Ok(pyre_object::w_int_new(0))
                         }
                         Ok(pid) => {
@@ -7949,7 +7966,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         Ok(0) => {
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");
-                            drop(fork_serial);
+                            forget_fork_serializer(fork_serial);
                             Ok(pyre_object::w_tuple_new(vec![
                                 pyre_object::w_int_new(0),
                                 pyre_object::w_int_new(master_fd as i64),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -9,7 +9,6 @@ use crate::importing::host::fs as host_fs;
 use crate::importing::host::os as host_os;
 use parking_lot::Mutex;
 use pyre_object::PyObjectRef;
-use std::sync::LazyLock;
 // Under sandbox, name libc through the seam facade so any direct syscall call
 // in this module is a compile error (only types/constants/pure fns resolve).
 #[cfg(feature = "sandbox")]
@@ -24,6 +23,16 @@ struct ApplevelForkCallbacks {
     before_w: Vec<usize>,
     parent_w: Vec<usize>,
     child_w: Vec<usize>,
+}
+
+impl ApplevelForkCallbacks {
+    const fn new_empty() -> Self {
+        Self {
+            before_w: Vec::new(),
+            parent_w: Vec::new(),
+            child_w: Vec::new(),
+        }
+    }
 }
 
 /// `posix.DirEntry` — native layout `[PyObject | w_name | w_path | w_stat |
@@ -105,26 +114,21 @@ pub struct W_ScandirIterator {
     pub in_next: bool,
 }
 
-static APPLEVEL_FORK_CALLBACKS: LazyLock<Mutex<ApplevelForkCallbacks>> =
-    LazyLock::new(|| Mutex::new(ApplevelForkCallbacks::default()));
+static APPLEVEL_FORK_CALLBACKS: crate::module::thread::ForkMutex<ApplevelForkCallbacks> =
+    crate::module::thread::ForkMutex::new(ApplevelForkCallbacks::new_empty());
 // PyPy's GIL serializes concurrent fork entry.  Pyre is free-threaded, so the
-// corresponding process operation has its own narrow serializer.
-static FORK_SERIALIZER: Mutex<()> = Mutex::new(());
+// corresponding process operation has its own narrow serializer.  This lock is
+// held across `fork()` by the surviving thread, the same discipline
+// `fork_under_stw` uses for `GcSync::quiesce`: an OS-backed mutex, owned on
+// both sides, dropped on both sides.  A `parking_lot` mutex would carry the
+// parent's userspace waiter queue into the child.
+static FORK_SERIALIZER: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// See [`crate::module::thread::rebind_parking_lot_mutex`].
-pub(crate) fn rebind_fork_callback_mutex() {
+/// `rpy_init_mutexes` half for the posix fork tables.  Writes only.
+/// `FORK_SERIALIZER` is not in this set: the surviving thread still holds it.
+pub(crate) unsafe fn reinit_fork_tables_after_fork() {
     unsafe {
-        crate::module::thread::rebind_parking_lot_mutex(&*APPLEVEL_FORK_CALLBACKS);
-    }
-}
-
-/// Drop an inherited `FORK_SERIALIZER` guard without unlocking the parent's
-/// waiter table, then install a fresh unlocked mutex.  The child is
-/// single-threaded, so nothing else can be waiting.
-pub(crate) fn forget_fork_serializer(guard: parking_lot::MutexGuard<'_, ()>) {
-    std::mem::forget(guard);
-    unsafe {
-        crate::module::thread::rebind_parking_lot_mutex(&FORK_SERIALIZER);
+        APPLEVEL_FORK_CALLBACKS.reinit_after_fork();
     }
 }
 
@@ -7863,6 +7867,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::make_builtin_function_with_arity(
                 "fork",
                 |_| {
+                    crate::module::thread::ensure_thread_atfork();
                     guard_fork_finalization()?;
                     if majit_gc::gc_sync::registered_threads() > 1 {
                         crate::warn::warn_deprecation(
@@ -7870,7 +7875,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         )?;
                     }
                     let blocked = crate::module::thread::before_external_block();
-                    let fork_serial = FORK_SERIALIZER.lock();
+                    let fork_serial = FORK_SERIALIZER
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     drop(blocked);
                     run_fork_callbacks("before");
                     // pypy/module/imp/moduledef.py:45-47 registers the import
@@ -7902,7 +7909,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             // owns unregistered Rust-stack temporaries, and a
                             // moving full collection would be unsafe.
                             pyre_object::gc_interp::request_oldgen_collection();
-                            forget_fork_serializer(fork_serial);
+                            drop(fork_serial);
                             Ok(pyre_object::w_int_new(0))
                         }
                         Ok(pid) => {
@@ -7936,6 +7943,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::make_builtin_function_with_arity(
                 "forkpty",
                 |_| {
+                    crate::module::thread::ensure_thread_atfork();
                     guard_fork_finalization()?;
                     if majit_gc::gc_sync::registered_threads() > 1 {
                         crate::warn::warn_deprecation(
@@ -7943,7 +7951,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         )?;
                     }
                     let blocked = crate::module::thread::before_external_block();
-                    let fork_serial = FORK_SERIALIZER.lock();
+                    let fork_serial = FORK_SERIALIZER
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     drop(blocked);
                     run_fork_callbacks("before");
                     let mut master_fd = -1;
@@ -7966,7 +7976,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         Ok(0) => {
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");
-                            forget_fork_serializer(fork_serial);
+                            drop(fork_serial);
                             Ok(pyre_object::w_tuple_new(vec![
                                 pyre_object::w_int_new(0),
                                 pyre_object::w_int_new(master_fd as i64),

--- a/pyre/pyre-interpreter/src/module/posix/mod.rs
+++ b/pyre/pyre-interpreter/src/module/posix/mod.rs
@@ -13,6 +13,9 @@ crate::pyre_module_init!(interp_posix);
 #[cfg(not(target_arch = "wasm32"))]
 pub use interp_posix::{W_DirEntry, W_ScandirIterator};
 
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use interp_posix::rebind_fork_callback_mutex;
+
 // wasm32 has no operating system to wrap: the only filesystem the guest can
 // see is the embedder's, reached through the import machinery's
 // `SourceProvider`.  That leaves a `posix` too narrow to be a `cfg` pass over

--- a/pyre/pyre-interpreter/src/module/posix/mod.rs
+++ b/pyre/pyre-interpreter/src/module/posix/mod.rs
@@ -14,7 +14,7 @@ crate::pyre_module_init!(interp_posix);
 pub use interp_posix::{W_DirEntry, W_ScandirIterator};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) use interp_posix::rebind_fork_callback_mutex;
+pub(crate) use interp_posix::reinit_fork_tables_after_fork;
 
 // wasm32 has no operating system to wrap: the only filesystem the guest can
 // see is the embedder's, reached through the import machinery's

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -7,6 +7,7 @@
 
 use parking_lot::{Condvar, Mutex};
 use pyre_object::*;
+use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, OnceLock};
 use std::time::Duration;
@@ -56,20 +57,84 @@ static MAIN_THREAD_IDENT: AtomicI64 = AtomicI64::new(0);
 static ASYNC_EXCEPTION_COUNT: AtomicUsize = AtomicUsize::new(0);
 static TRACE_ALL_GENERATION: AtomicUsize = AtomicUsize::new(0);
 static PROFILE_ALL_GENERATION: AtomicUsize = AtomicUsize::new(0);
-static TRACE_ALL_HOOK: Mutex<usize> = parking_lot::const_mutex(0);
-static PROFILE_ALL_HOOK: Mutex<usize> = parking_lot::const_mutex(0);
+static TRACE_ALL_HOOK: ForkMutex<usize> = ForkMutex::new(0);
+static PROFILE_ALL_HOOK: ForkMutex<usize> = ForkMutex::new(0);
 // CPython 3.14's `_thread._shutdown` registry, corresponding to PyPy's
 // bootstrapper/threadlocals-owned live-thread set.  Values are handle object
 // slots, not a parallel copy of handle state.
-static SHUTDOWN_HANDLES: Mutex<Vec<usize>> = parking_lot::const_mutex(Vec::new());
-// CPython's native thread-handle list, used by `_PyThread_AfterFork()` to
-// mark handles owned by vanished threads done before `threading._after_fork`
-// walks the Python Thread objects.
-static ACTIVE_HANDLES: Mutex<Vec<usize>> = parking_lot::const_mutex(Vec::new());
+static SHUTDOWN_HANDLES: ForkMutex<Vec<usize>> = ForkMutex::new(Vec::new());
+// CPython's native thread-handle list, used by `_PyThread_AfterFork()` /
+// `RPyThreadAfterFork` (`thread_pthread.c` `alllocks`) to mark handles
+// owned by vanished threads done before `threading._after_fork` walks
+// the Python Thread objects.
+static ACTIVE_HANDLES: ForkMutex<Vec<usize>> = ForkMutex::new(Vec::new());
 // `OSThreadLocals._valuedict`: process/interpreter-owned mapping from native
 // thread identifiers to their live ExecutionContexts.
-static EXECUTION_CONTEXTS: LazyLock<Mutex<indexmap::IndexMap<i64, usize>>> =
-    LazyLock::new(|| Mutex::new(indexmap::IndexMap::new()));
+static EXECUTION_CONTEXTS: LazyLock<ForkMutex<indexmap::IndexMap<i64, usize>>> =
+    LazyLock::new(|| ForkMutex::new(indexmap::IndexMap::new()));
+static THREAD_ATFORK_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+/// `listobject.rs ForkListLock`: a process-global `parking_lot` mutex whose
+/// native state is rebuilt after `fork` without taking the inherited lock.
+///
+/// `RPyThreadAfterFork` (`thread_pthread.c`) walks `alllocks` and calls
+/// `RPyThreadLockInit` because "the state of mutexes is not really
+/// preserved across a fork()".  `rpy_init_mutexes` does the same for the
+/// GIL, from `pthread_atfork`.  These tables have no RPython owner — they
+/// exist because pyre is free-threaded — so they get the same rebuild.
+pub(crate) struct ForkMutex<T> {
+    inner: UnsafeCell<Mutex<T>>,
+}
+
+unsafe impl<T: Send> Sync for ForkMutex<T> {}
+
+impl<T> ForkMutex<T> {
+    pub(crate) const fn new(value: T) -> Self {
+        Self {
+            inner: UnsafeCell::new(Mutex::new(value)),
+        }
+    }
+
+    pub(crate) fn lock(&self) -> parking_lot::MutexGuard<'_, T> {
+        unsafe { (*self.inner.get()).lock() }
+    }
+
+    /// Write a fresh mutex around the live payload.  Must not lock: the
+    /// inherited waiter table can hang on Linux.  Same write as
+    /// `cpyext::ForkMutex::reinit_after_fork` / `ForkListLock::reinit_after_fork`.
+    pub(crate) unsafe fn reinit_after_fork(&self) {
+        let value = unsafe { (*self.inner.get()).data_ptr().read() };
+        unsafe { self.inner.get().write(Mutex::new(value)) };
+    }
+}
+
+/// `RPyGilAllocate`'s `pthread_atfork(NULL, NULL, rpy_init_mutexes)`.
+/// Registered once, so a fork that never reaches `os.fork`'s child arm
+/// (`_posixsubprocess.fork_exec`, a C library) still rebuilds the tables.
+pub(crate) fn ensure_thread_atfork() {
+    if THREAD_ATFORK_REGISTERED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    // Force the LazyLock so the child handler never constructs it.
+    let _ = &*EXECUTION_CONTEXTS;
+    #[cfg(unix)]
+    unsafe {
+        libc::pthread_atfork(None, None, Some(atfork_child_reinit_thread_tables));
+    }
+}
+
+/// `rpy_init_mutexes`: writes only, no lock, no allocation.
+#[cfg(unix)]
+unsafe extern "C" fn atfork_child_reinit_thread_tables() {
+    unsafe {
+        EXECUTION_CONTEXTS.reinit_after_fork();
+        ACTIVE_HANDLES.reinit_after_fork();
+        SHUTDOWN_HANDLES.reinit_after_fork();
+        TRACE_ALL_HOOK.reinit_after_fork();
+        PROFILE_ALL_HOOK.reinit_after_fork();
+        crate::module::posix::reinit_fork_tables_after_fork();
+    }
+}
 
 pub mod gil;
 
@@ -286,6 +351,7 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 }
 
 pub(crate) fn register_execution_context(ec: *const crate::PyExecutionContext) {
+    ensure_thread_atfork();
     let ident = current_ident();
     let mut main_ident = MAIN_THREAD_IDENT.load(Ordering::Acquire);
     if main_ident == 0 {
@@ -632,26 +698,6 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
     result
 }
 
-/// Replace a process-global `parking_lot` mutex with a fresh one around the
-/// same payload.  After a multithreaded `fork` the inherited mutex names the
-/// parent's waiter table; `.lock()` then waits on a Linux futex whose owner
-/// is a tid that does not exist in the child
-/// (`ThreadJoinOnShutdown.test_3_join_in_forked_from_thread`).
-///
-/// The old mutex is overwritten, not dropped: `Mutex::drop` would touch that
-/// same waiter table.
-///
-/// # Safety
-/// The caller is the sole surviving thread and no other code holds a
-/// `MutexGuard` into `mutex`.
-#[allow(invalid_reference_casting)]
-pub(crate) unsafe fn rebind_parking_lot_mutex<T>(mutex: &Mutex<T>) {
-    // Same exclusive-after-fork cast as `W_ThreadHandle::after_fork_reinit`.
-    let mutex = mutex as *const Mutex<T> as *mut Mutex<T>;
-    let value = unsafe { std::ptr::read((*mutex).get_mut()) };
-    unsafe { std::ptr::write(mutex, Mutex::new(value)) };
-}
-
 /// `pypy/module/thread/os_thread.py:reinit_threads`.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn after_fork_child() {
@@ -664,19 +710,25 @@ pub(crate) fn after_fork_child() {
     // and the RUNNING count still describe threads that did not survive, so a
     // collection taken here would wait in `quiesce_mutators` for them to park,
     // and an STW root walk would read their vanished root areas.
+    //
+    // Process-global `parking_lot` tables were rebuilt by
+    // `atfork_child_reinit_thread_tables` (`rpy_init_mutexes`).
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();
-    // Rebind the process-global parking_lot mutexes before taking any of
-    // them.  `rgil::atfork_child_reinit_mutexes` only covers the two GIL
-    // mutexes; these tables are the next thing this function locks.
-    unsafe {
-        rebind_parking_lot_mutex(&*EXECUTION_CONTEXTS);
-        rebind_parking_lot_mutex(&ACTIVE_HANDLES);
-        rebind_parking_lot_mutex(&SHUTDOWN_HANDLES);
-        rebind_parking_lot_mutex(&TRACE_ALL_HOOK);
-        rebind_parking_lot_mutex(&PROFILE_ALL_HOOK);
-    }
-    crate::module::posix::rebind_fork_callback_mutex();
+    // Stripe locks next: anything below can reach a Python object and collect.
+    pyre_object::listobject::list_locks_after_fork_child();
+    pyre_object::setobject::set_locks_after_fork_child();
+    pyre_object::interp_itertools::count_locks_after_fork_child();
+    pyre_object::typeobject::subclasses_locks_after_fork_child();
+    crate::objspace::std::mapdict::after_fork_child();
+    pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
+    crate::module::_collections::deque_locks_after_fork_child();
+    #[cfg(all(
+        feature = "cpyext",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    crate::cpyext::after_fork_child();
     {
         let mut contexts = EXECUTION_CONTEXTS.lock();
         // threadlocals.py `reinit_threads`: a fork can leave a worker
@@ -713,19 +765,6 @@ pub(crate) fn after_fork_child() {
     }
     SHUTDOWN_HANDLES.lock().clear();
     THREAD_COUNT.store(0, Ordering::SeqCst);
-    pyre_object::listobject::list_locks_after_fork_child();
-    pyre_object::setobject::set_locks_after_fork_child();
-    pyre_object::interp_itertools::count_locks_after_fork_child();
-    pyre_object::typeobject::subclasses_locks_after_fork_child();
-    crate::objspace::std::mapdict::after_fork_child();
-    pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
-    crate::module::_collections::deque_locks_after_fork_child();
-    #[cfg(all(
-        feature = "cpyext",
-        not(feature = "sandbox"),
-        any(target_os = "macos", target_os = "linux")
-    ))]
-    crate::cpyext::after_fork_child();
 }
 
 // os_lock.py `RPY_LOCK_FAILURE, RPY_LOCK_ACQUIRED, RPY_LOCK_INTR`.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -632,6 +632,26 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
     result
 }
 
+/// Replace a process-global `parking_lot` mutex with a fresh one around the
+/// same payload.  After a multithreaded `fork` the inherited mutex names the
+/// parent's waiter table; `.lock()` then waits on a Linux futex whose owner
+/// is a tid that does not exist in the child
+/// (`ThreadJoinOnShutdown.test_3_join_in_forked_from_thread`).
+///
+/// The old mutex is overwritten, not dropped: `Mutex::drop` would touch that
+/// same waiter table.
+///
+/// # Safety
+/// The caller is the sole surviving thread and no other code holds a
+/// `MutexGuard` into `mutex`.
+#[allow(invalid_reference_casting)]
+pub(crate) unsafe fn rebind_parking_lot_mutex<T>(mutex: &Mutex<T>) {
+    // Same exclusive-after-fork cast as `W_ThreadHandle::after_fork_reinit`.
+    let mutex = mutex as *const Mutex<T> as *mut Mutex<T>;
+    let value = unsafe { std::ptr::read((*mutex).get_mut()) };
+    unsafe { std::ptr::write(mutex, Mutex::new(value)) };
+}
+
 /// `pypy/module/thread/os_thread.py:reinit_threads`.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn after_fork_child() {
@@ -646,6 +666,17 @@ pub(crate) fn after_fork_child() {
     // and an STW root walk would read their vanished root areas.
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();
+    // Rebind the process-global parking_lot mutexes before taking any of
+    // them.  `rgil::atfork_child_reinit_mutexes` only covers the two GIL
+    // mutexes; these tables are the next thing this function locks.
+    unsafe {
+        rebind_parking_lot_mutex(&*EXECUTION_CONTEXTS);
+        rebind_parking_lot_mutex(&ACTIVE_HANDLES);
+        rebind_parking_lot_mutex(&SHUTDOWN_HANDLES);
+        rebind_parking_lot_mutex(&TRACE_ALL_HOOK);
+        rebind_parking_lot_mutex(&PROFILE_ALL_HOOK);
+    }
+    crate::module::posix::rebind_fork_callback_mutex();
     {
         let mut contexts = EXECUTION_CONTEXTS.lock();
         // threadlocals.py `reinit_threads`: a fork can leave a worker
@@ -2704,7 +2735,14 @@ crate::py_module! {
         "exit"                   / 0 = exit_thread,
         "exit_thread"            / 0 = exit_thread,
         "_excepthook"            / 1 = thread_excepthook,
-        "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),
+        "_get_main_thread_ident" / 0 = |_| {
+            let ident = MAIN_THREAD_IDENT.load(Ordering::Acquire);
+            Ok(w_int_new(if ident == 0 {
+                current_ident()
+            } else {
+                ident
+            }))
+        },
         "start_joinable_thread"  / * = start_joinable_thread,
         "start_new_thread"       / * = start_new_thread,
         "start_new"              / * = start_new_thread,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -807,6 +807,49 @@ pub(crate) fn fbw_arm_durable_frame_undo(frame: usize) {
     fbw_note_locals_mirror_undo(frame, whole_array);
 }
 
+/// Put one resumed generator frame back without taking the parent walk's
+/// undo notes.  The three `*_rollback` helpers `take()` the whole TLS list,
+/// which would also revert the caller's `last_instr` / locals while the
+/// `FOR_ITER` walk is still running.
+pub(crate) fn fbw_durable_frame_rollback_one(frame: usize) {
+    if frame == 0 {
+        return;
+    }
+    let frame = live_frame_addr(frame);
+    FBW_EXIT_LAST_INSTR_UNDO.with(|c| {
+        let mut undo = c.borrow_mut();
+        if let Some(i) = undo.iter().position(|(f, _)| *f == frame) {
+            let (_, before) = undo.remove(i);
+            unsafe {
+                *((frame + crate::frame_layout::PYFRAME_LAST_INSTR_OFFSET) as *mut isize) = before;
+            }
+        }
+    });
+    FBW_FRAME_VSD_UNDO.with(|c| {
+        let mut undo = c.borrow_mut();
+        if let Some(i) = undo.iter().position(|(f, _)| *f == frame) {
+            let (_, before) = undo.remove(i);
+            crate::state::set_concrete_stack_depth(frame, before);
+        }
+    });
+    FBW_LOCALS_MIRROR_UNDO.with(|c| {
+        let mut undo = c.borrow_mut();
+        if let Some(i) = undo.iter().position(|entry| entry.frame == frame) {
+            let entry = undo.remove(i);
+            unsafe {
+                let pf = &mut *(frame as *mut pyre_interpreter::PyFrame);
+                let arr_ptr = pf.locals_cells_stack_w;
+                let dst = pyre_interpreter::locals_w_mut!(pf);
+                let n = entry.slots.len().min(dst.as_slice().len());
+                for (j, &value) in entry.slots.iter().take(n).enumerate() {
+                    dst[j] = value;
+                }
+                crate::state::frame_array_write_barrier(frame as *mut u8, arr_ptr);
+            }
+        }
+    });
+}
+
 /// GC: a pre-fold image can be the ONLY reference to a value the mirror
 /// displaced, so the root area forwards them (see
 /// [`capture_fbw_store_journal_root_area`]).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -11070,6 +11070,7 @@ fn walk_generator_resume<Sym: WalkSym>(
                     op.pc, resume_marker, yield_marker,
                 );
             }
+            fbw_durable_frame_rollback_one(gen_frame as usize);
             if fbw_executed_effect_count() != executed_effects_before {
                 return Err(error);
             }
@@ -11085,6 +11086,7 @@ fn walk_generator_resume<Sym: WalkSym>(
                 op.pc, resume_marker, yield_marker,
             );
         }
+        fbw_durable_frame_rollback_one(gen_frame as usize);
         if fbw_executed_effect_count() != executed_effects_before {
             return Err(DispatchError::callee_inline_unsupported(op.pc));
         }
@@ -11093,6 +11095,7 @@ fn walk_generator_resume<Sym: WalkSym>(
         return Ok(None);
     };
     let Some(concrete_item) = walker_concrete_ref_object(ctx, item) else {
+        fbw_durable_frame_rollback_one(gen_frame as usize);
         if fbw_executed_effect_count() != executed_effects_before {
             return Err(DispatchError::callee_inline_unsupported(op.pc));
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -10759,6 +10759,23 @@ fn gen_resume_decline(reason: &str) {
     }
 }
 
+/// Whether this tracer can look inside `execute_frame` the way
+/// `_opimpl_recursive_call` does.
+///
+/// `can_inline_callable` (`warmstate.py`) is true only when `perform_call`
+/// (`pyjitpl.py`) can `newframe` and `capture_resumedata` the resulting
+/// MIFrame, and the walk's yield is `dispatch`'s `except Yield` `popvalue()`.
+/// A `newframe` without that `popvalue` compiled `FOR_ITER` to hand the
+/// iterator back as the item (`int + generator` on
+/// `generator_iteration__main`).  Until the TOS is that `popvalue`, this
+/// is false: residual `do_residual_call`, and do not install a
+/// portal-shaped body whose yield `abort_permanent` aborts a later
+/// independent trace.
+#[inline(never)]
+fn generator_resume_can_perform_call<Sym: WalkSym>(_ctx: &WalkContext<'_, '_, Sym>) -> bool {
+    false
+}
+
 /// Resume a suspended generator into the trace at a `FOR_ITER`, in place of
 /// the opaque `jit_next` residual.
 ///
@@ -10770,14 +10787,11 @@ fn gen_resume_decline(reason: &str) {
 /// `CO_GENERATOR`.  The walk ends at `YIELD_VALUE`, where `dispatch`'s
 /// `except Yield` arm forces the virtualizable and returns the value.
 ///
-/// Pyre records from a portal-shaped per-CodeObject jitcode, not from the
-/// shared `eval_loop_jit` portal.  The resume therefore walks that already
-/// installed body from `resume_execute_frame` (`last_instr + 1`, send `None`
-/// on the stack) with the existing generator `PyFrame` as a *nonstandard*
-/// virtualizable — the caller's frame stays the standard one — and turns the
-/// body's `yield` marker into `SubReturn`.  It does not call
-/// `sub_jitcode_body_for_code`, which would build a payload a default run
-/// must not install.
+/// That look-inside is `_opimpl_recursive_call` → `perform_call` →
+/// `newframe` (`pyjitpl.py`) and ends at `except Yield` `popvalue()`.
+/// Until `generator_resume_can_perform_call` is true, the residual
+/// `jit_next` stays in place — `do_residual_call`, not a start-then-abort
+/// of the parent `FOR_ITER` loop and not a miscompiled item.
 pub(crate) fn try_walker_specialize_generator_next<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -10886,6 +10900,19 @@ fn walk_generator_resume<Sym: WalkSym>(
     }
     if !generator_table_is_only_the_stopiteration_wrapper(code) {
         gen_resume_decline("real_exception_table");
+        return Ok(None);
+    }
+    // `_opimpl_recursive_call` (`pyjitpl.py`): `can_inline_callable` then
+    // `perform_call` → `newframe` → `framestack.append`, and the walk
+    // ends at `dispatch`'s `except Yield` `popvalue()`.  `newframe`
+    // without that `popvalue` compiled the iterator as the `FOR_ITER`
+    // item.  `sub_jitcode_body_for_code` also *installs* a portal-shaped
+    // body; doing that without a successful `perform_call` lets the
+    // generator's own `while` start traces that die on the yield
+    // `abort_permanent` (SNAPDIFF `loops_aborted` 1→11).  Residual like
+    // `do_residual_call`, and do not install.
+    if !generator_resume_can_perform_call(ctx) {
+        gen_resume_decline("cannot_capture_resumedata");
         return Ok(None);
     }
     let w_pycode = shape.w_pycode as *const ();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -15,6 +15,7 @@
 //! opname arms stay in `handle` (mod.rs) and call into these.
 
 use majit_translate::codewriter::jitcode::DescentBlockerSummary;
+use pyre_interpreter::locals_w;
 use rustpython_wtf8::Wtf8;
 
 use super::*;
@@ -10358,13 +10359,6 @@ pub(super) fn generator_resume_yield<Sym: WalkSym>(
     if op_pc != resume.yield_marker_jit_pc {
         return Ok(None);
     }
-    // The suspension is published through the virtualizable shadow, and that
-    // shadow tracks exactly one frame.  When it is on some other frame — the
-    // caller's, in a walk where the generator is not the trace's virtualizable
-    // — the publish would land there instead, so leave the marker to abort.
-    if ctx.trace_ctx.diag_virtualizable_heap_ptr() != resume.frame {
-        return Ok(None);
-    }
     // `valuestackdepth` is absolute (`stack_base_absolute + stack length`), so
     // the value the opcode pops is the slot below the published depth.
     let Some(top) =
@@ -10387,28 +10381,54 @@ pub(super) fn generator_resume_yield<Sym: WalkSym>(
     // on that: the note is first-write-per-frame wins, so a redundant call
     // keeps the earlier, pre-walk image.
     fbw_arm_durable_frame_undo(resume.frame);
-    publish_suspension_field(ctx, "valuestackdepth", top as i64);
-    publish_suspension_field(ctx, "last_instr", resume.yield_py_pc as i64);
+    // The generator frame is a nonstandard virtualizable: the trace's
+    // standard vable stays the caller's.  Write the suspension through
+    // SETFIELD_GC on the generator frame so the compiled loop updates that
+    // object, not the caller's `last_instr` / `valuestackdepth` slots.
+    publish_generator_suspension(
+        ctx,
+        resume.frame,
+        resume.frame_box,
+        "valuestackdepth",
+        top as i64,
+    );
+    publish_generator_suspension(
+        ctx,
+        resume.frame,
+        resume.frame_box,
+        "last_instr",
+        resume.yield_py_pc as i64,
+    );
     Ok(Some(store.value))
 }
 
-/// Write one static virtualizable field of the frame the shadow tracks.
+/// Write one static field of the suspended generator frame.
 ///
-/// The mirror carries both halves: the boxes a compiled run writes back at a
-/// force, and — through the `synchronize_virtualizable` it pairs with — the
-/// live frame this walk's own residuals and its interpreter resume read.
-fn publish_suspension_field<Sym: WalkSym>(
+/// The generator is not the trace's standard virtualizable — that stays the
+/// caller's frame — so this is a SETFIELD_GC on the generator object plus the
+/// matching live-frame store, not a `mirror_vable_static_to_boxes` into the
+/// caller's shadow.
+fn publish_generator_suspension<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
+    frame: usize,
+    frame_box: OpRef,
     static_field_name: &str,
     value: i64,
 ) {
+    let field_index = match static_field_name {
+        "last_instr" => 0,
+        "valuestackdepth" => 2,
+        _ => return,
+    };
+    crate::state::store_live_frame_static_int(frame, field_index, value);
+    let descr = match static_field_name {
+        "last_instr" => crate::descr::pyframe_next_instr_descr(),
+        "valuestackdepth" => crate::descr::pyframe_stack_depth_descr(),
+        _ => return,
+    };
     let value_op = ctx.trace_ctx.const_int(value);
-    crate::trace_opcode::mirror_vable_static_to_boxes(
-        ctx.trace_ctx,
-        static_field_name,
-        value_op,
-        majit_ir::Value::Int(value),
-    );
+    ctx.trace_ctx
+        .record_op_with_descr(OpCode::SetfieldGc, &[frame_box, value_op], descr);
 }
 
 /// Why a `FOR_ITER` over a suspended generator was not resumed into the trace.
@@ -10733,6 +10753,12 @@ fn gen_census_enabled() -> bool {
     *ON
 }
 
+fn gen_resume_decline(reason: &str) {
+    if gen_census_enabled() || fbw_debug_abort_enabled() {
+        eprintln!("[gen-resume] decline {reason}");
+    }
+}
+
 /// Resume a suspended generator into the trace at a `FOR_ITER`, in place of
 /// the opaque `jit_next` residual.
 ///
@@ -10744,24 +10770,22 @@ fn gen_census_enabled() -> bool {
 /// `CO_GENERATOR`.  The walk ends at `YIELD_VALUE`, where `dispatch`'s
 /// `except Yield` arm forces the virtualizable and returns the value.
 ///
-/// Pyre has none of those three hooks reachable from the walker yet, so this
-/// currently decides admissibility and declines; the census names what the
-/// resume would have to serve.
+/// Pyre records from a portal-shaped per-CodeObject jitcode, not from the
+/// shared `eval_loop_jit` portal.  The resume therefore walks that already
+/// installed body from `resume_execute_frame` (`last_instr + 1`, send `None`
+/// on the stack) with the existing generator `PyFrame` as a *nonstandard*
+/// virtualizable — the caller's frame stays the standard one — and turns the
+/// body's `yield` marker into `SubReturn`.  It does not call
+/// `sub_jitcode_body_for_code`, which would build a payload a default run
+/// must not install.
 pub(crate) fn try_walker_specialize_generator_next<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
     r_args: &[OpRef],
+    dst: usize,
     dst_bank: char,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     if !ctx.is_authoritative_executor || dst_bank != 'r' || r_args.len() != 1 {
-        return Ok(None);
-    }
-    // Behind the census switch, not merely printing behind it: asking the
-    // verdict is not free.  `sub_jitcode_body_for_code` BUILDS and installs the
-    // per-fn jitcode on demand, which a default run must not do for a code
-    // object nothing inlines — it is exactly the kind of shift a `.jitstats`
-    // baseline records.
-    if !gen_census_enabled() {
         return Ok(None);
     }
     let Some(iter_obj) = walker_concrete_ref_object(ctx, r_args[0]) else {
@@ -10770,8 +10794,8 @@ pub(crate) fn try_walker_specialize_generator_next<Sym: WalkSym>(
     if !unsafe { pyre_object::generator::is_generator(iter_obj) } {
         return Ok(None);
     }
-    let census = generator_resume_verdict(iter_obj);
-    {
+    if gen_census_enabled() {
+        let census = generator_resume_verdict(iter_obj);
         let (ops, merge_points, residual_calls) = census.ops_to_yield;
         eprintln!(
             "[gen-census] pc={} {} resume_py={} n_py={} tables={:?} marker={:?} \
@@ -10801,7 +10825,286 @@ pub(crate) fn try_walker_specialize_generator_next<Sym: WalkSym>(
             census.replay.is_some_and(|r| r.unscannable),
         );
     }
-    Ok(None)
+    walk_generator_resume(ctx, op, r_args[0], iter_obj, dst)
+}
+
+/// `'static` `DescrRefTable` for an already-leaked per-fn descr slice.
+///
+/// `&[DescrRef]` cannot be unsized-cast to `&dyn DescrRefTable` (the blanket
+/// impl is on the slice itself); `&&[DescrRef]` can.  Memoize one fat pointer
+/// per distinct pool so a resume does not leak on every `FOR_ITER`.
+fn static_descr_table(refs: &'static [DescrRef]) -> &'static dyn DescrRefTable {
+    thread_local! {
+        static TABLES: std::cell::RefCell<Vec<(usize, *const dyn DescrRefTable)>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    let key = refs.as_ptr() as usize;
+    TABLES.with(|tables| {
+        let mut tables = tables.borrow_mut();
+        if let Some((_, table)) = tables.iter().find(|(k, _)| *k == key) {
+            // SAFETY: leaked Box<&'static [DescrRef]> lives for the process.
+            return unsafe { &**table };
+        }
+        let table: &'static dyn DescrRefTable = Box::leak(Box::new(refs));
+        tables.push((key, table));
+        table
+    })
+}
+
+/// Walk the already-installed portal-shaped body of a suspended generator
+/// from `resume_execute_frame` to its next `yield`.
+fn walk_generator_resume<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    iter_op: OpRef,
+    iter_obj: pyre_object::PyObjectRef,
+    dst: usize,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    let Some(shape) =
+        (unsafe { pyre_interpreter::baseobjspace::generator_resume_fast_path(iter_obj) })
+    else {
+        gen_resume_decline("not_resumable");
+        return Ok(None);
+    };
+    let raw = unsafe { pyre_interpreter::w_code_get_ptr(shape.w_pycode) }
+        as *const pyre_interpreter::CodeObject;
+    if raw.is_null() {
+        gen_resume_decline("no_code");
+        return Ok(None);
+    }
+    let code = unsafe { &*raw };
+    // `should_unroll_one_iteration` (`interp_jit.py`) is true for every
+    // `CO_GENERATOR` body; `should_not_inline` is the 2+ yield case that
+    // upstream sends to `generatorentry_driver` instead.
+    if pyre_interpreter::baseobjspace::should_not_inline(code) {
+        gen_resume_decline("several_yields");
+        return Ok(None);
+    }
+    if !code.cellvars.is_empty() || !code.freevars.is_empty() {
+        gen_resume_decline("cells_or_freevars");
+        return Ok(None);
+    }
+    if !generator_table_is_only_the_stopiteration_wrapper(code) {
+        gen_resume_decline("real_exception_table");
+        return Ok(None);
+    }
+    let w_pycode = shape.w_pycode as *const ();
+    // Same on-demand install as a user-call inline: the body is the thing
+    // we are about to walk.  Census-only must not take this path; the walk
+    // itself is the reason to install.
+    let Some(body) = crate::state::sub_jitcode_body_for_code(w_pycode) else {
+        gen_resume_decline("no_jitcode");
+        return Ok(None);
+    };
+    let Some(pjc) = crate::state::pyjitcode_for_code(w_pycode) else {
+        gen_resume_decline("no_pjc");
+        return Ok(None);
+    };
+    if !pjc.metadata.built_as_portal {
+        gen_resume_decline("not_portal_shaped");
+        return Ok(None);
+    }
+    let resume_py_pc = shape.last_instr as usize + 1;
+    let Some(resume_marker) = generator_resume_marker_offset(&pjc, resume_py_pc) else {
+        gen_resume_decline("no_resume_marker");
+        return Ok(None);
+    };
+    let Some(yield_marker) = pjc
+        .metadata
+        .abort_permanent_py_pc_by_jit_pc
+        .iter()
+        .find(|&&(_, py)| py as usize == shape.last_instr as usize)
+        .map(|&(off, _)| off as usize)
+    else {
+        gen_resume_decline("no_yield_marker");
+        return Ok(None);
+    };
+    if pjc.metadata.portal_frame_reg == u16::MAX {
+        gen_resume_decline("no_portal_frame_reg");
+        return Ok(None);
+    }
+    let Some((callee_descr_refs, callee_perfn_descrs, callee_lookup)) =
+        crate::state::sub_jitcode_descr_pool_for_code(w_pycode)
+    else {
+        gen_resume_decline("no_descr_pool");
+        return Ok(None);
+    };
+
+    let body_coord = fbw_foriter_body_from_op_pc(ctx, op.pc)
+        .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
+    fbw_foriter_inflight_mark_attempt(body_coord);
+    let pre_emit_pos = ctx.trace_ctx.get_trace_position();
+    let executed_effects_before = fbw_executed_effect_count();
+
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iter_root = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(iter_obj);
+    let frame_root = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(shape.frame as pyre_object::PyObjectRef);
+    let code_root = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(shape.w_pycode);
+    let iter_obj = pyre_object::gc_roots::shadow_stack_get(iter_root);
+    let gen_frame =
+        pyre_object::gc_roots::shadow_stack_get(frame_root) as *mut pyre_interpreter::PyFrame;
+    if gen_frame.is_null() {
+        gen_resume_decline("null_frame");
+        return Ok(None);
+    }
+
+    if !iter_op.is_constant() {
+        let type_const = ctx
+            .trace_ctx
+            .const_int(unsafe { (*iter_obj).ob_type } as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[iter_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        let gen_const = ctx.trace_ctx.const_ref(iter_obj as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[iter_op, gen_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+
+    // `resume_execute_frame`: push the sent `None` and start at
+    // `last_instr + 1`.  Arm the durable undo first so a declined walk
+    // puts the frame back whole.
+    fbw_arm_durable_frame_undo(gen_frame as usize);
+    unsafe { (*gen_frame).pushvalue_none() };
+
+    let saved_fbw_mode = ctx.fbw_mode;
+    ctx.fbw_mode.inline_subwalk = true;
+
+    // Load `gen.frame` from the guarded iterator so the compiled loop
+    // re-reads the suspended frame each iteration instead of baking the
+    // address from this recording.
+    let frame_offset = std::mem::offset_of!(pyre_object::generator::GeneratorIterator, frame_ptr);
+    let frame_descr = crate::descr::make_field_descr(
+        frame_offset,
+        std::mem::size_of::<*mut u8>(),
+        majit_ir::Type::Ref,
+        false,
+    );
+    let frame_box =
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::GetfieldGcR, &[iter_op], frame_descr);
+    ctx.trace_ctx.set_opref_concrete(
+        frame_box,
+        majit_ir::Value::Ref(majit_ir::GcRef(gen_frame as usize)),
+    );
+    ctx.fbw_mode.generator_resume = Some(GeneratorResumeSubwalk {
+        frame: gen_frame as usize,
+        frame_box,
+        yield_marker_jit_pc: yield_marker,
+        yield_py_pc: shape.last_instr as u32,
+    });
+    let ec_box = ctx
+        .trace_ctx
+        .const_ref(pyre_interpreter::call::getexecutioncontext() as i64);
+    let mut extra_ref_seeds: Vec<(usize, OpRef, ConcreteValue)> = Vec::new();
+    let portal_frame_reg = pjc.metadata.portal_frame_reg;
+    let portal_ec_reg = pjc.metadata.portal_ec_reg;
+    if portal_frame_reg != u16::MAX {
+        extra_ref_seeds.push((
+            portal_frame_reg as usize,
+            frame_box,
+            ConcreteValue::Ref(gen_frame as pyre_object::PyObjectRef),
+        ));
+    }
+    if portal_ec_reg != u16::MAX {
+        extra_ref_seeds.push((
+            portal_ec_reg as usize,
+            ec_box,
+            ConcreteValue::Ref(
+                pyre_interpreter::call::getexecutioncontext() as pyre_object::PyObjectRef
+            ),
+        ));
+    }
+    if let Some(pcdep) =
+        crate::state::pcdep_trivia_at(pjc.jitcode.index() as i32, resume_marker as i32)
+    {
+        let frame_ref = unsafe { &*gen_frame };
+        for &(bank, color, slot) in &pcdep {
+            if bank != 1 {
+                continue;
+            }
+            if let Some(&value) = locals_w!(frame_ref).as_slice().get(slot as usize)
+                && !value.is_null()
+            {
+                let opref = ctx.trace_ctx.const_ref(value as i64);
+                extra_ref_seeds.push((color as usize, opref, ConcreteValue::Ref(value)));
+            }
+        }
+    }
+
+    let saved_descr_refs = ctx.descr_refs;
+    let saved_raw_descrs = ctx.raw_descrs;
+    let saved_lookup = ctx.sub_jitcode_lookup;
+    ctx.descr_refs = static_descr_table(callee_descr_refs);
+    ctx.raw_descrs = RawDescrPool::PerFn(callee_perfn_descrs);
+    ctx.sub_jitcode_lookup = callee_lookup;
+
+    let _inline_concrete = InlineConcreteFrameGuard::enter(gen_frame);
+    let walk_result = run_sub_jitcode_walk_from(
+        ctx,
+        op.pc,
+        resume_marker,
+        &body,
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &extra_ref_seeds,
+    );
+
+    ctx.fbw_mode = saved_fbw_mode;
+    ctx.descr_refs = saved_descr_refs;
+    ctx.raw_descrs = saved_raw_descrs;
+    ctx.sub_jitcode_lookup = saved_lookup;
+
+    let walk_result = match walk_result {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!(
+                    "[gen-resume] walk err pc={} resume_marker={} yield_marker={} err={error:?}",
+                    op.pc, resume_marker, yield_marker,
+                );
+            }
+            if fbw_executed_effect_count() != executed_effects_before {
+                return Err(error);
+            }
+            ctx.trace_ctx.cut_trace_with_snapshots(pre_emit_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            return Ok(None);
+        }
+    };
+    let DispatchOutcome::SubReturn { result: Some(item) } = walk_result else {
+        if fbw_debug_abort_enabled() {
+            eprintln!(
+                "[gen-resume] walk outcome pc={} resume_marker={} yield_marker={} outcome={walk_result:?}",
+                op.pc, resume_marker, yield_marker,
+            );
+        }
+        if fbw_executed_effect_count() != executed_effects_before {
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
+        }
+        ctx.trace_ctx.cut_trace_with_snapshots(pre_emit_pos);
+        ctx.trace_ctx.heap_cache_mut().reset();
+        return Ok(None);
+    };
+    let Some(concrete_item) = walker_concrete_ref_object(ctx, item) else {
+        if fbw_executed_effect_count() != executed_effects_before {
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
+        }
+        ctx.trace_ctx.cut_trace_with_snapshots(pre_emit_pos);
+        ctx.trace_ctx.heap_cache_mut().reset();
+        return Ok(None);
+    };
+    write_ref_reg(ctx, op.pc, dst, item, ConcreteValue::Ref(concrete_item))?;
+    fbw_foriter_inflight_capture(concrete_item, body_coord);
+    ctx.vstack_last_ref = item;
+    let _ = code_root;
+    Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
 
 /// Forward dunder selected by `try_dispatch_binary_special` for a non-inplace
@@ -11991,6 +12294,39 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
     ref_arg_concretes: &[ConcreteValue],
     float_args: &[OpRef],
 ) -> Result<DispatchOutcome, DispatchError> {
+    run_sub_jitcode_walk_from(
+        ctx,
+        pc,
+        0,
+        sub_body,
+        int_args,
+        int_arg_concretes,
+        ref_args,
+        ref_arg_concretes,
+        float_args,
+        &[],
+    )
+}
+
+/// Same as [`run_sub_jitcode_walk`], but enter the callee body at
+/// `start_pc` and seed extra Ref-bank registers after the call args.
+///
+/// A generator resume starts at `resume_execute_frame` (`last_instr + 1`),
+/// not at function entry, and needs the portal frame / ec colors plus the
+/// live locals the resume block reads.  `extra_ref_seeds` is `(reg, box,
+/// concrete)` — later entries overwrite earlier ones at the same color.
+pub(crate) fn run_sub_jitcode_walk_from<'frame, 'a: 'frame, Sym: WalkSym>(
+    ctx: &mut WalkContext<'frame, 'a, Sym>,
+    pc: usize,
+    start_pc: usize,
+    sub_body: &SubJitCodeBody,
+    int_args: &[OpRef],
+    int_arg_concretes: &[ConcreteValue],
+    ref_args: &[OpRef],
+    ref_arg_concretes: &[ConcreteValue],
+    float_args: &[OpRef],
+    extra_ref_seeds: &[(usize, OpRef, ConcreteValue)],
+) -> Result<DispatchOutcome, DispatchError> {
     // A parent frame re-enters its inline_call opcode after the explicit
     // driver popped the callee. Consume that result before allocating or
     // reseeding anything, exactly as PyPy's `_interpret` delivers the value to
@@ -12085,6 +12421,21 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
             );
         }
     }
+    for &(reg, opref, concrete) in extra_ref_seeds {
+        if reg >= callee_regs_r.len() {
+            continue;
+        }
+        callee_regs_r[reg] = opref;
+        callee_concrete_r[reg] = concrete;
+        if let ConcreteValue::Ref(value) = concrete
+            && !value.is_null()
+        {
+            ctx.trace_ctx.try_set_opref_concrete(
+                opref,
+                majit_ir::Value::Ref(majit_ir::GcRef(value as usize)),
+            );
+        }
+    }
 
     let frame_id = if driver_pointer.is_null() {
         0
@@ -12099,9 +12450,9 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         box_replacements: FrameBoxReplacements::new(ctx.session),
         id: frame_id,
         caller_pc: pc,
-        pc: 0,
+        pc: start_pc,
         body: sub_body.clone(),
-        seed_from_active_resume: true,
+        seed_from_active_resume: start_pc == 0,
         registers_r: callee_regs_r,
         registers_i: callee_regs_i,
         registers_f: callee_regs_f,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1666,6 +1666,10 @@ pub struct GeneratorResumeSubwalk {
     /// resumed from again after this yield.  Durable, so every walk-time write
     /// to it is journalled (`fbw_arm_durable_frame_undo`).
     pub frame: usize,
+    /// The OpRef that names that frame in the trace — a `GetfieldGc` off the
+    /// generator, not a baked address — so suspension stores land on the
+    /// same box the compiled loop re-reads.
+    pub frame_box: OpRef,
     /// JitCode offset of the `abort_permanent` the body's `yield` lowered to.
     /// Exact rather than "any `abort_permanent`": a body can carry markers for
     /// unported opcodes too, and those still abort.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -7178,7 +7178,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // instance, so neither route above sees it and the residual advances
         // it by calling back into the interpreter.
         if let Some(resumed) = spec_gate(SpecFold::GeneratorNext, || {
-            try_walker_specialize_generator_next(ctx, op, &r_args, dst_bank)
+            try_walker_specialize_generator_next(ctx, op, &r_args, dst, dst_bank)
         })? {
             return Ok(resumed);
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1677,6 +1677,12 @@ pub(crate) fn sub_jitcode_body_for_code(
         return None;
     }
     let pjc = pyjitcode_for_code(code)?;
+    sub_jitcode_body_from_payload(&pjc)
+}
+
+fn sub_jitcode_body_from_payload(
+    pjc: &crate::PyJitCode,
+) -> Option<crate::jitcode_dispatch::SubJitCodeBody> {
     let jc = &pjc.jitcode;
     // SAFETY: the payload lives for the program in the append-only jitcodes
     // store (a second Arc keeps the allocation alive after this local clone
@@ -1744,12 +1750,16 @@ pub(crate) type SubDescrPool = (
 /// refinements, not per trace attempt). `'static` coerces to the walker's
 /// `'static_a`.
 pub(crate) fn sub_jitcode_descr_pool_for_code(code: *const ()) -> Option<SubDescrPool> {
-    use majit_metainterp::jitcode::RuntimeBhDescr;
     if code.is_null() || jitcode_for(code).is_null() {
         return None;
     }
     let pjc = pyjitcode_for_code(code)?;
-    Some(*pjc.sub_descr_pool.get_or_init(|| {
+    Some(sub_descr_pool_for_payload(&pjc))
+}
+
+fn sub_descr_pool_for_payload(pjc: &crate::PyJitCode) -> SubDescrPool {
+    use majit_metainterp::jitcode::RuntimeBhDescr;
+    *pjc.sub_descr_pool.get_or_init(|| {
         // SAFETY: the borrow is valid for `'static` because the payload is
         // retained for the program lifetime by the append-only
         // `MetaInterpStaticData.jitcodes` store, and `exec.descrs` is
@@ -1790,7 +1800,7 @@ pub(crate) fn sub_jitcode_descr_pool_for_code(code: *const ()) -> Option<SubDesc
         });
         let lookup: &'static crate::jitcode_dispatch::SubJitCodeLookup = Box::leak(lookup);
         (descr_refs, perfn_descrs, lookup)
-    }))
+    })
 }
 
 /// `resume.py` `consume_one_section` → `enumerate_vars` parity:


### PR DESCRIPTION
## Summary

Two pieces on top of current `main`.

### 1. Multithreaded `os.fork` child no longer hangs on parking_lot tables

`ThreadJoinOnShutdown.test_3_join_in_forked_from_thread` timed out on ubuntu because the child never marked the pre-fork main handle done. After a multithreaded `fork()`, process-global `parking_lot` mutexes still name the parent's waiter table; `.lock()` hangs on Linux futexes, so `after_fork_child` never walks `ACTIVE_HANDLES`.

This rebuilds those tables the way `rpy_init_mutexes` / `RPyThreadLockInit` do: `ForkMutex` (`UnsafeCell` write, no lock) from the `pthread_atfork` child arm, before any child code takes them. `FORK_SERIALIZER` stays an OS mutex held across the fork (`fork_under_stw` / `GcSync::quiesce` discipline). `_get_main_thread_ident` reads `MAIN_THREAD_IDENT`. Stripe locks and cpyext reinits run before the child touches Python objects.

`pyre/extra_tests/snippets/thread_join_after_fork_from_thread.py` is the reduced path (gate=1). It passed on macOS and on the Linux container.

### 2. Restore the raised pypy ceilings; lengthen the loops

The earlier census commit widened several `max-pypy-ratio` headers to absorb `?` band noise. Those numbers go back. Fixtures whose pypy exec sat under `FLOOR_GATE_MIN_BASELINE_S` (Windows ~0.16s) are lengthened so the denominator is a measurement. `generator_tree_recursion` jitstats follow the longer run.

`foriter_exempt_nested_foriter` stays at N=20000 / ceiling 20. Lengthening it reveals a ~100x residual: single-yield generator resume is not yet walked into the caller's trace (PyPy looks inside `send_ex` → `execute_frame` with that frame as the virtualizable). That is follow-up, not a ceiling change.

## Test plan

- [x] `thread_join_after_fork_from_thread` on macOS dynasm
- [x] same extra_test in `pyre-linux-7` (placeholder-JIT binary; interpreter fork path)
- [x] local pypy-ratio spot checks on the lengthened fixtures
- [ ] ubuntu `test.test_threading` / full `pyre/check.py` on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved JIT support for generator resumption, suspension, and execution.
  - Improved WebAssembly JIT handling for optimized calls and frame cleanup.

- **Bug Fixes**
  - Improved thread-state recovery and synchronization after process forks.
  - Fixed handling of pre-fork thread joins from forked child processes.
  - Improved recovery from interrupted or previously failed fork synchronization locks.

- **Tests**
  - Added coverage for thread joining after forking.

- **Performance**
  - Updated benchmark workloads, timing guidance, and measurement data for more consistent cross-platform results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->