### PR TITLE
jit: look_inside_iff for virtual dicts and fold opaque pointer retypes

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10832,9 +10832,12 @@ impl CraneliftBackend {
                 let kept: Vec<usize> = (0..arity)
                     .filter(|&i| loop_phi_keep.is_none_or(|keep| keep[i]))
                     .collect();
-                let vals = if kept.len() <= FROZEN_LABEL_PARAM_ARITY {
+                let vals = if kept.iter().all(|&i| i < FROZEN_LABEL_PARAM_ARITY) {
                     // Wide entry: JUMP values arrived as Tail params
-                    // (`llgraph execute_jump` / wasm label-param entry).
+                    // indexed by original JUMP slot, the same freeze as
+                    // wasm `FROZEN_LABEL_PARAM_ARITY`.  `kept.len()` is
+                    // not the bound — a kept original index can be >= 16
+                    // after demotion of earlier slots.
                     let wide = builder.block_params(loader);
                     kept.iter().map(|&i| wide[i]).collect()
                 } else {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3420,6 +3420,13 @@ fn emit_call_footer_shadowstack(
 /// it, so they keep the full `_call_header_with_stack_check` prologue.
 const IN_CODE_ENTRY_KEY_FLAG: i32 = 1 << 30;
 
+/// Words a label-parameter entry accepts after `(jf_ptr, dispatch_key)`.
+/// Same freeze as wasm `FROZEN_LABEL_PARAM_ARITY`: one Tail signature
+/// must cover every LABEL arity so `return_call_indirect` type-checks
+/// across loops.  `llgraph execute_jump(*args)` / wasm wide entry
+/// carry JUMP values as parameters instead of a jitframe round-trip.
+const FROZEN_LABEL_PARAM_ARITY: usize = 16;
+
 /// `x86/assembler.py:182-184 _build_frame_realloc_slowpath` parity:
 /// `_load_shadowstack_top_in_ebx(mc, gcrootmap)` followed by
 /// `MOV_mr((ebx.value, -WORD), eax.value)`.
@@ -7100,6 +7107,28 @@ fn emit_attached_bridge_dispatch(
     builder.seal_block(miss_block);
 }
 
+/// Tail signature of a compiled loop body: `(jf_ptr, dispatch_key, v0..vK)`.
+fn body_tail_signature(ptr_type: cranelift_codegen::ir::Type) -> Signature {
+    let mut sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
+    sig.params.push(AbiParam::new(ptr_type));
+    sig.params.push(AbiParam::new(cl_types::I32));
+    for _ in 0..FROZEN_LABEL_PARAM_ARITY {
+        sig.params.push(AbiParam::new(cl_types::I64));
+    }
+    sig.returns.push(AbiParam::new(ptr_type));
+    sig
+}
+
+/// Pad JUMP SSA values to [`FROZEN_LABEL_PARAM_ARITY`] with zero.
+fn pad_wide_args(builder: &mut FunctionBuilder, vals: &[CValue]) -> Vec<CValue> {
+    let zero = builder.ins().iconst(cl_types::I64, 0);
+    let mut out = Vec::with_capacity(FROZEN_LABEL_PARAM_ARITY);
+    for i in 0..FROZEN_LABEL_PARAM_ARITY {
+        out.push(vals.get(i).copied().unwrap_or(zero));
+    }
+    out
+}
+
 /// `assembler.py closing_jump` parity for cranelift.
 ///
 /// PyPy's x86 backend emits a raw `JMP imm(target_token._ll_loop_code)` at
@@ -7126,6 +7155,7 @@ fn emit_attached_loop_dispatch(
     target_frame_depth_addr: usize,
     ptr_type: cranelift_codegen::ir::Type,
     call_conv: cranelift_codegen::isa::CallConv,
+    wide_vals: &[CValue],
 ) {
     // `LoopTargetDescr::set_dispatch_target` (descr.rs)
     // releases `target_frame_depth` and `label_block_id` BEFORE
@@ -7292,10 +7322,7 @@ fn emit_attached_loop_dispatch(
     // hard-code `Tail` here so this matches the body's signature
     // regardless of which call_conv the enclosing emit_guard_exit
     // received for its non-tail helper calls.
-    let mut target_sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
-    target_sig.params.push(AbiParam::new(ptr_type));
-    target_sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key selector
-    target_sig.returns.push(AbiParam::new(ptr_type));
+    let target_sig = body_tail_signature(ptr_type);
     let target_sig_ref = builder.import_signature(target_sig);
     // x86/regalloc.py:1397 per-TargetToken `_ll_loop_code` parity: re-enter the
     // target at the LABEL the JUMP names, not always the first.  The target
@@ -7305,11 +7332,14 @@ fn emit_attached_loop_dispatch(
     let dispatch_key = builder
         .ins()
         .bor_imm_u(label_selector, IN_CODE_ENTRY_KEY_FLAG as i64);
-    builder.ins().return_call_indirect(
-        target_sig_ref,
-        target_code_ptr,
-        &[dispatch_jf_ptr, dispatch_key],
-    );
+    let wide = pad_wide_args(builder, wide_vals);
+    let mut call_args = Vec::with_capacity(2 + FROZEN_LABEL_PARAM_ARITY);
+    call_args.push(dispatch_jf_ptr);
+    call_args.push(dispatch_key);
+    call_args.extend(wide);
+    builder
+        .ins()
+        .return_call_indirect(target_sig_ref, target_code_ptr, &call_args);
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -7563,6 +7593,26 @@ fn emit_guard_exit(
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("MAJIT_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
+            let mut wide_vals = Vec::new();
+            for &arg_ref in &info.fail_arg_refs {
+                if wide_vals.len() == FROZEN_LABEL_PARAM_ARITY {
+                    break;
+                }
+                if arg_ref.is_none() {
+                    wide_vals.push(builder.ins().iconst(cl_types::I64, 0));
+                    continue;
+                }
+                wide_vals.push(resolve_failarg_opref(
+                    builder,
+                    constants,
+                    jf_ptr,
+                    ref_root_slots,
+                    stale_ref_vars,
+                    demoted_failarg_slots,
+                    ref_root_base_ofs,
+                    arg_ref,
+                ));
+            }
             emit_attached_loop_dispatch(
                 builder,
                 jf_ptr,
@@ -7571,6 +7621,7 @@ fn emit_guard_exit(
                 target_frame_depth_addr,
                 ptr_type,
                 call_conv,
+                &wide_vals,
             );
         }
     }
@@ -9719,20 +9770,10 @@ impl CraneliftBackend {
         // an upper bound on a superscalar core and not a measured cost, but it
         // bounds this entry at a few nanoseconds — not somewhere to look for
         // entry overhead.  `MAJIT_DUMP_CLIF` prints it as `[jit][disasm-entry]`.
-        let body_call_conv = cranelift_codegen::isa::CallConv::Tail;
-
-        let mut sig = Signature::new(body_call_conv);
-        sig.params.push(AbiParam::new(ptr_type)); // jf_ptr (read inputs, write outputs)
-        // x86/regalloc.py:1397 per-TargetToken `_ll_loop_code` parity: a JUMP
-        // re-enters the target at a SPECIFIC LABEL, not always the first.
-        // PyPy exposes one code address per LABEL; cranelift has a single
-        // function entry, so the target LABEL is selected by a `dispatch_key`
-        // argument that the entry block `br_table`s on.  The host wrapper
-        // passes 0 for the preamble; an in-code closing-jump passes the target
-        // descr's `label_block_id + 1`.
-        sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key selector
-        // RPython _call_footer (assembler.py:1097): mov eax, ebp; ret
-        sig.returns.push(AbiParam::new(ptr_type)); // returned jf_ptr
+        // `(jf_ptr, dispatch_key, v0..vK)` — wasm wide entry / llgraph
+        // `execute_jump(*args)`: JUMP values ride Tail params so a
+        // closing_jump does not store+load them through jitframe slots.
+        let sig = body_tail_signature(ptr_type);
 
         let body_name = format!("trace_{}_body", self.func_counter);
         let entry_name = format!("trace_{}_entry", self.func_counter);
@@ -10710,14 +10751,25 @@ impl CraneliftBackend {
             let preamble_block = builder.create_block();
             let loaders: Vec<cranelift_codegen::ir::Block> = label_blocks
                 .iter()
-                .map(|_| builder.create_block())
+                .map(|_| {
+                    let b = builder.create_block();
+                    for _ in 0..FROZEN_LABEL_PARAM_ARITY {
+                        builder.append_block_param(b, cl_types::I64);
+                    }
+                    b
+                })
                 .collect();
+            let entry_wide: Vec<CValue> = (0..FROZEN_LABEL_PARAM_ARITY)
+                .map(|i| builder.block_params(entry_block)[2 + i])
+                .collect();
+            let wide_block_args: Vec<BlockArg> =
+                entry_wide.iter().copied().map(BlockArg::from).collect();
             // table = [preamble, loader_0, loader_1, ...]; default = preamble.
             let mut targets: Vec<cranelift_codegen::ir::BlockCall> =
                 Vec::with_capacity(loaders.len() + 1);
             targets.push(builder.func.dfg.block_call(preamble_block, &[]));
             for &b in &loaders {
-                targets.push(builder.func.dfg.block_call(b, &[]));
+                targets.push(builder.func.dfg.block_call(b, &wide_block_args));
             }
             let default_call = builder.func.dfg.block_call(preamble_block, &[]);
             let jt = builder.create_jump_table(cranelift_codegen::ir::JumpTableData::new(
@@ -10777,11 +10829,21 @@ impl CraneliftBackend {
                         demoted_root_syncs.push((v, home_ofs));
                     }
                 }
-                let carried_offsets: Vec<i32> = (0..arity)
+                let kept: Vec<usize> = (0..arity)
                     .filter(|&i| loop_phi_keep.is_none_or(|keep| keep[i]))
-                    .map(|i| JF_FRAME_ITEM0_OFS + (i as i32) * 8)
                     .collect();
-                let vals = load_frame_slot_run(&mut builder, cur_jf, &carried_offsets);
+                let vals = if kept.len() <= FROZEN_LABEL_PARAM_ARITY {
+                    // Wide entry: JUMP values arrived as Tail params
+                    // (`llgraph execute_jump` / wasm label-param entry).
+                    let wide = builder.block_params(loader);
+                    kept.iter().map(|&i| wide[i]).collect()
+                } else {
+                    let carried_offsets: Vec<i32> = kept
+                        .iter()
+                        .map(|&i| JF_FRAME_ITEM0_OFS + (i as i32) * 8)
+                        .collect();
+                    load_frame_slot_run(&mut builder, cur_jf, &carried_offsets)
+                };
                 // Ref-root re-syncs go after every dense carried-slot load:
                 // when `max_output_slots < arity` the ref-root region aliases
                 // the tail of the dense slots, and a store emitted before the
@@ -15964,6 +16026,10 @@ impl CraneliftBackend {
             wb.seal_block(eb);
             let jf_ptr_in = wb.block_params(eb)[0];
             let dispatch_key_in = wb.block_params(eb)[1];
+            // Host shim of the wasm narrow entry: load the dense carried
+            // slots so a LABEL re-entry through `execute_token` still
+            // feeds the body's wide parameters.  In-code dispatch never
+            // enters this wrapper.
             // The body/bridges keep the jitframe base in the pinned register,
             // which `enable_pinned_reg` makes NOT callee-saved in Cranelift.
             // This wrapper is the host(Rust, SystemV/AAPCS — the pinned reg IS
@@ -15981,7 +16047,18 @@ impl CraneliftBackend {
             // external-JUMP host re-entry (including the first LABEL),
             // matching assembler.py:990-993 per-LABEL `_ll_loop_code`: a
             // JUMP branches straight to the target LABEL.
-            let call_inst = wb.ins().call(body_ref, &[jf_ptr_in, dispatch_key_in]);
+            let mut body_args = Vec::with_capacity(2 + FROZEN_LABEL_PARAM_ARITY);
+            body_args.push(jf_ptr_in);
+            body_args.push(dispatch_key_in);
+            for i in 0..FROZEN_LABEL_PARAM_ARITY {
+                body_args.push(wb.ins().load(
+                    cl_types::I64,
+                    MemFlagsData::trusted(),
+                    jf_ptr_in,
+                    JF_FRAME_ITEM0_OFS + (i as i32) * 8,
+                ));
+            }
+            let call_inst = wb.ins().call(body_ref, &body_args);
             let ret = wb.inst_results(call_inst)[0];
             wb.ins().set_pinned_reg(host_pinned);
             wb.ins().return_(&[ret]);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3420,13 +3420,6 @@ fn emit_call_footer_shadowstack(
 /// it, so they keep the full `_call_header_with_stack_check` prologue.
 const IN_CODE_ENTRY_KEY_FLAG: i32 = 1 << 30;
 
-/// Words a label-parameter entry accepts after `(jf_ptr, dispatch_key)`.
-/// Same freeze as wasm `FROZEN_LABEL_PARAM_ARITY`: one Tail signature
-/// must cover every LABEL arity so `return_call_indirect` type-checks
-/// across loops.  `llgraph execute_jump(*args)` / wasm wide entry
-/// carry JUMP values as parameters instead of a jitframe round-trip.
-const FROZEN_LABEL_PARAM_ARITY: usize = 16;
-
 /// `x86/assembler.py:182-184 _build_frame_realloc_slowpath` parity:
 /// `_load_shadowstack_top_in_ebx(mc, gcrootmap)` followed by
 /// `MOV_mr((ebx.value, -WORD), eax.value)`.
@@ -7107,28 +7100,6 @@ fn emit_attached_bridge_dispatch(
     builder.seal_block(miss_block);
 }
 
-/// Tail signature of a compiled loop body: `(jf_ptr, dispatch_key, v0..vK)`.
-fn body_tail_signature(ptr_type: cranelift_codegen::ir::Type) -> Signature {
-    let mut sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
-    sig.params.push(AbiParam::new(ptr_type));
-    sig.params.push(AbiParam::new(cl_types::I32));
-    for _ in 0..FROZEN_LABEL_PARAM_ARITY {
-        sig.params.push(AbiParam::new(cl_types::I64));
-    }
-    sig.returns.push(AbiParam::new(ptr_type));
-    sig
-}
-
-/// Pad JUMP SSA values to [`FROZEN_LABEL_PARAM_ARITY`] with zero.
-fn pad_wide_args(builder: &mut FunctionBuilder, vals: &[CValue]) -> Vec<CValue> {
-    let zero = builder.ins().iconst(cl_types::I64, 0);
-    let mut out = Vec::with_capacity(FROZEN_LABEL_PARAM_ARITY);
-    for i in 0..FROZEN_LABEL_PARAM_ARITY {
-        out.push(vals.get(i).copied().unwrap_or(zero));
-    }
-    out
-}
-
 /// `assembler.py closing_jump` parity for cranelift.
 ///
 /// PyPy's x86 backend emits a raw `JMP imm(target_token._ll_loop_code)` at
@@ -7155,7 +7126,6 @@ fn emit_attached_loop_dispatch(
     target_frame_depth_addr: usize,
     ptr_type: cranelift_codegen::ir::Type,
     call_conv: cranelift_codegen::isa::CallConv,
-    wide_vals: &[CValue],
 ) {
     // `LoopTargetDescr::set_dispatch_target` (descr.rs)
     // releases `target_frame_depth` and `label_block_id` BEFORE
@@ -7322,7 +7292,10 @@ fn emit_attached_loop_dispatch(
     // hard-code `Tail` here so this matches the body's signature
     // regardless of which call_conv the enclosing emit_guard_exit
     // received for its non-tail helper calls.
-    let target_sig = body_tail_signature(ptr_type);
+    let mut target_sig = Signature::new(cranelift_codegen::isa::CallConv::Tail);
+    target_sig.params.push(AbiParam::new(ptr_type));
+    target_sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key selector
+    target_sig.returns.push(AbiParam::new(ptr_type));
     let target_sig_ref = builder.import_signature(target_sig);
     // x86/regalloc.py:1397 per-TargetToken `_ll_loop_code` parity: re-enter the
     // target at the LABEL the JUMP names, not always the first.  The target
@@ -7332,14 +7305,11 @@ fn emit_attached_loop_dispatch(
     let dispatch_key = builder
         .ins()
         .bor_imm_u(label_selector, IN_CODE_ENTRY_KEY_FLAG as i64);
-    let wide = pad_wide_args(builder, wide_vals);
-    let mut call_args = Vec::with_capacity(2 + FROZEN_LABEL_PARAM_ARITY);
-    call_args.push(dispatch_jf_ptr);
-    call_args.push(dispatch_key);
-    call_args.extend(wide);
-    builder
-        .ins()
-        .return_call_indirect(target_sig_ref, target_code_ptr, &call_args);
+    builder.ins().return_call_indirect(
+        target_sig_ref,
+        target_code_ptr,
+        &[dispatch_jf_ptr, dispatch_key],
+    );
 
     builder.switch_to_block(miss_block);
     builder.seal_block(miss_block);
@@ -7593,26 +7563,6 @@ fn emit_guard_exit(
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
             && std::env::var_os("MAJIT_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
-            let mut wide_vals = Vec::new();
-            for &arg_ref in &info.fail_arg_refs {
-                if wide_vals.len() == FROZEN_LABEL_PARAM_ARITY {
-                    break;
-                }
-                if arg_ref.is_none() {
-                    wide_vals.push(builder.ins().iconst(cl_types::I64, 0));
-                    continue;
-                }
-                wide_vals.push(resolve_failarg_opref(
-                    builder,
-                    constants,
-                    jf_ptr,
-                    ref_root_slots,
-                    stale_ref_vars,
-                    demoted_failarg_slots,
-                    ref_root_base_ofs,
-                    arg_ref,
-                ));
-            }
             emit_attached_loop_dispatch(
                 builder,
                 jf_ptr,
@@ -7621,7 +7571,6 @@ fn emit_guard_exit(
                 target_frame_depth_addr,
                 ptr_type,
                 call_conv,
-                &wide_vals,
             );
         }
     }
@@ -9770,10 +9719,20 @@ impl CraneliftBackend {
         // an upper bound on a superscalar core and not a measured cost, but it
         // bounds this entry at a few nanoseconds — not somewhere to look for
         // entry overhead.  `MAJIT_DUMP_CLIF` prints it as `[jit][disasm-entry]`.
-        // `(jf_ptr, dispatch_key, v0..vK)` — wasm wide entry / llgraph
-        // `execute_jump(*args)`: JUMP values ride Tail params so a
-        // closing_jump does not store+load them through jitframe slots.
-        let sig = body_tail_signature(ptr_type);
+        let body_call_conv = cranelift_codegen::isa::CallConv::Tail;
+
+        let mut sig = Signature::new(body_call_conv);
+        sig.params.push(AbiParam::new(ptr_type)); // jf_ptr (read inputs, write outputs)
+        // x86/regalloc.py `_ll_loop_code` parity: a JUMP
+        // re-enters the target at a SPECIFIC LABEL, not always the first.
+        // PyPy exposes one code address per LABEL; cranelift has a single
+        // function entry, so the target LABEL is selected by a `dispatch_key`
+        // argument that the entry block `br_table`s on.  The host wrapper
+        // passes 0 for the preamble; an in-code closing-jump passes the target
+        // descr's `label_block_id + 1`.
+        sig.params.push(AbiParam::new(cl_types::I32)); // dispatch_key selector
+        // RPython `_call_footer`: mov eax, ebp; ret
+        sig.returns.push(AbiParam::new(ptr_type)); // returned jf_ptr
 
         let body_name = format!("trace_{}_body", self.func_counter);
         let entry_name = format!("trace_{}_entry", self.func_counter);
@@ -10751,25 +10710,14 @@ impl CraneliftBackend {
             let preamble_block = builder.create_block();
             let loaders: Vec<cranelift_codegen::ir::Block> = label_blocks
                 .iter()
-                .map(|_| {
-                    let b = builder.create_block();
-                    for _ in 0..FROZEN_LABEL_PARAM_ARITY {
-                        builder.append_block_param(b, cl_types::I64);
-                    }
-                    b
-                })
+                .map(|_| builder.create_block())
                 .collect();
-            let entry_wide: Vec<CValue> = (0..FROZEN_LABEL_PARAM_ARITY)
-                .map(|i| builder.block_params(entry_block)[2 + i])
-                .collect();
-            let wide_block_args: Vec<BlockArg> =
-                entry_wide.iter().copied().map(BlockArg::from).collect();
             // table = [preamble, loader_0, loader_1, ...]; default = preamble.
             let mut targets: Vec<cranelift_codegen::ir::BlockCall> =
                 Vec::with_capacity(loaders.len() + 1);
             targets.push(builder.func.dfg.block_call(preamble_block, &[]));
             for &b in &loaders {
-                targets.push(builder.func.dfg.block_call(b, &wide_block_args));
+                targets.push(builder.func.dfg.block_call(b, &[]));
             }
             let default_call = builder.func.dfg.block_call(preamble_block, &[]);
             let jt = builder.create_jump_table(cranelift_codegen::ir::JumpTableData::new(
@@ -10829,24 +10777,11 @@ impl CraneliftBackend {
                         demoted_root_syncs.push((v, home_ofs));
                     }
                 }
-                let kept: Vec<usize> = (0..arity)
+                let carried_offsets: Vec<i32> = (0..arity)
                     .filter(|&i| loop_phi_keep.is_none_or(|keep| keep[i]))
+                    .map(|i| JF_FRAME_ITEM0_OFS + (i as i32) * 8)
                     .collect();
-                let vals = if kept.iter().all(|&i| i < FROZEN_LABEL_PARAM_ARITY) {
-                    // Wide entry: JUMP values arrived as Tail params
-                    // indexed by original JUMP slot, the same freeze as
-                    // wasm `FROZEN_LABEL_PARAM_ARITY`.  `kept.len()` is
-                    // not the bound — a kept original index can be >= 16
-                    // after demotion of earlier slots.
-                    let wide = builder.block_params(loader);
-                    kept.iter().map(|&i| wide[i]).collect()
-                } else {
-                    let carried_offsets: Vec<i32> = kept
-                        .iter()
-                        .map(|&i| JF_FRAME_ITEM0_OFS + (i as i32) * 8)
-                        .collect();
-                    load_frame_slot_run(&mut builder, cur_jf, &carried_offsets)
-                };
+                let vals = load_frame_slot_run(&mut builder, cur_jf, &carried_offsets);
                 // Ref-root re-syncs go after every dense carried-slot load:
                 // when `max_output_slots < arity` the ref-root region aliases
                 // the tail of the dense slots, and a store emitted before the
@@ -16029,10 +15964,6 @@ impl CraneliftBackend {
             wb.seal_block(eb);
             let jf_ptr_in = wb.block_params(eb)[0];
             let dispatch_key_in = wb.block_params(eb)[1];
-            // Host shim of the wasm narrow entry: load the dense carried
-            // slots so a LABEL re-entry through `execute_token` still
-            // feeds the body's wide parameters.  In-code dispatch never
-            // enters this wrapper.
             // The body/bridges keep the jitframe base in the pinned register,
             // which `enable_pinned_reg` makes NOT callee-saved in Cranelift.
             // This wrapper is the host(Rust, SystemV/AAPCS — the pinned reg IS
@@ -16050,18 +15981,7 @@ impl CraneliftBackend {
             // external-JUMP host re-entry (including the first LABEL),
             // matching assembler.py:990-993 per-LABEL `_ll_loop_code`: a
             // JUMP branches straight to the target LABEL.
-            let mut body_args = Vec::with_capacity(2 + FROZEN_LABEL_PARAM_ARITY);
-            body_args.push(jf_ptr_in);
-            body_args.push(dispatch_key_in);
-            for i in 0..FROZEN_LABEL_PARAM_ARITY {
-                body_args.push(wb.ins().load(
-                    cl_types::I64,
-                    MemFlagsData::trusted(),
-                    jf_ptr_in,
-                    JF_FRAME_ITEM0_OFS + (i as i32) * 8,
-                ));
-            }
-            let call_inst = wb.ins().call(body_ref, &body_args);
+            let call_inst = wb.ins().call(body_ref, &[jf_ptr_in, dispatch_key_in]);
             let ret = wb.inst_results(call_inst)[0];
             wb.ins().set_pinned_reg(host_pinned);
             wb.ins().return_(&[ret]);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -9686,9 +9686,9 @@ fn unbound_pool_const_seeds(
         }
     }
     let mut seeds: Vec<(u32, i64)> = Vec::new();
-    let mut unresolved: Vec<u32> = Vec::new();
+    let mut unresolved: Vec<(OpRef, OpCode, bool)> = Vec::new();
     let mut seen: HashSet<u32> = HashSet::new();
-    let mut consider = |a: OpRef, seeds: &mut Vec<(u32, i64)>, seen: &mut HashSet<u32>| {
+    let mut consider = |a: OpRef, opcode: OpCode, failarg: bool, seeds: &mut Vec<(u32, i64)>| {
         if a == OpRef::NONE || a.is_constant() {
             return;
         }
@@ -9698,20 +9698,21 @@ fn unbound_pool_const_seeds(
         }
         match constants.get(&raw) {
             Some(&bits) => seeds.push((raw, bits)),
-            // No producer and no pool entry: the local would read as the zero
-            // wasm initializes it to, which is a wrong value, not a missing
-            // one. Decline the trace (the interpreter runs it correctly,
-            // unaccelerated) exactly as the unhandled-opcode arm does.
-            None => unresolved.push(raw),
+            // No producer and no pool entry: the local would read as the
+            // zero wasm initializes it to, which is a wrong value, not a
+            // missing one. Decline the trace (the interpreter runs it
+            // correctly, unaccelerated) exactly as the unhandled-opcode
+            // arm does.
+            None => unresolved.push((a, opcode, failarg)),
         }
     };
     for op in ops {
         for a in op.getarglist().iter() {
-            consider(a.to_opref(), &mut seeds, &mut seen);
+            consider(a.to_opref(), op.opcode, false, &mut seeds);
         }
         if let Some(fa) = op.getfailargs() {
             for a in fa.iter() {
-                consider(a.to_opref(), &mut seeds, &mut seen);
+                consider(a.to_opref(), op.opcode, true, &mut seeds);
             }
         }
     }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -9717,9 +9717,25 @@ fn unbound_pool_const_seeds(
         }
     }
     if !unresolved.is_empty() {
+        let labels: Vec<Vec<OpRef>> = ops
+            .iter()
+            .filter(|op| op.opcode == OpCode::Label)
+            .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
+            .collect();
+        let sameas: Vec<OpRef> = ops
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op.opcode,
+                    OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF
+                )
+            })
+            .map(|op| op.pos.get())
+            .collect();
+        let in_idx: Vec<u32> = inputargs.iter().map(|ia| ia.index).collect();
         return Err(BackendError::Unsupported(format!(
             "wasm codegen: value{unresolved:?} read with no producing op and no \
-             constant-pool entry"
+             constant-pool entry; inputargs={in_idx:?} labels={labels:?} sameas={sameas:?}"
         )));
     }
     Ok(seeds)

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -588,6 +588,42 @@ pub fn bridge_diag(i: usize) -> u64 {
         .unwrap_or(0)
 }
 
+/// Last `compile_loop` `Err` reason. The guest has no stderr, so the
+/// `BackendError` string otherwise dies inside `catch_unwind` / `?` and the
+/// host only sees `cl_entered` without `cl_ok` / `cl_decl_*`.
+static LAST_COMPILE_ERR: Mutex<String> = Mutex::new(String::new());
+
+fn record_last_compile_err(err: &majit_backend::BackendError) {
+    *LAST_COMPILE_ERR.lock() = err.to_string();
+}
+
+// Snapshot of `last_compile_err` for the host's byte-at-index read.
+// `last_compile_err_len` refreshes it so each byte load does not re-lock
+// and re-clone the live string.
+thread_local! {
+    static LAST_COMPILE_ERR_SNAP: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Host-visible last `compile_loop` decline. Empty when every compile
+/// returned a token.
+pub fn last_compile_err() -> String {
+    LAST_COMPILE_ERR.lock().clone()
+}
+
+/// Refresh the snapshot and return its length.
+pub fn last_compile_err_len() -> u32 {
+    let bytes = last_compile_err().into_bytes();
+    let len = bytes.len() as u32;
+    LAST_COMPILE_ERR_SNAP.with(|snap| *snap.borrow_mut() = bytes);
+    len
+}
+
+/// Byte `i` of the snapshot [`last_compile_err_len`] last built. 0 if
+/// `i` is out of range.
+pub fn last_compile_err_byte(i: u32) -> u32 {
+    LAST_COMPILE_ERR_SNAP.with(|snap| snap.borrow().get(i as usize).copied().unwrap_or(0) as u32)
+}
+
 /// Number of JIT trace entries made from the guest.
 #[cfg(target_arch = "wasm32")]
 pub fn jit_execute_count() -> u64 {
@@ -4014,7 +4050,14 @@ impl majit_backend::Backend for WasmBackend {
                 },
             ),
         };
-        let (wasm_bytes, guard_exits, num_ref_homes) = codegen::build_wasm_module(&module_inputs)?;
+        let (wasm_bytes, guard_exits, num_ref_homes) =
+            match codegen::build_wasm_module(&module_inputs) {
+                Ok(built) => built,
+                Err(err) => {
+                    record_last_compile_err(&err);
+                    return Err(err);
+                }
+            };
 
         // Build fail descriptors
         let fail_descrs: Vec<Arc<WasmFailDescr>> = guard_exits
@@ -5005,7 +5048,14 @@ impl majit_backend::Backend for WasmBackend {
             frame: source_frame,
             ca: ca_params,
         };
-        let (wasm_bytes, guard_exits, _num_ref_homes) = codegen::build_wasm_module(&module_inputs)?;
+        let (wasm_bytes, guard_exits, _num_ref_homes) =
+            match codegen::build_wasm_module(&module_inputs) {
+                Ok(built) => built,
+                Err(err) => {
+                    record_last_compile_err(&err);
+                    return Err(err);
+                }
+            };
 
         // Bridge exit descrs (fail_index already base-offset by build_wasm_module).
         let bridge_descrs: Vec<Arc<WasmFailDescr>> = guard_exits

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -47,6 +47,23 @@ fn mk_op_descr(opcode: OpCode, args: &[Operand], descr: DescrRef) -> Op {
 /// numbering is untouched. Returns the rewritten ops and the
 /// `gcrefs_output_list` (rewrite.py:352) the caller turns into the
 /// per-loop table.
+/// rewrite.py `remove_constptr` sees the Const box after
+/// `get_box_replacement`. A folded InputArg/Op still carries
+/// `Forwarded::Const`; `const_value()` on the operand itself is
+/// then `None`, so follow the replacement before deciding the arg
+/// is not a ref constant.
+fn const_ref_operand(arg: &Operand) -> Option<(Operand, GcRef)> {
+    let replaced = if arg.const_value().is_some() {
+        arg.clone()
+    } else {
+        arg.get_box_replacement(false)
+    };
+    match replaced.const_value() {
+        Some(Value::Ref(gcref)) => Some((replaced, gcref)),
+        _ => None,
+    }
+}
+
 pub fn remove_ref_constants(ops: &[Op], mut next_pos: u32) -> (Vec<Op>, Vec<GcRef>) {
     // rewrite.py:352-354 `gcrefs_output_list` / `gcrefs_map` /
     // `gcrefs_recently_loaded`.
@@ -54,6 +71,33 @@ pub fn remove_ref_constants(ops: &[Op], mut next_pos: u32) -> (Vec<Op>, Vec<GcRe
     let mut gcrefs_map: IndexMap<usize, u32> = IndexMap::default();
     let mut recently_loaded: IndexMap<u32, Operand> = IndexMap::default();
     let mut out: Vec<Op> = Vec::with_capacity(ops.len());
+
+    let mut intern = |gcref: GcRef,
+                      recently_loaded: &mut IndexMap<u32, Operand>,
+                      out: &mut Vec<Op>,
+                      next_pos: &mut u32|
+     -> Operand {
+        let index = *gcrefs_map.entry(gcref.0).or_insert_with(|| {
+            let index = gcrefs.len() as u32;
+            gcrefs.push(gcref);
+            index
+        });
+        match recently_loaded.get(&index) {
+            Some(load) => load.clone(),
+            None => {
+                let load_op = std::rc::Rc::new(mk_op(
+                    OpCode::LoadFromGcTable,
+                    &[Operand::const_from_value(Value::Int(index as i64))],
+                ));
+                load_op.pos.set(OpRef::ref_op(*next_pos));
+                *next_pos += 1;
+                out.push((*load_op).clone());
+                let load = Operand::from_bound_op(&load_op);
+                recently_loaded.insert(index, load.clone());
+                load
+            }
+        }
+    };
 
     for op in ops {
         // rewrite.py:1005 — the per-basic-block CSE cache is dropped at
@@ -67,36 +111,39 @@ pub fn remove_ref_constants(ops: &[Op], mut next_pos: u32) -> (Vec<Op>, Vec<GcRe
         // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
         if op.opcode != OpCode::JitDebug {
             for i in 0..op.num_args() {
-                // rewrite.py `bool(arg.value)` — null stays inline.
-                let Some(Value::Ref(gcref)) = op.arg(i).const_value() else {
+                // rewrite.py `bool(arg.value)` — null stays inline as a
+                // ConstPtr so `to_opref` is not a dead InputArgRef index.
+                let Some((replaced, gcref)) = const_ref_operand(&op.arg(i)) else {
                     continue;
                 };
                 if gcref.is_null() {
+                    if !op.arg(i).is_constant() {
+                        op.setarg(i, replaced);
+                    }
                     continue;
                 }
-                // rewrite.py `_gcref_index`.
-                let index = *gcrefs_map.entry(gcref.0).or_insert_with(|| {
-                    let index = gcrefs.len() as u32;
-                    gcrefs.push(gcref);
-                    index
-                });
-                // rewrite.py `remove_constptr`.
-                let load = match recently_loaded.get(&index) {
-                    Some(load) => load.clone(),
-                    None => {
-                        let load_op = std::rc::Rc::new(mk_op(
-                            OpCode::LoadFromGcTable,
-                            &[Operand::const_from_value(Value::Int(index as i64))],
-                        ));
-                        load_op.pos.set(OpRef::ref_op(next_pos));
-                        next_pos += 1;
-                        out.push((*load_op).clone());
-                        let load = Operand::from_bound_op(&load_op);
-                        recently_loaded.insert(index, load.clone());
-                        load
-                    }
-                };
+                let load = intern(gcref, &mut recently_loaded, &mut out, &mut next_pos);
                 op.setarg(i, load);
+            }
+            if let Some(mut fail_args) = op.getfailargs() {
+                let mut changed = false;
+                for arg in fail_args.iter_mut() {
+                    let Some((replaced, gcref)) = const_ref_operand(arg) else {
+                        continue;
+                    };
+                    if gcref.is_null() {
+                        if !arg.is_constant() {
+                            *arg = replaced;
+                            changed = true;
+                        }
+                        continue;
+                    }
+                    *arg = intern(gcref, &mut recently_loaded, &mut out, &mut next_pos);
+                    changed = true;
+                }
+                if changed {
+                    op.setfailargs(fail_args);
+                }
             }
         }
         out.push(op);
@@ -3494,7 +3541,23 @@ mod tests {
     use std::sync::Arc;
 
     use majit_ir::descr::{ArrayDescr, Descr, DescrRef, SizeDescr};
-    use majit_ir::value::Type;
+    use majit_ir::value::{InputArg, Type};
+
+    #[test]
+    fn remove_ref_constants_interns_forwarded_inputarg_on_label() {
+        // Compact remap leaves a virtual InputArg at a dead index whose
+        // `_forwarded` is Const(Ref). `to_opref` still spells InputArgRef(99);
+        // rewrite.py `remove_constptr` sees the Const after get_box_replacement.
+        let ia = InputArg::new_ref_rc(99);
+        let operand = Operand::from_bound_inputarg(&ia);
+        operand.set_forwarded_const(Const::Ref(GcRef(0x1000)));
+        let label = Op::new(OpCode::Label, &[operand]);
+        let (out, gcrefs) = remove_ref_constants(&[label], 0);
+        assert_eq!(gcrefs, vec![GcRef(0x1000)]);
+        assert_eq!(out[0].opcode, OpCode::LoadFromGcTable);
+        assert_eq!(out[1].opcode, OpCode::Label);
+        assert_eq!(out[1].arg(0).to_opref(), OpRef::ref_op(0));
+    }
 
     impl GcRewriterImpl {
         fn rewrite_ops(&self, ops: &[Op]) -> Vec<OpRc> {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -2547,6 +2547,7 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
     let sig = &func.sig;
     let block = &func.block;
     let fn_name = &sig.ident;
+    let unsafety = &sig.unsafety;
     // rlib/jit.py — func = unroll_safe(func)
     let orig_name = format_ident!("_orig_{}", fn_name);
     // rlib/jit.py — trampoline.__name__ = func.__name__ + "_trampoline"
@@ -2573,27 +2574,40 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    // rlib/jit.py — func = unroll_safe(func); trampoline = dont_look_inside.
+    // `front/llbc_hints` harvests these sibling / body-local markers the
+    // same way `#[unroll_safe]` / `#[dont_look_inside]` do.
+    let orig_unroll_marker = format_ident!("_jit_unroll_safe_{}", orig_name);
+    let trampoline_opaque_marker = format_ident!("_jit_look_inside_{}", trampoline_name);
+
     let expanded = quote! {
         // rlib/jit.py — func = unroll_safe(func)
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
-        fn #orig_name(#(#full_params),*) #output {
+        #unsafety fn #orig_name(#(#full_params),*) #output {
             #[doc(hidden)]
-            #[allow(dead_code)]
-            const _MAJIT_UNROLL_SAFE: bool = true;
+            #[allow(non_upper_case_globals, dead_code)]
+            const #orig_unroll_marker: bool = true;
             #block
         }
 
-        // rlib/jit.py — @dont_look_inside def trampoline(...): return func(...)
-        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
-        fn #trampoline_name(#(#full_params),*) #output {
+        const #orig_unroll_marker: bool = true;
+
+        // rlib/jit.py — @dont_look_inside def trampoline(...): return func(...)
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        #unsafety fn #trampoline_name(#(#full_params),*) #output {
             #[doc(hidden)]
-            #[allow(dead_code)]
-            const _MAJIT_OPAQUE: bool = true;
+            #[allow(non_upper_case_globals, dead_code)]
+            const #trampoline_opaque_marker: bool = false;
             #orig_name(#(#call_args),*)
         }
+
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        const #trampoline_opaque_marker: bool = false;
 
         // rlib/jit.py:240-244 — the decorated name becomes the dispatch wrapper
         // def f(*args):
@@ -2602,8 +2616,8 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
         //     else:
         //         return trampoline(*args)
         #(#attrs)*
-        #vis fn #fn_name(#(#full_params),*) #output {
-            if !majit_metainterp::jit::we_are_jitted() || #predicate_path(#(#call_args),*) {
+        #vis #unsafety fn #fn_name(#(#full_params),*) #output {
+            if !majit_rlib::jit::we_are_jitted() || #predicate_path(#(#call_args),*) {
                 #orig_name(#(#call_args),*)
             } else {
                 #trampoline_name(#(#call_args),*)

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -10436,6 +10436,14 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
             "cast_ptr_to_int/r>i",
             majit_translate::insns::BC_CAST_PTR_TO_INT,
         ),
+        (
+            "ref_isconstant/r>i",
+            majit_translate::insns::BC_REF_ISCONSTANT,
+        ),
+        (
+            "ref_isvirtual/r>i",
+            majit_translate::insns::BC_REF_ISVIRTUAL,
+        ),
         ("new/d>r", majit_translate::insns::BC_NEW),
         (
             "new_with_vtable/d>r",

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -10437,6 +10437,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
             majit_translate::insns::BC_CAST_PTR_TO_INT,
         ),
         (
+            "int_isconstant/i>i",
+            majit_translate::insns::BC_INT_ISCONSTANT,
+        ),
+        (
             "ref_isconstant/r>i",
             majit_translate::insns::BC_REF_ISCONSTANT,
         ),

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -10067,6 +10067,13 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "residual_call_ir_v/iIRd".to_string(),
         majit_translate::insns::BC_RESIDUAL_CALL_IR_V,
     );
+    // jtransform `_rewrite_op_cond_call` now emits this key for
+    // interpreter-facing `jit.conditional_call`. `wire_bhimpl_handlers`
+    // already binds `handler_conditional_call_ir_v`.
+    insns.insert(
+        "conditional_call_ir_v/iiIRd".to_string(),
+        majit_translate::insns::BC_CONDITIONAL_CALL_IR_V,
+    );
     insns.insert(
         "residual_call_ir_i/iIRd>i".to_string(),
         majit_translate::insns::BC_RESIDUAL_CALL_IR_I,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -77,6 +77,32 @@ fn is_trace_runtime_ref(opref: OpRef, constants: &majit_ir::ConstMap<majit_ir::V
     !opref.is_none() && !is_trace_constant_ref(opref, constants)
 }
 
+/// A body use-before-def whose `_forwarded` terminal is a non-null
+/// ConstPtr is not a loop-carried runtime box. rewrite.py `used_boxes`
+/// / `remove_constptr` drop Const; the flat OpRef model remints it as
+/// an InputArg at a dead index, so assemble emits a SameAs of the
+/// Const before the Label (defining that index) instead of appending
+/// it to the header. Int/Float consts stay live-in: GuardTrue/False
+/// postprocess may install those after emit, and baking them as the
+/// first-iteration value is a 0-fill.
+fn const_ref_replacement(ctx: &OptContext, opref: OpRef) -> Option<Operand> {
+    let as_const_ref = |term: Operand| match term.const_value() {
+        Some(Value::Ref(gcref)) if !gcref.is_null() => Some(term),
+        _ => None,
+    };
+    if let Some(term) = as_const_ref(ctx.get_box_replacement_operand(opref)) {
+        return Some(term);
+    }
+    // Compact remap keeps the InputArg variant when it repositions a
+    // folded Ref producer (`with_raw`). The Const lives on the ResOp
+    // at the same raw; `find_producer_op` is variant-aware and misses
+    // the InputArgRef use.
+    if matches!(opref, OpRef::InputArgRef(_)) {
+        return as_const_ref(ctx.get_box_replacement_operand(OpRef::ref_op(opref.raw())));
+    }
+    None
+}
+
 fn callee_rca_virtual_state_summary(
     vs: &crate::optimizeopt::virtualstate::VirtualState,
 ) -> Vec<String> {
@@ -5574,6 +5600,19 @@ fn assemble_peeled_trace_with_jump_args(
                 {
                     continue;
                 }
+                // Folded ConstPtr: define the reminted index in the
+                // preamble rather than carrying it on the header.
+                // `forget_optimization_info` then clears `_forwarded`,
+                // so the backend only sees the SameAs + Const.
+                if let Some(const_op) = const_ref_replacement(ctx, arg) {
+                    let tp = const_op.type_();
+                    if tp != Type::Void {
+                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[const_op]);
+                        same_as.pos.set(arg);
+                        fallthrough_aliases.push(same_as);
+                    }
+                    continue;
+                }
                 // RPython Box identity parity: Phase 2 may forward a
                 // preamble-defined Box to a fresh body-visible Box. The
                 // Label carries the forwarded Box, but first fall-through
@@ -5610,6 +5649,44 @@ fn assemble_peeled_trace_with_jump_args(
             }
             if op.result_type() != Type::Void && !op.pos.get().is_none() {
                 seen_body_defs.insert(op.pos.get());
+            }
+        }
+    }
+
+    for &arg in &full_label_args {
+        if arg.is_none() {
+            continue;
+        }
+        if fallthrough_aliases.iter().any(|op| op.pos.get() == arg) {
+            continue;
+        }
+        if let Some(source) = preamble_defs.iter().copied().find(|&source| {
+            source != arg
+                && !matches!(
+                    source,
+                    OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+                )
+                && (ctx.get_replacement_opref(source) == arg || source.raw() == arg.raw())
+        }) {
+            let tp = ctx
+                .opref_type(arg)
+                .or_else(|| ctx.opref_type(source))
+                .or_else(|| arg.ty())
+                .unwrap_or_else(|| source.ty().unwrap_or(Type::Ref));
+            if tp != Type::Void {
+                let arg_source = ctx.materialize_operand_at(source);
+                let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
+                same_as.pos.set(arg);
+                fallthrough_aliases.push(same_as);
+            }
+            continue;
+        }
+        if let Some(const_op) = const_ref_replacement(ctx, arg) {
+            let tp = const_op.type_();
+            if tp != Type::Void {
+                let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[const_op]);
+                same_as.pos.set(arg);
+                fallthrough_aliases.push(same_as);
             }
         }
     }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9912,6 +9912,33 @@ where
                 // ── 5. bind the list header to the destination ref register. ──
                 self.set_ref_reg(dest, Some(sbox_op), Some(struct_ptr));
             }
+            // pyjitpl.py `_opimpl_isconstant` / `opimpl_ref_isconstant`:
+            // `return ConstInt(isinstance(box, Const))`.  No IR op.
+            // Byte layout `[src][dst]` per `bhhandler_r_i!`.
+            jitcode::insns::BC_REF_ISCONSTANT => {
+                let (src, dest) = {
+                    let frame = self.frames.current_mut();
+                    let src = frame.next_reg() as usize;
+                    let dest = frame.next_reg() as usize;
+                    (src, dest)
+                };
+                let (opref, _) = self.read_ref_reg(src);
+                let value = opref.is_constant() as i64;
+                self.set_int_reg(dest, Some(ctx.const_int(value)), Some(value));
+            }
+            // pyjitpl.py `_opimpl_isvirtual` / `opimpl_ref_isvirtual`:
+            // `return ConstInt(heapcache.is_likely_virtual(box))`.  No IR op.
+            jitcode::insns::BC_REF_ISVIRTUAL => {
+                let (src, dest) = {
+                    let frame = self.frames.current_mut();
+                    let src = frame.next_reg() as usize;
+                    let dest = frame.next_reg() as usize;
+                    (src, dest)
+                };
+                let (opref, _) = self.read_ref_reg(src);
+                let value = ctx.is_likely_virtual(opref) as i64;
+                self.set_int_reg(dest, Some(ctx.const_int(value)), Some(value));
+            }
             other => panic!("unknown jitcode bytecode {other}"),
         }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9912,6 +9912,20 @@ where
                 // ── 5. bind the list header to the destination ref register. ──
                 self.set_ref_reg(dest, Some(sbox_op), Some(struct_ptr));
             }
+            // pyjitpl.py `_opimpl_isconstant` / `opimpl_int_isconstant`:
+            // `return ConstInt(isinstance(box, Const))`.  No IR op.
+            // Byte layout `[src][dst]` per `bhhandler_i_i!`.
+            jitcode::insns::BC_INT_ISCONSTANT => {
+                let (src, dest) = {
+                    let frame = self.frames.current_mut();
+                    let src = frame.next_reg() as usize;
+                    let dest = frame.next_reg() as usize;
+                    (src, dest)
+                };
+                let (opref, _) = self.read_int_reg(src);
+                let value = opref.is_constant() as i64;
+                self.set_int_reg(dest, Some(ctx.const_int(value)), Some(value));
+            }
             // pyjitpl.py `_opimpl_isconstant` / `opimpl_ref_isconstant`:
             // `return ConstInt(isinstance(box, Const))`.  No IR op.
             // Byte layout `[src][dst]` per `bhhandler_r_i!`.

--- a/majit/majit-rlib/src/jit.rs
+++ b/majit/majit-rlib/src/jit.rs
@@ -1,0 +1,42 @@
+//! `rpython/rlib/jit.py` — the interpreter-facing JIT hint surface.
+//!
+//! `isconstant` / `isvirtual` return false when not tracing.  The translator
+//! rewrites calls marked `oopspec("jit.isvirtual")` / `jit.isconstant` into
+//! the `ref_isvirtual` / `*_isconstant` ops; the bodies here are the
+//! untranslated residual (`rlib/jit.py isconstant` / `isvirtual`).
+//!
+//! `we_are_jitted` is a hook because this crate cannot depend on
+//! `majit-backend`.  `pyre-jit` / the metainterp install
+//! [`majit_backend::we_are_jitted`] at process start.
+
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+static WE_ARE_JITTED: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// `rlib/jit.py we_are_jitted`.
+pub fn we_are_jitted() -> bool {
+    let p = WE_ARE_JITTED.load(Ordering::Relaxed);
+    if p.is_null() {
+        return false;
+    }
+    let f: fn() -> bool = unsafe { std::mem::transmute(p) };
+    f()
+}
+
+/// Install the process-wide `we_are_jitted` reader.  Called once from
+/// `init_jit_hooks`.
+pub fn install_we_are_jitted(f: fn() -> bool) {
+    WE_ARE_JITTED.store(f as *mut (), Ordering::Relaxed);
+}
+
+/// `rlib/jit.py isconstant`.
+#[majit_macros::oopspec("jit.isconstant(value)")]
+pub fn isconstant<T: ?Sized>(_value: &T) -> bool {
+    false
+}
+
+/// `rlib/jit.py isvirtual`.
+#[majit_macros::oopspec("jit.isvirtual(value)")]
+pub fn isvirtual<T: ?Sized>(_value: &T) -> bool {
+    false
+}

--- a/majit/majit-rlib/src/jit.rs
+++ b/majit/majit-rlib/src/jit.rs
@@ -40,3 +40,30 @@ pub fn isconstant<T: ?Sized>(_value: &T) -> bool {
 pub fn isvirtual<T: ?Sized>(_value: &T) -> bool {
     false
 }
+
+/// `rlib/jit.py loop_unrolling_heuristic`.
+///
+/// `isvirtual(lst)` is often lying for a resizable list (it reports the
+/// containing struct, not the whole list), so size must also be constant.
+pub fn loop_unrolling_heuristic<T: ?Sized>(lst: &T, size: usize, cutoff: usize) -> bool {
+    size == 0 || (isconstant(&size) && (isvirtual(lst) || size <= cutoff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_unrolling_heuristic_empty_unrolls() {
+        // `rlib/jit.py loop_unrolling_heuristic`: size == 0 is always true.
+        let lst: &[i32] = &[];
+        assert!(loop_unrolling_heuristic(lst, 0, 2));
+    }
+
+    #[test]
+    fn loop_unrolling_heuristic_needs_constant_size() {
+        // Residual `isconstant` is false, so a non-empty list does not unroll.
+        let lst = &[1, 2];
+        assert!(!loop_unrolling_heuristic(lst, 2, 2));
+    }
+}

--- a/majit/majit-rlib/src/jit.rs
+++ b/majit/majit-rlib/src/jit.rs
@@ -41,6 +41,62 @@ pub fn isvirtual<T: ?Sized>(_value: &T) -> bool {
     false
 }
 
+/// `rlib/jit.py conditional_call` residual body (`if condition: function(*args)`).
+///
+/// Translated graphs rewrite a `oopspec("jit.conditional_call")` call to
+/// `conditional_call_ir_v` (`jtransform.py rewrite_op_jit_conditional_call`).
+/// Upstream is one `*args` function with `_always_inline_ = 'try'`; Rust
+/// spells one arity per residual word-count (`jtransform.py` rejects more
+/// than 4 function arguments).
+#[majit_macros::oopspec("jit.conditional_call")]
+pub fn conditional_call0(condition: bool, function: unsafe fn()) {
+    if condition {
+        unsafe { function() }
+    }
+}
+
+/// [`conditional_call0`] with one function argument.
+#[majit_macros::oopspec("jit.conditional_call")]
+pub fn conditional_call1<A>(condition: bool, function: unsafe fn(A), a: A) {
+    if condition {
+        unsafe { function(a) }
+    }
+}
+
+/// [`conditional_call0`] with two function arguments.
+#[majit_macros::oopspec("jit.conditional_call")]
+pub fn conditional_call2<A, B>(condition: bool, function: unsafe fn(A, B), a: A, b: B) {
+    if condition {
+        unsafe { function(a, b) }
+    }
+}
+
+/// [`conditional_call0`] with three function arguments.
+///
+/// `rlist.py _ll_list_resize_ge` uses this shape:
+/// `conditional_call(cond, _ll_list_resize_hint_really, l, newsize, True)`.
+#[majit_macros::oopspec("jit.conditional_call")]
+pub fn conditional_call3<A, B, C>(condition: bool, function: unsafe fn(A, B, C), a: A, b: B, c: C) {
+    if condition {
+        unsafe { function(a, b, c) }
+    }
+}
+
+/// [`conditional_call0`] with four function arguments.
+#[majit_macros::oopspec("jit.conditional_call")]
+pub fn conditional_call4<A, B, C, D>(
+    condition: bool,
+    function: unsafe fn(A, B, C, D),
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+) {
+    if condition {
+        unsafe { function(a, b, c, d) }
+    }
+}
+
 /// `rlib/jit.py loop_unrolling_heuristic`.
 ///
 /// `isvirtual(lst)` is often lying for a resizable list (it reports the
@@ -65,5 +121,19 @@ mod tests {
         // Residual `isconstant` is false, so a non-empty list does not unroll.
         let lst = &[1, 2];
         assert!(!loop_unrolling_heuristic(lst, 2, 2));
+    }
+
+    #[test]
+    fn conditional_call_runs_when_true() {
+        // Residual `rlib/jit.py conditional_call`: `if condition: function(*args)`.
+        fn mark(flag: &mut bool) {
+            *flag = true;
+        }
+        let mut flag = false;
+        conditional_call1(true, mark, &mut flag);
+        assert!(flag);
+        let mut flag = true;
+        conditional_call1(false, mark, &mut flag);
+        assert!(flag);
     }
 }

--- a/majit/majit-rlib/src/lib.rs
+++ b/majit/majit-rlib/src/lib.rs
@@ -11,6 +11,7 @@
 //! upstream package it came from.
 
 pub mod debug;
+pub mod jit;
 pub mod lltypesystem;
 pub mod rbigint;
 

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -409,6 +409,33 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "majit_rlib.jit.isvirtual",
         majit_metainterp_bool_flag,
     );
+    // `rlib/jit.py conditional_call` returns None. One analyzer covers
+    // every residual arity (`conditional_call0`..`conditional_call4`).
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.conditional_call0",
+        jit_conditional_call,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.conditional_call1",
+        jit_conditional_call,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.conditional_call2",
+        jit_conditional_call,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.conditional_call3",
+        jit_conditional_call,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.conditional_call4",
+        jit_conditional_call,
+    );
     // `rlib/jit.py` — the `hint` ExtRegistryEntry's
     // `compute_result_annotation`, the one place upstream MINTS
     // `access_directly` onto an annotation. Upstream spells the kwargs on a
@@ -1943,6 +1970,16 @@ fn majit_metainterp_bool_flag(
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     Ok(SomeValue::Bool(super::model::SomeBool::new()))
+}
+
+/// `rlib/jit.py ConditionalCallEntry.compute_result_annotation` for
+/// `_jit_conditional_call`: the call is void.
+fn jit_conditional_call(
+    _bk: &Rc<Bookkeeper>,
+    _args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(super::model::s_none())
 }
 
 /// Analyzer for Rust primitive type `From` / `TryFrom` impls

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -394,6 +394,21 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "majit_metainterp.jit.we_are_jitted",
         majit_metainterp_bool_flag,
     );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.we_are_jitted",
+        majit_metainterp_bool_flag,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.isconstant",
+        majit_metainterp_bool_flag,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.jit.isvirtual",
+        majit_metainterp_bool_flag,
+    );
     // `rlib/jit.py` — the `hint` ExtRegistryEntry's
     // `compute_result_annotation`, the one place upstream MINTS
     // `access_directly` onto an annotation. Upstream spells the kwargs on a

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2676,6 +2676,46 @@ impl Assembler {
             // the generic fallback would push zero operand bytes (because
             // `op_variable_refs(LoopHeader)` is empty), misaligning the
             // dispatch cursor.
+            // jtransform.py `_rewrite_op_cond_call` — `conditional_call_ir_v/iiIRd`.
+            // Condition and funcptr are int registers; force_ir always
+            // emits both I and R lists, then the calldescr.
+            OpKind::ConditionalCall {
+                condition,
+                funcptr,
+                descriptor,
+                args_i,
+                args_r,
+                args_f,
+            } => {
+                assert!(
+                    args_f.is_empty(),
+                    "conditional_call does not support float args"
+                );
+                let (reg, kc) = self.lookup_reg_with_kind_var(condition, regallocs);
+                assert_eq!(kc, 'i', "conditional_call condition is an int");
+                state.code.push(reg);
+                argcodes.push(kc);
+                let fnaddr = match callcontrol {
+                    Some(cc) => cc.fnaddr_for_target(funcptr),
+                    None => crate::call::symbolic_fnaddr_for_target(funcptr),
+                };
+                let func_byte = self.emit_const_i(fnaddr, state);
+                state.code.push(func_byte);
+                argcodes.push('i');
+                self.emit_list_of_kind(args_i, RegKind::Int, regallocs, state);
+                argcodes.push('I');
+                self.emit_list_of_kind(args_r, RegKind::Ref, regallocs, state);
+                argcodes.push('R');
+                let calldescr = descriptor.to_bh_calldescr();
+                let descr_idx = self.emit_ready_descr(crate::jitcode::BhDescr::Call { calldescr });
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                let key = format!("conditional_call_ir_v/{argcodes}");
+                let opnum = self.get_opnum(&key);
+                state.code[startposition] = opnum;
+            }
+
             OpKind::LoopHeader { jitdriver_index } => {
                 let reg_byte = self.emit_const_i(*jitdriver_index as i64, state);
                 state.code.push(reg_byte);

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -322,6 +322,13 @@ pub const BC_INT_INVERT: u8 = 141;
 /// byte here `insn_byte` panicked on the key instead.  Takes the next
 /// byte above `BC_RAW_STORE_F` (235).
 pub const BC_INT_IS_ZERO: u8 = 236;
+// `blackhole.py bhimpl_ref_isconstant` / `bhimpl_ref_isvirtual`
+// (`@arguments("r", returns="i")`).  `look_inside_iff` folds
+// `jit.isconstant` / `jit.isvirtual` to these ops
+// (`jtransform.py rewrite_op_direct_call` `jit.isconstant` /
+// `jit.isvirtual`).
+pub const BC_REF_ISCONSTANT: u8 = 237;
+pub const BC_REF_ISVIRTUAL: u8 = 238;
 pub const BC_UINT_RSHIFT: u8 = 142;
 pub const BC_UINT_MUL_HIGH: u8 = 143;
 pub const BC_UINT_LT: u8 = 144;
@@ -1079,6 +1086,8 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     // The `/ri` suffix matches `blackhole.py:616`; tracing reboxes a
     // constant int class pointer as a ConstPtr before recording.
     m.insert("assert_not_none/r", BC_ASSERT_NOT_NONE);
+    m.insert("ref_isconstant/r>i", BC_REF_ISCONSTANT);
+    m.insert("ref_isvirtual/r>i", BC_REF_ISVIRTUAL);
     m.insert("record_exact_class/ri", BC_RECORD_EXACT_CLASS);
 
     // Float comparisons — `blackhole.py:721-746`

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -322,11 +322,11 @@ pub const BC_INT_INVERT: u8 = 141;
 /// byte here `insn_byte` panicked on the key instead.  Takes the next
 /// byte above `BC_RAW_STORE_F` (235).
 pub const BC_INT_IS_ZERO: u8 = 236;
-// `blackhole.py bhimpl_ref_isconstant` / `bhimpl_ref_isvirtual`
-// (`@arguments("r", returns="i")`).  `look_inside_iff` folds
-// `jit.isconstant` / `jit.isvirtual` to these ops
-// (`jtransform.py rewrite_op_direct_call` `jit.isconstant` /
-// `jit.isvirtual`).
+// `blackhole.py bhimpl_int_isconstant` / `bhimpl_ref_isconstant` /
+// `bhimpl_ref_isvirtual`.  `look_inside_iff` folds `jit.isconstant` /
+// `jit.isvirtual` to these ops (`jtransform.py rewrite_op_direct_call`
+// `jit.isconstant` / `jit.isvirtual`).
+pub const BC_INT_ISCONSTANT: u8 = 239;
 pub const BC_REF_ISCONSTANT: u8 = 237;
 pub const BC_REF_ISVIRTUAL: u8 = 238;
 pub const BC_UINT_RSHIFT: u8 = 142;
@@ -1086,6 +1086,7 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     // The `/ri` suffix matches `blackhole.py:616`; tracing reboxes a
     // constant int class pointer as a ConstPtr before recording.
     m.insert("assert_not_none/r", BC_ASSERT_NOT_NONE);
+    m.insert("int_isconstant/i>i", BC_INT_ISCONSTANT);
     m.insert("ref_isconstant/r>i", BC_REF_ISCONSTANT);
     m.insert("ref_isvirtual/r>i", BC_REF_ISVIRTUAL);
     m.insert("record_exact_class/ri", BC_RECORD_EXACT_CLASS);

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4313,12 +4313,14 @@ impl<'a> Transformer<'a> {
         // `jtransform.py rewrite_op_cast_opaque_ptr` returns None (alias
         // args[0]).  The same identity applies to the Rust spelling of
         // that op: `cast_int_to_ptr(cast_ptr_to_int(p))`.
+        // Match the `lltype.cast_*` host path `cast_call_segments` emits,
+        // not a bare leaf — a user function named `cast_int_to_ptr` is
+        // an ordinary call (`pointer_cast_function_names_do_not_alias`).
         if let CallTarget::FunctionPath { segments } = target {
-            let leaf = segments.last().map(String::as_str);
-            if leaf == Some("cast_opaque_ptr") && args.len() == 1 {
+            if is_lltype_cast_path(segments, "cast_opaque_ptr") && args.len() == 1 {
                 return RewriteResult::Identity(args[0].clone());
             }
-            if leaf == Some("cast_ptr_to_int") && args.len() == 1 {
+            if is_lltype_cast_path(segments, "cast_ptr_to_int") && args.len() == 1 {
                 if let Some(res) = op.result.clone() {
                     let src = resolve_alias(&args[0], &self.aliases);
                     self.cast_ptr_to_int_src.insert(res, src);
@@ -4327,7 +4329,7 @@ impl<'a> Transformer<'a> {
                 // fall through so the existing Call residual path still
                 // emits it.
             }
-            if leaf == Some("cast_int_to_ptr") && args.len() == 1 {
+            if is_lltype_cast_path(segments, "cast_int_to_ptr") && args.len() == 1 {
                 let arg = resolve_alias(&args[0], &self.aliases);
                 if let Some(src) = self.cast_ptr_to_int_src.get(&arg).cloned() {
                     return RewriteResult::Identity(src);
@@ -8826,6 +8828,17 @@ fn remap_op(
         result: op.result.clone(),
         kind,
     }
+}
+
+/// `rpython.rtyper.lltypesystem.lltype.cast_*` — the host-callable path
+/// `front::mir::cast_call_segments` emits for a bank-crossing cast.
+fn is_lltype_cast_path(segments: &[String], name: &str) -> bool {
+    segments.len() == 5
+        && segments[0] == "rpython"
+        && segments[1] == "rtyper"
+        && segments[2] == "lltypesystem"
+        && segments[3] == "lltype"
+        && segments[4] == name
 }
 
 /// Rewrite `we_are_jitted()` calls to the `_we_are_jitted` symbolic

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -6583,6 +6583,17 @@ impl<'a> Transformer<'a> {
                     None,
                 )
             }
+            // `rlib/jit.py` `_jit_conditional_call` is an llop in upstream
+            // (`ConditionalCallEntry.specialize_call` → `jit_conditional_call`),
+            // rewritten by `rewrite_op_jit_conditional_call`. pyre harvests
+            // the interpreter-facing helper as `oopspec("jit.conditional_call")`
+            // so this arm is the `__handle_jit_call` entry that reaches it.
+            "jit.conditional_call" => {
+                self.rewrite_op_jit_conditional_call(graph, op, target, args, result_ty, graph_name)
+            }
+            "jit.conditional_call_value" => self.rewrite_op_jit_conditional_call_value(
+                graph, op, target, args, result_ty, graph_name,
+            ),
             // jtransform.py:1756-1757
             _ => {
                 // jtransform.py:1757
@@ -6647,30 +6658,18 @@ impl<'a> Transformer<'a> {
         self.handle_residual_call(graph, op, target, descriptor, args, result_ty, graph_name)
     }
 
-    // NOTE: rewrite_op_jit_conditional_call, _rewrite_op_cond_call, and
-    // rewrite_op_jit_record_known_result are handled by jitcode_lower
-    // (proc-macro level), not jtransform. The codewriter AST parser does
-    // not expand macro_rules!, so these macros never reach jtransform.
-    // See jitcode_lower.rs: lower_conditional_call, lower_conditional_call_elidable,
-    // lower_record_known_result.
-    //
-    // `_rewrite_op_cond_call` below is a structural mirror of
-    // `rpython/jit/codewriter/jtransform.py:1665-1683`. pyre dispatches
-    // conditional_call via the proc-macro path (see above), so this
-    // function is never reached at runtime; the Rust #[allow(dead_code)]
-    // is deliberate. Keeping the body
-    // here lets future porters cross-reference our conditional_call
-    // lowering against the upstream flow line-by-line.
+    // `#[jit_interp] conditional_call!` still lowers through jitcode_lower.
+    // Interpreter-facing `majit_rlib::jit::conditional_call*` is an oopspec
+    // and reaches this rewrite via `_handle_jit_call`, matching
+    // `jtransform.py rewrite_op_jit_conditional_call`.
 
     /// RPython: `Transformer._rewrite_op_cond_call(op, rewritten_opname)`
     /// (jtransform.py:1665-1683).
     ///
-    /// Called by upstream `rewrite_op_jit_conditional_call` and
-    /// `rewrite_op_jit_conditional_call_value`; in pyre those two
-    /// lower through `jitcode_lower::lower_conditional_call` /
-    /// `lower_conditional_call_elidable` instead. This body is kept as
-    /// structural documentation so the two code paths stay aligned.
-    #[allow(dead_code)]
+    /// `rewrite_call(op, name, op.args[:2], args=op.args[2:])`: args[0] is
+    /// the condition (or elidable value), args[1] is the callee, args[2:]
+    /// are the callee's arguments. `target` is the oopspec wrapper and is
+    /// not the residual funcptr.
     #[expect(
         clippy::too_many_arguments,
         reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
@@ -6679,7 +6678,7 @@ impl<'a> Transformer<'a> {
         &mut self,
         graph: &mut FunctionGraph,
         op: &SpaceOperation,
-        target: &CallTarget,
+        _target: &CallTarget,
         args: &[crate::flowspace::model::Variable],
         result_ty: &ValueType,
         graph_name: &str,
@@ -6694,17 +6693,36 @@ impl<'a> Transformer<'a> {
         if args.len() > 4 + 2 {
             panic!("Conditional call does not support more than 4 arguments");
         }
-        // jtransform.py:1673-1676: calldescr from function call (args[1:] → result)
+        assert!(
+            args.len() >= 2,
+            "jit.conditional_call needs a condition and a function"
+        );
+        // jtransform.py `_rewrite_op_cond_call`: rewrite_call(..., op.args[:2], args=op.args[2:])
         let condition_or_value_var = args[0].clone();
-        let func_args: &[crate::flowspace::model::Variable] =
-            if args.len() > 1 { &args[1..] } else { &[] };
+        let func_var = &args[1];
+        let func_args = &args[2..];
+        let func_target = fn_const_target_for_var(graph, func_var, 0).unwrap_or_else(|| {
+            panic!(
+                "conditional_call function must be a constant function item \
+                 (rtyper get_concrete_llfn); graph={graph_name}"
+            )
+        });
+        // jtransform.py `_rewrite_op_cond_call`: `direct_call` of op.args[1:] (func + args)
         let non_void_args = resolve_non_void_arg_types_from_vars(func_args);
         let resolved_result = self.resolve_call_result(op.result.as_ref(), result_ty);
         let result_ir_type = resolved_result.ir_type;
+        let callee_op = SpaceOperation {
+            result: op.result.clone(),
+            kind: OpKind::Call {
+                target: func_target.clone(),
+                args: func_args.to_vec(),
+                result_ty: result_ty.clone(),
+            },
+        };
         let descriptor = {
             let cc_ref: &crate::call::CallControl = self.callcontrol.as_deref().unwrap();
             cc_ref.getcalldescr(
-                op,
+                &callee_op,
                 non_void_args,
                 result_ir_type,
                 OopSpecIndex::None,
@@ -6741,7 +6759,7 @@ impl<'a> Transformer<'a> {
         let call_kind = if is_value {
             OpKind::ConditionalCallValue {
                 value: condition_or_value_var,
-                funcptr: target.clone(),
+                funcptr: func_target,
                 descriptor: descriptor.clone(),
                 args_i,
                 args_r,
@@ -6751,7 +6769,7 @@ impl<'a> Transformer<'a> {
         } else {
             OpKind::ConditionalCall {
                 condition: condition_or_value_var,
-                funcptr: target.clone(),
+                funcptr: func_target,
                 descriptor: descriptor.clone(),
                 args_i,
                 args_r,
@@ -6772,10 +6790,7 @@ impl<'a> Transformer<'a> {
         RewriteResult::Replace(ops)
     }
 
-    /// RPython: `Transformer.rewrite_op_jit_conditional_call(op)`
-    /// (jtransform.py:1685-1686). Dispatch wrapper kept for structural
-    /// parity; pyre's `rewrite_operation` match does not reach it.
-    #[allow(dead_code)]
+    /// RPython: `Transformer.rewrite_op_jit_conditional_call(op)`.
     fn rewrite_op_jit_conditional_call(
         &mut self,
         graph: &mut FunctionGraph,
@@ -6788,10 +6803,7 @@ impl<'a> Transformer<'a> {
         self._rewrite_op_cond_call(graph, op, target, args, result_ty, graph_name, false)
     }
 
-    /// RPython: `Transformer.rewrite_op_jit_conditional_call_value(op)`
-    /// (jtransform.py:1687-1688). Dispatch wrapper kept for structural
-    /// parity; pyre's `rewrite_operation` match does not reach it.
-    #[allow(dead_code)]
+    /// RPython: `Transformer.rewrite_op_jit_conditional_call_value(op)`.
     fn rewrite_op_jit_conditional_call_value(
         &mut self,
         graph: &mut FunctionGraph,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -8845,6 +8845,15 @@ fn remap_op(
 /// un-annotatable `SpecTag` out of `Bookkeeper.immutablevalue` (which
 /// has no symbolic branch — in RPython the symbolic is likewise
 /// introduced only post-annotation, at rtype).
+/// `rlib/jit.py we_are_jitted` — both the metainterp hook and the
+/// `majit_rlib` interpreter-facing spelling `look_inside_iff` emits.
+fn is_we_are_jitted_path(segments: &[String], args: &[crate::flowspace::model::Variable]) -> bool {
+    args.is_empty()
+        && segments.len() >= 2
+        && segments[segments.len() - 2] == "jit"
+        && segments[segments.len() - 1] == "we_are_jitted"
+}
+
 fn fold_we_are_jitted_calls(graph: &mut crate::model::FunctionGraph) {
     for block in graph.blocks.iter_mut() {
         for op in block.operations.iter_mut() {
@@ -8856,12 +8865,7 @@ fn fold_we_are_jitted_calls(graph: &mut crate::model::FunctionGraph) {
             else {
                 continue;
             };
-            if !args.is_empty()
-                || segments.len() != 3
-                || segments[0] != "majit_metainterp"
-                || segments[1] != "jit"
-                || segments[2] != "we_are_jitted"
-            {
+            if !is_we_are_jitted_path(segments, args) {
                 continue;
             }
             op.kind = OpKind::ConstSymbolic {
@@ -14928,6 +14932,40 @@ mod tests {
         let mut graph = FunctionGraph::new("we_are_jitted_specialize");
         let entry = graph.startblock;
         let target = CallTarget::function_path(["majit_metainterp", "jit", "we_are_jitted"]);
+        let result_var = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target,
+                    args: vec![],
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(entry, Some(result_var.clone()));
+        fold_we_are_jitted_calls(&mut graph);
+        let op = graph.blocks[0]
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&result_var))
+            .expect("we_are_jitted op present");
+        match &op.kind {
+            OpKind::ConstSymbolic { tag, .. } => assert_eq!(
+                *tag,
+                crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID
+            ),
+            other => panic!("expected ConstSymbolic, got {other:?}"),
+        }
+    }
+
+    /// `look_inside_iff` emits `majit_rlib::jit::we_are_jitted`; the
+    /// fold must recognise that spelling too (`rlib/jit.py we_are_jitted`).
+    #[test]
+    fn we_are_jitted_rlib_path_specializes_to_symbolic() {
+        let mut graph = FunctionGraph::new("we_are_jitted_rlib_specialize");
+        let entry = graph.startblock;
+        let target = CallTarget::function_path(["majit_rlib", "jit", "we_are_jitted"]);
         let result_var = graph
             .push_op_var(
                 entry,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -472,6 +472,13 @@ pub struct Transformer<'a> {
         crate::flowspace::model::Variable,
         crate::flowspace::model::Variable,
     >,
+    /// Source GC pointer of each `cast_ptr_to_int` result.  Rust spells
+    /// `lltype.cast_opaque_ptr` as `p as usize as *mut T`; the second
+    /// cast folds back to this source (`rewrite_op_cast_opaque_ptr`).
+    cast_ptr_to_int_src: std::collections::HashMap<
+        crate::flowspace::model::Variable,
+        crate::flowspace::model::Variable,
+    >,
     notes: Vec<GraphTransformNote>,
     vable_rewrites: usize,
     calls_classified: usize,
@@ -1235,6 +1242,7 @@ impl<'a> Transformer<'a> {
             vable_array_vars: std::collections::HashMap::new(),
             vable_flags: std::collections::HashMap::new(),
             aliases: std::collections::HashMap::new(),
+            cast_ptr_to_int_src: std::collections::HashMap::new(),
             notes: Vec::new(),
             vable_rewrites: 0,
             calls_classified: 0,
@@ -1990,6 +1998,8 @@ impl<'a> Transformer<'a> {
             // RPython `Transformer.rewrite_op_cast_opaque_ptr` aliases
             // only the explicit low-level operation. A ptr/int roundtrip
             // remains two casts; it is not an opaque-pointer cast.
+            // The Rust `p as usize as *mut T` spelling is the Call pair
+            // folded in `rewrite_op_direct_call`.
             OpKind::UnaryOp {
                 op: unop_name,
                 operand,
@@ -4300,6 +4310,30 @@ impl<'a> Transformer<'a> {
             "CallTarget::Indirect must be lowered by translator/rtyper/rpbc.rs \
              before reaching rewrite_op_direct_call",
         );
+        // `jtransform.py rewrite_op_cast_opaque_ptr` returns None (alias
+        // args[0]).  The same identity applies to the Rust spelling of
+        // that op: `cast_int_to_ptr(cast_ptr_to_int(p))`.
+        if let CallTarget::FunctionPath { segments } = target {
+            let leaf = segments.last().map(String::as_str);
+            if leaf == Some("cast_opaque_ptr") && args.len() == 1 {
+                return RewriteResult::Identity(args[0].clone());
+            }
+            if leaf == Some("cast_ptr_to_int") && args.len() == 1 {
+                if let Some(res) = op.result.clone() {
+                    let src = resolve_alias(&args[0], &self.aliases);
+                    self.cast_ptr_to_int_src.insert(res, src);
+                }
+                // `rewrite_op_cast_ptr_to_int` keeps a GC pointer cast;
+                // fall through so the existing Call residual path still
+                // emits it.
+            }
+            if leaf == Some("cast_int_to_ptr") && args.len() == 1 {
+                let arg = resolve_alias(&args[0], &self.aliases);
+                if let Some(src) = self.cast_ptr_to_int_src.get(&arg).cloned() {
+                    return RewriteResult::Identity(src);
+                }
+            }
+        }
         // RPython `IntegerRepr.rtype_float` (`rint.py`) converts an
         // Unsigned input to Float, emitting `cast_uint_to_float`; jtransform
         // then applies `_do_builtin_call` (`jtransform.py`) and reaches
@@ -14377,6 +14411,106 @@ mod tests {
                 ),
                 "ordinary call to {name} must not alias its argument"
             );
+        }
+    }
+
+    /// `jtransform.py rewrite_op_cast_opaque_ptr` returns None.
+    #[test]
+    fn cast_opaque_ptr_elides_to_operand_alias() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("cast_opaque");
+        let arg = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let target = CallTarget::function_path([
+            "rpython",
+            "rtyper",
+            "lltypesystem",
+            "lltype",
+            "cast_opaque_ptr",
+        ]);
+        let result_ty = ValueType::Ref(None);
+        let op = SpaceOperation {
+            result: Some(result_var),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![arg.clone()],
+                result_ty: result_ty.clone(),
+            },
+        };
+        let rewritten = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            std::slice::from_ref(&arg),
+            &result_ty,
+            "cast_opaque",
+            &mut graph,
+        );
+        match rewritten {
+            RewriteResult::Identity(alias) => assert_eq!(alias, arg),
+            _ => panic!("expected Identity alias to the operand"),
+        }
+    }
+
+    /// Rust `p as usize as *mut T` is `cast_opaque_ptr`; the int-to-ptr
+    /// half folds back to the original GC pointer.
+    #[test]
+    fn cast_ptr_int_ptr_roundtrip_elides_to_original() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("cast_roundtrip");
+        let ptr = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let as_int = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let as_ptr = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let to_int = CallTarget::function_path([
+            "rpython",
+            "rtyper",
+            "lltypesystem",
+            "lltype",
+            "cast_ptr_to_int",
+        ]);
+        let to_ptr = CallTarget::function_path([
+            "rpython",
+            "rtyper",
+            "lltypesystem",
+            "lltype",
+            "cast_int_to_ptr",
+        ]);
+        let first = SpaceOperation {
+            result: Some(as_int.clone()),
+            kind: OpKind::Call {
+                target: to_int.clone(),
+                args: vec![ptr.clone()],
+                result_ty: ValueType::Int,
+            },
+        };
+        let _ = transformer.rewrite_op_direct_call(
+            &first,
+            &to_int,
+            std::slice::from_ref(&ptr),
+            &ValueType::Int,
+            "cast_roundtrip",
+            &mut graph,
+        );
+        let second = SpaceOperation {
+            result: Some(as_ptr),
+            kind: OpKind::Call {
+                target: to_ptr.clone(),
+                args: vec![as_int.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let rewritten = transformer.rewrite_op_direct_call(
+            &second,
+            &to_ptr,
+            std::slice::from_ref(&as_int),
+            &ValueType::Ref(None),
+            "cast_roundtrip",
+            &mut graph,
+        );
+        match rewritten {
+            RewriteResult::Identity(alias) => assert_eq!(alias, ptr),
+            _ => panic!("expected Identity alias to the original pointer"),
         }
     }
 

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2167,6 +2167,26 @@ impl HostEnv {
             "isvirtual",
             HostObject::new_builtin_callable("majit_rlib.jit.isvirtual"),
         );
+        majit_rlib_jit.module_set(
+            "conditional_call0",
+            HostObject::new_builtin_callable("majit_rlib.jit.conditional_call0"),
+        );
+        majit_rlib_jit.module_set(
+            "conditional_call1",
+            HostObject::new_builtin_callable("majit_rlib.jit.conditional_call1"),
+        );
+        majit_rlib_jit.module_set(
+            "conditional_call2",
+            HostObject::new_builtin_callable("majit_rlib.jit.conditional_call2"),
+        );
+        majit_rlib_jit.module_set(
+            "conditional_call3",
+            HostObject::new_builtin_callable("majit_rlib.jit.conditional_call3"),
+        );
+        majit_rlib_jit.module_set(
+            "conditional_call4",
+            HostObject::new_builtin_callable("majit_rlib.jit.conditional_call4"),
+        );
 
         // Container constructors emitted as `[Type, "new"]` 2-segment
         // FunctionPath callsites by pyre-source helpers.  Same shape

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2154,6 +2154,19 @@ impl HostEnv {
             "we_are_jitted",
             HostObject::new_builtin_callable("majit_metainterp.jit.we_are_jitted"),
         );
+        let majit_rlib_jit = HostObject::new_module("majit_rlib.jit");
+        majit_rlib_jit.module_set(
+            "we_are_jitted",
+            HostObject::new_builtin_callable("majit_rlib.jit.we_are_jitted"),
+        );
+        majit_rlib_jit.module_set(
+            "isconstant",
+            HostObject::new_builtin_callable("majit_rlib.jit.isconstant"),
+        );
+        majit_rlib_jit.module_set(
+            "isvirtual",
+            HostObject::new_builtin_callable("majit_rlib.jit.isvirtual"),
+        );
 
         // Container constructors emitted as `[Type, "new"]` 2-segment
         // FunctionPath callsites by pyre-source helpers.  Same shape
@@ -2430,6 +2443,7 @@ impl HostEnv {
         mods.insert("longlong2float".into(), longlong2float);
         mods.insert("majit_metainterp".into(), majit_metainterp);
         mods.insert("majit_metainterp.jit".into(), majit_metainterp_jit);
+        mods.insert("majit_rlib.jit".into(), majit_rlib_jit);
         mods.insert("u32".into(), primitive_u32);
         mods.insert("i64".into(), primitive_i64);
         mods.insert("usize".into(), primitive_usize);

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3701,6 +3701,9 @@ struct Lowering<'a> {
     /// two-variant enum tag switches (real `__discriminant` reads) are absent
     /// and keep the `Int`-exitcase path.
     niche_disc_vars: std::collections::HashSet<u64>,
+    /// Source GC pointer of each `cast_ptr_to_int` / `p as usize` result.
+    /// A following `cast_int_to_ptr` is `jtransform.py rewrite_op_cast_opaque_ptr`.
+    cast_ptr_to_int_src: std::collections::HashMap<Variable, Variable>,
 }
 
 impl<'a> Lowering<'a> {
@@ -3958,6 +3961,7 @@ impl<'a> Lowering<'a> {
             is_none_sites: Vec::new(),
             closure_select_sites: Vec::new(),
             niche_disc_vars: std::collections::HashSet::new(),
+            cast_ptr_to_int_src: std::collections::HashMap::new(),
         })
     }
 
@@ -5502,9 +5506,20 @@ impl<'a> Lowering<'a> {
                         && matches!(dst_kind, ValueType::Unsigned)
                     {
                         let bb_id = self.block_id[mir_bb];
+                        let orig = arg.clone();
                         let (retype, result) =
                             push_ptr_to_unsigned_cast(&mut self.graph, bb_id, arg);
+                        self.cast_ptr_to_int_src.insert(result.clone(), orig);
                         return Ok((Some(retype), result));
+                    }
+                    // `p as usize as *mut T` is `lltype.cast_opaque_ptr`.
+                    // Fold the int→ptr half back to the original GC pointer
+                    // so OptEarlyForce does not force_box a virtual
+                    // W_IntObject (`jtransform.py rewrite_op_cast_opaque_ptr`).
+                    if matches!(dst_kind, ValueType::Ref(_))
+                        && let Some(orig) = self.cast_ptr_to_int_src.get(&arg).cloned()
+                    {
+                        return Ok((None, orig));
                     }
                     return Ok(
                         match src_kind
@@ -5515,6 +5530,11 @@ impl<'a> Lowering<'a> {
                                 let res = self
                                     .graph
                                     .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                                if matches!(src_kind, Some(ValueType::Ref(_)))
+                                    && matches!(dst_kind, ValueType::Int | ValueType::Unsigned)
+                                {
+                                    self.cast_ptr_to_int_src.insert(res.clone(), arg.clone());
+                                }
                                 (
                                     Some(OpKind::Call {
                                         target: CallTarget::FunctionPath { segments },
@@ -8693,7 +8713,7 @@ impl<'a> Lowering<'a> {
                 // phaseA lift and drop the whole graph to the legacy walker.
                 if let CallKind::Fun(FunId::Regular { id }) = &reg.kind
                     && let Some(fd) = self.llbc.fn_by_id(*id)
-                    && fd.item_meta.name_path() == "majit_metainterp::jit::we_are_jitted"
+                    && fd.item_meta.name_path().ends_with("jit::we_are_jitted")
                 {
                     let res = self
                         .graph

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8713,7 +8713,7 @@ impl<'a> Lowering<'a> {
                 // phaseA lift and drop the whole graph to the legacy walker.
                 if let CallKind::Fun(FunId::Regular { id }) = &reg.kind
                     && let Some(fd) = self.llbc.fn_by_id(*id)
-                    && fd.item_meta.name_path().ends_with("jit::we_are_jitted")
+                    && path_ends_with_segments(&fd.item_meta.name_path(), "jit::we_are_jitted")
                 {
                     let res = self
                         .graph

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2174,6 +2174,7 @@ fn analyze_pipeline_from_module_paths(
             parse::CallPath::from_segments(["jit", func_name]),
             parse::CallPath::from_segments(["crate", "jit", func_name]),
             parse::CallPath::from_segments(["majit_metainterp", "jit", func_name]),
+            parse::CallPath::from_segments(["majit_rlib", "jit", func_name]),
         ] {
             call_control.mark_oopspec(path, spec.to_string());
         }

--- a/majit/majit-translate/tests/test_unroll_safe_inventory.rs
+++ b/majit/majit-translate/tests/test_unroll_safe_inventory.rs
@@ -219,6 +219,25 @@ const REVIEWED_UNROLL_SAFE: &[(&str, &str)] = &[
         "release_arguments",
         "ctypefunc.py W_CTypeFunc._call's finally block",
     ),
+    // `look_inside_iff` does `func = unroll_safe(func)` (`rlib/jit.py`
+    // `look_inside_iff.inner`).  The harvested name is the inlined original
+    // (`_orig_*`), not the dispatch wrapper.
+    //
+    // Evidence: `pypy/module/sys/vm.py getframe` is
+    // `@jit.look_inside_iff(jit.isconstant(depth))`.  Windows
+    // `pyre/check.py --backend dynasm` on this SHA passed, and a local
+    // remesure of the getframe/list/join fixtures did not raise
+    // `fbw_rolled_back_with_effects`.
+    (
+        "_orig_getframe",
+        "rlib/jit.py look_inside_iff unroll_safe(getframe)",
+    ),
+    // Same `func = unroll_safe(func)` as above, for
+    // `stringmethods.py _str_join_many_items`.
+    (
+        "_orig_str_join_many_items",
+        "rlib/jit.py look_inside_iff unroll_safe(_str_join_many_items)",
+    ),
 ];
 
 /// `builtins::leading_non_null_count` has carried its own `unroll_safe`

--- a/pyre/bench/synth/short_circuit_falsy_func_entry_resume.py
+++ b/pyre/bench/synth/short_circuit_falsy_func_entry_resume.py
@@ -1,4 +1,10 @@
 # pyre-check: max-pypy-ratio=16
+# pyre-check: max-wasm-ratio=5.0
+# Function-entry resume: `f` compiles as a function-entry trace and the
+# falsy `or` guard fails into blackhole, then ContinueRunningNormally at
+# the merge-point. wasm compiles each of those traces as its own module.
+# ubuntu-24.04 (PR 1738, production `isconstant` walk) measured 4.3x
+# against dynasm; 5.0x is that reading plus `WASM_RATIO_FIT_HEADROOM` (15%).
 # Loop-carried short-circuit `or` exercised on the FALSY leg, where the loop
 # lives in a callee invoked repeatedly from a hot outer loop.
 #

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -980,6 +980,12 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
 /// guarded positive-depth specialization admits only its completed immediate
 /// `f_locals` slice, so it cannot bake a stale inline `last_instr` into those
 /// other getters.
+/// `pypy/module/sys/vm.py getframe` — `@jit.look_inside_iff(lambda space, depth: jit.isconstant(depth))`.
+fn getframe_iff(depth: i64) -> bool {
+    majit_rlib::jit::isconstant(&depth)
+}
+
+#[majit_macros::look_inside_iff(getframe_iff)]
 pub fn getframe(depth: i64) -> crate::PyResult {
     let ec = current_execution_context();
     let mut current = if ec.is_null() {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -996,6 +996,20 @@ pub fn str_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         }
         return Ok(str_result_unchanged(item));
     }
+    str_join_many_items(sep, &items)
+}
+
+/// `stringmethods.py _str_join_many_items`:
+/// `@jit.look_inside_iff(lambda self, space, list_w, size: jit.loop_unrolling_heuristic(list_w, size))`.
+fn str_join_many_items_iff(_sep: &rustpython_wtf8::Wtf8, items: &[PyObjectRef]) -> bool {
+    majit_rlib::jit::loop_unrolling_heuristic(items, items.len(), 2)
+}
+
+#[majit_macros::look_inside_iff(str_join_many_items_iff)]
+fn str_join_many_items(
+    sep: &rustpython_wtf8::Wtf8,
+    items: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     let mut out = rustpython_wtf8::Wtf8Buf::new();
     for (i, item) in items.iter().enumerate() {
         if unsafe { !is_str(*item) } {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2047,7 +2047,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // `ca_result` with the executed concrete on success, and seeds the
     // standing exception state on a raise.
     let argbox_types: Vec<Type> = vec![Type::Ref; r_args.len()];
-    let allboxes = build_allboxes(funcptr, r_args, &argbox_types, call_descr.arg_types());
+    let allboxes = build_allboxes(funcptr, r_args, &argbox_types, call_descr.arg_types(), None);
     let exec = {
         let _selfrec_ca_fold_guard = SelfRecCaFoldGuard::enter();
         try_execute_residual_call_via_executor(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -10136,7 +10136,7 @@ pub(crate) fn try_walker_specialize_instance_iter<Sym: WalkSym>(
     let Some(body_facts) = sub_jitcode_body_facts_for_code(w_code) else {
         return Ok(None);
     };
-    if body_facts.owns_loop_header || body_facts.has_exception_table {
+    if body_facts.owns_loop_header {
         return Ok(None);
     }
 
@@ -10288,7 +10288,11 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
     let Some(body_facts) = sub_jitcode_body_facts_for_code(w_code) else {
         return Ok(None);
     };
-    if body_facts.owns_loop_header || body_facts.has_exception_table {
+    // Admit a raising `__next__` the way `try_walker_inline_subscr_getitem`
+    // admits a raising `__getitem__`: StopIteration at the end of the
+    // iterator is the shape worth inlining.  A callee that owns a portal
+    // loop header is still declined — that body is a trace of its own.
+    if body_facts.owns_loop_header {
         return Ok(None);
     }
     let body_coord = fbw_foriter_body_from_op_pc(ctx, op.pc)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4732,6 +4732,18 @@ unsafe fn raw_store_float(addr: *mut u8, itemsize: usize, value: f64) {
 /// * `ConcreteValue::Null` — the handler doesn't know (e.g. residual
 ///   `Call*I`, `getfield_gc_i` cache miss).  Downstream consumers
 ///   surface `GotoIfNotValueNotConcrete` for unknown branch inputs.
+/// `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual`: `ConstInt`, no IR.
+fn write_hint_bool<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    pc: usize,
+    dst: usize,
+    predicate: bool,
+) -> Result<(), DispatchError> {
+    let value = i64::from(predicate);
+    let result = ctx.trace_ctx.const_int(value);
+    write_int_reg(ctx, pc, dst, result, ConcreteValue::Int(value))
+}
+
 fn write_int_reg<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     pc: usize,
@@ -12677,26 +12689,20 @@ fn handle<Sym: WalkSym>(
         // `ConstInt(...)` and record no IR.  Operand layout `[src][dst]`.
         "int_isconstant/i>i" => {
             let src = read_int_reg(code, op, 0, ctx)?;
-            let value = i64::from(src.is_constant());
-            let result = ctx.trace_ctx.const_int(value);
             let dst = code[op.pc + 2] as usize;
-            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            write_hint_bool(ctx, op.pc, dst, src.is_constant())?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "ref_isconstant/r>i" => {
             let src = read_ref_reg(code, op, 0, ctx)?;
-            let value = i64::from(src.is_constant());
-            let result = ctx.trace_ctx.const_int(value);
             let dst = code[op.pc + 2] as usize;
-            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            write_hint_bool(ctx, op.pc, dst, src.is_constant())?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "ref_isvirtual/r>i" => {
             let src = read_ref_reg(code, op, 0, ctx)?;
-            let value = i64::from(ctx.trace_ctx.is_likely_virtual(src));
-            let result = ctx.trace_ctx.const_int(value);
             let dst = code[op.pc + 2] as usize;
-            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            write_hint_bool(ctx, op.pc, dst, ctx.trace_ctx.is_likely_virtual(src))?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         // RPython `pyjitpl.py opimpl_new` delegates to `execute_new`:

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -12673,6 +12673,32 @@ fn handle<Sym: WalkSym>(
             ctx.trace_ctx.trace_record_exact_class(opref, cls);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
+        // `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual`: write
+        // `ConstInt(...)` and record no IR.  Operand layout `[src][dst]`.
+        "int_isconstant/i>i" => {
+            let src = read_int_reg(code, op, 0, ctx)?;
+            let value = i64::from(src.is_constant());
+            let result = ctx.trace_ctx.const_int(value);
+            let dst = code[op.pc + 2] as usize;
+            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "ref_isconstant/r>i" => {
+            let src = read_ref_reg(code, op, 0, ctx)?;
+            let value = i64::from(src.is_constant());
+            let result = ctx.trace_ctx.const_int(value);
+            let dst = code[op.pc + 2] as usize;
+            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
+        "ref_isvirtual/r>i" => {
+            let src = read_ref_reg(code, op, 0, ctx)?;
+            let value = i64::from(ctx.trace_ctx.is_likely_virtual(src));
+            let result = ctx.trace_ctx.const_int(value);
+            let dst = code[op.pc + 2] as usize;
+            write_int_reg(ctx, op.pc, dst, result, ConcreteValue::Int(value))?;
+            Ok((DispatchOutcome::Continue, op.next_pc))
+        }
         // RPython `pyjitpl.py opimpl_new` delegates to `execute_new`:
         //
         //   resbox = self.execute_and_record(rop.NEW, typedescr)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4732,18 +4732,6 @@ unsafe fn raw_store_float(addr: *mut u8, itemsize: usize, value: f64) {
 /// * `ConcreteValue::Null` — the handler doesn't know (e.g. residual
 ///   `Call*I`, `getfield_gc_i` cache miss).  Downstream consumers
 ///   surface `GotoIfNotValueNotConcrete` for unknown branch inputs.
-/// `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual`: `ConstInt`, no IR.
-fn write_hint_bool<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    pc: usize,
-    dst: usize,
-    predicate: bool,
-) -> Result<(), DispatchError> {
-    let value = i64::from(predicate);
-    let result = ctx.trace_ctx.const_int(value);
-    write_int_reg(ctx, pc, dst, result, ConcreteValue::Int(value))
-}
-
 fn write_int_reg<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     pc: usize,
@@ -4782,6 +4770,18 @@ fn write_int_reg<Sym: WalkSym>(
         *c_slot = sanitized;
     }
     Ok(())
+}
+
+/// `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual`: `ConstInt`, no IR.
+fn write_hint_bool<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    pc: usize,
+    dst: usize,
+    predicate: bool,
+) -> Result<(), DispatchError> {
+    let value = i64::from(predicate);
+    let result = ctx.trace_ctx.const_int(value);
+    write_int_reg(ctx, pc, dst, result, ConcreteValue::Int(value))
 }
 
 /// Derive a `ConcreteValue` for shadow write-back from a freshly

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5409,15 +5409,14 @@ fn replace_movable_load_global_namespace_with_frame_globals<Sym: WalkSym>(
 /// `read_float_var_list`) tag each entry with its bank, so the parallel
 /// array is correct without needing a runtime type query.
 ///
-/// The RPython `prepend_box` parameter is unused at every
-/// `residual_call*` call site (only `conditional_call*` uses it, not
-/// yet ported), so it's omitted from the walker signature. Add it back
-/// when porting `opimpl_conditional_call*`.
+/// `pyjitpl.py _build_allboxes(..., prepend_box=)`. Residual calls pass
+/// `None`; `opimpl_conditional_call*` prepends the condition/value box.
 fn build_allboxes(
     funcbox: OpRef,
     argboxes: &[OpRef],
     argbox_types: &[Type],
     arg_types: &[Type],
+    prepend_box: Option<OpRef>,
 ) -> Vec<OpRef> {
     debug_assert_eq!(
         argboxes.len(),
@@ -5425,8 +5424,12 @@ fn build_allboxes(
         "argboxes and argbox_types must align",
     );
     // RPython line 1961: `allboxes = [None] * (len(argboxes)+1 + …)`.
-    let total = arg_types.len() + 1;
+    let extra = usize::from(prepend_box.is_some());
+    let total = arg_types.len() + 1 + extra;
     let mut allboxes: Vec<OpRef> = Vec::with_capacity(total);
+    if let Some(pre) = prepend_box {
+        allboxes.push(pre);
+    }
     // RPython line 1966: `allboxes[i] = funcbox`.
     allboxes.push(funcbox);
     // RPython line 1968: `src_i = src_r = src_f = 0`.
@@ -12228,6 +12231,8 @@ fn handle<Sym: WalkSym>(
         // family per `resoperation.py Type::Void => CallN`.
         "residual_call_r_v/iRd" => dispatch_residual_call_iRd_kind(code, op, ctx, 'v'),
         "residual_call_ir_v/iIRd" => dispatch_residual_call_iIRd_kind(code, op, ctx, 'v'),
+        // `pyjitpl.py opimpl_conditional_call_ir_v`: condition + func + I/R.
+        "conditional_call_ir_v/iiIRd" => dispatch_conditional_call_ir_v(code, op, ctx),
         "residual_call_irf_v/iIRFd" => dispatch_residual_call_iIRFd_kind(code, op, ctx, 'v'),
         // The `int_*` / `float_*` / `ptr_*` record families are routed
         // through `dispatch_regular_record` (see `arith.rs`) before this

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6763,7 +6763,13 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     // `_r_*` shape: argboxes = R-list only; argbox_types = [Ref; n].
     let argbox_types: Vec<Type> = vec![Type::Ref; r_args.len()];
-    let allboxes = build_allboxes(funcptr, &r_args, &argbox_types, call_descr.arg_types());
+    let allboxes = build_allboxes(
+        funcptr,
+        &r_args,
+        &argbox_types,
+        call_descr.arg_types(),
+        None,
+    );
     if let Err(e) = ensure_residual_call_args_bound(&allboxes, op.pc) {
         if fbw_debug_abort_enabled() {
             let len_pc = op.pc + 1 + 1;
@@ -8149,6 +8155,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         &argboxes,
         &argbox_types,
         original_call_descr.arg_types(),
+        None,
     );
 
     // pyjitpl.py `opimpl_jit_force_quasi_immutable` must run before
@@ -9647,7 +9654,13 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
     argbox_types.extend(std::iter::repeat(Type::Ref).take(r_args.len()));
     argboxes.extend_from_slice(&f_args);
     argbox_types.extend(std::iter::repeat(Type::Float).take(f_args.len()));
-    let allboxes = build_allboxes(funcptr, &argboxes, &argbox_types, call_descr.arg_types());
+    let allboxes = build_allboxes(
+        funcptr,
+        &argboxes,
+        &argbox_types,
+        call_descr.arg_types(),
+        None,
+    );
     ensure_residual_call_args_bound(&allboxes, op.pc)?;
 
     let ei = call_descr.get_extra_info();
@@ -9851,5 +9864,87 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         }
     }
 
+    Ok((DispatchOutcome::Continue, op.next_pc))
+}
+
+/// `pyjitpl.py opimpl_conditional_call_ir_v` / `do_conditional_call`.
+///
+/// Operand layout `iiIRd`: condition, funcptr, I-list, R-list, descr.
+/// A constant-false condition records nothing so the heapcache can keep
+/// the arguments virtual.
+pub(crate) fn dispatch_conditional_call_ir_v<Sym: WalkSym>(
+    code: &[u8],
+    op: &DecodedOp,
+    ctx: &mut WalkContext<'_, '_, Sym>,
+) -> Result<(DispatchOutcome, usize), DispatchError> {
+    let cond = read_int_reg(code, op, 0, ctx)?;
+    let funcptr = read_int_reg(code, op, 1, ctx)?;
+    let (i_args, i_width) = read_int_var_list(code, op, 2, ctx)?;
+    let (r_args, r_width) = read_ref_var_list(code, op, 2 + i_width, ctx)?;
+    let descr_offset = 2 + i_width + r_width;
+    let descr = read_descr(code, op, descr_offset, ctx)?;
+    let call_descr = descr
+        .as_call_descr()
+        .ok_or(DispatchError::ResidualCallDescrNotCallDescr {
+            pc: op.pc,
+            descr_index: decode_descr_index(code, op, descr_offset),
+        })?;
+    // pyjitpl.py `opimpl_conditional_call_ir_v`: ConstInt(0) returns without recording.
+    if cond.is_constant() {
+        let zero = matches!(ctx.trace_ctx.box_value(cond), Some(majit_ir::Value::Int(0)));
+        if zero {
+            return Ok((DispatchOutcome::Continue, op.next_pc));
+        }
+    }
+    let mut argboxes: Vec<OpRef> = Vec::with_capacity(i_args.len() + r_args.len());
+    let mut argbox_types: Vec<Type> = Vec::with_capacity(i_args.len() + r_args.len());
+    argboxes.extend_from_slice(&i_args);
+    argbox_types.extend(std::iter::repeat(Type::Int).take(i_args.len()));
+    argboxes.extend_from_slice(&r_args);
+    argbox_types.extend(std::iter::repeat(Type::Ref).take(r_args.len()));
+    let allboxes = build_allboxes(
+        funcptr,
+        &argboxes,
+        &argbox_types,
+        call_descr.arg_types(),
+        Some(cond),
+    );
+    assert!(
+        !call_descr
+            .get_extra_info()
+            .check_forces_virtual_or_virtualizable(),
+        "conditional_call target must not force virtualizable"
+    );
+    ctx.trace_ctx
+        .profiler()
+        .count_ops(OpCode::CondCallN, majit_metainterp::counters::OPS);
+    ctx.trace_ctx
+        .profiler()
+        .count_ops(OpCode::CondCallN, majit_metainterp::counters::RECORDED_OPS);
+    let _recorded = ctx
+        .trace_ctx
+        .record_op_with_descr(OpCode::CondCallN, &allboxes, descr);
+    let cond_true = match ctx.trace_ctx.box_value(cond) {
+        Some(majit_ir::Value::Int(n)) => n != 0,
+        _ => match read_int_reg_concrete(code, op, 0, ctx) {
+            ConcreteValue::Int(n) => n != 0,
+            ConcreteValue::Bool(b) => b,
+            _ => false,
+        },
+    };
+    if cond_true {
+        let Some(majit_ir::Value::Int(func_addr)) = ctx.trace_ctx.box_value(funcptr) else {
+            return Ok((DispatchOutcome::Continue, op.next_pc));
+        };
+        let mut concrete_args = Vec::with_capacity(allboxes.len().saturating_sub(2));
+        for boxref in allboxes.iter().skip(2) {
+            match ctx.trace_ctx.box_value(*boxref) {
+                Some(majit_ir::Value::Int(n)) => concrete_args.push(n),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(p))) => concrete_args.push(p as i64),
+                _ => return Ok((DispatchOutcome::Continue, op.next_pc)),
+            }
+        }
+        majit_metainterp::call_void_function(func_addr as *const (), &concrete_args);
+    }
     Ok((DispatchOutcome::Continue, op.next_pc))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -2765,6 +2765,98 @@ fn assert_not_none_uses_known_nonnull_heapcache_without_a_ref_shadow() {
 }
 
 #[test]
+fn int_isconstant_writes_constint_and_records_no_ir() {
+    let byte = *insns_opname_to_byte()
+        .get("int_isconstant/i>i")
+        .expect("`int_isconstant/i>i` must be in insns table");
+    let code = [byte, 0x00, 0x01];
+    let mut tc = fresh_trace_ctx();
+    let src = tc.const_int(5);
+    let ops_before = tc.num_ops();
+    let mut regs_i = [src, OpRef::NONE];
+    let mut concrete_i = [ConcreteValue::Int(5), ConcreteValue::Null];
+    let (outcome, next_pc) = run_hint_step_full(
+        &code,
+        &mut tc,
+        &mut [],
+        &mut [],
+        &mut regs_i,
+        &mut concrete_i,
+        &mut [],
+        &[],
+    )
+    .expect("`int_isconstant/i>i` must dispatch");
+    assert_eq!(outcome, DispatchOutcome::Continue);
+    assert_eq!(next_pc, 3);
+    assert_eq!(regs_i[1], tc.const_int(1));
+    assert_eq!(concrete_i[1], ConcreteValue::Int(1));
+    assert_eq!(tc.num_ops(), ops_before, "isconstant records no IR");
+}
+
+#[test]
+fn ref_isconstant_is_false_for_a_recorded_box() {
+    let byte = *insns_opname_to_byte()
+        .get("ref_isconstant/r>i")
+        .expect("`ref_isconstant/r>i` must be in insns table");
+    let code = [byte, 0x00, 0x00];
+    let mut tc = fresh_trace_ctx();
+    let src = tc.record_op(majit_ir::OpCode::New, &[]);
+    let ops_before = tc.num_ops();
+    let mut regs_r = [src];
+    let mut concrete_r = [ConcreteValue::Null];
+    let mut regs_i = [OpRef::NONE];
+    let mut concrete_i = [ConcreteValue::Null];
+    let (outcome, next_pc) = run_hint_step_full(
+        &code,
+        &mut tc,
+        &mut regs_r,
+        &mut concrete_r,
+        &mut regs_i,
+        &mut concrete_i,
+        &mut [],
+        &[],
+    )
+    .expect("`ref_isconstant/r>i` must dispatch");
+    assert_eq!(outcome, DispatchOutcome::Continue);
+    assert_eq!(next_pc, 3);
+    assert_eq!(regs_i[0], tc.const_int(0));
+    assert_eq!(concrete_i[0], ConcreteValue::Int(0));
+    assert_eq!(tc.num_ops(), ops_before, "isconstant records no IR");
+}
+
+#[test]
+fn ref_isvirtual_follows_the_heapcache() {
+    let byte = *insns_opname_to_byte()
+        .get("ref_isvirtual/r>i")
+        .expect("`ref_isvirtual/r>i` must be in insns table");
+    let code = [byte, 0x00, 0x00];
+    let mut tc = fresh_trace_ctx();
+    let src = tc.record_op(majit_ir::OpCode::New, &[]);
+    tc.heap_cache_mut().new_object(src);
+    let ops_before = tc.num_ops();
+    let mut regs_r = [src];
+    let mut concrete_r = [ConcreteValue::Null];
+    let mut regs_i = [OpRef::NONE];
+    let mut concrete_i = [ConcreteValue::Null];
+    let (outcome, next_pc) = run_hint_step_full(
+        &code,
+        &mut tc,
+        &mut regs_r,
+        &mut concrete_r,
+        &mut regs_i,
+        &mut concrete_i,
+        &mut [],
+        &[],
+    )
+    .expect("`ref_isvirtual/r>i` must dispatch");
+    assert_eq!(outcome, DispatchOutcome::Continue);
+    assert_eq!(next_pc, 3);
+    assert_eq!(regs_i[0], tc.const_int(1));
+    assert_eq!(concrete_i[0], ConcreteValue::Int(1));
+    assert_eq!(tc.num_ops(), ops_before, "isvirtual records no IR");
+}
+
+#[test]
 fn fused_int_compare_folds_same_box_and_constant_operands_without_guards() {
     let byte = *insns_opname_to_byte()
         .get("goto_if_not_int_eq/iiL")

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -3601,7 +3601,6 @@ mod tests {
             "cast_int_to_float/i>f",
             "cast_int_to_ptr/i>r",
             "check_neg_index/rid>i",
-            "conditional_call_ir_v/iiIRd",
             "conditional_call_value_ir_i/iiIRd>i",
             "conditional_call_value_ir_r/riIRd>r",
             "gc_load_indexed_f/riiii>f",

--- a/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
+++ b/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
@@ -232,11 +232,6 @@ const MAJIT_ONLY: &[&str] = &[
     // this file exists to make visible.
     "arraybase_vable/rdd>i",
     "newlist_clear/idddd>r",
-    // `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual` live in the
-    // majit tracer (`dispatch.rs`); the pyre walker has no arm.
-    "int_isconstant/i>i",
-    "ref_isconstant/r>i",
-    "ref_isvirtual/r>i",
     "rvmprof_code/ii",
 ];
 

--- a/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
+++ b/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
@@ -232,6 +232,10 @@ const MAJIT_ONLY: &[&str] = &[
     // this file exists to make visible.
     "arraybase_vable/rdd>i",
     "newlist_clear/idddd>r",
+    // `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual` live in the
+    // majit tracer (`dispatch.rs`); the pyre walker has no arm.
+    "ref_isconstant/r>i",
+    "ref_isvirtual/r>i",
     "rvmprof_code/ii",
 ];
 

--- a/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
+++ b/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
@@ -239,6 +239,9 @@ const MAJIT_ONLY: &[&str] = &[
 const PYRE_ONLY: &[&str] = &[
     // The walker's own abort marker.
     "abort/>r",
+    // jtransform `_rewrite_op_cond_call` emits this key; majit's tracer
+    // walks the `#[jit_interp]` `cond_call_void_ext/P` byte instead.
+    "conditional_call_ir_v/iiIRd",
     // Pointer/integer casts.
     "cast_int_to_ptr/i>r",
     "cast_ptr_to_int/r>i",

--- a/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
+++ b/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
@@ -234,6 +234,7 @@ const MAJIT_ONLY: &[&str] = &[
     "newlist_clear/idddd>r",
     // `pyjitpl.py` `_opimpl_isconstant` / `_opimpl_isvirtual` live in the
     // majit tracer (`dispatch.rs`); the pyre walker has no arm.
+    "int_isconstant/i>i",
     "ref_isconstant/r>i",
     "ref_isvirtual/r>i",
     "rvmprof_code/ii",

--- a/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
+++ b/pyre/pyre-jit-trace/tests/walker_opcode_parity.rs
@@ -285,7 +285,6 @@ const PYRE_ONLY: &[&str] = &[
 /// so a new arrival costs compilation rather than correctness.
 const NEITHER: &[&str] = &[
     "check_neg_index/rid>i",
-    "conditional_call_ir_v/iiIRd",
     "gc_load_indexed_f/riiii>f",
     "gc_load_indexed_i/riiii>i",
     "getinteriorfield_gc_f/rid>f",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7932,6 +7932,10 @@ fn drive_unpack_iterable_trace(
 /// before its first JIT-traced bytecode still routes through to the
 /// real `WarmState::set_param("trace_limit", 10000)`.
 pub fn init_jit_hooks() {
+    // `rlib/jit.py we_are_jitted` lives in majit-rlib so `look_inside_iff`
+    // dispatch (object crate included) can read it without depending on
+    // the metainterp.
+    majit_rlib::jit::install_we_are_jitted(majit_backend::we_are_jitted);
     // Phase A: build the GC and install it into the backend + pyre-object
     // hooks.  Safe at boot — no interpreter state referenced.  This makes
     // frames GC-owned even under PYRE_JIT=0 (#383).

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -503,13 +503,14 @@ pub fn module_dict_storage_gc_type_id() -> u32 {
 /// `celldict.py getitem_str`'s
 /// `self.unerase(w_dict.dstorage).get(key)`.
 ///
-/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py`), the
-/// twin of `dictmultiobject::dict_entries_probe_str`: the `IndexMap::get` it
-/// wraps is an external-crate heap lookup the tracer cannot model — the
-/// oopspec'd residual arm of `rordereddict.ll_dict_getitem` (traced only for a
-/// virtual dict).  The keys are owned `String`s, so no user `__eq__` or
-/// `__hash__` can run inside the boundary at all.
-#[majit_macros::dont_look_inside]
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).  Keys are owned `String`s, so no
+/// user `__eq__` or `__hash__` runs inside the probe.
+fn module_dict_entries_get_iff(entries: &ModuleDictEntries, key: &str) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(key)
+}
+
+#[majit_macros::look_inside_iff(module_dict_entries_get_iff)]
 pub fn module_dict_entries_get(entries: &ModuleDictEntries, key: &str) -> Option<PyObjectRef> {
     entries.get(key).copied()
 }
@@ -518,14 +519,18 @@ pub fn module_dict_entries_get(entries: &ModuleDictEntries, key: &str) -> Option
 /// `self.unerase(w_dict.dstorage)[key] = w_value`, returning the displaced
 /// value so the caller can tell an overwrite from an insert.
 ///
-/// `IndexMap::insert` preserves the existing slot's position on overwrite,
-/// matching Python `{}`'s assignment semantics (rewriting an existing key does
-/// not move it to the end).  Residualised for [`module_dict_entries_get`]'s
-/// reason; upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py`)
-/// is likewise `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`
-/// and neither conjunct can hold for an `IndexMap` here.  The borrowed name is
-/// copied to the owned `String` the entry table stores inside the boundary.
-#[majit_macros::dont_look_inside]
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py`).  Overwrite keeps
+/// the existing slot's position (`{}` assignment).
+fn module_dict_entries_insert_iff(
+    entries: &mut ModuleDictEntries,
+    key: &str,
+    _w_value: PyObjectRef,
+) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(key)
+}
+
+#[majit_macros::look_inside_iff(module_dict_entries_insert_iff)]
 pub fn module_dict_entries_insert(
     entries: &mut ModuleDictEntries,
     key: &str,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -291,20 +291,17 @@ impl crate::rordereddict::Equivalent<ObjectKey> for StrLookupKey<'_> {
 /// has produced `hash` — `celldict.py getitem_str`'s single
 /// `self.unerase(w_dict.dstorage).get(key)`.
 ///
-/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py`), the
-/// twin of [`w_dict_lookup_int_strategy`] and
-/// [`w_module_dict_lookup_object_entries`]: the `IndexMap::get` it wraps is an
-/// external-crate heap lookup the tracer cannot model — the oopspec'd residual
-/// arm of `rordereddict.ll_dict_getitem` (traced only for a virtual dict).  The
-/// user `__eq__` a str-subclass key can run sits inside the same probe upstream
-/// (`rdict.py ll_dict_lookup` carries `@jit.oopspec('dict.lookup')` over
-/// the whole `keyeq` loop), so it does not argue for a narrower boundary.  The
-/// enclosing [`dict_entries_get_str`] keeps its hook gate and its allocating
-/// fallback visible.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).  The trampoline is the residual
+/// arm when the dict is not virtual.
 ///
 /// # Safety
 /// `entries` must be a live entry table whose keys are valid `ObjectKey`s.
-#[majit_macros::dont_look_inside]
+fn dict_entries_probe_str_iff(entries: &ObjectDictStorage, _hash: i64, key: &str) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_probe_str_iff)]
 pub unsafe fn dict_entries_probe_str(
     entries: &ObjectDictStorage,
     hash: i64,
@@ -322,7 +319,12 @@ pub unsafe fn dict_entries_probe_str(
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_str`]; `key` must be a valid PyObjectRef.
-#[majit_macros::dont_look_inside]
+fn dict_entries_probe_object_iff(entries: &ObjectDictStorage, key: PyObjectRef) -> bool {
+    // rordereddict.py ll_dict_lookup: isvirtual(d) and isconstant(key)
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_probe_object_iff)]
 pub unsafe fn dict_entries_probe_object(
     entries: &ObjectDictStorage,
     key: PyObjectRef,
@@ -333,19 +335,19 @@ pub unsafe fn dict_entries_probe_object(
 /// The object-keyed remove side of the same table — `dictmultiobject.py:1081
 /// delitem`'s `del self.unerase(w_dict.dstorage)[self.unwrap(w_key)]`.
 ///
-/// Residualised (`@dont_look_inside`, `rlib/jit.py`) because upstream's
-/// `_ll_dict_del` (`rordereddict.py`) carries
-/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))`, and an
-/// `IndexMap` can never be virtual to this front end, so the predicate is
-/// permanently false and the residual arm is the only reachable one.  Every
-/// arm that reaches the remove must go through here: leaving one traced keeps
-/// the enclosing graph blocked no matter what the others do
-/// ([`dict_entries_probe_object`]'s lesson).  The `bool` result is a single
-/// word, and the strategy / keys-version bumps stay traced.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))` on
+/// `_ll_dict_del` (`rordereddict.py`).  The storage is an `RDict` now, so
+/// the predicate is spelled; when it is false the trampoline is the same
+/// residual as the former `dont_look_inside`.
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_object`].
-#[majit_macros::dont_look_inside]
+fn dict_entries_remove_object_iff(entries: &mut ObjectDictStorage, key: PyObjectRef) -> bool {
+    // rordereddict.py _ll_dict_del: isvirtual(d) and isconstant(i)
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_remove_object_iff)]
 pub unsafe fn dict_entries_remove_object(
     entries: &mut ObjectDictStorage,
     key: PyObjectRef,
@@ -365,7 +367,16 @@ pub unsafe fn dict_entries_remove_object(
 /// # Safety
 /// Same as [`dict_entries_probe_object`]; `hash` must be the digest
 /// [`object_key_for_checked`] produced for `obj`.
-#[majit_macros::dont_look_inside]
+fn dict_entries_probe_hashed_iff(
+    entries: &ObjectDictStorage,
+    _hash: i64,
+    obj: PyObjectRef,
+) -> bool {
+    // rordereddict.py ll_dict_lookup: isvirtual(d) and isconstant(key)
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&obj)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_probe_hashed_iff)]
 pub unsafe fn dict_entries_probe_hashed(
     entries: &ObjectDictStorage,
     hash: i64,
@@ -387,7 +398,17 @@ pub unsafe fn dict_entries_probe_hashed(
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_hashed`].
-#[majit_macros::dont_look_inside]
+fn dict_entries_insert_hashed_iff(
+    entries: &mut ObjectDictStorage,
+    _hash: i64,
+    obj: PyObjectRef,
+    _value: PyObjectRef,
+) -> bool {
+    // rordereddict.py _ll_dict_setitem_lookup_done: isvirtual(d) and isconstant(key)
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&obj)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_insert_hashed_iff)]
 pub unsafe fn dict_entries_insert_hashed(
     entries: &mut ObjectDictStorage,
     hash: i64,
@@ -401,14 +422,12 @@ pub unsafe fn dict_entries_insert_hashed(
 /// `rordereddict.py ll_dict_getitem`'s `d.entries[i].value` after
 /// `ll_dict_lookup` returned the slot.
 ///
-/// Residualised for [`dict_entries_probe_hashed`]'s reason: `IndexMap` has no
-/// lowering, so `get_index` is the last modellable point.  No comparison runs
-/// here — the index is already known, so this is a pure slot read and the
-/// residual boundary swallows no user code at all.
+/// `d.entries[i].value` after `ll_dict_lookup` returned the slot
+/// (`rordereddict.py ll_dict_getitem`).  A positional field read, so
+/// the body stays look-inside.
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_hashed`]; `index` must be a live entry index.
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_value_at(entries: &ObjectDictStorage, index: usize) -> PyObjectRef {
     *entries.get_slot(index).unwrap().1
 }
@@ -417,13 +436,10 @@ pub unsafe fn dict_entries_value_at(entries: &ObjectDictStorage, index: usize) -
 /// `dictmultiobject.py setitem_str`'s in-place update, which reuses
 /// the stored key rather than re-inserting.
 ///
-/// Residualised for [`dict_entries_value_at`]'s reason, and the store twin of
-/// it: the index is already known, so the boundary swallows a slot write and
-/// no comparison.
+/// In-place update of `d.entries[i].value` (`dictmultiobject.py setitem_str`).
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_value_set_at(
     entries: &mut ObjectDictStorage,
     index: usize,
@@ -435,14 +451,20 @@ pub unsafe fn dict_entries_value_set_at(
 /// The owned-key store — [`dict_entries_probe_object`]'s twin, hashing `key`
 /// through [`object_key_for`] the way `dict_entries_remove_object` does.
 ///
-/// Residualised for [`dict_entries_insert_hashed`]'s reason: `IndexMap` has no
-/// lowering, and upstream's `_ll_dict_setitem_lookup_done`
-/// (`rordereddict.py:674`) is `@jit.look_inside_iff(jit.isvirtual(d) and
-/// jit.isconstant(key))`, neither conjunct of which can hold here.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py`).
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_object`].
-#[majit_macros::dont_look_inside]
+fn dict_entries_insert_object_iff(
+    entries: &mut ObjectDictStorage,
+    key: PyObjectRef,
+    _value: PyObjectRef,
+) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_insert_object_iff)]
 pub unsafe fn dict_entries_insert_object(
     entries: &mut ObjectDictStorage,
     key: PyObjectRef,
@@ -462,16 +484,11 @@ pub unsafe fn dict_entries_insert_object(
 /// passed the last entry — `rordereddict.py ll_dict_lookup`'s
 /// `entries[i].key` plus the bound that ends its scan.
 ///
-/// Residualised for [`dict_entries_value_at`]'s reason: a positional slot read
-/// runs no comparison, so the boundary swallows no user code.  It is the read
-/// [`scan_dict_key_reentrant`] performs per step; the scan's `keyeq` loop and
-/// its paranoia restart stay traced around it, which is what
-/// `ll_dict_lookup`'s own `@jit.look_inside_iff(jit.isvirtual(d))` keeps
-/// visible for a dict the tracer can see.
+/// `entries[i].key` (`rordereddict.py ll_dict_lookup`).  A positional
+/// field read, so the body stays look-inside.
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_key_obj_at(
     entries: &ObjectDictStorage,
     index: usize,
@@ -488,7 +505,6 @@ pub unsafe fn dict_entries_key_obj_at(
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_key_hash_at(entries: &ObjectDictStorage, index: usize) -> i64 {
     entries.get_slot(index).unwrap().0.hash
 }
@@ -498,7 +514,6 @@ pub unsafe fn dict_entries_key_hash_at(entries: &ObjectDictStorage, index: usize
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_slot_count(entries: &ObjectDictStorage) -> usize {
     entries.entry_slots()
 }
@@ -510,7 +525,6 @@ pub unsafe fn dict_entries_slot_count(entries: &ObjectDictStorage) -> usize {
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_key_is_at(
     entries: &ObjectDictStorage,
     index: usize,
@@ -533,7 +547,6 @@ pub unsafe fn dict_entries_key_is_at(
 ///
 /// # Safety
 /// Same as [`dict_entries_value_at`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_generation(entries: &ObjectDictStorage) -> u32 {
     entries.generation()
 }
@@ -541,12 +554,11 @@ pub unsafe fn dict_entries_generation(entries: &ObjectDictStorage) -> u32 {
 /// Drop the last entry — the undo the checked store runs when a user `__eq__`
 /// raised mid-probe and `insert` therefore appended a spurious entry.
 ///
-/// Residual for the same reason its `insert` twin is; separating it keeps the
-/// error test itself traced.
+/// Undo a checked store that appended a spurious entry after a raising
+/// `__eq__`.  A slot pop, so the body stays look-inside.
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_hashed`].
-#[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_pop_last(entries: &mut ObjectDictStorage) {
     entries.pop();
 }
@@ -618,16 +630,21 @@ unsafe fn dict_entries_index_of_str(
 /// str hash hook has produced `hash` — [`dict_entries_probe_str`]'s twin,
 /// returning the entry index instead of the value.
 ///
-/// Residualised for [`dict_entries_probe_str`]'s reason: the
-/// `IndexMap::get_index_of` it wraps is the same external-crate heap lookup,
-/// and the user `__eq__` a str-subclass key can run sits inside the probe
-/// upstream too (`rdict.py ll_dict_lookup` carries
-/// `@jit.oopspec('dict.lookup')` over the whole `keyeq` loop).  The enclosing
-/// router keeps its hook gate and its allocating fallback visible.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`), the index-returning twin of
+/// [`dict_entries_probe_str`].
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_str`].
-#[majit_macros::dont_look_inside]
+fn dict_entries_index_of_str_hashed_iff(
+    entries: &ObjectDictStorage,
+    _hash: i64,
+    key: &str,
+) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_index_of_str_hashed_iff)]
 pub unsafe fn dict_entries_index_of_str_hashed(
     entries: &ObjectDictStorage,
     hash: i64,
@@ -639,13 +656,15 @@ pub unsafe fn dict_entries_index_of_str_hashed(
 /// The owned-key membership probe [`dict_entries_index_of_str`]'s no-hook arm
 /// runs — [`dict_entries_probe_object`]'s twin.
 ///
-/// Residualised for [`dict_entries_probe_object`]'s reason: a body that
-/// reaches either `get_index_of` stops there, so leaving one arm traced keeps
-/// the enclosing graph blocked no matter what the other arm does.
+/// Same predicate as [`dict_entries_probe_object`].
 ///
 /// # Safety
 /// Same as [`dict_entries_probe_object`].
-#[majit_macros::dont_look_inside]
+fn dict_entries_index_of_object_iff(entries: &ObjectDictStorage, key: PyObjectRef) -> bool {
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(dict_entries_index_of_object_iff)]
 pub unsafe fn dict_entries_index_of_object(
     entries: &ObjectDictStorage,
     key: PyObjectRef,
@@ -2908,20 +2927,21 @@ pub unsafe fn w_module_dict_lookup_inner(
 /// perform — `celldict.py:139 self.unerase(w_dict.dstorage).get(w_key)` once
 /// the module dict has been promoted to object storage.
 ///
-/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py`), the
-/// twin of [`w_dict_lookup_int_strategy`]: the `IndexMap::get` it wraps is an
-/// external-crate heap-lookup the tracer cannot model — the oopspec'd residual
-/// arm of `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
-/// The enclosing router keeps its str fast path, its never-equal shortcut and
-/// its strategy promotion visible, because `celldict.py:131-141` carries no
-/// residual marker of its own.
-///
-/// Returns `None` when the dict is not on object storage, matching the `?` the
-/// second call site used to spell.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).  Returns `None` when the dict is
+/// not on object storage, matching the `?` the second call site used to spell.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
-#[majit_macros::dont_look_inside]
+fn w_module_dict_lookup_object_entries_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    // The storage box is what `ll_dict_lookup` sees as `d`.
+    let entries = unsafe { w_module_dict_object_storage(obj) };
+    entries.is_some_and(|entries| {
+        majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+    })
+}
+
+#[majit_macros::look_inside_iff(w_module_dict_lookup_object_entries_iff)]
 pub unsafe fn w_module_dict_lookup_object_entries(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -4697,15 +4717,19 @@ pub unsafe fn w_dict_copy(obj: PyObjectRef) -> PyObjectRef {
 /// have already verified `is_correct_type(w_key)`.
 ///
 /// Residualise the int-storage setitem leaf (`@dont_look_inside`,
-/// `rlib/jit.py:139`): the `IndexMap::insert` it wraps is an external-crate
-/// heap-store the tracer cannot model — the oopspec'd residual arm of
-/// `rordereddict.ll_dict_setitem` (traced only for a virtual dict).
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py`).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::INT_DICT_STRATEGY`]; `key` must be a
 /// plain `W_IntObject` (not bool).
-#[majit_macros::dont_look_inside]
+fn w_dict_store_int_strategy_iff(obj: PyObjectRef, key: PyObjectRef, _value: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_int_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_store_int_strategy_iff)]
 pub unsafe fn w_dict_store_int_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
     lock_dict_refs!(_dict_guard, obj, key, value);
     let dict = &mut *(obj as *mut W_DictObject);
@@ -4721,14 +4745,17 @@ pub unsafe fn w_dict_store_int_strategy(obj: PyObjectRef, key: PyObjectRef, valu
 /// `dictmultiobject.py self.unerase(w_dict.dstorage).get(self.unwrap(w_key), None)`.
 /// Caller must have already verified `is_correct_type(w_key)`.
 ///
-/// Residualise the int-storage getitem leaf (`@dont_look_inside`,
-/// `rlib/jit.py:139`): the `IndexMap::get` it wraps is an external-crate
-/// heap-lookup the tracer cannot model — the oopspec'd residual arm of
-/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).
 ///
 /// # Safety
 /// Same as [`w_dict_store_int_strategy`].
-#[majit_macros::dont_look_inside]
+fn w_dict_lookup_int_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_int_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_lookup_int_strategy_iff)]
 pub unsafe fn w_dict_lookup_int_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -4741,12 +4768,16 @@ pub unsafe fn w_dict_lookup_int_strategy(
 
 /// Return the insertion-order index selected by an int-strategy lookup.
 ///
-/// Residualise the native table probe for the same reason as
-/// [`w_dict_lookup_int_strategy`] (`rdict.py:576`).
+/// Same predicate as [`w_dict_lookup_int_strategy`].
 ///
 /// # Safety
 /// Same as [`w_dict_lookup_int_strategy`].
-#[majit_macros::dont_look_inside]
+fn w_dict_index_of_int_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_int_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_index_of_int_strategy_iff)]
 pub unsafe fn w_dict_index_of_int_strategy(obj: PyObjectRef, key: PyObjectRef) -> Option<usize> {
     lock_dict_refs!(_dict_guard, obj, key);
     w_dict_index_of_int_locked(obj, key)
@@ -4768,15 +4799,16 @@ unsafe fn w_dict_index_of_int_locked(obj: PyObjectRef, key: PyObjectRef) -> Opti
 
 /// Return the live value selected by an int-strategy lookup.
 ///
-/// Residualise the native table probe for the same reason as
-/// [`w_dict_lookup_int_strategy`] (`rdict.py:576`). The index lookup and value
-/// read share one dict lock so the insertion-order index cannot be invalidated
-/// between the two operations — this guard is that lock, and both steps run
-/// under it directly rather than through helpers that take one each.
+/// Same predicate as [`w_dict_lookup_int_strategy`].
 ///
 /// # Safety
 /// Same as [`w_dict_lookup_int_strategy`].
-#[majit_macros::dont_look_inside]
+fn w_dict_lookup_or_null_int_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_int_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_lookup_or_null_int_strategy_iff)]
 pub unsafe fn w_dict_lookup_or_null_int_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -4798,7 +4830,12 @@ pub unsafe fn w_dict_lookup_or_null_int_strategy(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::UNICODE_DICT_STRATEGY`].
-#[majit_macros::dont_look_inside]
+fn w_dict_index_of_unicode_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_object_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_index_of_unicode_strategy_iff)]
 pub unsafe fn w_dict_index_of_unicode_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -4863,7 +4900,12 @@ unsafe fn w_str_memoized_hash(key: PyObjectRef, key_str: &str) -> Option<i64> {
 ///
 /// # Safety
 /// Same as [`w_dict_index_of_unicode_strategy`].
-#[majit_macros::dont_look_inside]
+fn w_dict_lookup_or_null_unicode_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_object_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_lookup_or_null_unicode_strategy_iff)]
 pub unsafe fn w_dict_lookup_or_null_unicode_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -5048,16 +5090,23 @@ pub unsafe fn w_dict_switch_int_to_object_strategy(w_dict: PyObjectRef) {
 /// `dictmultiobject.py:1061-1064` direct typed-storage write.  Caller
 /// must have already verified `is_correct_type(w_key)`.
 ///
-/// Residualise the bytes-storage setitem leaf (`@dont_look_inside`,
-/// `rlib/jit.py:139`): the `IndexMap::insert` it wraps is an external-crate
-/// heap-store the tracer cannot model — the oopspec'd residual arm of
-/// `rordereddict.ll_dict_setitem` (traced only for a virtual dict).
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py`).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::BYTES_DICT_STRATEGY`]; `key` must be a
 /// `W_BytesObject`.
-#[majit_macros::dont_look_inside]
+fn w_dict_store_bytes_strategy_iff(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    _value: PyObjectRef,
+) -> bool {
+    let entries = unsafe { w_dict_bytes_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_store_bytes_strategy_iff)]
 pub unsafe fn w_dict_store_bytes_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
     lock_dict_refs!(_dict_guard, obj, key, value);
     let dict = &mut *(obj as *mut W_DictObject);
@@ -5073,14 +5122,17 @@ pub unsafe fn w_dict_store_bytes_strategy(obj: PyObjectRef, key: PyObjectRef, va
 /// `dictmultiobject.py:1098`.  Caller must have already verified
 /// `is_correct_type(w_key)`.
 ///
-/// Residualise the bytes-storage getitem leaf (`@dont_look_inside`,
-/// `rlib/jit.py:139`): the `IndexMap::get` it wraps is an external-crate
-/// heap-lookup the tracer cannot model — the oopspec'd residual arm of
-/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).
 ///
 /// # Safety
 /// Same as [`w_dict_store_bytes_strategy`].
-#[majit_macros::dont_look_inside]
+fn w_dict_lookup_bytes_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let entries = unsafe { w_dict_bytes_storage(obj) };
+    majit_rlib::jit::isvirtual(entries) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_lookup_bytes_strategy_iff)]
 pub unsafe fn w_dict_lookup_bytes_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -75,18 +75,19 @@ unsafe fn identity_storage<'a>(obj: PyObjectRef) -> &'a IdentityDictStorage {
 /// Internal helper: `IdentityDictStrategy::getitem` body.  Caller must have
 /// already verified `is_correct_type(w_key)`.
 ///
-/// Residualise the identity-storage getitem leaf (`@dont_look_inside`,
-/// `rlib/jit.py:139`), the twin of `dictmultiobject::w_dict_lookup_int_strategy`:
-/// the `IndexMap::get` it wraps is an external-crate heap-lookup the tracer
-/// cannot model — the oopspec'd residual arm of
-/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
-/// [`IdentityKey`] hashes and compares by address, so the probe runs no user
-/// Python code at all.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `ll_dict_lookup` (`rordereddict.py`).  [`IdentityKey`] hashes and
+/// compares by address, so the probe runs no user Python code.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on
 /// [`IDENTITY_DICT_STRATEGY`].
-#[majit_macros::dont_look_inside]
+fn w_dict_lookup_identity_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let storage = unsafe { identity_storage(obj) };
+    majit_rlib::jit::isvirtual(storage) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_lookup_identity_strategy_iff)]
 pub unsafe fn w_dict_lookup_identity_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
@@ -97,17 +98,17 @@ pub unsafe fn w_dict_lookup_identity_strategy(
 /// `dictmultiobject.py delitem`'s identity-keyed remove — drop the
 /// entry for `key` and report whether one was there.
 ///
-/// Residualise the storage remove alone (`@dont_look_inside`,
-/// `rlib/jit.py:139`), the delete twin of [`w_dict_lookup_identity_strategy`]:
-/// upstream's `_ll_dict_del` (`rordereddict.py`) carries
-/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))`, and the
-/// storage can never be virtual to this front end, so the predicate is
-/// permanently false and the residual arm is the only one reachable.  The
-/// keys-version bump stays traced.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))` on
+/// `_ll_dict_del` (`rordereddict.py`).  The keys-version bump stays traced.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
-#[majit_macros::dont_look_inside]
+fn w_dict_delete_identity_strategy_iff(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let storage = unsafe { identity_storage(obj) };
+    majit_rlib::jit::isvirtual(storage) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_delete_identity_strategy_iff)]
 pub unsafe fn w_dict_delete_identity_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
     identity_storage_mut(obj)
         .remove(&IdentityKey(key))
@@ -118,18 +119,23 @@ pub unsafe fn w_dict_delete_identity_strategy(obj: PyObjectRef, key: PyObjectRef
 /// `value` under the address-identity of `key`, reporting whether the slot was
 /// newly filled so the caller bumps the keys-version only on a real insert.
 ///
-/// Residualise the storage insert alone (`@dont_look_inside`,
-/// `rlib/jit.py:139`), the store twin of [`w_dict_lookup_identity_strategy`]:
-/// upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py`) is
-/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`, and an
-/// `IndexMap` can never be virtual to this front end, so neither conjunct can
-/// hold and the residual arm is the only one reachable.  [`IdentityKey`]
-/// hashes and compares by address, so the store runs no user Python code at
-/// all; the keys-version bump and the GC write barrier stay traced.
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))` on
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py`).  [`IdentityKey`]
+/// hashes and compares by address; the keys-version bump and write barrier
+/// stay traced.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
-#[majit_macros::dont_look_inside]
+fn w_dict_store_identity_strategy_iff(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    _value: PyObjectRef,
+) -> bool {
+    let storage = unsafe { identity_storage(obj) };
+    majit_rlib::jit::isvirtual(storage) && majit_rlib::jit::isconstant(&key)
+}
+
+#[majit_macros::look_inside_iff(w_dict_store_identity_strategy_iff)]
 pub unsafe fn w_dict_store_identity_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -214,7 +214,8 @@ impl IntArray {
         false
     }
 
-    fn grow(&mut self, min_cap: usize) {
+    /// `_ll_list_resize_hint_really(overallocate=True)` for this block.
+    pub fn grow(&mut self, min_cap: usize) {
         // rlist.py `_ll_list_resize_hint_really(overallocate=True)`:
         // 0, 4, 8, 16, 25, 35, ...
         let extra = if min_cap < 9 { 3 } else { 6 };

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -733,11 +733,7 @@ impl W_ListObject {
         // instead of manufacturing a Rust fat slice over the over-allocated
         // items block.
         //
-        // Its `@jit.look_inside_iff(lambda l: jit.isvirtual(l) and
-        // jit.isconstant(l.ll_length()))` is not carried: pyre has no
-        // `jit.isvirtual` / `jit.isconstant` intrinsic, so the predicate
-        // cannot be spelled — the same gap the four `look_inside_iff` notes
-        // in `dictmultiobject.rs` record.
+        // `rlist.py ll_reverse` look_inside_iff lives on [`w_list_reverse`].
         let base = items_block_items_base(this.items);
         let mut i = 0;
         let mut length_1_i = this.length_relaxed() as isize - 1;
@@ -1186,11 +1182,15 @@ unsafe fn float_to_int_or_float(list: &mut W_ListObject) -> bool {
 
 /// listobject.py AbstractUnwrappedStrategy.getitems_copy.
 ///
-/// The two hints on the same function -- `getitems_unroll =
-/// jit.unroll_safe(...)` and `getitems_copy = jit.look_inside_iff(lambda
-/// self, w_list: w_list._unrolling_heuristic())(...)` -- are absent;
-/// `look_inside_iff` needs `jit.isvirtual`/`isconstant`, which pyre has no
-/// intrinsic for yet.
+/// `listobject.py AbstractUnwrappedStrategy.getitems_copy`:
+/// `getitems_copy = jit.look_inside_iff(lambda self, w_list: w_list._unrolling_heuristic())`.
+/// Default `_unrolling_heuristic` is `size == 0 or (isconstant(size) and size <= UNROLL_CUTOFF)`.
+fn boxed_from_ints_iff(values: &[i64], _we_are_jitted: bool) -> bool {
+    let size = values.len();
+    size == 0 || (majit_rlib::jit::isconstant(&size) && size <= UNROLL_CUTOFF)
+}
+
+#[majit_macros::look_inside_iff(boxed_from_ints_iff)]
 fn boxed_from_ints(values: &[i64], we_are_jitted: bool) -> Vec<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
@@ -1544,8 +1544,18 @@ unsafe fn switch_to_correct_strategy(list: &mut W_ListObject, w_item: PyObjectRe
 
 /// The strategy `w_list_new` picks for a given item set.
 ///
+/// `listobject.py UNROLL_CUTOFF`.
+const UNROLL_CUTOFF: usize = 5;
+
+/// `listobject.py _get_strategy_from_list_object_*`:
+/// `@jit.look_inside_iff(lambda space, list_w: jit.loop_unrolling_heuristic(list_w, len(list_w), UNROLL_CUTOFF))`.
+fn list_strategy_for_iff(items: &[PyObjectRef]) -> bool {
+    majit_rlib::jit::loop_unrolling_heuristic(items, items.len(), UNROLL_CUTOFF)
+}
+
 /// listobject.py EmptyListStrategy: a freshly created list with no
 /// items uses Empty until first append picks a typed strategy.
+#[majit_macros::look_inside_iff(list_strategy_for_iff)]
 pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
     if items.is_empty() {
         ListStrategy::Empty
@@ -2971,6 +2981,15 @@ pub unsafe fn w_list_physical_size(obj: PyObjectRef) -> Option<usize> {
 /// permits a lying private hint to truncate the backing below live elements,
 /// but Rust slices require the same `length <= capacity` invariant that the
 /// real caller is documented to uphold.
+/// `rlist.py _ll_list_resize_hint`: `@jit.look_inside_iff(lambda l, newsize: jit.isconstant(len(l.items)) and jit.isconstant(newsize))`.
+fn w_list_resize_hint_iff(obj: PyObjectRef, newsize: i64) -> bool {
+    unsafe {
+        let cap = strategy_capacity(&*(obj as *const W_ListObject)).unwrap_or(0);
+        majit_rlib::jit::isconstant(&cap) && majit_rlib::jit::isconstant(&newsize)
+    }
+}
+
+#[majit_macros::look_inside_iff(w_list_resize_hint_iff)]
 pub unsafe fn w_list_resize_hint(obj: PyObjectRef, newsize: i64) -> bool {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
@@ -4218,11 +4237,20 @@ pub unsafe fn w_list_switch_to_strategy_for(obj: PyObjectRef, value: PyObjectRef
     crate::gc_roots::shadow_stack_get(root_base)
 }
 
+/// `rlist.py ll_reverse`: `@jit.look_inside_iff(lambda l: jit.isvirtual(l) and jit.isconstant(l.ll_length()))`.
+fn w_list_reverse_iff(obj: PyObjectRef) -> bool {
+    unsafe {
+        majit_rlib::jit::isvirtual(&*(obj as *const W_ListObject))
+            && majit_rlib::jit::isconstant(&(*(obj as *const W_ListObject)).live_len())
+    }
+}
+
 /// listobject.py IntegerListStrategy.reverse
 /// Strategy-preserving: reverses typed storage in place.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
+#[majit_macros::look_inside_iff(w_list_reverse_iff)]
 pub unsafe fn w_list_reverse(obj: PyObjectRef) {
     let roots = crate::gc_roots::push_roots();
     let obj = roots.pin_root(obj);
@@ -5715,7 +5743,19 @@ mod tests {
                 crate::intobject::w_int_get_value(w_list_getitem(list, 2).unwrap()),
                 1
             );
+            // Residual `look_inside_iff` takes the orig arm (`!we_are_jitted()`).
+            assert!(!w_list_reverse_iff(list));
         }
+    }
+
+    #[test]
+    fn list_strategy_for_iff_uses_loop_unrolling_heuristic() {
+        // `rlib/jit.py loop_unrolling_heuristic`: empty unrolls; residual
+        // `isconstant` is false so a non-empty list does not.
+        assert!(list_strategy_for_iff(&[]));
+        let items = [w_int_new(1), w_int_new(2)];
+        assert!(!list_strategy_for_iff(&items));
+        assert_eq!(list_strategy_for(&items), ListStrategy::Integer);
     }
 
     #[test]

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -2761,12 +2761,19 @@ pub unsafe fn w_list_append_inner(obj: PyObjectRef, value: PyObjectRef) {
             if is_plain_int1(value) {
                 // ll_append (rtyper/rlist.py): length = ll_length();
                 // _ll_resize_ge(length+1); ll_setitem_fast(length, item).
+                // The #171 append fold walks this capacity `goto_if_not`
+                // (`specialize.rs orthodox_list_append_recognize`) and lowers
+                // the `list.int_*` oopspecs; always calling
+                // `ll_list_int_resize_ge` is a residual the fold declines,
+                // so the compiled loop residual-calls every integer append.
                 let item = plain_int_w(value);
                 let length = ll_list_int_length(list);
-                ll_list_int_resize_ge(obj, length + 1);
-                let obj = current_gc_ref(obj);
-                let list = &mut *(obj as *mut W_ListObject);
-                ll_list_int_setitem_fast(list, length, item);
+                if length < ll_list_int_capacity(list) {
+                    ll_list_int_set_len(list, length + 1);
+                    ll_list_int_setitem_fast(list, length, item);
+                } else {
+                    list.int_items.push(item);
+                }
             } else if is_float_strategy_item(value) && integer_to_int_or_float(list) {
                 let obj = current_gc_ref(obj);
                 let value = current_gc_ref(value);

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1184,10 +1184,10 @@ unsafe fn float_to_int_or_float(list: &mut W_ListObject) -> bool {
 ///
 /// `listobject.py AbstractUnwrappedStrategy.getitems_copy`:
 /// `getitems_copy = jit.look_inside_iff(lambda self, w_list: w_list._unrolling_heuristic())`.
-/// Default `_unrolling_heuristic` is `size == 0 or (isconstant(size) and size <= UNROLL_CUTOFF)`.
+/// `AbstractUnwrappedStrategy._unrolling_heuristic` is
+/// `loop_unrolling_heuristic(storage, len(storage), UNROLL_CUTOFF)`.
 fn boxed_from_ints_iff(values: &[i64], _we_are_jitted: bool) -> bool {
-    let size = values.len();
-    size == 0 || (majit_rlib::jit::isconstant(&size) && size <= UNROLL_CUTOFF)
+    majit_rlib::jit::loop_unrolling_heuristic(values, values.len(), UNROLL_CUTOFF)
 }
 
 #[majit_macros::look_inside_iff(boxed_from_ints_iff)]

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -2241,6 +2241,55 @@ pub fn ll_list_int_set_len(l: &mut W_ListObject, n: usize) {
     l.int_items.set_len(n);
 }
 
+/// `rlist.py _ll_list_resize_hint_really` for Integer storage.
+///
+/// `@jit.look_inside_iff(lambda l, newsize, overallocate: jit.isconstant(len(l.items)) and jit.isconstant(newsize))`.
+fn ll_list_int_resize_hint_really_iff(
+    obj: PyObjectRef,
+    newsize: usize,
+    _overallocate: bool,
+) -> bool {
+    unsafe {
+        let cap = ll_list_int_capacity(&*(obj as *const W_ListObject));
+        majit_rlib::jit::isconstant(&cap) && majit_rlib::jit::isconstant(&newsize)
+    }
+}
+
+#[majit_macros::look_inside_iff(ll_list_int_resize_hint_really_iff)]
+pub unsafe fn ll_list_int_resize_hint_really(obj: PyObjectRef, newsize: usize, overallocate: bool) {
+    let list = &mut *(obj as *mut W_ListObject);
+    if overallocate {
+        list.int_items.grow(newsize);
+    } else if newsize > list.int_items.heap_capacity() {
+        list.int_items.grow(newsize);
+    }
+}
+
+/// `rlist.py _ll_list_resize_ge` for Integer storage.
+///
+/// `cond = len(l.items) < newsize`; a constant pair inlines the realloc,
+/// otherwise `jit.conditional_call` keeps the fast path bridge-free.
+pub unsafe fn ll_list_int_resize_ge(obj: PyObjectRef, newsize: usize) {
+    let list = &*(obj as *const W_ListObject);
+    let allocated = ll_list_int_capacity(list);
+    let cond = allocated < newsize;
+    if majit_rlib::jit::isconstant(&allocated) && majit_rlib::jit::isconstant(&newsize) {
+        if cond {
+            ll_list_int_resize_hint_really(obj, newsize, true);
+        }
+    } else {
+        majit_rlib::jit::conditional_call3(
+            cond,
+            ll_list_int_resize_hint_really,
+            obj,
+            newsize,
+            true,
+        );
+    }
+    let list = &mut *(obj as *mut W_ListObject);
+    ll_list_int_set_len(list, newsize);
+}
+
 // Float-strategy storage leaves, mirroring the Integer leaves above but
 // addressing `float_items.{len,block}` and holding unboxed `f64` scalars.
 // The codewriter recognises the `#[oopspec("list.float_*")]` tag and emits
@@ -2712,17 +2761,12 @@ pub unsafe fn w_list_append_inner(obj: PyObjectRef, value: PyObjectRef) {
             if is_plain_int1(value) {
                 // ll_append (rtyper/rlist.py): length = ll_length();
                 // _ll_resize_ge(length+1); ll_setitem_fast(length, item).
-                // The resize-ge fast case (rlist.py:285) inlines only while
-                // there is spare capacity; bump the length and store in
-                // place. Otherwise fall back to the resizing push.
                 let item = plain_int_w(value);
                 let length = ll_list_int_length(list);
-                if length < ll_list_int_capacity(list) {
-                    ll_list_int_set_len(list, length + 1);
-                    ll_list_int_setitem_fast(list, length, item);
-                } else {
-                    list.int_items.push(item);
-                }
+                ll_list_int_resize_ge(obj, length + 1);
+                let obj = current_gc_ref(obj);
+                let list = &mut *(obj as *mut W_ListObject);
+                ll_list_int_setitem_fast(list, length, item);
             } else if is_float_strategy_item(value) && integer_to_int_or_float(list) {
                 let obj = current_gc_ref(obj);
                 let value = current_gc_ref(value);
@@ -5369,6 +5413,23 @@ mod tests {
             // The write is observable through the public accessor.
             let item = w_list_getitem(list, 1).unwrap();
             assert_eq!(crate::intobject::w_int_get_value(item), 99);
+        }
+    }
+
+    #[test]
+    fn integer_resize_ge_grows_then_stores() {
+        // Residual `_ll_list_resize_ge` + `ll_setitem_fast` (rlist.py ll_append).
+        let list = w_list_new(vec![w_int_new(1)]);
+        unsafe {
+            w_list_append(list, w_int_new(2));
+            w_list_append(list, w_int_new(3));
+            w_list_append(list, w_int_new(4));
+            w_list_append(list, w_int_new(5));
+            assert_eq!(w_list_len(list), 5);
+            let l = &*(list as *const W_ListObject);
+            assert_eq!(l.strategy, ListStrategy::Integer);
+            assert!(ll_list_int_capacity(l) >= 5);
+            assert_eq!(ll_list_int_getitem_fast(l, 4), 5);
         }
     }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -922,6 +922,25 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             }
             eprintln!("[jit-stats] bridge_diag {}", parts.join(" "));
         }
+        // `compile_loop` `Err` reason. `cl_entered` without `cl_ok` /
+        // `cl_decl_*` means `build_wasm_module` declined and the string
+        // never left the guest; this is the only host-visible copy.
+        if let (Ok(len_fn), Ok(byte_fn)) = (
+            instance.get_typed_func::<(), u32>(&mut store, "pyre_jit_last_compile_err_len"),
+            instance.get_typed_func::<u32, u32>(&mut store, "pyre_jit_last_compile_err_byte"),
+        ) {
+            let len = len_fn.call(&mut store, ()).unwrap_or(0);
+            if len > 0 {
+                let mut bytes = Vec::with_capacity(len as usize);
+                for i in 0..len {
+                    bytes.push(byte_fn.call(&mut store, i).unwrap_or(0) as u8);
+                }
+                eprintln!(
+                    "[jit-stats] last_compile_err {}",
+                    String::from_utf8_lossy(&bytes)
+                );
+            }
+        }
         // The portal's own decision tallies. POSITIONAL MIRROR of
         // `pyre_jit::eval::PORTAL_DIAG_LABELS`, but unlike `bridge_diag` above
         // the guest also exports the slot count, so a slot added there without

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -467,6 +467,21 @@ pub extern "C" fn pyre_jit_bridge_diag(i: u32) -> u64 {
     majit_backend_wasm::bridge_diag(i as usize)
 }
 
+/// Last `compile_loop` `Err` string, byte `i`. The guest has no stderr, so
+/// this is how the host reads `build_wasm_module`'s decline. Pair with
+/// [`pyre_jit_last_compile_err_len`].
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_last_compile_err_byte(i: u32) -> u32 {
+    majit_backend_wasm::last_compile_err_byte(i)
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_last_compile_err_len() -> u32 {
+    majit_backend_wasm::last_compile_err_len()
+}
+
 /// Packed `(kind, needed, available)` geometry for an inline-module trial that
 /// did not fit its owner's frozen frame. The host formats this diagnostic only.
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]


### PR DESCRIPTION
## Summary

Open virtual-dict probes the way `rordereddict.py` does: `@look_inside_iff(isvirtual and isconstant)`. Port `rlib/jit.py` `we_are_jitted` / `isconstant` / `isvirtual` into `majit-rlib`, fold those paths in the translator, and register `ref_isconstant` / `ref_isvirtual` on the production blackhole (`bhimpl_ref_isconstant` / `bhimpl_ref_isvirtual`).

Fold the Rust `p as usize as *mut T` spelling as `rewrite_op_cast_opaque_ptr`: the `cast_int_to_ptr(cast_ptr_to_int(p))` Call pair aliases the original GC pointer. UnaryOp ptr/int roundtrips stay explicit.

Admit a raising instance `__next__` / `__iter__` the way `__getitem__` already does (`owns_loop_header` still declines). Keep JitCode descr slots as body indexes.

A cranelift 16-wide Tail JUMP entry was attempted and restored: it SIGBUS'd on high-arity loops. JUMP values stay in jitframe slots.

`synth/global_reassign` `max-pypy-ratio` is 5 after the compiled loop reached pypy parity.

`python3 pyre/check.py`: dynasm 549/549, cranelift 549/549, wasm 542/542.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved JIT tracing for constant and virtual object checks.
  * Improved specialization of dictionary, list, string-joining, and `sys._getframe` operations.
  * Iterator methods that raise exceptions can now be inlined in more cases.
  * Improved handling of pointer conversions and conditional calls during compilation.
* **Reliability**
  * Preserved safety qualifiers and runtime JIT-state detection across optimized execution paths.
* **Diagnostics**
  * WASM JIT statistics now report the most recent compilation failure reason.
* **Testing**
  * Added coverage for dispatch, casting, loop-unrolling, and JIT specialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->