### PR TITLE
stdlib: address #1726 review on suite colon and baseline cells

### DIFF
--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -104,8 +104,8 @@ before any test, a denied resource, or a suite whose every case was skipped).
 
 ## Current state and backlog (Phase 0)
 
-The baseline records **262 `PASS`**, 32 `IMPORTERROR`, 62 `SKIP`,
-69 `FAIL`, 7 `CRASH`, and 7 `TIMEOUT` (439 recorded rows, stdlib 3.14.6). These are a
+The baseline records **262 `PASS`**, 27 `IMPORTERROR`, 61 `SKIP`,
+69 `FAIL`, 7 `CRASH`, and 7 `TIMEOUT` (433 recorded rows, stdlib 3.14.6). These are a
 snapshot counted from `baseline.json`, which is the authority when they disagree.
 `IMPORTERROR` here means unittest never printed a summary — many of those
 labels are stale (the modules now import and run). Re-measure with

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -496,8 +496,7 @@
       "reason": "implementation detail"
     },
     "test.test_free_threading": {
-      "dynasm": "SKIP",
-      "reason": "CPython free-threading internals"
+      "dynasm": "IMPORTERROR"
     },
     "test.test_frozen": {
       "dynasm": "SKIP",
@@ -764,9 +763,6 @@
       "dynasm": "PASS"
     },
     "test.test_monitoring": {
-      "dynasm": "IMPORTERROR"
-    },
-    "test.test_msvcrt": {
       "dynasm": "IMPORTERROR"
     },
     "test.test_multibytecodec": {
@@ -1081,9 +1077,6 @@
       "dynasm": "SKIP",
       "reason": "needs ctypes.pythonapi"
     },
-    "test.test_startfile": {
-      "dynasm": "IMPORTERROR"
-    },
     "test.test_stat": {
       "dynasm": "PASS"
     },
@@ -1385,15 +1378,6 @@
     "test.test_webbrowser": {
       "dynasm": "PASS"
     },
-    "test.test_winapi": {
-      "dynasm": "IMPORTERROR"
-    },
-    "test.test_winconsoleio": {
-      "dynasm": "IMPORTERROR"
-    },
-    "test.test_winreg": {
-      "dynasm": "IMPORTERROR"
-    },
     "test.test_winsound": {
       "dynasm": "SKIP",
       "reason": "needs audio hardware"
@@ -1401,9 +1385,6 @@
     "test.test_with": {
       "cranelift": "PASS",
       "dynasm": "PASS"
-    },
-    "test.test_wmi": {
-      "dynasm": "IMPORTERROR"
     },
     "test.test_wsgiref": {
       "dynasm": "PASS"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -133,7 +133,6 @@ KNOWN_SKIPS = {
     "test.test__interpchannels": "CPython subinterpreter API; PyPy has no owner",
     "test.test__interpreters": "CPython subinterpreter API; PyPy has no owner",
     "test.test_crossinterp": "CPython subinterpreter API; PyPy has no owner",
-    "test.test_free_threading": "CPython free-threading internals",
     "test.test_thread_local_bytecode": "CPython specializing-interpreter internals",
     "test.test_generated_cases": "CPython bytecode case generator",
     "test.test_optimizer": "CPython specializing optimizer",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14990,8 +14990,19 @@ fn compile_err_to_syntax_error_maybe_incomplete(
             // below to the forgot-a-comma form).
             ParseErrorType::ExpectedToken {
                 expected: rustpython_compiler::ast::token::TokenKind::Colon,
-                ..
-            } if compound_suite_header_at(source, parse_err.raw_location.start().to_usize()) => {
+                found,
+            } if matches!(
+                found,
+                rustpython_compiler::ast::token::TokenKind::Newline
+                    | rustpython_compiler::ast::token::TokenKind::NonLogicalNewline
+                    | rustpython_compiler::ast::token::TokenKind::EndOfFile
+                    | rustpython_compiler::ast::token::TokenKind::Indent
+                    | rustpython_compiler::ast::token::TokenKind::Dedent
+            ) && compound_suite_header_at(
+                source,
+                parse_err.raw_location.start().to_usize(),
+            ) =>
+            {
                 "expected ':'".to_owned()
             }
             ParseErrorType::ExpectedToken { .. } => "invalid syntax".to_owned(),
@@ -15684,14 +15695,30 @@ fn scan_line_nesting(bytes: &[u8], depth: &mut usize, in_triple: &mut Option<u8>
     Some(())
 }
 
-/// Whether `loc` sits on a compound suite header that is missing its `:`.
+/// Whether `loc` sits after a compound suite header that is missing its `:`.
 ///
 /// The 3.14 `invalid_colon` rule names `try`/`if`/`def`/…, not every
-/// colon the parser can demand (`lambda`, dict displays).
+/// colon the parser can demand (`lambda`, dict displays).  A parenthesized
+/// `if`/`def` header can place `loc` on the newline after `)`, so the
+/// keyword is found by walking back through balanced brackets.
 fn compound_suite_header_at(source: &str, loc: usize) -> bool {
     let loc = loc.min(source.len());
-    let line_start = source[..loc].rfind('\n').map_or(0, |i| i + 1);
-    let mut rest = source[line_start..].trim_start();
+    let bytes = source.as_bytes();
+    let mut i = loc;
+    let mut depth = 0i32;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b')' | b']' | b'}' => depth += 1,
+            b'(' | b'[' | b'{' if depth > 0 => depth -= 1,
+            b'\n' if depth == 0 => {
+                i += 1;
+                break;
+            }
+            _ => {}
+        }
+    }
+    let mut rest = source[i..loc].trim_start();
     if let Some(after) = rest.strip_prefix("async") {
         if after.starts_with(|c: char| c.is_whitespace()) {
             rest = after.trim_start();


### PR DESCRIPTION
## Summary

Follow-up to #1726 (squash-merged as `5ae16e40c4d`). Codex/CodeRabbit comments that landed after the merge:

- Rewrite `expected ':'` only when the parser found a newline/EOF/indent after a compound header. `class R&D:` stays `invalid syntax`. Parenthesized `if`/`def` headers still get `expected ':'`.
- Remove `test_free_threading` from `KNOWN_SKIPS` (concurrent builtin cases stay on the backlog).
- Drop shared `IMPORTERROR` cells for Windows-only modules; POSIX still uses `platform_gate`, win32 overlay keeps PASS.
- README counts match `baseline.json` (262 PASS / 27 IMPORTERROR / 61 SKIP / 69 FAIL / 7 CRASH / 7 TIMEOUT).

No extra_tests snippets; `test_syntax` owns the colon cases.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved missing-colon diagnostics for compound statements, including statements spanning parentheses and other bracketed expressions.
  - Diagnostics now appear more reliably at relevant line boundaries, such as end-of-file, indentation changes, and line breaks.

- **Tests**
  - Updated CPython regression-test baselines to reflect current outcomes.
  - Free-threading tests are now run and recorded instead of being automatically skipped.
  - Removed obsolete Windows-specific baseline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->