### PR TITLE
blackhole: put GC FieldRead bases in the Ref bank

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5908,23 +5908,20 @@ mod tests {
 
         #[test]
         fn wire_bhimpl_handlers_wires_non_vable_int_base_access_aliases() {
-            // Raw/tagged-pointer getfield/setfield/array operations may carry
-            // their base in the Int bank.  Virtualizable operations may not:
-            // every PyPy `bhimpl_*_vable_*` declares its base as `"r"`, and
-            // only the Ref bank is GC-forwarded.
+            // setfield/array int-base forms still exist (FieldWrite /
+            // ArrayRead emit has not been rehomed).  getfield_gc is
+            // Ref-bank only — an Int-bank base is getfield_raw.
             let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
-            insns.insert("getfield_gc_i/id>i".to_string(), 0u8);
-            insns.insert("getfield_gc_r/id>r".to_string(), 1u8);
-            insns.insert("setfield_gc_i/iid".to_string(), 2u8);
-            insns.insert("setfield_gc_r/ird".to_string(), 3u8);
-            insns.insert("getarrayitem_gc_i/iid>i".to_string(), 4u8);
+            insns.insert("setfield_gc_i/iid".to_string(), 0u8);
+            insns.insert("setfield_gc_r/ird".to_string(), 1u8);
+            insns.insert("getarrayitem_gc_i/iid>i".to_string(), 2u8);
 
             let mut builder = BlackholeInterpBuilder::new();
             builder.setup_insns(&insns);
             super::wire_bhimpl_handlers(&mut builder);
 
             let placeholder = super::unwired_handler_placeholder as *const () as usize;
-            for slot in 0usize..=4 {
+            for slot in 0usize..=2 {
                 assert_ne!(
                     builder.dispatch_table[slot] as *const () as usize, placeholder,
                     "slot {slot} must be wired",
@@ -5935,9 +5932,11 @@ mod tests {
         #[test]
         fn wire_bhimpl_handlers_rejects_vable_int_base_aliases() {
             let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
-            insns.insert("getfield_vable_i/id>i".to_string(), 0u8);
-            insns.insert("setfield_vable_i/iid".to_string(), 1u8);
-            insns.insert("setfield_vable_r/ird".to_string(), 2u8);
+            insns.insert("getfield_gc_i/id>i".to_string(), 0u8);
+            insns.insert("getfield_gc_r/id>r".to_string(), 1u8);
+            insns.insert("getfield_vable_i/id>i".to_string(), 2u8);
+            insns.insert("setfield_vable_i/iid".to_string(), 3u8);
+            insns.insert("setfield_vable_r/ird".to_string(), 4u8);
 
             let mut builder = BlackholeInterpBuilder::new();
             builder.setup_insns(&insns);
@@ -5946,6 +5945,8 @@ mod tests {
             assert_eq!(
                 builder.unwired_opnames(),
                 vec![
+                    "getfield_gc_i/id>i",
+                    "getfield_gc_r/id>r",
                     "getfield_vable_i/id>i",
                     "setfield_vable_i/iid",
                     "setfield_vable_r/ird",
@@ -8530,36 +8531,12 @@ fn handler_getfield_gc_i(
     bh.registers_i[code[pos] as usize] = result;
     Ok(pos + 1)
 }
-fn handler_getfield_gc_i_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let struct_ptr = bh.registers_i[code[position] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    let result = cpu.bh_getfield_gc_i(struct_ptr, descr);
-    bh.registers_i[code[pos] as usize] = result;
-    Ok(pos + 1)
-}
 fn handler_getfield_gc_r(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     position: usize,
 ) -> Result<usize, DispatchError> {
     let struct_ptr = bh.registers_r[code[position] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    let result = cpu.bh_getfield_gc_r(struct_ptr, descr);
-    bh.registers_r[code[pos] as usize] = result.0 as i64;
-    Ok(pos + 1)
-}
-fn handler_getfield_gc_r_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let struct_ptr = bh.registers_i[code[position] as usize];
     let (descr, pos) = read_descr(bh, code, position + 1);
     let cpu = bh.cpu();
     let result = cpu.bh_getfield_gc_r(struct_ptr, descr);
@@ -8578,19 +8555,6 @@ fn handler_getfield_gc_f(
     bh.registers_f[code[pos] as usize] = result.to_bits() as i64;
     Ok(pos + 1)
 }
-fn handler_getfield_gc_f_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let struct_ptr = bh.registers_i[code[position] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 1);
-    let cpu = bh.cpu();
-    let result = cpu.bh_getfield_gc_f(struct_ptr, descr);
-    bh.registers_f[code[pos] as usize] = result.to_bits() as i64;
-    Ok(pos + 1)
-}
-
 // bhimpl_setfield_gc_i: @arguments("cpu", "r", "i", "d")
 fn handler_setfield_gc_i(
     bh: &mut BlackholeInterpreter,
@@ -10003,8 +9967,9 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // (an int field store, `setfield_gc_i/rid` = BC_SETFIELD_GC_I 0xac)
     // landed on the unwired-opcode placeholder.
     // Canonical `rd`/`r{i,r,f}d` argcodes only (these access fields off a
-    // ref base); intbase (`id`/`iid`/`ird`) forms have no canonical byte
-    // and are not emitted here.  Additive: every byte is currently unwired.
+    // ref base).  `getfield_gc` intbase (`id`) is no longer a handler;
+    // `promote_gc_field_bases` rehomes a Signed GC pointer so the
+    // assembler emits `/rd>X`.  Additive: every byte is currently unwired.
     for (key, byte) in [
         (
             "getfield_gc_i/rd>i",
@@ -10751,21 +10716,16 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
 
     // Field operations (blackhole.py:1432-1481).
     //
-    // Canonical `/rd>X` and `/rXd` are the RPython-exact keys. The
-    // `/id>X` / `/iXd` variants carry a pyre tagged-int base in an int
-    // register (same backend primitive `bh_{get,set}field_gc_*`, only
-    // the base's register class differs). The emit side at
-    // `majit-translate/src/codewriter/assembler.rs` OpKind::FieldRead/
-    // FieldWrite derives the opname kind suffix from the VALUE / RESULT
-    // register kind and the argcodes from each register's class, so the
-    // tagged-int variant is indistinguishable from the canonical one
-    // except at the first argcode character.
+    // Canonical `/rd>X` and `/rXd` are the RPython-exact keys.
+    // `bhimpl_getfield_gc_*` takes the struct in the Ref bank
+    // (`@arguments("cpu", "r", "d", returns="X")`).  An Int-bank base
+    // is `getfield_raw_*` (`@arguments("cpu", "i", "d", returns="X")`),
+    // not a `getfield_gc` alias — `promote_gc_field_bases` rehomes a
+    // GC pointer that arrived as Signed so the assembler never emits
+    // `/id>X` for `getfield_gc`.
     builder.wire_handler("getfield_gc_i/rd>i", handler_getfield_gc_i);
     builder.wire_handler("getfield_gc_r/rd>r", handler_getfield_gc_r);
     builder.wire_handler("getfield_gc_f/rd>f", handler_getfield_gc_f);
-    builder.wire_handler("getfield_gc_i/id>i", handler_getfield_gc_i_intbase);
-    builder.wire_handler("getfield_gc_r/id>r", handler_getfield_gc_r_intbase);
-    builder.wire_handler("getfield_gc_f/id>f", handler_getfield_gc_f_intbase);
     builder.wire_handler("getfield_gc_i_pure/rd>i", handler_getfield_gc_i);
     builder.wire_handler("getfield_gc_r_pure/rd>r", handler_getfield_gc_r);
     builder.wire_handler("getfield_gc_f_pure/rd>f", handler_getfield_gc_f);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1667,6 +1667,13 @@ impl Assembler {
                 pure,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
+                assert_eq!(
+                    kc, 'r',
+                    "getfield_gc base must use the Ref register bank \
+                     (blackhole.py bhimpl_getfield_gc_* @arguments(\"cpu\", \"r\", \"d\", returns=\"X\")); \
+                     an Int-bank base is getfield_raw — graph {:?}",
+                    self.current_graph_name,
+                );
                 state.code.push(reg);
                 argcodes.push(kc);
                 let descr_idx = self.emit_ready_descr(fielddescrof(field, ty, callcontrol));
@@ -7713,6 +7720,94 @@ mod tests {
                 asm.insns.keys().collect::<Vec<_>>()
             );
         }
+    }
+
+    /// `bhimpl_getfield_gc_*` declares the struct as `r`.  An Int-bank
+    /// base is `getfield_raw`, not a GC field load.
+    #[test]
+    #[should_panic(expected = "getfield_gc base must use the Ref register bank")]
+    fn assemble_rejects_int_bank_getfield_gc_base() {
+        use crate::flatten::flatten_graph;
+        use crate::model::{FieldDescriptor, FunctionGraph, OpKind, ValueType};
+
+        let mut graph = FunctionGraph::new("int_getfield_base");
+        let base_var = push_input_var(&mut graph, "obj", ValueType::Int);
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::FieldRead {
+                    base: base_var.clone(),
+                    field: FieldDescriptor::new("x", Some("Point".into())),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .expect("field read has a result");
+        graph.set_return(graph.startblock, Some(result.clone()));
+        FunctionGraph::set_concretetype_of_inline(
+            &base_var,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+        FunctionGraph::set_concretetype_of_inline(
+            &result,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+
+        regalloc::augment_canonical_exceptblock_on_graph(&mut graph);
+        let mut regallocs = regalloc::perform_all_register_allocations(&graph);
+        let mut flat = flatten_graph(&graph, &mut regallocs);
+        let mut asm = Assembler::new();
+        let _ = asm.assemble(&mut flat, &regallocs);
+    }
+
+    /// `promote_gc_field_bases` rehomes a Signed GC FieldRead base so
+    /// the assembler emits the canonical `/rd>i` key.
+    #[test]
+    fn promote_then_assemble_emits_canonical_getfield_gc_rd() {
+        use crate::flatten::flatten_graph;
+        use crate::model::{FieldDescriptor, FunctionGraph, OpKind, ValueType};
+
+        let mut graph = FunctionGraph::new("promoted_getfield");
+        let base_var = push_input_var(&mut graph, "obj", ValueType::Int);
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::FieldRead {
+                    base: base_var.clone(),
+                    field: FieldDescriptor::new("x", Some("Point".into())),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .expect("field read has a result");
+        graph.set_return(graph.startblock, Some(result.clone()));
+        FunctionGraph::set_concretetype_of_inline(
+            &base_var,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+        FunctionGraph::set_concretetype_of_inline(
+            &result,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+
+        crate::codewriter::type_state::promote_gc_field_bases(&graph, None);
+        regalloc::augment_canonical_exceptblock_on_graph(&mut graph);
+        let mut regallocs = regalloc::perform_all_register_allocations(&graph);
+        let mut flat = flatten_graph(&graph, &mut regallocs);
+        let mut asm = Assembler::new();
+        let _ = asm.assemble(&mut flat, &regallocs);
+        assert!(
+            asm.insns.contains_key("getfield_gc_i/rd>i"),
+            "promoted GC base must assemble as getfield_gc_i/rd>i, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !asm.insns.keys().any(|k| k.contains("/id>")),
+            "promoted GC base must not emit an int-base getfield key, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
     }
 
     /// Every upstream vable handler declares its base as `r`. An Int-bank

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -776,6 +776,11 @@ impl CodeWriter {
         // already in SSI form (empty pending set), so non-split graphs are
         // unaffected.
         crate::model_ssa::ssa_to_ssi(rewritten_graph);
+        // `history.getkind(Ptr(GC))` is `"ref"`.  Stamp GC FieldRead /
+        // FieldWrite bases that still carry Signed so regalloc colours
+        // them in the Ref bank and the assembler emits `getfield_gc_*/rd>X`
+        // instead of the pyre-only `/id>X` form.
+        super::type_state::promote_gc_field_bases(rewritten_graph, Some(callcontrol));
         let mut regallocs = crate::codewriter::transform_profile::time_phase(
             "step2_perform_all_register_allocations",
             || crate::regalloc::perform_all_register_allocations(rewritten_graph),

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -185,3 +185,136 @@ pub(crate) fn authoritative_result_types(graph: &FunctionGraph) -> HashMap<Varia
 // `regalloc::perform_register_allocation`'s internal
 // `concretetype_to_regkind`, matching RPython's
 // `getkind(v.concretetype)` access pattern bit for bit.
+
+/// Stamp GC `getfield`/`setfield` bases into the Ref bank before regalloc.
+///
+/// RPython `history.getkind`: a `Ptr` whose `TO._gckind != 'raw'` is
+/// `"ref"`, so `bhimpl_getfield_gc_*` is always
+/// `@arguments("cpu", "r", "d", returns="X")`.  Pyre's MIR sometimes
+/// leaves a GC object pointer as `Signed` (a Rust raw pointer /
+/// address-sized word).  The assembler then keys the first argcode off
+/// that bank and emits the pyre-only `getfield_gc_*/id>X` form.
+///
+/// Walk every surviving `FieldRead`/`FieldWrite` of a GC owner
+/// (unknown owner defaults to `_gckind='gc'`, matching
+/// `jtransform.py rewrite_op_getfield`'s `getattr(STRUCT, '_gckind',
+/// 'gc')`) and publish `GcRef` on a `Signed`/`Unknown`/`Void` base.
+///
+/// Raw owners (`CallControl::struct_storage_for` →
+/// `is_gc_managed=false`) are left alone: a `Signed` base stays an
+/// address, a `GcRef` base stays a Ref-banked raw struct (`PyType` /
+/// `CLASSTYPE` travels through the Ref bank even though its storage
+/// is not a GC object).
+pub(crate) fn promote_gc_field_bases(
+    graph: &FunctionGraph,
+    callcontrol: Option<&crate::call::CallControl>,
+) {
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let (base, force_gc) = match &op.kind {
+                OpKind::FieldRead { base, field, .. } | OpKind::FieldWrite { base, field, .. } => {
+                    (base, field_owner_is_gc(field, callcontrol))
+                }
+                OpKind::VableFieldRead { base, .. } | OpKind::VableFieldWrite { base, .. } => {
+                    (base, true)
+                }
+                _ => continue,
+            };
+            if !force_gc {
+                continue;
+            }
+            match FunctionGraph::concretetype_of(base) {
+                ConcreteType::GcRef => {}
+                ConcreteType::Float => panic!(
+                    "GC field base {base:?} has Float concretetype — \
+                     history.getkind(Ptr(GC)) is 'ref' (graph {})",
+                    graph.name
+                ),
+                ConcreteType::Signed | ConcreteType::Unknown | ConcreteType::Void => {
+                    FunctionGraph::set_concretetype_of_inline(base, ConcreteType::GcRef);
+                }
+            }
+        }
+    }
+}
+
+fn field_owner_is_gc(
+    field: &crate::model::FieldDescriptor,
+    callcontrol: Option<&crate::call::CallControl>,
+) -> bool {
+    let Some(owner) = field.owner_root.as_deref() else {
+        return true;
+    };
+    callcontrol
+        .and_then(|cc| cc.struct_storage_for(owner))
+        .map(|(is_gc, _)| is_gc)
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{FieldDescriptor, OpKind, ValueType};
+
+    fn push_input(
+        graph: &mut FunctionGraph,
+        name: &str,
+        ty: ValueType,
+    ) -> crate::flowspace::model::Variable {
+        let var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: name.into(),
+                    ty,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(graph.startblock, var.clone());
+        var
+    }
+
+    #[test]
+    fn promote_gc_field_bases_lifts_a_signed_gc_owner_into_the_ref_bank() {
+        let mut graph = FunctionGraph::new("int_base_getfield");
+        let base = push_input(&mut graph, "obj", ValueType::Int);
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::FieldRead {
+                    base: base.clone(),
+                    field: FieldDescriptor::new("x", Some("Point".into())),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(result));
+        FunctionGraph::set_concretetype_of_inline(&base, ConcreteType::Signed);
+
+        promote_gc_field_bases(&graph, None);
+
+        assert_eq!(
+            FunctionGraph::concretetype_of(&base),
+            ConcreteType::GcRef,
+            "a GC FieldRead base that arrived as Signed must be published as GcRef"
+        );
+    }
+
+    #[test]
+    fn field_owner_is_gc_defaults_unknown_owners_to_gc() {
+        let named = FieldDescriptor::new("x", Some("Point".into()));
+        let unnamed = FieldDescriptor::new("x", None);
+        assert!(
+            field_owner_is_gc(&named, None),
+            "jtransform.py getattr(STRUCT, '_gckind', 'gc') defaults to gc"
+        );
+        assert!(
+            field_owner_is_gc(&unnamed, None),
+            "a descriptor with no owner_root is treated as GC"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- stamp Signed GC `FieldRead`/`FieldWrite` bases as `GcRef` before regalloc (`history.getkind(Ptr(GC))` is `"ref"`)
- assemble `getfield_gc_*` only as `/rd>X`; an Int-bank base is `getfield_raw`, not a `getfield_gc` alias
- drop the `getfield_gc_* /id>X` intbase handlers

## Validation

- `cargo test --all --no-default-features --features dynasm`