### PR TITLE
gc: reload frames and birth heap types in the nursery

### DIFF
--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,17 +1,17 @@
 {
   "darwin": {
-    "base": "5f2c4f688230346ec908bbeae5b9db580380d80e",
-    "brackets_reaching_no_collection": 3,
+    "base": "ebcb8f09ddfe6c6a2e9fb666a09c36ba456c577a",
+    "brackets_reaching_no_collection": 1,
     "frame_tier1_calls": 0,
     "frame_tier1_calls_fns": 0,
-    "frames_across_collecting": 10,
-    "frames_across_collecting_fns": 4,
+    "frames_across_collecting": 0,
+    "frames_across_collecting_fns": 0,
     "tier15_calls": 101,
     "tier15_calls_fns": 55,
     "tier1_calls": 0,
     "tier1_calls_fns": 0,
-    "unbracketed_calls": 2057,
-    "unbracketed_calls_fns": 832,
+    "unbracketed_calls": 2044,
+    "unbracketed_calls_fns": 826,
     "unmatched_seeds": [
       "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
       "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6786,27 +6786,28 @@ fn type_descr_new_with_metaclass(
         // `weak_subclasses` is weak — while the passes below allocate, so a
         // major cycle sweeps it out from under `create_all_slots` and the
         // barrier in `tag_subclass_instance` then writes through a freed
-        // header.  This is the `_entry_roots` scope's reasoning extended back
-        // to the construction; a type does not move, so the local stays a good
-        // address and the root is for liveness only.
+        // header.  `allocate_instance` puts the type in the nursery, so each
+        // collecting pass below reloads it from the slot.
+        let w_type_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(w_type);
+        let w_type = || pyre_object::gc_roots::shadow_stack_get(w_type_slot);
         // The type allocation may have moved the namespace, so the qualname
         // pass receives the forwarded address rather than the word above.
-        type_new_take_qualname(w_type, pyre_object::gc_roots::shadow_stack_get(dict_root))?;
+        type_new_take_qualname(w_type(), pyre_object::gc_roots::shadow_stack_get(dict_root))?;
         // typeobject.py create_all_slots parity.
         unsafe {
             crate::call::create_all_slots(
-                w_type,
+                w_type(),
                 pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
             )?
         };
         // `type_ready_fill_dict` defaults the doc entry once the slot and
         // instance descriptors own their names.
-        type_dict_set_doc(w_type);
+        type_dict_set_doc(w_type());
         // rclass.py:739-743 — set w_class (typeptr) at allocation time.
         // For type objects, w_class is the metaclass (type(C) → Meta).
         // baseobjspace.py getclass() returns the metatype.
-        crate::typedef::tag_subclass_instance(w_type, w_metaclass);
+        crate::typedef::tag_subclass_instance(w_type(), w_metaclass);
 
         // type_new_classcell — bind the captured `__classcell__` to the
         // new type so `__class__` / zero-arg `super()` in the methods
@@ -6815,23 +6816,23 @@ fn type_descr_new_with_metaclass(
         // whose `ensure_common_attributes` invokes a custom metaclass mro().
         if let Some(classcell_root) = classcell_root {
             let classcell = pyre_object::gc_roots::shadow_stack_get(classcell_root);
-            unsafe { pyre_object::w_cell_set(classcell, w_type) };
+            unsafe { pyre_object::w_cell_set(classcell, w_type()) };
         }
 
         // typeobject.py compute_mro — a custom metaclass `mro`
         // runs after the class cell is bound and before ready().
-        unsafe { crate::baseobjspace::compute_and_set_mro(w_type)? };
+        unsafe { crate::baseobjspace::compute_and_set_mro(w_type())? };
         // typeobject.py ready() — link self into each base's
         // `weak_subclasses` so `mutated()` and `__subclasses__()`
         // observe this class.
-        unsafe { pyre_object::typeobject::w_type_ready(w_type) };
+        unsafe { pyre_object::typeobject::w_type_ready(w_type()) };
 
         // CPython type_new_set_classdict precedes type_new_set_names: lazy
         // annotation thunks invoked by __set_name__ must resolve class-local
         // names through the completed type dictionary.
         if let Some(classdictcell_root) = classdictcell_root {
             let classdictcell = pyre_object::gc_roots::shadow_stack_get(classdictcell_root);
-            let type_dict = unsafe { pyre_object::w_type_get_dict_ptr(w_type) as PyObjectRef };
+            let type_dict = unsafe { pyre_object::w_type_get_dict_ptr(w_type()) as PyObjectRef };
             if !type_dict.is_null() {
                 unsafe { pyre_object::w_cell_set(classdictcell, type_dict) };
             }
@@ -6860,14 +6861,14 @@ fn type_descr_new_with_metaclass(
         // `__set_name__` runs Python, so a class body's list and dict values
         // move out from under the entries still to come.  Pin them and read
         // each back at the call that consumes it.  The owner goes in the same
-        // scope: a type never moves, so the local stays a good address, but
-        // nothing refers to a class this young — the classcell is optional and
-        // `weak_subclasses` is weak — so a major cycle under a hook would
-        // sweep it.  The scope runs to the end of the branch, which is what
-        // keeps the owner alive through `__init_subclass__` as well.
+        // scope: `allocate_instance` put it in the nursery, and nothing refers
+        // to a class this young — the classcell is optional and
+        // `weak_subclasses` is weak — so a collection under a hook would
+        // move or sweep it.  The scope runs to the end of the branch, which
+        // is what keeps the owner alive through `__init_subclass__` as well.
         let _entry_roots = pyre_object::gc_roots::push_roots();
         let mut livevars = Vec::with_capacity(set_name_entries.len() * 2 + 1);
-        livevars.push(w_type);
+        livevars.push(w_type());
         livevars.extend(
             set_name_entries
                 .iter()
@@ -6879,7 +6880,13 @@ fn type_descr_new_with_metaclass(
         for index in 0..set_name_entries.len() {
             let key = pyre_object::gc_roots::shadow_stack_get(owner_slot + 1 + index * 2);
             let value = pyre_object::gc_roots::shadow_stack_get(owner_slot + 2 + index * 2);
-            unsafe { crate::baseobjspace::set_name(w_type, key, value) }?;
+            unsafe {
+                crate::baseobjspace::set_name(
+                    pyre_object::gc_roots::shadow_stack_get(owner_slot),
+                    key,
+                    value,
+                )
+            }?;
         }
 
         // type_new_init_subclass — fire __init_subclass__ with the
@@ -6899,12 +6906,12 @@ fn type_descr_new_with_metaclass(
             None => Vec::new(),
         };
         crate::call::call_init_subclass_on_bases(
-            w_type,
+            w_type(),
             pyre_object::gc_roots::shadow_stack_get(effective_bases_slot),
             &init_subclass_kwargs,
         )?;
 
-        return Ok(w_type);
+        return Ok(w_type());
     }
 
     unreachable!("type.__new__ argument count was checked by type_descr_new")
@@ -16705,9 +16712,16 @@ pub(crate) fn exec_or_eval(
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
     // `setdefault` / `__contains__` / `__setitem__` override fires.
     if is_eval {
-        ensure_eval_builtins(w_globals, exec_ctx)?;
+        ensure_eval_builtins(
+            w_globals_slot.map_or(w_globals, pyre_object::gc_roots::shadow_stack_get),
+            exec_ctx,
+        )?;
     } else {
-        ensure_exec_builtins(w_globals, caller_frame, exec_ctx)?;
+        ensure_exec_builtins(
+            w_globals_slot.map_or(w_globals, pyre_object::gc_roots::shadow_stack_get),
+            caller_anchor.live(),
+            exec_ctx,
+        )?;
     }
     // Shadow the two namespace arguments with their post-collection addresses
     // rather than reading each use site, so the identity test below
@@ -16771,7 +16785,10 @@ pub(crate) fn exec_or_eval(
             pyre_object::gc_roots::shadow_stack_get(code_slot) as *const (),
             name,
             pyre_object::PY_NULL,
-            closure_slot.map_or(closure, pyre_object::gc_roots::shadow_stack_get),
+            match closure_slot {
+                Some(slot) => pyre_object::gc_roots::shadow_stack_get(slot),
+                None => closure,
+            },
         );
         let f = pyre_object::gc_roots::pin_root(f);
         Some(f)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11087,16 +11087,16 @@ pub(crate) fn py_ascii_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyErr
     let out = ascii_escape_wtf8(r_wtf8);
     let changed = r_wtf8.as_str().map(|s| s != out).unwrap_or(true);
     if unsafe { is_exact_type(r, &STR_TYPE) } || changed {
-        return Ok(w_str_new(&out));
+        return Ok(w_str_new_managed(&out));
     }
     let Some(tp) = (unsafe { crate::typedef::r#type(r) }) else {
-        return Ok(w_str_new(&out));
+        return Ok(w_str_new_managed(&out));
     };
     let Some(new_fn) = (unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__new__") })
     else {
-        return Ok(w_str_new(&out));
+        return Ok(w_str_new_managed(&out));
     };
-    crate::builtins::call_and_check(new_fn, &[tp.as_ptr(), w_str_new(&out)])
+    crate::builtins::call_and_check(new_fn, &[tp.as_ptr(), w_str_new_managed(&out)])
 }
 
 /// `bltinmodule.c:builtin_ascii` — like `repr`, but escape every
@@ -22919,7 +22919,7 @@ fn builtin_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         )));
     }
     let s = format_index_radix(args[0], 16, "0x")?;
-    Ok(w_str_new(&s))
+    Ok(w_str_new_managed(&s))
 }
 
 /// `oct(x)` — PyPy: operation.py oct
@@ -22937,7 +22937,7 @@ fn builtin_oct(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         )));
     }
     let s = format_index_radix(args[0], 8, "0o")?;
-    Ok(w_str_new(&s))
+    Ok(w_str_new_managed(&s))
 }
 
 /// `bin(x)` — PyPy: operation.py bin
@@ -22955,7 +22955,7 @@ fn builtin_bin(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         )));
     }
     let s = format_index_radix(args[0], 2, "0b")?;
-    Ok(w_str_new(&s))
+    Ok(w_str_new_managed(&s))
 }
 
 /// Parse a complex literal string into `(real, imag)`, delegated to

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3659,16 +3659,11 @@ fn call_with_kwargs_in_ctx_impl(
             if crate::pyframe::code_flags_make_generator(code.flags) {
                 return frame_into_generator_for_function(func_frame, current_callable());
             }
-            let plain_mode = FORCE_PLAIN_EVAL.with(|c| c.get() > 0);
-            let eval_fn = if plain_mode {
-                crate::eval::eval_frame_plain
-            } else {
-                EVAL_OVERRIDE
-                    .get()
-                    .copied()
-                    .unwrap_or(crate::eval::eval_frame_plain)
-            };
-            return eval_fn(&mut func_frame, None);
+            // Same callee `FrameLocalsRoot` the positional portal sites
+            // install.  `Function.call_args` keeps the new frame as a GC
+            // local; this ABI boundary is outside that transform.
+            let _callee_locals_root = FrameLocalsRoot::new_mut(&mut func_frame);
+            return get_eval_fn()(&mut func_frame, None);
         } // end user function branch
     } // end is_function
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1501,6 +1501,10 @@ fn call_function_ex_impl(
     kwargs_or_null: PyObjectRef,
     profile_frame: *mut PyFrame,
 ) -> PyResult {
+    // `pyopcode.py CALL_FUNCTION_EX` keeps `self` across `argument_factory`
+    // and `call_args_and_c_profile`.  Reload that frame after each collecting
+    // unpack, the way gctransform reloads the executing `PyFrame`.
+    let profile_anchor = unsafe { crate::eval::FrameAnchor::from_raw(profile_frame) };
     // Unpacking `*` already runs Python — a generator body, or a subtype's
     // `__iter__` — so `callable`, the mapping and the prepended receiver are
     // stale by the time the `**` merge and the dispatch read them.  Publish
@@ -1601,7 +1605,7 @@ fn call_function_ex_impl(
                 &args(),
                 &entries,
                 true,
-                profile_frame,
+                profile_anchor.live(),
             );
         }
     }
@@ -1611,7 +1615,7 @@ fn call_function_ex_impl(
         callable(),
         &args(),
         CallMode::Jit,
-        profile_frame,
+        profile_anchor.live(),
     )
 }
 
@@ -2123,6 +2127,10 @@ fn call_non_function_callable_with_mode(
     mode: CallMode,
     profile_frame: *mut PyFrame,
 ) -> PyResult {
+    // `call_args_and_c_profile` keeps `frame` across `c_call_trace` /
+    // `call_args`.  Override binding (`space.get`) can collect, so reload
+    // the profile frame after those lookups.
+    let profile_anchor = unsafe { crate::eval::FrameAnchor::from_raw(profile_frame) };
     // Binding an override below runs `baseobjspace::get`, whose property and
     // general `__get__` arms execute Python.  Root the arguments first and
     // dispatch each bound call from the forwarded roots — this native slice is
@@ -2245,7 +2253,13 @@ fn call_non_function_callable_with_mode(
         return Ok(result);
     }
 
-    call_function_carrier_with_mode(execution_context, callable, args, mode, profile_frame)
+    call_function_carrier_with_mode(
+        execution_context,
+        callable,
+        args,
+        mode,
+        profile_anchor.live(),
+    )
 }
 
 pub fn call_user_function(
@@ -3049,6 +3063,10 @@ fn call_with_kwargs_in_ctx_impl(
     dispatch_metaclass_call: bool,
     profile_frame: *mut crate::pyframe::PyFrame,
 ) -> PyResult {
+    // `call_args_and_c_profile` / `CALL_FUNCTION_KW` keep `frame` across
+    // override binding and argument marshalling.  Reload it after each
+    // collecting lookup rather than passing the entry copy on.
+    let profile_anchor = unsafe { crate::eval::FrameAnchor::from_raw(profile_frame) };
     // RPython's `Arguments` is GC-traced for the whole call. Mirror the GC
     // transform explicitly: keyword binding below allocates tuples, dicts,
     // and keyword-name strings before the callee frame owns these values.
@@ -3145,7 +3163,7 @@ fn call_with_kwargs_in_ctx_impl(
             &full_args,
             kwargs,
             dispatch_metaclass_call,
-            profile_frame,
+            profile_anchor.live(),
         );
     }
 
@@ -3216,7 +3234,7 @@ fn call_with_kwargs_in_ctx_impl(
                 // `c_call_trace` / `c_return_trace`, so route the bound flat
                 // slice through the profile-aware path like the marker branch
                 // below rather than invoking the builtin directly.
-                let frame_ptr = c_profile_frame(profile_frame);
+                let frame_ptr = c_profile_frame(profile_anchor.live());
                 if !frame_ptr.is_null() {
                     // The argument marshalling below allocates before the frame
                     // is handed to the profiling call, so the profiled frame is
@@ -3322,7 +3340,7 @@ fn call_with_kwargs_in_ctx_impl(
                 // breaking the FunctionWithFixedCode rebinding's
                 // firstarg() (`argument.py` returns `None`
                 // when positional count is zero, not the kwargs dict).
-                let frame_ptr = c_profile_frame(profile_frame);
+                let frame_ptr = c_profile_frame(profile_anchor.live());
                 if !frame_ptr.is_null() {
                     // The argument marshalling below allocates before the frame
                     // is handed to the profiling call, so the profiled frame is
@@ -3837,7 +3855,7 @@ fn call_with_kwargs_in_ctx_impl(
             &full_args,
             kwargs,
             dispatch_metaclass_call,
-            profile_frame,
+            profile_anchor.live(),
         );
     }
 
@@ -4960,7 +4978,15 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     } else {
         None
     };
-    let extra_roots = kwds_dict.map(|_| pyre_object::gc_roots::push_roots());
+    // Open the keyword-dict bracket in this function, not in a `map`
+    // closure: `compiling.py build_class` roots `kwds_w` on `build_class`
+    // itself, and a generated `FnOnce` would own a `push_roots` that cannot
+    // see the collections below.
+    let extra_roots = if kwds_dict.is_some() {
+        Some(pyre_object::gc_roots::push_roots())
+    } else {
+        None
+    };
     let (base_args, metaclass, extra_kwargs) = if let Some(last) = kwds_dict {
         {
             let extra_roots = extra_roots.as_ref().expect("opened for a kwargs dict");
@@ -5132,12 +5158,16 @@ fn build_class_inner(
     // sites that consume it. A class statement without keywords opens no
     // scope: `pin_root` is `dont_look_inside`, so an unconditional one would
     // residualise in every traced class body.
-    let kwds_roots = extra_kwargs.map(|kw| {
+    // Same as `build_class`: the keyword mapping is a local of this
+    // function, so the bracket lives here rather than on a `map` closure.
+    let kwds_roots = if let Some(kw) = extra_kwargs {
         let scope = pyre_object::gc_roots::push_roots();
         let slot = scope.base();
         let _ = scope.pin_root(kw);
-        (scope, slot)
-    });
+        Some((scope, slot))
+    } else {
+        None
+    };
     let current_kwds = || kwds_roots.as_ref().map(|(scope, slot)| scope.get(*slot));
 
     // `bases` and `w_orig_bases` are raw copies taken before `__prepare__` and

--- a/pyre/pyre-interpreter/src/cpyext/capsule.rs
+++ b/pyre/pyre-interpreter/src/cpyext/capsule.rs
@@ -119,7 +119,7 @@ fn capsule_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         Some(name) => format!("\"{name}\""),
         None => "NULL".to_string(),
     };
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<capsule object {name} at {:#x}>",
         slot_get(args[0], POINTER_KEY)
     )))

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -874,7 +874,7 @@ fn method_name(carrier: PyObjectRef) -> String {
 
 fn descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let carrier = args[0];
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<built-in function {}>",
         method_name(carrier)
     )))

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -2847,7 +2847,7 @@ fn defining_class(
 fn descr_repr(args: &[PyObjectRef], kind: &str) -> Result<PyObjectRef, crate::PyError> {
     let carrier = args[0];
     let owner = owner_name(carrier);
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<{kind} '{}' of '{owner}' objects>",
         descriptor_name(carrier)
     )))

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1318,7 +1318,7 @@ impl PyError {
                 arg_slots.push(slot);
             };
             push(pyre_object::w_int_new(errno as i64));
-            push(pyre_object::w_str_new(&strerror));
+            push(pyre_object::w_str_new_managed(&strerror));
             if let Some(code) = winerror.filter(|_| filename_slot.is_none()) {
                 push(pyre_object::w_none());
                 push(pyre_object::w_int_new(code as i64));
@@ -1338,7 +1338,7 @@ impl PyError {
             // rather than the one that existed before it.
             let w_errno = pyre_object::w_int_new(errno as i64);
             pyre_object::interp_exceptions::w_exception_set_errno(exc(), w_errno);
-            let w_strerror = pyre_object::w_str_new(&strerror);
+            let w_strerror = pyre_object::w_str_new_managed(&strerror);
             pyre_object::interp_exceptions::w_exception_set_strerror(exc(), w_strerror);
             #[cfg(windows)]
             if let Some(code) = winerror {
@@ -1402,7 +1402,7 @@ impl PyError {
         let errno_slot = exc_slot + 1;
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(errno as i64));
         let strerror_slot = errno_slot + 1;
-        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&strerror));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(&strerror));
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
             pyre_object::gc_roots::shadow_stack_get(errno_slot),
             pyre_object::gc_roots::shadow_stack_get(strerror_slot),
@@ -4735,7 +4735,7 @@ pub fn exception_from_errno(
     let w_type = _roots.pin_root(w_type);
     let w_errno = pyre_object::w_int_new(errno as i64);
     let w_errno = _roots.pin_root(w_errno);
-    let w_msg = pyre_object::w_str_new(&msg);
+    let w_msg = pyre_object::w_str_new_managed(&msg);
     let w_msg = _roots.pin_root(w_msg);
     let (w_type, w_errno, w_msg) = (_roots.get(base), _roots.get(base + 1), _roots.get(base + 2));
     operation_error_from_instance(
@@ -4921,7 +4921,7 @@ pub fn wrap_oserror2(
     let base = _roots.base();
     let _ = _roots.pin_root(w_exc);
     let _ = _roots.pin_root(pyre_object::w_int_new(errno as i64));
-    let _ = _roots.pin_root(pyre_object::w_str_new(&msg));
+    let _ = _roots.pin_root(pyre_object::w_str_new_managed(&msg));
     let _ = _roots.pin_root(w_filename.unwrap_or_else(pyre_object::w_none));
     let _ = _roots.pin_root(w_filename2.unwrap_or_else(pyre_object::w_none));
     // The five the constructor takes, in `_wrap_oserror2_impl`'s order.  A

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3560,7 +3560,7 @@ pub unsafe fn method_class_bound_qualname(
             "type.__qualname__ is not a unicode object",
         ));
     };
-    Ok(Some(pyre_object::w_str_new(&format!(
+    Ok(Some(pyre_object::w_str_new_managed(&format!(
         "{owner_qualname}.{inherited_name}"
     ))))
 }
@@ -3638,7 +3638,7 @@ pub unsafe fn descr_function_get(
 pub unsafe fn descr_function_repr(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         let name = function_get_name(obj);
-        pyre_object::w_str_new(&format!("function {name}"))
+        pyre_object::w_str_new_managed(&format!("function {name}"))
     }
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1482,12 +1482,13 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
             joined.push(path);
         }
         unsafe {
-            let w_key = pyre_object::w_str_new("TZPATH");
+            let key_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new("TZPATH"));
             let w_value =
                 pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_os_str_wtf8(&joined));
             pyre_object::w_dict_store(
                 pyre_object::gc_roots::shadow_stack_get(vars_slot),
-                w_key,
+                pyre_object::gc_roots::shadow_stack_get(key_slot),
                 w_value,
             );
         }
@@ -1585,9 +1586,10 @@ fn init_scproxy(ns: PyObjectRef) -> Result<(), crate::PyError> {
                 let w_key = pyre_object::w_str_new("exclude_simple");
                 let w_value = pyre_object::w_bool_from(false);
                 pyre_object::w_dict_store(roots.get(d_slot), w_key, w_value);
-                let w_key = pyre_object::w_str_new("exceptions");
+                let key_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = roots.pin_root(pyre_object::w_str_new("exceptions"));
                 let w_value = pyre_object::w_list_new(Vec::new());
-                pyre_object::w_dict_store(roots.get(d_slot), w_key, w_value);
+                pyre_object::w_dict_store(roots.get(d_slot), roots.get(key_slot), w_value);
             }
             Ok(roots.get(d_slot))
         }),

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -144,12 +144,12 @@ fn strategy(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     let obj = args[0];
     let dict = crate::type_methods::resolve_dict_backing(obj);
     if !dict.is_null() && unsafe { pyre_object::is_dict(dict) } {
-        return Ok(pyre_object::w_str_new(unsafe {
+        return Ok(pyre_object::w_str_new_managed(unsafe {
             pyre_object::dictmultiobject::w_dict_strategy_name(dict)
         }));
     }
     if unsafe { pyre_object::is_list(obj) } {
-        return Ok(pyre_object::w_str_new(unsafe {
+        return Ok(pyre_object::w_str_new_managed(unsafe {
             pyre_object::listobject::w_list_strategy_name(obj)
         }));
     }
@@ -157,10 +157,10 @@ fn strategy(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
         // W_SetObject currently has one ObjectKey-backed representation.  The
         // helper reports that real shape; EmptySetStrategy and
         // IntegerSetStrategy remain explicit builtin-type porting work.
-        return Ok(pyre_object::w_str_new("ObjectSetStrategy"));
+        return Ok(pyre_object::w_str_new_managed("ObjectSetStrategy"));
     }
     if let Some(name) = unsafe { crate::objspace::std::mapdict::mapdict_strategy_repr(obj) } {
-        return Ok(pyre_object::w_str_from_wtf8(name));
+        return Ok(pyre_object::w_str_from_wtf8_managed(name));
     }
     Err(crate::PyError::type_error(
         "expecting dict or list or set object, or instance of some kind",

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cdataobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cdataobj.rs
@@ -693,7 +693,7 @@ fn cdata_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     } else {
         ""
     };
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<cdata '{}{extra1}' {extra}>",
         ct.name()
     )))

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
@@ -893,7 +893,10 @@ pub fn kind_name(ct: &W_CType) -> &'static str {
 /// `W_CType.repr`.
 fn ctype_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let ct = ctype_arg(args[0])?;
-    Ok(pyre_object::w_str_new(&format!("<ctype '{}'>", ct.name())))
+    Ok(pyre_object::w_str_new_managed(&format!(
+        "<ctype '{}'>",
+        ct.name()
+    )))
 }
 
 /// `W_CType.dir` — every attribute above that this ctype answers.

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
@@ -345,7 +345,7 @@ fn get_attr(
                     .ok_or_else(|| PyError::system_error("module type is not initialized"));
             }
             "__name__" => {
-                return Ok(pyre_object::w_str_new(&format!(
+                return Ok(pyre_object::w_str_new_managed(&format!(
                     "{}.lib",
                     libname(lib_arg(roots.get(lib_slot))?)?
                 )));
@@ -552,7 +552,7 @@ pub unsafe fn w_lib_dealloc(obj: PyObjectRef) {
 }
 
 fn lib_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<Lib object for '{}'>",
         libname(lib_arg(args[0])?)?
     )))

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/libraryobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/libraryobj.rs
@@ -197,7 +197,7 @@ fn variable_address(lib: &W_Library, name: &str) -> Result<*const u8, PyError> {
 /// `W_Library.repr`.
 fn library_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let lib = library_arg(args[0])?;
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<clibrary '{}'>",
         lib.name()
     )))

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
@@ -511,7 +511,7 @@ pub fn detect_custom_layout(
         ));
         err.exc_object = crate::builtins::exc_exception_new(&[
             ffi_error(),
-            pyre_object::w_str_new(&format!(
+            pyre_object::w_str_new_managed(&format!(
                 "{name}: {msg} (cdef says {cdef_value}, but C compiler says {compiler_value}). fix it or use \"...;\" as the last field in the cdef for {name} to make it flexible"
             )),
         ])?;

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/wrapper.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/wrapper.rs
@@ -204,7 +204,7 @@ fn wrapper_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         .ok_or_else(|| PyError::system_error("function wrapper lost its raw type"))?;
     let fnname = crate::baseobjspace::text_w(wrapper.w_fnname)?.to_string();
     let doc = raw.repr_fn_type(wrapper.w_ffi, &fnname)?;
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<FFIFunctionWrapper '{doc}'>"
     )))
 }
@@ -216,7 +216,7 @@ fn wrapper_get_doc(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let fnname = crate::baseobjspace::text_w(wrapper.w_fnname)?.to_string();
     let modulename = crate::baseobjspace::text_w(wrapper.w_modulename)?.to_string();
     let doc = raw.repr_fn_type(wrapper.w_ffi, &fnname)?;
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "{doc};\n\nCFFI C function from {}.lib",
         modulename
     )))

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -208,7 +208,7 @@ fn strict_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn ignore_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let exc = codec_error_arg(args)?;
-    Ok(codec_result(w_str_new(""), exc.w_end))
+    Ok(codec_result(w_str_new_managed(""), exc.w_end))
 }
 
 fn error_codepoints(exc: &CodecException) -> Result<Vec<u32>, crate::PyError> {
@@ -250,7 +250,7 @@ fn replace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             ));
         }
     };
-    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+    Ok(codec_result(w_str_new_managed(&replacement), exc.w_end))
 }
 
 fn xmlcharrefreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -264,7 +264,7 @@ fn xmlcharrefreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         .into_iter()
         .map(|code| format!("&#{code};"))
         .collect();
-    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+    Ok(codec_result(w_str_new_managed(&replacement), exc.w_end))
 }
 
 fn backslashreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -295,7 +295,7 @@ fn backslashreplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
             ));
         }
     };
-    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+    Ok(codec_result(w_str_new_managed(&replacement), exc.w_end))
 }
 
 fn namereplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -317,7 +317,7 @@ fn namereplace_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             replacement.push_str(&raw_unicode_escape(code));
         }
     }
-    Ok(codec_result(w_str_new(&replacement), exc.w_end))
+    Ok(codec_result(w_str_new_managed(&replacement), exc.w_end))
 }
 
 #[derive(Clone, Copy)]

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -597,7 +597,7 @@ fn simplecdata_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             .is_some_and(|base| base == simplecdata_type());
     if !direct {
         let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
-        return Ok(pyre_object::w_str_new(&format!(
+        return Ok(pyre_object::w_str_new_managed(&format!(
             "<{name} object at {}>",
             crate::display::repr_addr(obj as usize)
         )));
@@ -605,14 +605,14 @@ fn simplecdata_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
     if tc == "O" && host_ctypes::read_pointer_from_buffer(cdata_bytes(obj).unwrap_or(&[])) == 0 {
         let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
-        return Ok(pyre_object::w_str_new(&format!("{name}(<NULL>)")));
+        return Ok(pyre_object::w_str_new_managed(&format!("{name}(<NULL>)")));
     }
     let value = decode_slot(&tc, cdata_bytes(obj).unwrap_or(&[]));
     let rendered = unsafe { crate::display::py_repr_wtf8(value) }?;
     let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
-    Ok(pyre_object::w_str_from_wtf8(crate::display::wtf8_format!(
-        name, "(", rendered, ")"
-    )))
+    Ok(pyre_object::w_str_from_wtf8_managed(
+        crate::display::wtf8_format!(name, "(", rendered, ")"),
+    ))
 }
 
 /// `_SimpleCData.from_param(cls, value)` — identity stub (see caller note).

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -142,11 +142,11 @@ fn cfuncptr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let address = crate::display::repr_addr(obj as usize);
     #[cfg(windows)]
     if let Some(index) = com_index(obj) {
-        return Ok(pyre_object::w_str_new(&format!(
+        return Ok(pyre_object::w_str_new_managed(&format!(
             "<COM method offset {index}: {name} at {address}>"
         )));
     }
-    Ok(pyre_object::w_str_new(&format!(
+    Ok(pyre_object::w_str_new_managed(&format!(
         "<{name} object at {address}>"
     )))
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -575,6 +575,8 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
             );
             pyre_object::w_dict_setitem_str(roots.get(ns_slot), "_ctypes_native_peer", cls);
         }
+        let cls_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(cls);
         let bases = unsafe { pyre_object::typeobject::w_type_get_bases(cls) };
         let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
         let w_name = pyre_object::w_str_new(name);
@@ -582,6 +584,7 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
             pycsimpletype_type(),
             &[w_name, bases, roots.get(ns_slot)],
         )?;
+        let cls = roots.get(cls_slot);
         // The new class does not move, but nothing references it until the
         // first `set_type_attr` below completes and that store allocates its
         // key string, so it takes one pin for liveness.

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -409,7 +409,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let territory = windows_default_locale_component(LOCALE_SISO3166CTRYNAME);
                 let locale = match (language, territory) {
                     (Some(language), Some(territory)) => {
-                        pyre_object::w_str_new(&format!("{language}_{territory}"))
+                        pyre_object::w_str_new_managed(&format!("{language}_{territory}"))
                     }
                     _ => pyre_object::w_none(),
                 };
@@ -418,7 +418,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 // to a codec name is `locale.getdefaultlocale`'s job, not this
                 // hook's.
                 let codepage = active_acp();
-                let encoding = pyre_object::w_str_new(&format!("cp{codepage}"));
+                let encoding = pyre_object::w_str_new_managed(&format!("cp{codepage}"));
                 Ok(pyre_object::w_tuple_new(vec![locale, encoding]))
             },
             0,

--- a/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
@@ -410,7 +410,7 @@ fn create_spec_for_method(w_function: PyObjectRef, w_type: PyObjectRef) -> PyObj
     } else {
         "object"
     };
-    pyre_object::w_str_new(&format!("<method '{name}' of '{class_name}' objects>"))
+    pyre_object::w_str_new_managed(&format!("<method '{name}' of '{class_name}' objects>"))
 }
 
 fn create_spec_for_function(w_func: PyObjectRef) -> PyObjectRef {
@@ -436,7 +436,7 @@ fn create_spec_for_object(w_type: PyObjectRef) -> PyObjectRef {
     } else {
         "object"
     };
-    pyre_object::w_str_new(&format!("<'{class_name}' object>"))
+    pyre_object::w_str_new_managed(&format!("<'{class_name}' object>"))
 }
 
 fn prepare_spec(w_arg: PyObjectRef) -> (PyObjectRef, PyObjectRef, PyObjectRef) {

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -355,8 +355,8 @@ pub(crate) fn compat_map(
     // Build the (module, name) key before touching the cached slots, then read
     // each mapping slot immediately before its probe.
     let key = pyre_object::tupleobject::w_tuple_new(vec![
-        pyre_object::w_str_new(module),
-        pyre_object::w_str_new(name),
+        pyre_object::w_str_new_managed(module),
+        pyre_object::w_str_new_managed(name),
     ]);
     // `finditem` below is generic: a replaced or non-dict `*_MAPPING` routes
     // through `getitem`, which can run Python and drive a collection. Pin the

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -2859,7 +2859,7 @@ fn save_global(
     }
 
     if ctx.proto >= 4 {
-        save(ctx, buf, pyre_object::w_str_new(&module_name))?;
+        save(ctx, buf, pyre_object::w_str_new_managed(&module_name))?;
         save(ctx, buf, pyre_object::gc_roots::shadow_stack_get(name_slot))?;
         buf.push(op::STACK_GLOBAL);
     } else if name.contains('.') {
@@ -2881,7 +2881,7 @@ fn save_global(
         }
         save_toplevel_by_name(ctx, buf, &module_name, parts[0])?;
         for attrname in rest {
-            save(ctx, buf, pyre_object::w_str_new(attrname))?;
+            save(ctx, buf, pyre_object::w_str_new_managed(attrname))?;
             if ctx.proto < 2 {
                 buf.push(op::TUPLE);
             } else {
@@ -3072,10 +3072,10 @@ fn save_toplevel_by_name(
     };
     let encoding = if ctx.proto < 3 { "ascii" } else { "utf-8" };
     let _roots = pyre_object::gc_roots::push_roots();
-    let w_module_name = pyre_object::w_str_new(&module_name);
+    let w_module_name = pyre_object::w_str_new_managed(&module_name);
     let _ = pyre_object::gc_roots::pin_root(w_module_name);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let w_name = pyre_object::w_str_new(&name);
+    let w_name = pyre_object::w_str_new_managed(&name);
     let _ = pyre_object::gc_roots::pin_root(w_name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let module_bytes = crate::type_methods::encode_object(
@@ -3117,8 +3117,8 @@ fn extension_code(module_name: &str, name: &str) -> Option<i64> {
     let copyreg = import_module("copyreg").ok()?;
     let registry = crate::baseobjspace::getattr_str(copyreg, "_extension_registry").ok()?;
     let key = pyre_object::tupleobject::w_tuple_new(vec![
-        pyre_object::w_str_new(module_name),
-        pyre_object::w_str_new(name),
+        pyre_object::w_str_new_managed(module_name),
+        pyre_object::w_str_new_managed(name),
     ]);
     let code = unsafe { pyre_object::w_dict_lookup(registry, key) }?;
     crate::baseobjspace::int_w(code).ok()

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -1587,7 +1587,7 @@ fn packed_list_from_args(
                 if !text.is_ascii() {
                     return Err(PyError::value_error(error));
                 }
-                pyre_object::w_str_new(text)
+                pyre_object::w_str_new_managed(text)
             }
             PackedListKind::Bytes => {
                 pyre_object::bytesobject::w_bytes_from_bytes(&data[offset..end])
@@ -1661,14 +1661,14 @@ fn read_line_int(slot: usize) -> Result<i64, PyError> {
 /// Dispatch to `self.find_class(module, name)` through the instance, so a
 /// Python subclass override (the standard security hook) is honoured.
 /// `call_find_class` for two fresh module/name strings: allocate and pin the
-/// module string before allocating the name string, so the second `w_str_new`
-/// cannot relocate the first before both are rooted.
+/// module string before allocating the name string, so the second constructor
+/// cannot reclaim the first before both are rooted.
 fn call_find_class_names(slot: usize, module: &str, name: &str) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    let w_module = pyre_object::w_str_new(module);
+    let w_module = pyre_object::w_str_new_managed(module);
     let _ = pyre_object::gc_roots::pin_root(w_module);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let w_name = pyre_object::w_str_new(name);
+    let w_name = pyre_object::w_str_new_managed(name);
     call_find_class(
         slot,
         pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -1711,8 +1711,8 @@ fn audit_find_class(module: &str, name: &str) -> Result<(), PyError> {
             audit,
             &[
                 pyre_object::w_str_new("pickle.find_class"),
-                pyre_object::w_str_new(module),
-                pyre_object::w_str_new(name),
+                pyre_object::w_str_new_managed(module),
+                pyre_object::w_str_new_managed(name),
             ],
         )?;
     }
@@ -1800,10 +1800,10 @@ fn decode_string(slot: usize, data: &[u8]) -> Result<PyObjectRef, PyError> {
     let w_bytes = pyre_object::w_bytes_from_bytes(data);
     let _ = pyre_object::gc_roots::pin_root(w_bytes);
     let b = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let w_encoding = pyre_object::w_str_new(&encoding);
+    let w_encoding = pyre_object::w_str_new_managed(&encoding);
     let _ = pyre_object::gc_roots::pin_root(w_encoding);
     let e = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let w_errors = pyre_object::w_str_new(&errors);
+    let w_errors = pyre_object::w_str_new_managed(&errors);
     call_meth(
         pyre_object::gc_roots::shadow_stack_get(b),
         "decode",

--- a/pyre/pyre-interpreter/src/module/_queue/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_queue/mod.rs
@@ -112,9 +112,13 @@ fn empty_error() -> crate::PyError {
 }
 
 fn simplequeue_put(queue: &W_SimpleQueue, item: PyObjectRef) -> PyObjectRef {
-    // Taking the lock can drop the GIL and rooting is itself a collection
-    // point, so `item` is read back out of its shadow-stack slot rather than
-    // from the argument, which a move would have left stale.
+    // `_PySimpleQueue.put` keeps `item` as a frame local across the append.
+    // There is no `pypy/module/_queue`; this native `put` is the same live
+    // word.  `queue_lock` can take `before_external_block` (`rffi.aroundstate
+    // .before` / `_RPyGilRelease`), which leaves the census so another
+    // mutator can collect before `push_back`.  Same-thread reachability
+    // cannot see that collect, so the bracket is kept even when the
+    // intra-function scan reports none.
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(item);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1089,7 +1089,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let Some(text) = rffi::inet_ntoa([data[0], data[1], data[2], data[3]]) else {
                     return Err(crate::PyError::os_error("inet_ntoa failed"));
                 };
-                Ok(pyre_object::w_str_new(&text))
+                Ok(pyre_object::w_str_new_managed(&text))
             },
             1,
         ),
@@ -1171,7 +1171,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let Some(text) = rffi::ntop(af, data) else {
                     return Err(crate::PyError::os_error("inet_ntop failed"));
                 };
-                Ok(pyre_object::w_str_new(&text))
+                Ok(pyre_object::w_str_new_managed(&text))
             },
             2,
         ),
@@ -1286,7 +1286,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             "gethostbyname: address is not representable",
                         ));
                     };
-                    Ok(pyre_object::w_str_new(&text))
+                    Ok(pyre_object::w_str_new_managed(&text))
                 },
                 1,
             ),
@@ -1480,7 +1480,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         .to_string_lossy()
                         .into_owned()
                 };
-                Ok(pyre_object::w_str_new(&name))
+                Ok(pyre_object::w_str_new_managed(&name))
             }),
         );
     }
@@ -1835,7 +1835,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         })?;
                     let name = rustpython_host_env::socket::if_indextoname_checked(index)
                         .map_err(interface_io_error)?;
-                    Ok(pyre_object::w_str_new(&name))
+                    Ok(pyre_object::w_str_new_managed(&name))
                 },
                 1,
             ),
@@ -2176,11 +2176,11 @@ fn unpack_hostent(he: *mut rffi::Hostent) -> Result<pyre_object::PyObjectRef, cr
         }
         let aliases = alias_strings
             .iter()
-            .map(|alias| pyre_object::w_str_new(alias))
+            .map(|alias| pyre_object::w_str_new_managed(alias))
             .collect();
         let addrs = addr_strings
             .iter()
-            .map(|addr| pyre_object::w_str_new(addr))
+            .map(|addr| pyre_object::w_str_new_managed(addr))
             .collect();
         // `w_list_new` roots the items it is handed, not the header it returns,
         // and that header is a movable nursery object (`rlist.py:116 LIST =
@@ -2192,7 +2192,7 @@ fn unpack_hostent(he: *mut rffi::Hostent) -> Result<pyre_object::PyObjectRef, cr
         let addrs_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(addrs));
         Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(&name),
+            pyre_object::w_str_new_managed(&name),
             pyre_object::gc_roots::shadow_stack_get(aliases_slot),
             pyre_object::gc_roots::shadow_stack_get(addrs_slot),
         ]))
@@ -2392,7 +2392,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         fields.push(pyre_object::w_int_new(ai.ai_family as i64));
                         fields.push(pyre_object::w_int_new(ai.ai_socktype as i64));
                         fields.push(pyre_object::w_int_new(ai.ai_protocol as i64));
-                        fields.push(pyre_object::w_str_new(&canon));
+                        fields.push(pyre_object::w_str_new_managed(&canon));
                         fields.push(unpack_inet_addr(&storage, copy_len as rffi::SockLen));
                         pyre_object::w_tuple_new(fields.take())
                     };
@@ -2571,8 +2571,8 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         .into_owned()
                 };
                 Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_str_new(&host_s),
-                    pyre_object::w_str_new(&serv_s),
+                    pyre_object::w_str_new_managed(&host_s),
+                    pyre_object::w_str_new_managed(&serv_s),
                 ]))
             },
             2,
@@ -3395,7 +3395,7 @@ fn unpack_bluetooth_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObj
     let bth: bt::SOCKADDR_BTH =
         unsafe { core::ptr::read_unaligned(storage as *const _ as *const bt::SOCKADDR_BTH) };
     pyre_object::w_tuple_new(vec![
-        pyre_object::w_str_new(&bdaddr_string(bth.btAddr)),
+        pyre_object::w_str_new_managed(&bdaddr_string(bth.btAddr)),
         pyre_object::w_int_new(i64::from(bth.port)),
     ])
 }
@@ -3521,8 +3521,8 @@ fn unpack_hyperv_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObject
     let vm_id = hyperv_guid_string(&hv.vm_id);
     let service_id = hyperv_guid_string(&hv.service_id);
     pyre_object::w_tuple_new(vec![
-        pyre_object::w_str_new(&vm_id),
-        pyre_object::w_str_new(&service_id),
+        pyre_object::w_str_new_managed(&vm_id),
+        pyre_object::w_str_new_managed(&service_id),
     ])
 }
 
@@ -3955,7 +3955,7 @@ fn unpack_inet_addr(
         };
         let port = u16::from_be(sin.sin_port) as i64;
         pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(&host),
+            pyre_object::w_str_new_managed(&host),
             pyre_object::w_int_new(port),
         ])
     } else if family == rffi::AF_INET6 {
@@ -3976,7 +3976,7 @@ fn unpack_inet_addr(
         };
         let port = u16::from_be(sin6.sin6_port) as i64;
         pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(&host),
+            pyre_object::w_str_new_managed(&host),
             pyre_object::w_int_new(port),
             pyre_object::w_int_new(u32::from_be(sin6.sin6_flowinfo) as i64),
             pyre_object::w_int_new(rffi::sockaddr_in6_get_scope_id(sin6) as i64),
@@ -6038,7 +6038,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family");
                 let ty = socket_get_attr_i64(obj, "_type");
                 let proto = socket_get_attr_i64(obj, "_proto");
-                Ok(pyre_object::w_str_new(&format!(
+                Ok(pyre_object::w_str_new_managed(&format!(
                     "<socket object, fd={fd}, family={family}, type={ty}, proto={proto}>"
                 )))
             },

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2723,7 +2723,7 @@ mod certificate_methods {
         fn __repr__(&self) -> Result<PyObjectRef, crate::PyError> {
             let der = unsafe { pyre_object::bytesobject::w_bytes_data(self.der) };
             let subject = native_result(pyre_native::ssl::certificate_subject_rfc2253(der))?;
-            Ok(w_str_new(&format!("<Certificate '{subject}'>")))
+            Ok(w_str_new_managed(&format!("<Certificate '{subject}'>")))
         }
 
         fn __hash__(&mut self) -> Result<i64, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
@@ -54,7 +54,7 @@ fn generate_suggestions(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         names.push(crate::baseobjspace::str_utf8_w(element)?.to_string());
     }
     Ok(match crate::error::best_suggestion(&names, &wrong_name) {
-        Some(name) => w_str_new(&name),
+        Some(name) => w_str_new_managed(&name),
         None => w_none(),
     })
 }

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -530,7 +530,7 @@ pub(crate) fn show_warning(
             if !visible.is_empty() {
                 crate::call::call_function_impl_result(
                     pyre_object::gc_roots::shadow_stack_get(write_slot),
-                    &[w_str_new(&format!("  {visible}\n"))],
+                    &[w_str_new_managed(&format!("  {visible}\n"))],
                 )?;
             }
         }

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -1915,7 +1915,7 @@ fn array_reduce_ex_method(args: &[PyObjectRef]) -> PyResult {
     let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
     let typecode = unsafe { arr::w_array_typecode(obj) };
     let tc = typecode as char;
-    let w_typecode = pyre_object::w_str_new(&tc.to_string());
+    let w_typecode = pyre_object::w_str_new_managed(&tc.to_string());
     let w_dict =
         crate::baseobjspace::findattr_result(obj, "__dict__")?.unwrap_or_else(pyre_object::w_none);
     let mformat = array_machine_format_code(typecode, unsafe { arr::w_array_itemsize(obj) });
@@ -2318,7 +2318,7 @@ pub fn init_array_type(ns: PyObjectRef) {
                     |args| {
                         let obj = require_array_receiver(args, "typecode", true)?;
                         let tc = unsafe { arr::w_array_typecode(obj) } as char;
-                        Ok(pyre_object::w_str_new(&tc.to_string()))
+                        Ok(pyre_object::w_str_new_managed(&tc.to_string()))
                     },
                     1,
                 ),

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -100,7 +100,7 @@ fn binascii_error(msg: impl Into<String>) -> crate::PyError {
     let msg = msg.into();
     let mut err = crate::PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class("binascii.Error") {
-        let args = [cls, w_str_new(&msg)];
+        let args = [cls, w_str_new_managed(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1105,7 +1105,7 @@ fn gc_stats_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     } else {
         String::new()
     };
-    Ok(w_str_new(&format!(
+    Ok(w_str_new_managed(&format!(
         concat!(
             "Total memory consumed:\n",
             "    GC used:                 {total_gc_memory} (peak: {peak_memory})\n",

--- a/pyre/pyre-interpreter/src/module/grp/grp.rs
+++ b/pyre/pyre-interpreter/src/module/grp/grp.rs
@@ -29,13 +29,16 @@ fn struct_group_type() -> pyre_object::PyObjectRef {
 pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyError> {
     #[cfg(feature = "host_env")]
     fn make_struct_group(g: &rustpython_host_env::grp::Group) -> pyre_object::PyObjectRef {
-        let mem_items: Vec<pyre_object::PyObjectRef> =
-            g.mem.iter().map(|s| pyre_object::w_str_new(s)).collect();
+        let mem_items: Vec<pyre_object::PyObjectRef> = g
+            .mem
+            .iter()
+            .map(|s| pyre_object::w_str_new_managed(s))
+            .collect();
         crate::_structseq::new_instance(
             struct_group_type(),
             vec![
-                pyre_object::w_str_new(&g.name),
-                pyre_object::w_str_new(&g.passwd),
+                pyre_object::w_str_new_managed(&g.name),
+                pyre_object::w_str_new_managed(&g.passwd),
                 pyre_object::w_int_new(g.gid as i64),
                 pyre_object::w_list_new(mem_items),
             ],
@@ -56,15 +59,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         let mut p = (*g).gr_mem;
         if !p.is_null() {
             while !(*p).is_null() {
-                mem_items.push(pyre_object::w_str_new(&cstr(*p)));
+                mem_items.push(pyre_object::w_str_new_managed(&cstr(*p)));
                 p = p.add(1);
             }
         }
         crate::_structseq::new_instance(
             struct_group_type(),
             vec![
-                pyre_object::w_str_new(&cstr((*g).gr_name)),
-                pyre_object::w_str_new(&cstr((*g).gr_passwd)),
+                pyre_object::w_str_new_managed(&cstr((*g).gr_name)),
+                pyre_object::w_str_new_managed(&cstr((*g).gr_passwd)),
                 pyre_object::w_int_new((*g).gr_gid as i64),
                 pyre_object::w_list_new(mem_items),
             ],

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -3225,9 +3225,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     )));
                 }
                 let code = crate::baseobjspace::c_int_w(args[0])?;
-                Ok(pyre_object::w_str_new(&crate::PyError::clean_strerror(
-                    code,
-                )))
+                Ok(pyre_object::w_str_new_managed(
+                    &crate::PyError::clean_strerror(code),
+                ))
             },
             1,
         ),
@@ -6683,11 +6683,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 Ok(crate::_structseq::new_instance(
                     uname_result_seq_type(),
                     vec![
-                        pyre_object::w_str_new(&sysname),
-                        pyre_object::w_str_new(&nodename),
-                        pyre_object::w_str_new(&release),
-                        pyre_object::w_str_new(&version),
-                        pyre_object::w_str_new(&machine),
+                        pyre_object::w_str_new_managed(&sysname),
+                        pyre_object::w_str_new_managed(&nodename),
+                        pyre_object::w_str_new_managed(&release),
+                        pyre_object::w_str_new_managed(&version),
+                        pyre_object::w_str_new_managed(&machine),
                     ],
                 ))
             },
@@ -7147,7 +7147,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         return Ok(crate::typedef::charp2uni(&msg));
                     }
                     #[cfg(not(feature = "sandbox"))]
-                    Ok(pyre_object::w_str_new(
+                    Ok(pyre_object::w_str_new_managed(
                         &rustpython_host_env::time::strerror(code),
                     ))
                 },
@@ -12254,7 +12254,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::make_builtin_function_with_arity(
                 "getlogin",
                 |_| match host_nt::getlogin() {
-                    Ok(name) => Ok(pyre_object::w_str_new(&name)),
+                    Ok(name) => Ok(pyre_object::w_str_new_managed(&name)),
                     Err(e) => Err(fs_err_with_filename2(
                         e,
                         0,
@@ -12613,7 +12613,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     }
                     match host_os::device_encoding(fd) {
                         // `GetConsoleCP` answers 0 for a process with no console.
-                        Some(name) if name != "cp0" => Ok(pyre_object::w_str_new(&name)),
+                        Some(name) if name != "cp0" => Ok(pyre_object::w_str_new_managed(&name)),
                         _ => Ok(pyre_object::w_none()),
                     }
                 },

--- a/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
+++ b/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
@@ -81,13 +81,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         crate::_structseq::new_instance(
             struct_passwd_type(),
             vec![
-                pyre_object::w_str_new(&pw.name),
-                pyre_object::w_str_new(&pw.passwd),
+                pyre_object::w_str_new_managed(&pw.name),
+                pyre_object::w_str_new_managed(&pw.passwd),
                 pyre_object::w_int_new(pw.uid as i64),
                 pyre_object::w_int_new(pw.gid as i64),
-                pyre_object::w_str_new(&pw.gecos),
-                pyre_object::w_str_new(&pw.dir),
-                pyre_object::w_str_new(&pw.shell),
+                pyre_object::w_str_new_managed(&pw.gecos),
+                pyre_object::w_str_new_managed(&pw.dir),
+                pyre_object::w_str_new_managed(&pw.shell),
             ],
         )
     }
@@ -106,13 +106,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         crate::_structseq::new_instance(
             struct_passwd_type(),
             vec![
-                pyre_object::w_str_new(&cstr((*pw).pw_name)),
-                pyre_object::w_str_new(&cstr((*pw).pw_passwd)),
+                pyre_object::w_str_new_managed(&cstr((*pw).pw_name)),
+                pyre_object::w_str_new_managed(&cstr((*pw).pw_passwd)),
                 pyre_object::w_int_new((*pw).pw_uid as i64),
                 pyre_object::w_int_new((*pw).pw_gid as i64),
-                pyre_object::w_str_new(&cstr((*pw).pw_gecos)),
-                pyre_object::w_str_new(&cstr((*pw).pw_dir)),
-                pyre_object::w_str_new(&cstr((*pw).pw_shell)),
+                pyre_object::w_str_new_managed(&cstr((*pw).pw_gecos)),
+                pyre_object::w_str_new_managed(&cstr((*pw).pw_dir)),
+                pyre_object::w_str_new_managed(&cstr((*pw).pw_shell)),
             ],
         )
     }

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -2198,14 +2198,19 @@ crate::py_module! {
                 continue;
             }
             let (msg, code) = ERROR_TABLE[idx - 1];
-            let w_msg = w_str_new(msg);
-            crate::baseobjspace::setdictvalue_native(errors, name, w_msg);
+            let msg_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = error_map_roots.pin_root(w_str_new(msg));
+            crate::baseobjspace::setdictvalue_native(
+                errors,
+                name,
+                error_map_roots.get(msg_slot),
+            );
             let w_code = w_int_new(code);
             let codes = error_map_roots.get(codes_slot);
             unsafe { w_dict_setitem_str(codes, msg, w_code) };
             let w_key = w_int_new(code);
             let messages = error_map_roots.get(messages_slot);
-            unsafe { w_dict_store(messages, w_key, w_msg) };
+            unsafe { w_dict_store(messages, w_key, error_map_roots.get(msg_slot)) };
         }
         let codes = error_map_roots.get(codes_slot);
         crate::baseobjspace::setdictvalue_native(errors, "codes", codes);

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -255,7 +255,7 @@ impl<'a> MiniXmlParser<'a> {
             match key.as_str() {
                 "version" => version = value,
                 "encoding" => {
-                    encoding = w_str_new(&value);
+                    encoding = w_str_new_managed(&value);
                     let _ = roots.pin_root(encoding);
                 }
                 "standalone" => {
@@ -277,7 +277,7 @@ impl<'a> MiniXmlParser<'a> {
         }
         self.call_handler(
             "XmlDeclHandler",
-            &[w_str_new(&version), encoding, standalone],
+            &[w_str_new_managed(&version), encoding, standalone],
         )?;
         if unsafe { is_int(standalone) && w_int_get_value(standalone) == 0 } {
             crate::baseobjspace::setdictvalue_native(
@@ -305,7 +305,7 @@ impl<'a> MiniXmlParser<'a> {
             self.bump_char();
         }
         self.set_event_position(event_pos);
-        self.call_handler("CommentHandler", &[w_str_new(&text)])
+        self.call_handler("CommentHandler", &[w_str_new_managed(&text)])
     }
 
     fn parse_pi(&mut self) -> Result<(), crate::PyError> {
@@ -328,7 +328,7 @@ impl<'a> MiniXmlParser<'a> {
         self.set_event_position(event_pos);
         self.call_handler(
             "ProcessingInstructionHandler",
-            &[w_str_new(&target), w_str_new(&data)],
+            &[w_str_new_managed(&target), w_str_new_managed(&data)],
         )
     }
 
@@ -373,15 +373,15 @@ impl<'a> MiniXmlParser<'a> {
         if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
-            pubid = w_str_new(&self.read_quoted()?);
+            pubid = w_str_new_managed(&self.read_quoted()?);
             let _ = roots.pin_root(pubid);
             self.skip_ws();
-            sysid = w_str_new(&self.read_quoted()?);
+            sysid = w_str_new_managed(&self.read_quoted()?);
             let sysid = roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
-            sysid = w_str_new(&self.read_quoted()?);
+            sysid = w_str_new_managed(&self.read_quoted()?);
             let _ = roots.pin_root(sysid);
         }
         self.skip_ws();
@@ -401,14 +401,14 @@ impl<'a> MiniXmlParser<'a> {
             self.set_event_position(event_pos);
             self.call_handler(
                 "StartDoctypeDeclHandler",
-                &[w_str_new(&name), sysid, pubid, w_int_new(1)],
+                &[w_str_new_managed(&name), sysid, pubid, w_int_new(1)],
             )?;
             self.parse_internal_subset()?;
         } else {
             self.set_event_position(event_pos);
             self.call_handler(
                 "StartDoctypeDeclHandler",
-                &[w_str_new(&name), sysid, pubid, w_int_new(0)],
+                &[w_str_new_managed(&name), sysid, pubid, w_int_new(0)],
             )?;
         }
         self.skip_ws();
@@ -471,12 +471,12 @@ impl<'a> MiniXmlParser<'a> {
         if matches!(self.peek_char(), Some('"' | '\'')) {
             let v = self.read_quoted()?;
             self.internal_entities.insert(name.clone(), v.clone());
-            value = w_str_new(&v);
+            value = w_str_new_managed(&v);
             let _ = roots.pin_root(value);
         } else if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
-            pubid = w_str_new(&self.read_quoted()?);
+            pubid = w_str_new_managed(&self.read_quoted()?);
             let pubid = roots.pin_root(pubid);
             self.skip_ws();
             let system = self.read_quoted()?;
@@ -487,7 +487,7 @@ impl<'a> MiniXmlParser<'a> {
                     Some(unsafe { w_str_get_value(pubid) }.to_string()),
                 ),
             );
-            sysid = w_str_new(&system);
+            sysid = w_str_new_managed(&system);
             let sysid = roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
@@ -495,14 +495,14 @@ impl<'a> MiniXmlParser<'a> {
             let system = self.read_quoted()?;
             self.external_entities
                 .insert(name.clone(), (system.clone(), None));
-            sysid = w_str_new(&system);
+            sysid = w_str_new_managed(&system);
             let _ = roots.pin_root(sysid);
         }
         self.skip_ws();
         if self.starts_with("NDATA") {
             self.expect("NDATA")?;
             self.skip_ws();
-            notation = w_str_new(&self.read_name()?);
+            notation = w_str_new_managed(&self.read_name()?);
             let _ = roots.pin_root(notation);
         }
         self.skip_until_gt()?;
@@ -511,14 +511,14 @@ impl<'a> MiniXmlParser<'a> {
         if !unsafe { is_none(notation) } {
             self.call_handler(
                 "UnparsedEntityDeclHandler",
-                &[w_str_new(&name), base, sysid, pubid, notation],
+                &[w_str_new_managed(&name), base, sysid, pubid, notation],
             )?;
             return Ok(());
         }
         self.call_handler(
             "EntityDeclHandler",
             &[
-                w_str_new(&name),
+                w_str_new_managed(&name),
                 w_int_new(is_param),
                 value,
                 base,
@@ -572,7 +572,7 @@ impl<'a> MiniXmlParser<'a> {
         ]);
         let model = roots.pin_root(model);
         self.set_event_position(event_pos);
-        self.call_handler("ElementDeclHandler", &[w_str_new(&name), model])
+        self.call_handler("ElementDeclHandler", &[w_str_new_managed(&name), model])
     }
 
     fn parse_attlist_decl(&mut self) -> Result<(), crate::PyError> {
@@ -605,9 +605,9 @@ impl<'a> MiniXmlParser<'a> {
             self.call_handler(
                 "AttlistDeclHandler",
                 &[
-                    w_str_new(&elem),
-                    w_str_new(&attr),
-                    w_str_new(&kind),
+                    w_str_new_managed(&elem),
+                    w_str_new_managed(&attr),
+                    w_str_new_managed(&kind),
                     w_none(),
                     w_int_new(required),
                 ],
@@ -631,24 +631,24 @@ impl<'a> MiniXmlParser<'a> {
         if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
-            pubid = w_str_new(&self.read_quoted()?);
+            pubid = w_str_new_managed(&self.read_quoted()?);
             let _ = roots.pin_root(pubid);
             self.skip_ws();
             if matches!(self.peek_char(), Some('"' | '\'')) {
-                sysid = w_str_new(&self.read_quoted()?);
+                sysid = w_str_new_managed(&self.read_quoted()?);
                 let _ = roots.pin_root(sysid);
             }
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
-            sysid = w_str_new(&self.read_quoted()?);
+            sysid = w_str_new_managed(&self.read_quoted()?);
             let _ = roots.pin_root(sysid);
         }
         self.skip_until_gt()?;
         self.set_event_position(event_pos);
         self.call_handler(
             "NotationDeclHandler",
-            &[w_str_new(&name), w_none(), sysid, pubid],
+            &[w_str_new_managed(&name), w_none(), sysid, pubid],
         )
     }
 
@@ -814,7 +814,7 @@ impl<'a> MiniXmlParser<'a> {
             let base = roots.base();
             for (name, value) in attrs {
                 let _ = roots.pin_root(self.intern_string(name));
-                let _ = roots.pin_root(w_str_new(value));
+                let _ = roots.pin_root(w_str_new_managed(value));
             }
             // `w_list_new` pins the vector it is handed, so the vector is built
             // out of the slots at the call rather than while the members are
@@ -833,7 +833,7 @@ impl<'a> MiniXmlParser<'a> {
                 let name_roots = pyre_object::gc_roots::push_roots();
                 let name_slot = name_roots.base();
                 let _ = name_roots.pin_root(self.intern_string(name));
-                let w_value = w_str_new(value);
+                let w_value = w_str_new_managed(value);
                 unsafe { w_dict_store(roots.get(attrs_slot), name_roots.get(name_slot), w_value) };
             }
             roots.get(attrs_slot)
@@ -850,7 +850,7 @@ impl<'a> MiniXmlParser<'a> {
                 self.flush_character_buffer()?;
             }
             if text.len() > size {
-                return self.call_handler_raw("CharacterDataHandler", &[w_str_new(text)]);
+                return self.call_handler_raw("CharacterDataHandler", &[w_str_new_managed(text)]);
             }
             self.char_buffer.push_str(text);
             crate::baseobjspace::setdictvalue_native(
@@ -860,7 +860,7 @@ impl<'a> MiniXmlParser<'a> {
             );
             Ok(())
         } else {
-            self.call_handler_raw("CharacterDataHandler", &[w_str_new(text)])
+            self.call_handler_raw("CharacterDataHandler", &[w_str_new_managed(text)])
         }
     }
 
@@ -892,7 +892,7 @@ impl<'a> MiniXmlParser<'a> {
         }
         let text = std::mem::take(&mut self.char_buffer);
         crate::baseobjspace::setdictvalue_native(self.parser, "buffer_used", w_int_new(0));
-        self.call_handler_raw("CharacterDataHandler", &[w_str_new(&text)])
+        self.call_handler_raw("CharacterDataHandler", &[w_str_new_managed(&text)])
     }
 
     fn call_handler(&mut self, name: &str, args: &[PyObjectRef]) -> Result<(), crate::PyError> {
@@ -918,13 +918,23 @@ impl<'a> MiniXmlParser<'a> {
         if self.suppress_current {
             return Ok(());
         }
+        // `getattr` and the handler call both run Python.  A plain Rust slice
+        // is not a place the collector updates, so the argument words are
+        // pinned before the lookup and read back out of their root slots at
+        // the call — the same bracket `call_handler` uses.
+        let roots = pyre_object::gc_roots::push_roots();
+        let base = roots.base();
+        for &arg in args {
+            let _ = roots.pin_root(arg);
+        }
         let Ok(handler) = crate::baseobjspace::getattr_str(self.parser, name) else {
             return Ok(());
         };
         if handler.is_null() || unsafe { is_none(handler) } {
             return Ok(());
         }
-        crate::call::call_function_impl_result(handler, args)?;
+        let args: Vec<PyObjectRef> = (0..args.len()).map(|i| roots.get(base + i)).collect();
+        crate::call::call_function_impl_result(handler, &args)?;
         Ok(())
     }
 
@@ -1012,9 +1022,12 @@ impl<'a> MiniXmlParser<'a> {
                 let w_prefix = if prefix.is_empty() {
                     w_none()
                 } else {
-                    w_str_new(&prefix)
+                    w_str_new_managed(&prefix)
                 };
-                self.call_handler("StartNamespaceDeclHandler", &[w_prefix, w_str_new(value)])?;
+                self.call_handler(
+                    "StartNamespaceDeclHandler",
+                    &[w_prefix, w_str_new_managed(value)],
+                )?;
             }
         }
         Ok(())
@@ -1026,7 +1039,7 @@ impl<'a> MiniXmlParser<'a> {
             let w_prefix = if prefix.is_empty() {
                 w_none()
             } else {
-                w_str_new(&prefix)
+                w_str_new_managed(&prefix)
             };
             self.call_handler("EndNamespaceDeclHandler", &[w_prefix])?;
         }
@@ -1125,8 +1138,11 @@ impl<'a> MiniXmlParser<'a> {
                         .map_err(|_| "error in processing external entity reference".to_string())?;
                 }
                 _ if content => {
-                    self.call_handler("SkippedEntityHandler", &[w_str_new(ent), w_int_new(0)])
-                        .map_err(|_| "undefined entity".to_string())?;
+                    self.call_handler(
+                        "SkippedEntityHandler",
+                        &[w_str_new_managed(ent), w_int_new(0)],
+                    )
+                    .map_err(|_| "undefined entity".to_string())?;
                 }
                 _ => return Err("undefined entity".to_string()),
             }
@@ -1161,15 +1177,13 @@ impl<'a> MiniXmlParser<'a> {
         let handler = roots.pin_root(handler);
         let base = crate::baseobjspace::getattr_str(self.parser, "_pyre_base")
             .unwrap_or_else(|_| w_none());
-        let ret = crate::call::call_function_impl_result(
-            handler,
-            &[
-                w_str_new(context),
-                base,
-                w_str_new(sysid),
-                pubid.map(w_str_new).unwrap_or_else(w_none),
-            ],
-        )?;
+        let w_context = roots.pin_root(w_str_new_managed(context));
+        let w_sysid = roots.pin_root(w_str_new_managed(sysid));
+        let w_pubid = pubid
+            .map(|s| roots.pin_root(w_str_new_managed(s)))
+            .unwrap_or_else(w_none);
+        let ret =
+            crate::call::call_function_impl_result(handler, &[w_context, base, w_sysid, w_pubid])?;
         if unsafe { is_int(ret) && w_int_get_value(ret) == 0 } {
             return self.fail("error in processing external entity reference");
         }
@@ -1313,7 +1327,7 @@ fn decode_xml_bytes(parser: PyObjectRef, data: &[u8]) -> Result<String, crate::P
     crate::baseobjspace::setdictvalue_native(
         parser,
         "_pyre_forced_encoding",
-        w_str_new(&normalized),
+        w_str_new_managed(&normalized),
     );
     match normalized.as_str() {
         "utf-8" | "us-ascii" => {
@@ -1462,7 +1476,7 @@ fn is_true_obj(obj: PyObjectRef) -> bool {
 fn make_builtin_error(name: &str, msg: &str) -> crate::PyError {
     let mut err = crate::PyError::value_error(msg.to_string());
     if let Some(cls) = crate::builtins::lookup_exc_class(name) {
-        let args = [cls, w_str_new(msg)];
+        let args = [cls, w_str_new_managed(msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }
@@ -1478,7 +1492,11 @@ fn parser_pending(parser: PyObjectRef) -> String {
 }
 
 fn set_parser_pending(parser: PyObjectRef, pending: &str) {
-    crate::baseobjspace::setdictvalue_native(parser, "_pyre_pending_xml", w_str_new(pending));
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_pending_xml",
+        w_str_new_managed(pending),
+    );
 }
 
 fn get_parser_int(parser: PyObjectRef, name: &str, default: i64) -> i64 {
@@ -1636,7 +1654,7 @@ const EXPAT_ERROR_NAME: &str = "xml.parsers.expat.ExpatError";
 fn pyexpat_error(msg: String, code: i64, lineno: i64, offset: i64) -> crate::PyError {
     let mut err = crate::PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class(EXPAT_ERROR_NAME) {
-        let args = [cls, w_str_new(&msg)];
+        let args = [cls, w_str_new_managed(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             // The fresh exception is named only by this local while the three
             // stores below build their values and grow its attribute storage.
@@ -1964,7 +1982,7 @@ fn parser_create3(
         crate::baseobjspace::setdictvalue_native(
             parser,
             "_pyre_namespace_separator",
-            w_str_new(value),
+            w_str_new_managed(value),
         );
     } else {
         return Err(parser_create_not_str(

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -126,7 +126,7 @@ fn errno_exception(class_name: &str, errno: i32) -> crate::PyError {
     let args = vec![
         cls,
         pyre_object::w_int_new(errno as i64),
-        pyre_object::w_str_new(&strerror),
+        pyre_object::w_str_new_managed(&strerror),
     ];
     let exc = crate::builtins::exc_os_error_new(&args)
         .expect("exc_os_error_new is infallible for int/str args");
@@ -940,7 +940,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     #[cfg(not(any(unix, windows)))]
                     let text = wasm_signals::strsignal(signum).map(str::to_owned);
                     Ok(text
-                        .map(|s| pyre_object::w_str_new(&s))
+                        .map(|s| pyre_object::w_str_new_managed(&s))
                         .unwrap_or(pyre_object::w_none()))
                 }
                 #[cfg(not(feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -25,7 +25,7 @@ fn termios_converted_error(errno: i32) -> crate::PyError {
     let args = vec![
         cls,
         pyre_object::w_int_new(errno as i64),
-        pyre_object::w_str_new(&message),
+        pyre_object::w_str_new_managed(&message),
     ];
     let exc = crate::builtins::exc_exception_new(&args)
         .expect("exc_exception_new is infallible for str/int args");

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -155,7 +155,7 @@ mod imp {
                 // The type keeps `object.__repr__`, so `repr` and `str` of a
                 // handle read differently.
                 let raw = get_handle(self_obj) as usize;
-                w_str_new(&format!(
+                w_str_new_managed(&format!(
                     "<PyHKEY:0x{raw:0width$X}>",
                     width = core::mem::size_of::<usize>() * 2
                 ))

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1941,9 +1941,9 @@ fn format_render(
         let converted = match conversion_spec {
             None => val,
             Some(cp) => match cp.to_char_lossy() {
-                's' => pyre_object::w_str_from_wtf8(unsafe { crate::py_str_wtf8(val)? }),
-                'r' => pyre_object::w_str_from_wtf8(unsafe { crate::py_repr_wtf8(val)? }),
-                'a' => pyre_object::w_str_new(&crate::builtins::py_ascii(val)?),
+                's' => pyre_object::w_str_from_wtf8_managed(unsafe { crate::py_str_wtf8(val)? }),
+                'r' => pyre_object::w_str_from_wtf8_managed(unsafe { crate::py_repr_wtf8(val)? }),
+                'a' => pyre_object::w_str_new_managed(&crate::builtins::py_ascii(val)?),
                 // `\0` is the sentinel for a field with no conversion
                 // requested, so a literal NUL conversion character formats the
                 // field as if the `!` had not been written.
@@ -7314,7 +7314,7 @@ fn dict_update_pair_note(mut err: crate::PyError, idx: usize) -> crate::PyError 
     }
     let exc = err.to_exc_object();
     err.exc_object = exc;
-    let note = w_str_new(&format!(
+    let note = w_str_new_managed(&format!(
         "Cannot convert dictionary update sequence element #{idx} to a sequence"
     ));
     unsafe {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15957,7 +15957,7 @@ fn init_slot_wrapper_type(ns: PyObjectRef) {
                     ));
                 };
                 let method_name = unsafe { crate::function::function_get_name(descr) };
-                Ok(pyre_object::w_str_new(&format!(
+                Ok(pyre_object::w_str_new_managed(&format!(
                     "{owner_qualname}.{method_name}"
                 )))
             }) as crate::gateway::BuiltinCodeFn,
@@ -16380,7 +16380,7 @@ fn init_method_descriptor_type(ns: PyObjectRef) {
                     ));
                 };
                 let method_name = unsafe { crate::function::function_get_name(descr) };
-                Ok(pyre_object::w_str_new(&format!(
+                Ok(pyre_object::w_str_new_managed(&format!(
                     "{owner_qualname}.{method_name}"
                 )))
             }) as crate::gateway::BuiltinCodeFn,
@@ -17300,7 +17300,9 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
             } else {
                 unsafe { pyre_object::w_type_get_qualname(owner) }.to_string()
             };
-            Ok(pyre_object::w_str_new(&format!("{owner_qualname}.{name}")))
+            Ok(pyre_object::w_str_new_managed(&format!(
+                "{owner_qualname}.{name}"
+            )))
         },
         2,
     );
@@ -29105,7 +29107,7 @@ fn coroutine_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn async_generator_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
     let name = generator_name_value(args[0], true)?;
-    Ok(w_str_new(&format!(
+    Ok(w_str_new_managed(&format!(
         "<async_generator object {} at {}>",
         unsafe { pyre_object::w_str_get_value(name) },
         crate::display::repr_addr(args[0] as usize)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8462,13 +8462,24 @@ fn traceback_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             type_name_of(w_frame)
         )));
     }
-    let frame = w_frame as *mut crate::pyframe::PyFrame;
-
-    // tb_lasti / tb_lineno: both are declared `int` in the signature, so the
-    // converter Argument Clinic emits is `PyLong_AsInt` — it reduces through
-    // `__index__` and refuses a value the C `int` cannot hold.
-    let lasti = traceback_c_int_arg(w_lasti)?;
-    let lineno = traceback_c_int_arg(w_lineno)?;
+    // `PyTraceback.descr_new` keeps `w_next` / `w_frame` as GC locals across
+    // the `unwrap_spec(lasti=int, lineno=int)` conversions (`space.index_w`
+    // / `__index__` can collect).  Pin the remaining wrapped args and reload
+    // the frame out of the anchor after the conversions, the way gctransform
+    // reloads those locals.
+    let _tb_roots = pyre_object::gc_roots::push_roots();
+    let next_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(next);
+    let lasti_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_lasti);
+    let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_lineno);
+    let frame_anchor =
+        unsafe { crate::eval::FrameAnchor::from_raw(w_frame as *mut crate::pyframe::PyFrame) };
+    let lasti = traceback_c_int_arg(pyre_object::gc_roots::shadow_stack_get(lasti_slot))?;
+    let lineno = traceback_c_int_arg(pyre_object::gc_roots::shadow_stack_get(lineno_slot))?;
+    let frame = frame_anchor.live();
+    let next = pyre_object::gc_roots::shadow_stack_get(next_slot);
     let w_code = unsafe { (*frame).fget_f_code() };
 
     Ok(crate::pytraceback::w_pytraceback_new(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -11894,7 +11894,7 @@ fn patch_getset_descriptor_metadata() {
                                 "<generic property>".to_string()
                             };
                             let combined =
-                                pyre_object::w_str_new(&format!("{type_qualname}.{name}"));
+                                pyre_object::w_str_new_managed(&format!("{type_qualname}.{name}"));
                             pyre_object::typedef::w_getset_set_qualname(descr, combined);
                             Ok(combined)
                         }
@@ -24796,7 +24796,7 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             for &byte in data {
                 out.push_str(&format!("{byte:02x}"));
             }
-            return Ok(pyre_object::w_str_new(&out));
+            return Ok(pyre_object::w_str_new_managed(&out));
         };
 
         // `pypy/objspace/std/bytearrayobject.py:645-687 _binascii_hexstr`
@@ -24846,7 +24846,7 @@ pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             }
             out.push_str(&format!("{byte:02x}"));
         }
-        Ok(pyre_object::w_str_new(&out))
+        Ok(pyre_object::w_str_new_managed(&out))
     })();
     receiver.release();
     result
@@ -25697,7 +25697,7 @@ fn bytes_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         }
     }
     out.push(quote);
-    Ok(pyre_object::w_str_new(&out))
+    Ok(pyre_object::w_str_new_managed(&out))
 }
 
 fn bytes_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -121,14 +121,25 @@ impl crate::lltype::GcType for W_BytearrayObject {
 fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
     let length = buf.len();
     let alloc = if buf.is_empty() { 0 } else { buf.len() + 1 };
+    // `build_bytes` (bytesobject.rs): the data box has no heap edge until
+    // the body is written, and both `get_instantiate` and the body malloc
+    // can collect.  Pin the box and the class, reload after the last
+    // allocation, and remember the old-to-young data edge.
+    let _roots = crate::gc_roots::push_roots();
     let data =
         crate::gc_storage::gc_alloc_storage_box(buf, crate::bytesobject::bytes_data_gc_type_id());
-    let header = PyObject {
-        ob_type: &BYTEARRAY_TYPE as *const PyType,
-        w_class: get_instantiate(&BYTEARRAY_TYPE),
-    };
+    let data_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(data as PyObjectRef);
+    let class_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(get_instantiate(&BYTEARRAY_TYPE));
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_BYTEARRAY_GC_TYPE_ID, W_BYTEARRAY_OBJECT_SIZE);
+    let data = crate::gc_roots::shadow_stack_get(data_slot) as *mut Vec<u8>;
     let body = W_BytearrayObject {
-        ob_header: header,
+        ob_header: PyObject {
+            ob_type: &BYTEARRAY_TYPE as *const PyType,
+            w_class: crate::gc_roots::shadow_stack_get(class_slot),
+        },
         data,
         length: AtomicUsize::new(length),
         alloc,
@@ -138,17 +149,15 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
         w_weakreflifeline: PY_NULL,
         w_slots: PY_NULL,
     };
-    let raw =
-        crate::gc_hook::try_gc_alloc_stable_raw(W_BYTEARRAY_GC_TYPE_ID, W_BYTEARRAY_OBJECT_SIZE);
-    let w_bytearray = if !raw.is_null() {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(raw as *mut W_BytearrayObject, body);
         }
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         raw as PyObjectRef
     } else {
         crate::lltype::malloc_typed(body) as PyObjectRef
-    };
-    w_bytearray
+    }
 }
 
 /// Allocate a new bytearray filled with zeros.
@@ -211,6 +220,7 @@ pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> Py
         crate::lltype::malloc_typed(payload) as PyObjectRef
     } else {
         unsafe { std::ptr::write(raw as *mut W_BytearrayObject, payload) };
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         raw as PyObjectRef
     };
     // `allocate_instance` registers the fresh instance on the finalizer queue

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -433,6 +433,7 @@ pub fn w_bytes_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObje
         crate::lltype::malloc_typed(payload) as PyObjectRef
     } else {
         unsafe { std::ptr::write(raw as *mut W_BytesObject, payload) };
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         raw as PyObjectRef
     };
     // `allocate_instance` registers the fresh instance on the finalizer queue

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -249,8 +249,8 @@ majit_gc::global_hook!(static GC_ALLOC_COLLECTING_HOOK: GcAllocHookFn);
 /// for callers that hold no unrooted GC pointer across the allocation and run at
 /// a JIT safepoint (gcmap-rooted). The elidable bigint payload helpers were the
 /// first; the rooted sibling now also carries every list header
-/// (`w_list_new_with_strategy`), `w_weakref_new`, and builtin `str()`'s
-/// `w_str_from_wtf8_managed_collecting`.
+/// (`w_list_new_with_strategy`), heap-type headers (`w_type_new`),
+/// `w_weakref_new`, and builtin `str()`'s `w_str_from_wtf8_managed_collecting`.
 pub fn register_gc_alloc_collecting_hook(hook: GcAllocHookFn) {
     GC_ALLOC_COLLECTING_HOOK.set(Some(hook));
 }

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -281,8 +281,9 @@ pub fn w_int_subclass_new(value: i64) -> PyObjectRef {
     } else {
         unsafe {
             std::ptr::write(raw as *mut W_IntObjectUser, obj);
-            raw as PyObjectRef
         }
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
+        raw as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -157,6 +157,15 @@ fn alloc_instance_object(w_class: PyObjectRef) -> PyObjectRef {
     // the interpreter's mapdict layer), so a type whose terminator has not
     // been created yet gets one on first access. The `is_type` test keeps the
     // sentinel used by single-crate tests from being dereferenced as a type.
+    // `gct_fv_gc_malloc` bracket (`framework.py`): `w_class` is a live
+    // child written after the malloc.  Heap types can sit in the nursery,
+    // so the slot is re-read after the allocation and the creation barrier
+    // remembers a black instance pointing at a still-white type
+    // (`w_bytes_from_block` / `w_cell_new`).
+    let _roots = crate::gc_roots::push_roots();
+    let class_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(w_class);
+    let w_class = crate::gc_roots::shadow_stack_get(class_slot);
     let map = unsafe {
         if crate::typeobject::is_type(w_class) {
             crate::typeobject::w_type_get_terminator(w_class) as usize
@@ -164,6 +173,9 @@ fn alloc_instance_object(w_class: PyObjectRef) -> PyObjectRef {
             0
         }
     };
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE);
+    let w_class = crate::gc_roots::shadow_stack_get(class_slot);
     let value = W_ObjectObject {
         ob_header: PyObject {
             ob_type: &INSTANCE_TYPE as *const PyType,
@@ -172,14 +184,12 @@ fn alloc_instance_object(w_class: PyObjectRef) -> PyObjectRef {
         map,
         storage: std::ptr::null_mut(),
     };
-
-    let raw =
-        crate::gc_hook::try_gc_alloc_stable_raw(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE);
     if !raw.is_null() {
         unsafe {
             std::ptr::write(raw as *mut W_ObjectObject, value);
-            raw as PyObjectRef
         }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        raw as PyObjectRef
     } else {
         crate::lltype::malloc(value) as PyObjectRef
     }

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -360,42 +360,7 @@ fn set_write_barrier(obj: PyObjectRef) {
 /// constructor models it by signature — a plain `PyObjectRef` GCREF.
 #[majit_macros::dont_look_inside]
 pub fn w_set_new() -> PyObjectRef {
-    let items =
-        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
-    let header = PyObject {
-        ob_type: &SET_TYPE as *const PyType,
-        w_class: get_instantiate(&SET_TYPE),
-    };
-    // Allocate the body in GC old-gen (mark-sweep, non-moving) so it
-    // carries TRACK_YOUNG_PTRS, mirroring `w_list_new` / `w_tuple_new`.
-    // `w_set_add` stores possibly-young elements into `items`; the write
-    // barrier (`set_write_barrier`) only remembers the set on a minor
-    // collection when the body is an old-gen object, so a body allocated
-    // through the plain `malloc_typed` (no TRACK_YOUNG_PTRS) would leave
-    // young elements unforwarded and collected. Falls back to
-    // `malloc_typed` when no GC hook is installed (unit tests).
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SET_GC_TYPE_ID, W_SET_OBJECT_SIZE);
-    if !raw.is_null() {
-        unsafe {
-            std::ptr::write(
-                raw as *mut W_SetObject,
-                W_SetObject {
-                    ob_header: header,
-                    items,
-                    len: AtomicUsize::new(0),
-                    hash: -1,
-                },
-            );
-        }
-        raw as PyObjectRef
-    } else {
-        crate::lltype::malloc_typed(W_SetObject {
-            ob_header: header,
-            items,
-            len: AtomicUsize::new(0),
-            hash: -1,
-        }) as PyObjectRef
-    }
+    alloc_set_object(&SET_TYPE)
 }
 
 /// Allocate an empty `frozenset`.
@@ -406,33 +371,49 @@ pub fn w_set_new() -> PyObjectRef {
 /// [`w_set_new`].
 #[majit_macros::dont_look_inside]
 pub fn w_frozenset_new() -> PyObjectRef {
+    alloc_set_object(&FROZENSET_TYPE)
+}
+
+fn alloc_set_object(set_type: &'static PyType) -> PyObjectRef {
+    // Allocate the body in GC old-gen (mark-sweep, non-moving) so it
+    // carries TRACK_YOUNG_PTRS, mirroring `w_list_new` / `w_tuple_new`.
+    // `w_set_add` stores possibly-young elements into `items`; the write
+    // barrier (`set_write_barrier`) only remembers the set on a minor
+    // collection when the body is an old-gen object, so a body allocated
+    // through the plain `malloc_typed` (no TRACK_YOUNG_PTRS) would leave
+    // young elements unforwarded and collected. Falls back to
+    // `malloc_typed` when no GC hook is installed (unit tests).
+    //
+    // The items box has no heap edge until the body is written, and both
+    // `get_instantiate` and the body malloc can collect.  Pin the box and
+    // the class, reload after the last allocation, and remember the
+    // old-to-young items edge (`w_bytearray_alloc` / `build_bytes`).
+    let _roots = crate::gc_roots::push_roots();
     let items =
         crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
-    let header = PyObject {
-        ob_type: &FROZENSET_TYPE as *const PyType,
-        w_class: get_instantiate(&FROZENSET_TYPE),
-    };
+    let items_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(items as PyObjectRef);
+    let class_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(get_instantiate(set_type));
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SET_GC_TYPE_ID, W_SET_OBJECT_SIZE);
+    let items = crate::gc_roots::shadow_stack_get(items_slot) as *mut SetItemsStorage;
+    let body = W_SetObject {
+        ob_header: PyObject {
+            ob_type: set_type as *const PyType,
+            w_class: crate::gc_roots::shadow_stack_get(class_slot),
+        },
+        items,
+        len: AtomicUsize::new(0),
+        hash: -1,
+    };
     if !raw.is_null() {
         unsafe {
-            std::ptr::write(
-                raw as *mut W_SetObject,
-                W_SetObject {
-                    ob_header: header,
-                    items,
-                    len: AtomicUsize::new(0),
-                    hash: -1,
-                },
-            );
+            std::ptr::write(raw as *mut W_SetObject, body);
         }
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         raw as PyObjectRef
     } else {
-        crate::lltype::malloc_typed(W_SetObject {
-            ob_header: header,
-            items,
-            len: AtomicUsize::new(0),
-            hash: -1,
-        }) as PyObjectRef
+        crate::lltype::malloc_typed(body) as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -569,39 +569,19 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     let save_point = crate::gc_roots::shadow_stack_len();
     let _ = crate::gc_roots::pin_root(bases);
     let _ = crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
-    // `space.allocate_instance(W_TypeObject, w_typetype)` — a heap type is an
-    // ordinary `GcStruct`, not a non-moving residual.  The list header already
-    // takes `try_gc_alloc_collecting_rooted`; the type header is the same
-    // shape.  `bases` / the namespace sit on the shadow stack; the extra
-    // rooted child is unused.
-    let mut allocation_root = std::ptr::null_mut();
-    let mut needs_write_barrier = true;
-    let raw = unsafe {
-        crate::gc_hook::try_gc_alloc_collecting_rooted(
-            W_TYPE_GC_TYPE_ID,
-            W_TYPE_OBJECT_SIZE,
-            &mut allocation_root,
-            &mut needs_write_barrier,
-        )
-    };
-    let raw = crate::gc_hook::GcAllocOutcome::from_hook(raw)
-        .allocated_or_abort(W_TYPE_OBJECT_SIZE)
-        .unwrap_or(std::ptr::null_mut());
-    // Name storage is a nursery box and can collect; pin the empty header
-    // first so a minor forwards it before the write below.
-    let type_slot = if !raw.is_null() {
-        let slot = crate::gc_roots::shadow_stack_len();
-        let _ = crate::gc_roots::pin_root(raw as PyObjectRef);
-        Some(slot)
-    } else {
-        None
-    };
+    // Heap types stay in the non-moving old generation.  Callers cache the
+    // resulting pointer in `OnceLock<usize>` (structseq types, sys.flags)
+    // and the JIT caches `w_class`; a nursery type would move and leave
+    // those addresses stale (`getfield_gc_r` sanity check, "no field
+    // verbose").  Full nursery types need those caches to follow
+    // forwarding first (#1449).
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
     // A mortal (GC-managed) heap type boxes its name in a GC-managed storage box
     // reclaimed by the box tid's drop glue (`NameStorage`), greyed through the
     // `name` slot in `type_object_custom_trace`. The immortal fallback (pre-GC /
     // snapshot tools) keeps a `malloc_raw` name that an immortal holder can never
-    // grey — pin the header above so a collecting name box cannot sweep it
-    // before it is stored into the type below.
+    // grey — the non-collecting old-gen alloc above cannot sweep this box before
+    // it is stored into the type below.
     let name_value = name.to_string();
     let (name, qualname) = if raw.is_null() {
         (
@@ -614,16 +594,13 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         let _ = crate::gc_roots::pin_root(name as PyObjectRef);
         let qualname =
             crate::gc_storage::gc_alloc_storage_box(name_value, name_storage_gc_type_id());
-        let name = crate::gc_roots::shadow_stack_get(save_point + 3) as *mut String;
+        let name = crate::gc_roots::shadow_stack_get(save_point + 2) as *mut String;
         (name, qualname)
     };
     // Install the forwarded bases and managed namespace addresses rather than the
     // pre-collection arguments (the pins survive any collection the alloc forces).
     let bases = crate::gc_roots::shadow_stack_get(save_point);
     let dict_ptr = crate::gc_roots::shadow_stack_get(save_point + 1) as *mut u8;
-    let raw = type_slot.map_or(raw, |slot| {
-        crate::gc_roots::shadow_stack_get(slot) as *mut u8
-    });
     let value = W_TypeObject {
         ob_header: PyObject {
             ob_type: &TYPE_TYPE as *const PyType,
@@ -682,11 +659,10 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // No GC hook yet (pre-init / snapshot tools): fall back to an immortal box.
         (crate::lltype::malloc_typed(value) as PyObjectRef, false)
     };
-    if gc_managed && needs_write_barrier {
-        // An old-gen spill stores young `bases`/namespace into an old object;
-        // remember it so the next minor collection scans it and its custom trace
-        // (`W_TYPE_GC_TYPE_ID`) forwards those young children.  A nursery
-        // header needs no creation barrier.
+    if gc_managed {
+        // A stable header is old-gen; `bases` / name boxes may still be
+        // young.  Remember the type so the next minor collection scans it
+        // and `type_object_custom_trace` forwards those children.
         crate::gc_hook::try_gc_write_barrier(w_type as *mut u8);
     } else {
         // Immortal fallback type (pre-GC): its trace never fires, so root its

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -569,13 +569,39 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     let save_point = crate::gc_roots::shadow_stack_len();
     let _ = crate::gc_roots::pin_root(bases);
     let _ = crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
+    // `space.allocate_instance(W_TypeObject, w_typetype)` — a heap type is an
+    // ordinary `GcStruct`, not a non-moving residual.  The list header already
+    // takes `try_gc_alloc_collecting_rooted`; the type header is the same
+    // shape.  `bases` / the namespace sit on the shadow stack; the extra
+    // rooted child is unused.
+    let mut allocation_root = std::ptr::null_mut();
+    let mut needs_write_barrier = true;
+    let raw = unsafe {
+        crate::gc_hook::try_gc_alloc_collecting_rooted(
+            W_TYPE_GC_TYPE_ID,
+            W_TYPE_OBJECT_SIZE,
+            &mut allocation_root,
+            &mut needs_write_barrier,
+        )
+    };
+    let raw = crate::gc_hook::GcAllocOutcome::from_hook(raw)
+        .allocated_or_abort(W_TYPE_OBJECT_SIZE)
+        .unwrap_or(std::ptr::null_mut());
+    // Name storage is a nursery box and can collect; pin the empty header
+    // first so a minor forwards it before the write below.
+    let type_slot = if !raw.is_null() {
+        let slot = crate::gc_roots::shadow_stack_len();
+        let _ = crate::gc_roots::pin_root(raw as PyObjectRef);
+        Some(slot)
+    } else {
+        None
+    };
     // A mortal (GC-managed) heap type boxes its name in a GC-managed storage box
     // reclaimed by the box tid's drop glue (`NameStorage`), greyed through the
     // `name` slot in `type_object_custom_trace`. The immortal fallback (pre-GC /
     // snapshot tools) keeps a `malloc_raw` name that an immortal holder can never
-    // grey — the non-collecting old-gen alloc above cannot sweep this box before
-    // it is stored into the type below.
+    // grey — pin the header above so a collecting name box cannot sweep it
+    // before it is stored into the type below.
     let name_value = name.to_string();
     let (name, qualname) = if raw.is_null() {
         (
@@ -588,13 +614,16 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         let _ = crate::gc_roots::pin_root(name as PyObjectRef);
         let qualname =
             crate::gc_storage::gc_alloc_storage_box(name_value, name_storage_gc_type_id());
-        let name = crate::gc_roots::shadow_stack_get(save_point + 2) as *mut String;
+        let name = crate::gc_roots::shadow_stack_get(save_point + 3) as *mut String;
         (name, qualname)
     };
     // Install the forwarded bases and managed namespace addresses rather than the
     // pre-collection arguments (the pins survive any collection the alloc forces).
     let bases = crate::gc_roots::shadow_stack_get(save_point);
     let dict_ptr = crate::gc_roots::shadow_stack_get(save_point + 1) as *mut u8;
+    let raw = type_slot.map_or(raw, |slot| {
+        crate::gc_roots::shadow_stack_get(slot) as *mut u8
+    });
     let value = W_TypeObject {
         ob_header: PyObject {
             ob_type: &TYPE_TYPE as *const PyType,
@@ -653,10 +682,11 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // No GC hook yet (pre-init / snapshot tools): fall back to an immortal box.
         (crate::lltype::malloc_typed(value) as PyObjectRef, false)
     };
-    if gc_managed {
-        // Fresh old-gen type stores young `bases`/namespace into an old object;
+    if gc_managed && needs_write_barrier {
+        // An old-gen spill stores young `bases`/namespace into an old object;
         // remember it so the next minor collection scans it and its custom trace
-        // (`W_TYPE_GC_TYPE_ID`) forwards those young children.
+        // (`W_TYPE_GC_TYPE_ID`) forwards those young children.  A nursery
+        // header needs no creation barrier.
         crate::gc_hook::try_gc_write_barrier(w_type as *mut u8);
     } else {
         // Immortal fallback type (pre-GC): its trace never fires, so root its

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -379,11 +379,22 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
     }
     let byte_len = value.len();
     let char_len = value.code_points().count();
+    // The value box is a live GC child with no heap edge until the header
+    // is written.  Pin it (and the class word `get_instantiate` may allocate)
+    // across the header malloc, then remember the old-to-young edge — the
+    // same bracket `w_str_from_storage` / `build_bytes` already use.
+    let _roots = crate::gc_roots::push_roots();
     let value = crate::gc_storage::gc_alloc_storage_box(value, unicode_value_gc_type_id());
+    let value_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(value as PyObjectRef);
+    let class_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(get_instantiate(&STR_TYPE));
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
+    let value = crate::gc_roots::shadow_stack_get(value_slot) as *mut Wtf8Buf;
     let unicode = W_UnicodeObject {
         ob_header: PyObject {
             ob_type: &STR_TYPE as *const PyType,
-            w_class: get_instantiate(&STR_TYPE),
+            w_class: crate::gc_roots::shadow_stack_get(class_slot),
         },
         value,
         byte_len,
@@ -392,7 +403,6 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
         index_storage: std::ptr::null_mut(),
         hash: 0,
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     if raw.is_null() {
         // Header alloc failed after the value box: rebuild a fully immortal
         // string rather than pair a `malloc_typed` header with a GC value box it
@@ -404,8 +414,9 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
     }
     unsafe {
         std::ptr::write(raw as *mut W_UnicodeObject, unicode);
-        raw as PyObjectRef
     }
+    crate::gc_hook::try_gc_write_barrier_managed(raw);
+    raw as PyObjectRef
 }
 
 /// Allocate a dynamic exact string at a terminal, GC-safe return site.
@@ -554,15 +565,25 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
     // Mortal (subclass) holder: the value buffer lives in a GC-managed box so
     // the sweep reclaims it through the box tid's drop glue, and the holder's
     // `value` gc-pointer edge greys it. Falls back to `malloc_raw` when no GC
-    // hook is installed (pre-init / unit tests).
+    // hook is installed (pre-init / unit tests).  Pin both pre-existing
+    // children across the header malloc (`w_bytes_subclass_from_bytes`).
+    let _roots = crate::gc_roots::push_roots();
+    let class_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(w_class);
     let value = crate::gc_storage::gc_alloc_storage_box(value, unicode_value_gc_type_id());
+    let value_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(value as PyObjectRef);
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        W_UNICODE_USER_GC_TYPE_ID.get(),
+        W_UNICODE_USER_OBJECT_SIZE,
+    );
     let unicode = W_UnicodeObjectUser {
         base: W_UnicodeObject {
             ob_header: PyObject {
                 ob_type: &STR_TYPE as *const PyType,
-                w_class,
+                w_class: crate::gc_roots::shadow_stack_get(class_slot),
             },
-            value,
+            value: crate::gc_roots::shadow_stack_get(value_slot) as *mut Wtf8Buf,
             byte_len,
             len: char_len,
             w_slots: PY_NULL,
@@ -572,17 +593,14 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
         map: 0,
         storage: std::ptr::null_mut(),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
-        W_UNICODE_USER_GC_TYPE_ID.get(),
-        W_UNICODE_USER_OBJECT_SIZE,
-    );
     let obj = if raw.is_null() {
         crate::lltype::malloc_typed(unicode) as PyObjectRef
     } else {
         unsafe {
             std::ptr::write(raw as *mut W_UnicodeObjectUser, unicode);
-            raw as PyObjectRef
         }
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
+        raw as PyObjectRef
     };
     crate::gc_hook::maybe_register_finalizer(obj);
     obj


### PR DESCRIPTION
## Summary

Follow-up to #1722 on `perf-memory`.

- Reload `PyFrame` / `profile_frame` via `FrameAnchor` after collecting calls (`descr_new`, `CALL_FUNCTION_EX` / kwargs / override binding), matching gctransform's live-frame restore.
- Keep `simplequeue_put`'s pin across GIL-dropping lock acquire; open `build_class` keyword brackets on the function, not a `map` closure.
- Birth heap types with `try_gc_alloc_collecting_rooted` (`allocate_instance`), and reload the type through `type.__new__` setup.
- Pin string keys that were live across later stores in `exec`, importing, pyexpat, and the ctypes metaclass.

Darwin bracket/frame ratchet: cannot-reach-collection 3→1, frames-across-collecting 10→0.

## Test plan

- [x] `cargo check -p pyre-interpreter --features dynasm`
- [x] `cargo test -p pyre-object --lib typeobject`
- [x] extra_tests / smoke for traceback, SimpleQueue, `__build_class__`, `type()`, `exec`
- [ ] `python3 pyre/check.py` (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interpreter stability during garbage collection, reducing the risk of stale object references and related crashes.
  - Strengthened memory handling for strings, collections, subclasses, exceptions, and built-in operations.
  - Improved reliability across object creation, function calls, formatting, importing, serialization, and standard-library modules.
  - Updated platform-specific runtime behavior and validation baselines.

- **Documentation**
  - Clarified internal memory-management and object-allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->