### PR TITLE
gc: IncrementalMiniMark credit, external malloc, and destructor rematerialize

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4204,14 +4204,25 @@ impl MiniMarkGC {
 
     /// incminimark.py `rrc_invoke_callback`.
     ///
-    /// Called from the public collection entry points (incminimark.py:808,
-    /// :821, :862), never from inside a phase: the collector is borrowed, so
-    /// the callback may only schedule the drain, not perform it.
+    /// Called from the public collection entry points (`collect`,
+    /// `collect_step`, `minor_collection_with_major_progress`), never from
+    /// inside a phase: the collector is borrowed, so the callback may only
+    /// schedule the drain, not perform it.
+    ///
+    /// Upstream fires only when `rrc_dealloc_pending` is non-empty. A
+    /// collection that queued only `tp_finalize` work or a C-only cycle
+    /// (`c_garbage`) would then leave `drain_dead` unscheduled.
+    /// `gcmodule.c finalize_garbage` runs before `delete_garbage` and is
+    /// what those two queues implement; the extra arms keep that order
+    /// observable. Evidence: `cpyext/pyobject.rs drain_dead` drains
+    /// finalize, then `clear_garbage`, then dealloc.
     fn rrc_invoke_callback(&mut self) {
-        if self.rrc.enabled
-            && (!self.rrc.dealloc_pending.is_empty()
-                || !self.rrc.finalize_pending.is_empty()
-                || self.rrc.c_garbage)
+        if !self.rrc.enabled {
+            return;
+        }
+        let has_dealloc = !self.rrc.dealloc_pending.is_empty();
+        let has_cpyext_work = !self.rrc.finalize_pending.is_empty() || self.rrc.c_garbage;
+        if (has_dealloc || has_cpyext_work)
             && let Some(trigger) = self.rrc.dealloc_trigger
         {
             self.rrc.c_garbage = false;
@@ -8547,6 +8558,10 @@ impl MiniMarkGC {
     /// If an incremental major cycle should start, it is initiated. If a cycle
     /// is already in progress, one bounded MARKING or SWEEPING step is
     /// performed. Returns true if any GC work was done.
+    ///
+    /// incminimark.py `gc_step_until` / `debug_gc_step`: a minor before every
+    /// `major_collection_step`. `collect_step` is the same pair plus the
+    /// rawrefcount callback; this is the JIT-safepoint half without that tail.
     pub fn gc_step(&mut self) -> bool {
         if !self.enabled {
             return false;
@@ -8554,6 +8569,7 @@ impl MiniMarkGC {
         if self.gc_state == GcState::Scanning && !self.threshold_reached(0) {
             return false;
         }
+        self.minor_collection_body();
         self.major_collection_step();
         true
     }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1670,7 +1670,9 @@ impl MiniMarkGC {
         // already present a complete root set at an allocation; the young birth
         // adds no requirement they do not already meet.
         if total_size >= self.config.large_object_threshold {
-            self.maybe_collect_for_external_malloc(total_size);
+            if self.maybe_collect_for_external_malloc(total_size) {
+                return GcRef(0);
+            }
             if let Some(obj) = self.try_alloc_young_nonmoving_clear(type_id, total_size) {
                 return obj;
             }
@@ -1849,18 +1851,24 @@ impl MiniMarkGC {
         root: *mut GcRef,
         needs_write_barrier: *mut bool,
     ) -> GcRef {
-        // Large objects never trigger a nursery collection, so the native
-        // slot needs no temporary registration. `alloc_with_type_slow` records
-        // why the oversized arm is a young non-moving birth.
-        //
         // `needs_write_barrier` stays true for the young birth as well. The
         // young object carries no GCFLAG_TRACK_YOUNG_PTRS, so the barrier the
         // caller then emits finds the flag clear and does nothing — a cost, not
         // a hazard, and the alternative is a caller that has to know which of
         // the two births it got.
+        //
+        // `external_malloc` may run a moving minor before the new block
+        // exists. The caller's live slot is not yet a nursery object, but it
+        // may be the only reference to one; register it across that collection
+        // the same way the nursery-full arm does.
         if total_size >= self.config.large_object_threshold {
             unsafe { *needs_write_barrier = true };
-            self.maybe_collect_for_external_malloc(total_size);
+            unsafe { self.roots.add(root) };
+            let oom = self.maybe_collect_for_external_malloc(total_size);
+            self.roots.remove(root);
+            if oom {
+                return GcRef(0);
+            }
             if let Some(obj) = self.try_alloc_young_nonmoving_clear(type_id, total_size) {
                 return obj;
             }
@@ -2695,13 +2703,17 @@ impl MiniMarkGC {
     /// Only collecting entry points call this. A no-collect path still
     /// cannot root the caller's native locals, so it keeps the deferred
     /// breaker in `finish_alloc_*`.
-    fn maybe_collect_for_external_malloc(&mut self, totalsize: usize) {
+    ///
+    /// Returns true when the collection armed `oom_pending`: the triggering
+    /// allocation must fail rather than allocate past `PYPY_GC_MAX`.
+    fn maybe_collect_for_external_malloc(&mut self, totalsize: usize) -> bool {
         if !self.threshold_reached(totalsize) {
-            return;
+            return false;
         }
         self.pending_reserving_size = totalsize.saturating_add(self.config.nursery_size / 2);
         self.minor_collection_with_major_progress(false);
         self.pending_reserving_size = 0;
+        std::mem::take(&mut self.oom_pending)
     }
 
     fn alloc_in_oldgen(&mut self, type_id: u32, total_size: usize) -> GcRef {
@@ -3009,7 +3021,9 @@ impl MiniMarkGC {
         length: usize,
         has_gc_ptrs_in_var: bool,
     ) -> GcRef {
-        self.maybe_collect_for_external_malloc(total_size);
+        if self.maybe_collect_for_external_malloc(total_size) {
+            return GcRef(0);
+        }
         self.try_alloc_young_nonmoving_with_cards(type_id, total_size, length, has_gc_ptrs_in_var)
             .unwrap_or_else(|| {
                 self.alloc_in_oldgen_with_cards(type_id, total_size, length, has_gc_ptrs_in_var)
@@ -8581,6 +8595,13 @@ impl MiniMarkGC {
         if self.gc_state == GcState::Scanning && !self.threshold_reached(0) {
             return false;
         }
+        // `collect_step` takes the same pause: a leading minor moves the
+        // nursery, so every registered mutator has to be off the heap.
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
         self.minor_collection_body();
         self.major_collection_step();
         true

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -7603,15 +7603,16 @@ impl MiniMarkGC {
     /// unreachable, but it need not collect when that graph contains no
     /// registered finalizer at all.  Walk the same traced edges as marking and
     /// use inspector.py's `GCFLAG_EXTRA` visited bit, restoring every bit
-    /// before returning.  This is a conservative prefilter: rawrefcount can
-    /// run external deallocators whose ownership graph is not represented by
-    /// these fields, so an enabled rawrefcount bridge always keeps the sweep.
+    /// before returning.  An enabled rawrefcount bridge keeps the sweep only
+    /// when a reached object itself has a mirror — a process-wide rrc flag
+    /// is not a per-graph witness.
     pub fn do_subgraph_has_pending_finalizer(&self, roots: &[GcRef]) -> bool {
-        if self.registered_finalizer_count() == 0 {
-            return self.rawrefcount_enabled();
-        }
-        if self.rawrefcount_enabled() {
-            return true;
+        // A process-wide rawrefcount bridge is not a witness that *this*
+        // released graph can run a death callback.  Walking the same edges
+        // as marking, an enabled rrc only keeps the sweep when a reached
+        // object itself has a mirror (`rawrefcount_from_obj`).
+        if self.registered_finalizer_count() == 0 && !self.rawrefcount_enabled() {
+            return false;
         }
 
         let mut pending = Vec::new();
@@ -7627,6 +7628,8 @@ impl MiniMarkGC {
                     && !(*hdr).has_flag(GcFlags::FINALIZER_RUN)
                     && !(*hdr).has_flag(GcFlags::GCFLAG_IGNORE_FINALIZER)
             } {
+                found = true;
+            } else if self.rawrefcount_enabled() && self.rawrefcount_from_obj(obj.0) != 0 {
                 found = true;
             }
             self.visit_referents(obj.0, &mut |child| self.heap_dump_add(child, &mut pending));
@@ -15421,6 +15424,13 @@ cache size\t: 8192 kB\n";
         unsafe { *(holder.0 as *mut GcRef) = finalizable };
         GcAllocator::register_finalizer(&mut gc, 0, finalizable, trigger);
 
+        assert!(!gc.do_subgraph_has_pending_finalizer(&[unrelated]));
+        assert!(gc.do_subgraph_has_pending_finalizer(&[holder]));
+        gc.rawrefcount_init(rrc_test_trigger);
+        assert!(
+            gc.rawrefcount_enabled(),
+            "rrc must not make an unrelated subgraph look finalizable"
+        );
         assert!(!gc.do_subgraph_has_pending_finalizer(&[unrelated]));
         assert!(gc.do_subgraph_has_pending_finalizer(&[holder]));
         // The inspector visited bit is scratch state, not a semantic mark.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1450,12 +1450,6 @@ impl MiniMarkGC {
             .oldgen
             .alloc_with_card_header(total_size, card_header_bytes);
         let obj = self.finish_alloc_in_oldgen(type_id, total_size, ptr, extra_flags);
-        // `allocsize = cardheadersize + round_up_for_allocation(totalsize)` is
-        // what upstream adds to `rawmalloced_total_size`; the shared tail
-        // accounted for the object, so the card header is what is left.
-        self.bytes_made_old_since_cycle = self
-            .bytes_made_old_since_cycle
-            .saturating_add(card_header_bytes);
         Self::raw_memclear(obj, total_size);
         obj
     }
@@ -2033,10 +2027,11 @@ impl MiniMarkGC {
     /// that young-result contract because the GC rewrite elides write barriers
     /// while initializing a fresh nursery object (`rewrite.py:911`).
     fn nursery_allocation_size(total_size: usize) -> usize {
+        let align = crate::header::MEMORY_ALIGNMENT;
         total_size
             .max(GcHeader::MIN_NURSERY_OBJ_SIZE)
-            .checked_add(7)
-            .map(|size| size & !7)
+            .checked_add(align - 1)
+            .map(|size| size & !(align - 1))
             .unwrap_or(usize::MAX)
     }
 
@@ -2858,8 +2853,8 @@ impl MiniMarkGC {
             type_id,
             self.oldgen_birth_flags(extra_flags | GcFlags::GCFLAG_TRACK_YOUNG_PTRS),
         );
-        self.bytes_made_old_since_cycle =
-            self.bytes_made_old_since_cycle.saturating_add(total_size);
+        // `size_objects_made_old` counts promotions, not old-gen births.
+        // `external_malloc(..., alloc_young=False)` does not bump it.
         let obj_addr = (ptr as usize) + GcHeader::SIZE;
         self.audit_allocation_size(type_id, total_size, obj_addr, "oldgen");
         if crate::gc_lifetime_log_enabled() {
@@ -3657,7 +3652,7 @@ impl MiniMarkGC {
             None
         };
         self.minor_collection_body();
-        self.run_major_progress_after_minor();
+        self.run_major_progress_after_minor(false);
         self.rrc_invoke_callback();
     }
 
@@ -6289,11 +6284,12 @@ impl MiniMarkGC {
     /// `nursery_size / 2` bytes of promotion credit, and allocation-heavy
     /// minors may need multiple consecutive steps so old-gen growth does not
     /// outrun marking.
-    fn run_major_progress_after_minor(&mut self) {
-        // incminimark.py:832 — automatic major progress after a minor stops
-        // while disabled; explicit collect() passes force_enabled and stays
-        // ungated (collect_full / collect_oldgen_nonmoving here).
-        if !self.enabled {
+    fn run_major_progress_after_minor(&mut self, force_enabled: bool) {
+        // incminimark.py `minor_collection_with_major_progress`: automatic
+        // major progress after a minor stops while disabled; explicit
+        // collect() passes force_enabled and stays ungated without flipping
+        // `enabled`.
+        if !self.enabled && !force_enabled {
             return;
         }
         let extrasize = self.pending_reserving_size;
@@ -7764,19 +7760,18 @@ impl MiniMarkGC {
     /// in progress, run at least one major collection step.  If there is no
     /// major GC but the threshold is reached, start a major GC."
     ///
-    /// `do_collect_nursery` is that function with `force_enabled=False` baked
-    /// in, because its tail `run_major_progress_after_minor` reads
-    /// `self.enabled`.  The forced form lends the flag for the call, which is
-    /// what `force_enabled` means: an explicit collection makes major progress
-    /// even while automatic progress is switched off.
+    /// `do_collect_nursery` is that function with `force_enabled=False`.
+    /// Explicit `collect(0/1)` passes `force_enabled=True` so major progress
+    /// still runs while automatic progress is switched off, without flipping
+    /// `enabled`.
     fn minor_collection_with_major_progress(&mut self, force_enabled: bool) {
         if !force_enabled {
             self.do_collect_nursery();
             return;
         }
-        let was_enabled = std::mem::replace(&mut self.enabled, true);
-        self.do_collect_nursery();
-        self.enabled = was_enabled;
+        self.minor_collection_body();
+        self.run_major_progress_after_minor(true);
+        self.rrc_invoke_callback();
     }
 
     /// incminimark.py `collect(gen=2)`: "Do a minor (gen=0), start a major
@@ -11696,8 +11691,8 @@ mod tests {
             std::mem::size_of::<usize>() * gc.card_marking_words_for_length(length);
         assert!(card_header_bytes > 0);
         assert_eq!(
-            gc.bytes_made_old_since_cycle - bytes_before,
-            card_header_bytes + total_size
+            gc.bytes_made_old_since_cycle, bytes_before,
+            "an old-gen birth is not a promotion"
         );
     }
 
@@ -12876,7 +12871,7 @@ mod tests {
         gc.bytes_made_old_since_cycle = gc.config.nursery_size;
         gc.threshold_bytes_made_old = 0;
         let minors_before = gc.minor_collections;
-        gc.run_major_progress_after_minor();
+        gc.run_major_progress_after_minor(false);
 
         assert!(
             gc.minor_collections > minors_before,
@@ -12916,7 +12911,7 @@ mod tests {
         gc.pending_reserving_size = gc.config.nursery_size / 4;
         let minors_before = gc.minor_collections;
 
-        gc.run_major_progress_after_minor();
+        gc.run_major_progress_after_minor(false);
 
         assert!(gc.minor_collections > minors_before);
         gc.pending_reserving_size = 0;
@@ -12946,7 +12941,7 @@ mod tests {
             gc.pending_reserving_size = extrasize;
             let minors_before = gc.minor_collections;
 
-            gc.run_major_progress_after_minor();
+            gc.run_major_progress_after_minor(false);
 
             assert_eq!(gc.gc_state, GcState::Marking);
             assert_eq!(gc.bytes_made_old_since_cycle, 0);

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3189,12 +3189,6 @@ impl MiniMarkGC {
         }
     }
 
-    /// incminimark.py:2344-2356
-    /// `remove_young_arrays_from_old_objects_pointing_to_young`.
-    ///
-    /// An entry naming a young rawmalloced object is a contradiction: this
-    /// minor visits it as an object, and if it dies the drain would be reading
-    /// a freed header. Upstream drops those entries before the walk starts.
     /// incminimark.py `_add_to_more_objects_to_trace_if_black`.
     ///
     /// Upstream then clears `GCFLAG_VISITED` because its drain re-marks on
@@ -3207,6 +3201,11 @@ impl MiniMarkGC {
         }
     }
 
+    /// incminimark.py `remove_young_arrays_from_old_objects_pointing_to_young`.
+    ///
+    /// An entry naming a young rawmalloced object is a contradiction: this
+    /// minor visits it as an object, and if it dies the drain would be reading
+    /// a freed header. Upstream drops those entries before the walk starts.
     fn remove_young_arrays_from_old_objects_pointing_to_young(&mut self) {
         let oldgen = &self.oldgen;
         self.old_objects_pointing_to_young
@@ -6701,6 +6700,16 @@ impl MiniMarkGC {
                 break;
             }
             if unsafe { (*header_of(candidate)).is_forwarded() } {
+                let fwd = unsafe { GcHeader::forwarding_address(header_of(candidate)) };
+                let Some(size) = self.try_size_for_typeid(
+                    fwd,
+                    unsafe { (*header_of(fwd)).type_id() },
+                ) else {
+                    continue;
+                };
+                if candidate + size <= obj_addr {
+                    continue;
+                }
                 return Some(candidate);
             }
         }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -5009,7 +5009,7 @@ impl MiniMarkGC {
                  nearest_header={}, \
                  child_nursery_offset={:#x}, child_gen={}, holder_gen={}, \
                  holder_tid_and_flags={:#x}, holder_in_remembered={}, \
-                 enclosing={}, gc_state={:?}, minors={}, majors={})",
+                 enclosing={}, extra_area={}, gc_state={:?}, minors={}, majors={})",
                 type_id,
                 obj_addr,
                 self.minor_collections,
@@ -5036,6 +5036,7 @@ impl MiniMarkGC {
                 holder_hdr_tid_and_flags,
                 self.old_objects_pointing_to_young.contains(&holder_addr),
                 self.describe_enclosing_container(holder_addr, slot_addr, &holder_words),
+                crate::shadow_stack::current_extra_area(),
                 self.gc_state,
                 self.minor_collections,
                 self.major_collections,
@@ -5207,8 +5208,14 @@ impl MiniMarkGC {
         );
         if self.is_nursery_object_start(gcref.0) {
             let slot_addr = gcref as *mut GcRef as usize;
+            // `is_nursery_object_start` is incminimark `is_in_nursery`: a
+            // range check, not a header check. A root slot that holds an
+            // interior address still has to name an object start — follow
+            // the enclosing header, which is what a precise map would have
+            // published. Do not change the range check itself.
+            let obj_addr = self.nursery_root_object_addr(gcref.0);
             *gcref =
-                self.copy_nursery_object(gcref.0, "minor_root_target", "minor_root", 0, slot_addr);
+                self.copy_nursery_object(obj_addr, "minor_root_target", "minor_root", 0, slot_addr);
         } else if self.is_young_rawmalloced(gcref.0) {
             // incminimark.py:2149-2159 `_trace_drag_out`: an object outside the
             // nursery needs nothing changed, *except* that a young rawmalloced
@@ -5263,18 +5270,22 @@ impl MiniMarkGC {
                         site,
                     );
                     if self.is_nursery_object_start(field_ref.0) {
-                        if deferred.is_none() && !self.nursery_start_decodes(field_ref.0) {
-                            deferred = Some((slot_ptr as usize, field_ref.0));
+                        let child = self.nursery_root_object_addr(field_ref.0);
+                        if child != field_ref.0 || self.nursery_start_decodes(field_ref.0) {
+                            let new_ref = self.copy_nursery_object(
+                                child,
+                                "minor_custom_trace_target",
+                                site,
+                                obj_addr,
+                                slot_ptr as usize,
+                            );
+                            *slot_ptr = new_ref;
                             return;
                         }
-                        let new_ref = self.copy_nursery_object(
-                            field_ref.0,
-                            "minor_custom_trace_target",
-                            site,
-                            obj_addr,
-                            slot_ptr as usize,
-                        );
-                        *slot_ptr = new_ref;
+                        if deferred.is_none() {
+                            deferred = Some((slot_ptr as usize, field_ref.0));
+                        }
+                        return;
                     } else if self.is_young_rawmalloced(field_ref.0) {
                         self.visit_young_rawmalloced_object(field_ref.0);
                     }
@@ -6660,6 +6671,42 @@ impl MiniMarkGC {
         hdr.is_forwarded() || (hdr.type_id() as usize) < self.types.len()
     }
 
+    /// Object-start address a root slot should name.
+    ///
+    /// A precise map publishes the payload start. A slot that landed
+    /// `N` words inside a nursery object still has to drag that object
+    /// out; snapping to the enclosing start is the walk-site counterpart
+    /// of `nursery_start_decodes`.
+    fn nursery_root_object_addr(&self, addr: usize) -> usize {
+        if self.nursery_start_decodes(addr) {
+            return addr;
+        }
+        self.enclosing_nursery_object_start(addr).unwrap_or(addr)
+    }
+
+    /// Payload start of a nursery object that already moved and whose
+    /// leftover header still covers `addr`.
+    ///
+    /// Only a forwarded header is a witness: a live object's payload
+    /// words can decode as a small type_id, and treating one as a start
+    /// would copy from the middle of the object. The `test_re` crash
+    /// walks the interior slot after another root has already forwarded
+    /// the real start (`nearest_header=forwarded back=3w`).
+    fn enclosing_nursery_object_start(&self, obj_addr: usize) -> Option<usize> {
+        let word = std::mem::size_of::<usize>();
+        let floor = self.nursery.start_ptr() as usize;
+        for back in 1..=64usize {
+            let candidate = obj_addr.checked_sub(back * word)?;
+            if candidate < floor + GcHeader::SIZE {
+                break;
+            }
+            if unsafe { (*header_of(candidate)).is_forwarded() } {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
     /// Every slot a custom trace names, with the state of the value in it.
     ///
     /// For a JITFRAME the slot set is whatever `jf_gcmap` says, so this is the
@@ -6713,7 +6760,7 @@ impl MiniMarkGC {
             let Some(candidate) = obj_addr.checked_sub(back * word) else {
                 break;
             };
-            if candidate <= floor + GcHeader::SIZE {
+            if candidate < floor + GcHeader::SIZE {
                 break;
             }
             let hdr = unsafe { *header_of(candidate) };
@@ -14843,6 +14890,39 @@ cache size\t: 8192 kB\n";
     // compiler), so interior-pointer filtering is not part of the GC
     // contract. The test disagreed with that contract and was removed
     // to keep majit-gc structurally aligned with RPython.
+    //
+    // `drag_out_root` still has to name an object start when a publisher
+    // puts an interior address in a root slot (`test_re` on linux
+    // dynasm: `+16` into a forwarded nursery object). Snapping to the
+    // enclosing header is that walk-site repair; the range check itself
+    // stays a range check.
+
+    #[test]
+    fn test_minor_root_walk_snaps_interior_pointer_to_object_start() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(32));
+        let obj = gc.alloc_with_type(tid, 32);
+        unsafe {
+            *((obj.0 + 8) as *mut u64) = 0x42;
+        }
+
+        // Exact root first so the object is forwarded before the interior
+        // slot is walked — the `test_re` ordering (`nearest_header=forwarded`).
+        let mut exact = obj;
+        gc.drag_out_root(&mut exact);
+        assert!(
+            gc.oldgen.contains(exact.0),
+            "exact root must promote the object"
+        );
+
+        let mut interior = GcRef(obj.0 + 16);
+        gc.drag_out_root(&mut interior);
+        assert_eq!(
+            exact.0, interior.0,
+            "interior root must snap to the same forwarded object"
+        );
+        assert_eq!(unsafe { *((exact.0 + 8) as *const u64) }, 0x42);
+    }
 
     /// incminimark.py:3068-3079 dead-target branch. A WEAKREF whose
     /// target is a nursery object with no GC root must have its

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1670,6 +1670,7 @@ impl MiniMarkGC {
         // already present a complete root set at an allocation; the young birth
         // adds no requirement they do not already meet.
         if total_size >= self.config.large_object_threshold {
+            self.maybe_collect_for_external_malloc(total_size);
             if let Some(obj) = self.try_alloc_young_nonmoving_clear(type_id, total_size) {
                 return obj;
             }
@@ -1859,6 +1860,7 @@ impl MiniMarkGC {
         // the two births it got.
         if total_size >= self.config.large_object_threshold {
             unsafe { *needs_write_barrier = true };
+            self.maybe_collect_for_external_malloc(total_size);
             if let Some(obj) = self.try_alloc_young_nonmoving_clear(type_id, total_size) {
                 return obj;
             }
@@ -2686,6 +2688,22 @@ impl MiniMarkGC {
     /// `malloc_zero_filled = False` (incminimark.py) no allocation tier
     /// clears, and a site that needs zeroed memory appends the clear itself —
     /// see [`alloc_in_oldgen_clear`](Self::alloc_in_oldgen_clear).
+    /// `external_malloc`: if the heap is already over the next-major
+    /// threshold, run `minor_collection_with_major_progress` *before* the
+    /// allocation, with extrasize `totalsize + nursery_size/2`.
+    ///
+    /// Only collecting entry points call this. A no-collect path still
+    /// cannot root the caller's native locals, so it keeps the deferred
+    /// breaker in `finish_alloc_*`.
+    fn maybe_collect_for_external_malloc(&mut self, totalsize: usize) {
+        if !self.threshold_reached(totalsize) {
+            return;
+        }
+        self.pending_reserving_size = totalsize.saturating_add(self.config.nursery_size / 2);
+        self.minor_collection_with_major_progress(false);
+        self.pending_reserving_size = 0;
+    }
+
     fn alloc_in_oldgen(&mut self, type_id: u32, total_size: usize) -> GcRef {
         let ptr = self.oldgen.alloc(total_size);
         self.finish_alloc_in_oldgen(type_id, total_size, ptr, GcFlags::empty())
@@ -2893,14 +2911,10 @@ impl MiniMarkGC {
             total_size - GcHeader::SIZE,
             crate::BH_PROBE_ORIGIN_BORN_OLD,
         );
-        // external_malloc (incminimark.py) tests the same threshold
-        // here and drives `minor_collection_with_major_progress` before
-        // handing the block back. Collecting at this point is what pyre cannot
-        // do: the caller is holding the raw pointer on the Rust stack, which
-        // is not a root, and so is whatever else it had live. Ask the question
-        // where upstream asks it and defer only the answer — the request rides
-        // the eval-breaker word to the interpreter dispatch loop, where the
-        // frame walker sees the whole root set.
+        // Collecting entries already ran `maybe_collect_for_external_malloc`
+        // before the block exists. A no-collect path still cannot root the
+        // caller's native locals, so it only arms the eval-breaker for the
+        // dispatch loop, where the frame walker sees the whole root set.
         //
         // Only where that walk will actually happen: the threshold stays
         // reached until a major completes, so arming past a consumer that
@@ -2995,6 +3009,7 @@ impl MiniMarkGC {
         length: usize,
         has_gc_ptrs_in_var: bool,
     ) -> GcRef {
+        self.maybe_collect_for_external_malloc(total_size);
         self.try_alloc_young_nonmoving_with_cards(type_id, total_size, length, has_gc_ptrs_in_var)
             .unwrap_or_else(|| {
                 self.alloc_in_oldgen_with_cards(type_id, total_size, length, has_gc_ptrs_in_var)
@@ -3166,6 +3181,18 @@ impl MiniMarkGC {
     /// An entry naming a young rawmalloced object is a contradiction: this
     /// minor visits it as an object, and if it dies the drain would be reading
     /// a freed header. Upstream drops those entries before the walk starts.
+    /// incminimark.py `_add_to_more_objects_to_trace_if_black`.
+    ///
+    /// Upstream then clears `GCFLAG_VISITED` because its drain re-marks on
+    /// visit. pyre's `mark_object` treats a push as already black, so the
+    /// object stays VISITED across the re-push.
+    fn add_to_more_objects_to_trace_if_black(&mut self, obj_addr: usize) {
+        let hdr = unsafe { header_of(obj_addr) };
+        if unsafe { (*hdr).has_flag(GcFlags::GCFLAG_VISITED) } {
+            self.incr_state.more_gray_stack.push(obj_addr);
+        }
+    }
+
     fn remove_young_arrays_from_old_objects_pointing_to_young(&mut self) {
         let oldgen = &self.oldgen;
         self.old_objects_pointing_to_young
@@ -3217,15 +3244,17 @@ impl MiniMarkGC {
         if self.oldgen.has_young_rawmalloced() {
             self.remove_young_arrays_from_old_objects_pointing_to_young();
         }
-        // incminimark.py:1800-1807: a black old parent may expose an unpinned
-        // child that will move during this minor, so make the parent gray
-        // again before the active major marking cycle can sweep that child.
+        // incminimark.py `_minor_collection`: before any root walk, turn
+        // already-black remembered / pinned-parent objects gray again so the
+        // active marking cycle rescans what they wrote since the last visit.
         if self.gc_state == GcState::Marking {
-            for &obj_addr in &self.old_objects_pointing_to_pinned {
-                let hdr = unsafe { header_of(obj_addr) };
-                if unsafe { (*hdr).has_flag(GcFlags::GCFLAG_VISITED) } {
-                    self.incr_state.more_gray_stack.push(obj_addr);
-                }
+            for index in 0..self.old_objects_pointing_to_young.len() {
+                let obj_addr = self.old_objects_pointing_to_young[index];
+                self.add_to_more_objects_to_trace_if_black(obj_addr);
+            }
+            for index in 0..self.old_objects_pointing_to_pinned.len() {
+                let obj_addr = self.old_objects_pointing_to_pinned[index];
+                self.add_to_more_objects_to_trace_if_black(obj_addr);
             }
         }
         // incminimark.py:1826-1832: replace the list before anything can append
@@ -3394,20 +3423,6 @@ impl MiniMarkGC {
         // still point to a pinned object.
         for obj_addr in old_parents_pointing_to_pinned {
             self.trace_and_update_object(obj_addr, "minor_old_parent_pinned");
-        }
-
-        // incminimark parity: during an active marking cycle, old objects
-        // remembered by the write barrier may already be black. Requeue
-        // those black objects so the major collector rescans their new
-        // outgoing references before sweep.
-        if self.gc_state == GcState::Marking {
-            let remembered_now: Vec<usize> = self.old_objects_pointing_to_young.to_vec();
-            for obj_addr in remembered_now {
-                let hdr = unsafe { header_of(obj_addr) };
-                if unsafe { (*hdr).has_flag(GcFlags::GCFLAG_VISITED) } {
-                    self.incr_state.more_gray_stack.push(obj_addr);
-                }
-            }
         }
 
         // incminimark.py:1834-1836: a mirror the C side still references roots

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3669,6 +3669,7 @@ impl MiniMarkGC {
         self.minor_collection_body();
         self.run_major_progress_after_minor(false);
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
     }
 
     /// incminimark.py `invalidate_young_weakrefs(self)`.
@@ -4208,21 +4209,27 @@ impl MiniMarkGC {
     /// `collect_step`, `minor_collection_with_major_progress`), never from
     /// inside a phase: the collector is borrowed, so the callback may only
     /// schedule the drain, not perform it.
-    ///
-    /// Upstream fires only when `rrc_dealloc_pending` is non-empty. A
-    /// collection that queued only `tp_finalize` work or a C-only cycle
-    /// (`c_garbage`) would then leave `drain_dead` unscheduled.
-    /// `gcmodule.c finalize_garbage` runs before `delete_garbage` and is
-    /// what those two queues implement; the extra arms keep that order
-    /// observable. Evidence: `cpyext/pyobject.rs drain_dead` drains
-    /// finalize, then `clear_garbage`, then dealloc.
     fn rrc_invoke_callback(&mut self) {
-        if !self.rrc.enabled {
-            return;
+        if self.rrc.enabled
+            && !self.rrc.dealloc_pending.is_empty()
+            && let Some(trigger) = self.rrc.dealloc_trigger
+        {
+            trigger();
         }
-        let has_dealloc = !self.rrc.dealloc_pending.is_empty();
-        let has_cpyext_work = !self.rrc.finalize_pending.is_empty() || self.rrc.c_garbage;
-        if (has_dealloc || has_cpyext_work)
+    }
+
+    /// Schedule `drain_dead` for work PyPy's `rrc_invoke_callback` does not
+    /// see: claimed `tp_finalize` blocks and C-only cycles.
+    ///
+    /// `gcmodule.c finalize_garbage` runs before `delete_garbage`. A
+    /// collection that queued only those two would leave the drain unscheduled
+    /// if this sat inside `rrc_invoke_callback`. The sibling keeps that
+    /// function dealloc-only and is called from the same entry points.
+    /// Evidence: `cpyext/pyobject.rs drain_dead` drains finalize, then
+    /// `clear_garbage`, then dealloc.
+    fn rrc_invoke_cpyext_drain(&mut self) {
+        if self.rrc.enabled
+            && (!self.rrc.finalize_pending.is_empty() || self.rrc.c_garbage)
             && let Some(trigger) = self.rrc.dealloc_trigger
         {
             self.rrc.c_garbage = false;
@@ -7779,6 +7786,7 @@ impl MiniMarkGC {
 
         // incminimark.py:808.
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
     }
 
     /// incminimark.py `minor_collection_with_major_progress`: "Do a minor
@@ -7798,6 +7806,7 @@ impl MiniMarkGC {
         self.minor_collection_body();
         self.run_major_progress_after_minor(true);
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
     }
 
     /// incminimark.py `collect(gen=2)`: "Do a minor (gen=0), start a major
@@ -7833,6 +7842,7 @@ impl MiniMarkGC {
             }
         }
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
     }
 
     /// incminimark.py `set_max_heap_size`.  `PYPY_GC_MAX` is read once at
@@ -7875,6 +7885,7 @@ impl MiniMarkGC {
 
         // incminimark.py:821.
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
 
         crate::GcStepTransition {
             old_state: old_state.encoded(),
@@ -7934,6 +7945,7 @@ impl MiniMarkGC {
         // This entry has no upstream counterpart, but it is a public collection
         // entry point and it can queue mirrors, so it owes the same schedule.
         self.rrc_invoke_callback();
+        self.rrc_invoke_cpyext_drain();
     }
 
     /// Clear the nursery VISITED bits accumulated by one non-moving major.
@@ -15923,6 +15935,73 @@ cache size\t: 8192 kB\n";
             1,
             "incminimark.py:3248-3250 schedules the drain for a non-empty queue"
         );
+    }
+
+    /// incminimark.py `rrc_invoke_callback` watches only `rrc_dealloc_pending`.
+    #[test]
+    fn rrc_invoke_callback_ignores_finalize_and_c_garbage() {
+        let mut gc = rrc_test_gc();
+        gc.rrc.finalize_pending.push_back(0x100);
+        gc.rrc.c_garbage = true;
+        RRC_TRIGGER_FIRED.with(|fired| fired.set(0));
+
+        gc.rrc_invoke_callback();
+
+        assert_eq!(RRC_TRIGGER_FIRED.with(|fired| fired.get()), 0);
+        assert!(
+            gc.rrc.c_garbage,
+            "the dealloc-only callback does not clear c_garbage"
+        );
+        assert_eq!(gc.rrc.finalize_pending.len(), 1);
+    }
+
+    /// A collection that queued only `tp_finalize` still owes `drain_dead`.
+    #[test]
+    fn rrc_invoke_cpyext_drain_fires_for_finalize_pending() {
+        let mut gc = rrc_test_gc();
+        gc.rrc.finalize_pending.push_back(0x100);
+        RRC_TRIGGER_FIRED.with(|fired| fired.set(0));
+
+        gc.rrc_invoke_cpyext_drain();
+
+        assert_eq!(RRC_TRIGGER_FIRED.with(|fired| fired.get()), 1);
+        assert_eq!(
+            gc.rawrefcount_next_finalize(),
+            0x100,
+            "the sibling only schedules; the embedder drains"
+        );
+    }
+
+    /// A C-only cycle sets `c_garbage` with an empty dealloc queue.
+    #[test]
+    fn rrc_invoke_cpyext_drain_fires_for_c_garbage() {
+        let mut gc = rrc_test_gc();
+        gc.rrc.c_garbage = true;
+        RRC_TRIGGER_FIRED.with(|fired| fired.set(0));
+
+        gc.rrc_invoke_cpyext_drain();
+
+        assert_eq!(RRC_TRIGGER_FIRED.with(|fired| fired.get()), 1);
+        assert!(
+            !gc.rrc.c_garbage,
+            "the sibling consumes the flag when it schedules"
+        );
+    }
+
+    /// Both functions fire independently when both kinds of work are queued.
+    #[test]
+    fn rrc_invoke_pair_fires_once_each_when_both_queues_are_full() {
+        let mut gc = rrc_test_gc();
+        gc.rrc.dealloc_pending.push(0x10);
+        gc.rrc.finalize_pending.push_back(0x20);
+        RRC_TRIGGER_FIRED.with(|fired| fired.set(0));
+
+        gc.rrc_invoke_callback();
+        gc.rrc_invoke_cpyext_drain();
+
+        assert_eq!(RRC_TRIGGER_FIRED.with(|fired| fired.get()), 2);
+        assert_eq!(gc.rawrefcount_next_dead(), 0x10);
+        assert_eq!(gc.rawrefcount_next_finalize(), 0x20);
     }
 
     /// incminimark.py `_rrc_free`: LIGHT means the mirror needs no C

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4221,12 +4221,12 @@ impl MiniMarkGC {
     /// Schedule `drain_dead` for work PyPy's `rrc_invoke_callback` does not
     /// see: claimed `tp_finalize` blocks and C-only cycles.
     ///
-    /// `gcmodule.c finalize_garbage` runs before `delete_garbage`. A
-    /// collection that queued only those two would leave the drain unscheduled
-    /// if this sat inside `rrc_invoke_callback`. The sibling keeps that
-    /// function dealloc-only and is called from the same entry points.
-    /// Evidence: `cpyext/pyobject.rs drain_dead` drains finalize, then
-    /// `clear_garbage`, then dealloc.
+    /// Pyre's spec is the free-threaded build only. This is not the
+    /// GIL generational collector and must not grow into a second compiled
+    /// GC. `tp_finalize` and C-side cycles are still observables there; a
+    /// collection that queued only those two would leave the drain
+    /// unscheduled if this sat inside `rrc_invoke_callback`. Called from
+    /// the same entry points so that function stays dealloc-only.
     fn rrc_invoke_cpyext_drain(&mut self) {
         if self.rrc.enabled
             && (!self.rrc.finalize_pending.is_empty() || self.rrc.c_garbage)

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -21,6 +21,14 @@ pub const TYPE_ID_MASK: u64 = (1u64 << TYPE_ID_BITS) - 1;
 /// logical header word. `GcFlags` declares each flag at position 0..N.
 pub const FLAG_SHIFT: u32 = TYPE_ID_BITS;
 
+/// `llarena.round_up_for_allocation` / `memory_alignment()`: objects align
+/// to the wider of the physical header and a machine word.
+pub const MEMORY_ALIGNMENT: usize = if GcHeader::ALIGN > std::mem::size_of::<usize>() {
+    GcHeader::ALIGN
+} else {
+    std::mem::size_of::<usize>()
+};
+
 /// The sentinel value written into a forwarded nursery object's header.
 /// Equivalent to incminimark's `tid = -42` in a native Signed word.
 pub const FORWARDED_MARKER: u64 = (usize::MAX - 41) as u64;

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -435,6 +435,21 @@ impl WriteBarrierDescr {
             jit_wb_cards_set_singlebyte: cards_set_singlebyte,
         }
     }
+
+    /// gc.py `WriteBarrierDescr.get_write_barrier_from_array_fn`.
+    ///
+    /// Upstream asks the CPU to cast the failing-case function; a backend
+    /// without `write_barrier_from_array` answers 0. MiniMark publishes the
+    /// array barrier exactly when card marking is configured, so a non-zero
+    /// `jit_wb_cards_set` is that same answer.
+    pub fn get_write_barrier_from_array_fn(&self) -> usize {
+        if self.jit_wb_cards_set != 0 { 1 } else { 0 }
+    }
+
+    /// gc.py `WriteBarrierDescr.has_write_barrier_from_array`.
+    pub fn has_write_barrier_from_array(&self) -> bool {
+        self.get_write_barrier_from_array_fn() != 0
+    }
 }
 
 /// GC allocator interface.

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -134,6 +134,14 @@ impl ArenaCollection {
         }
     }
 
+    /// `llarena.arena_reset(result, sizeof(Address), 0)` after reading the
+    /// next-free link stored in the block's first word.
+    unsafe fn take_free_link(block: *mut u8) -> *mut u8 {
+        let next = unsafe { *(block as *mut *mut u8) };
+        unsafe { *(block as *mut usize) = 0 };
+        next
+    }
+
     /// `ArenaCollection.malloc`: allocate an uninitialized arena block.
     pub fn malloc(&mut self, size: usize) -> *mut u8 {
         let nsize = size;
@@ -154,7 +162,7 @@ impl ArenaCollection {
             let result = (*page).freeblock;
             let freeblock = if (*page).nfree > 0 {
                 (*page).nfree -= 1;
-                *(result as *mut *mut u8)
+                Self::take_free_link(result)
             } else {
                 result.add(nsize)
             };
@@ -180,7 +188,7 @@ impl ArenaCollection {
             let result = (*arena).freepages;
             let freepages = if (*arena).nfreepages > 0 {
                 (*arena).nfreepages -= 1;
-                *(result as *mut *mut u8)
+                Self::take_free_link(result)
             } else {
                 assert!(self.num_uninitialized_pages > 0);
                 self.num_uninitialized_pages -= 1;
@@ -654,7 +662,9 @@ mod tests {
         let objects: Vec<_> = (0..5).map(|_| ac.malloc(2 * WORD)).collect();
         ac.mass_free(|obj| obj == objects[1] || obj == objects[3]);
         assert_eq!(ac.total_memory_used, 3 * 2 * WORD);
-        assert_eq!(ac.malloc(2 * WORD), objects[1]);
+        let reused_first = ac.malloc(2 * WORD);
+        assert_eq!(reused_first, objects[1]);
+        assert_eq!(unsafe { *(reused_first as *const usize) }, 0);
         assert_eq!(ac.malloc(2 * WORD), objects[3]);
     }
 

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -233,8 +233,8 @@ impl Nursery {
     pub fn alloc(&mut self, total_size: usize) -> *mut u8 {
         // Ensure minimum size for forwarding during collection.
         let total_size = total_size.max(GcHeader::MIN_NURSERY_OBJ_SIZE);
-        // Align to 8 bytes.
-        let total_size = (total_size + 7) & !7;
+        let total_size = (total_size + crate::header::MEMORY_ALIGNMENT - 1)
+            & !(crate::header::MEMORY_ALIGNMENT - 1);
 
         let result = self.ptrs.free;
         // Use wrapping_add for the bound probe: when the nursery is already

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2742,7 +2742,7 @@ impl GcRewriterImpl {
             .as_ref()
             .expect("gen_write_barrier_array reached with no write barrier descriptor");
         if wb_descr.has_write_barrier_from_array() {
-            // rewrite.py:957 `has_write_barrier_from_array`. If we know
+            // rewrite.py `gen_write_barrier_array`. If we know
             // statically the length of 'v_base', and it is not too big,
             // then produce a regular write_barrier. If it's unknown or
             // too big, produce a write_barrier_from_array.

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -2741,10 +2741,11 @@ impl GcRewriterImpl {
             .wb_descr
             .as_ref()
             .expect("gen_write_barrier_array reached with no write barrier descriptor");
-        if wb_descr.jit_wb_cards_set != 0 {
-            // If we know statically the length of 'v_base', and it is not
-            // too big, then produce a regular write_barrier. If it's
-            // unknown or too big, produce a write_barrier_from_array.
+        if wb_descr.has_write_barrier_from_array() {
+            // rewrite.py:957 `has_write_barrier_from_array`. If we know
+            // statically the length of 'v_base', and it is not too big,
+            // then produce a regular write_barrier. If it's unknown or
+            // too big, produce a write_barrier_from_array.
             const LARGE: usize = 130;
             let length = st.known_length(&v_base, LARGE);
             if length >= LARGE {

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -31,7 +31,7 @@
 //! bytecode, `GILReleaseAction` (gil.py) yields it from the periodic
 //! action; [`yield_thread`] is that yield.
 
-use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 // thread_pthread.c's mutex1_t and mutex2_t own native synchronization objects.
 // rpy_init_mutexes resets them in the forked child. A parking_lot mutex also
 // has waiters in a process-global queue: replacing its local bytes would leave
@@ -55,6 +55,11 @@ const GIL_NOT_INITIALIZED: isize = -42;
 /// thread_gil.c:88 `rpy_early_poll_n`, the running seed for the randomised
 /// early-poll count.
 static RPY_EARLY_POLL_N: AtomicIsize = AtomicIsize::new(0);
+
+/// rgil.py `_emulated_after_thread_switch` / translated
+/// `translator._rgil_invoke_after_thread_switch`. One callback, as upstream
+/// does not implement several.
+static AFTER_THREAD_SWITCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 
 /// thread_gil.c:111-112.
 const RPY_GIL_POKE_MIN: isize = 40;
@@ -279,6 +284,7 @@ pub fn acquire() {
     if !acquire_fast_path(ident) {
         acquire_slow_path(ident);
     }
+    after_thread_switch();
 }
 
 /// rgil.py `acquire_maybe_in_new_thread`, the acquire used by a thread
@@ -448,6 +454,29 @@ pub fn yield_thread() -> bool {
     true
 }
 
+/// rgil.py `invoke_after_thread_switch` — register the single callback
+/// `acquire` / `acquire_maybe_in_new_thread` / a real `yield_thread`
+/// run after taking the GIL. `yield_thread` goes through [`acquire`],
+/// so the hook fires once there, matching the translated C yield path
+/// that does not re-enter `rgil.acquire`.
+pub fn invoke_after_thread_switch(callback: fn()) {
+    let prev = AFTER_THREAD_SWITCH.swap(callback as *mut (), Ordering::SeqCst);
+    debug_assert!(
+        prev.is_null() || prev == callback as *mut (),
+        "not implemented yet: several invoke_after_thread_switch()"
+    );
+}
+
+/// rgil.py `_after_thread_switch`.
+fn after_thread_switch() {
+    let callback = AFTER_THREAD_SWITCH.load(Ordering::Acquire);
+    if !callback.is_null() {
+        // SAFETY: only [`invoke_after_thread_switch`] stores a `fn()`.
+        let callback: fn() = unsafe { std::mem::transmute(callback) };
+        callback();
+    }
+}
+
 /// RAII bracket for code that enters pyre from outside — a thread that has to
 /// take the GIL before it may touch the GC, and give it back afterwards.
 /// `rffi`'s callback wrappers hold it the same way around the RPython side of a
@@ -491,6 +520,21 @@ mod tests {
         drop(guard);
         assert_eq!(gil_get_holder(), 0);
         assert!(!am_i_holding_the_gil());
+    }
+
+    #[test]
+    fn acquire_runs_the_after_thread_switch_hook() {
+        let _serial = TEST_SERIAL.lock();
+        allocate();
+        static FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        fn hook() {
+            FIRED.store(true, Ordering::SeqCst);
+        }
+        invoke_after_thread_switch(hook);
+        FIRED.store(false, Ordering::SeqCst);
+        let _guard = GilGuard::acquire();
+        assert!(FIRED.load(Ordering::SeqCst));
+        AFTER_THREAD_SWITCH.store(std::ptr::null_mut(), Ordering::SeqCst);
     }
 
     #[test]

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -1114,6 +1114,10 @@ impl TypeRegistry {
     /// a late attach cannot leave the group describing a type without a
     /// destructor.
     pub fn set_destructor(&mut self, type_id: u32, destructor: DestructorFn) {
+        assert!(
+            self.entries[type_id as usize].old_style_finalizer.is_none(),
+            "a type cannot have both a light destructor and an old-style finalizer"
+        );
         self.entries[type_id as usize].destructor = Some(destructor);
         if self.frozen_layout_table.is_some() {
             self.rematerialize_type_entry(type_id as usize);

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -1106,10 +1106,76 @@ impl TypeRegistry {
     /// For `#[pyre_class]` types registered through the generic
     /// `object_subclass_with_gc_ptrs` path (which sets no destructor) that
     /// nonetheless own Rust heap needing drop glue when the collector
-    /// reclaims a dead instance. Reads back through `get(type_id).destructor`
-    /// in the sweep, so mutating the `entries` slot is sufficient.
+    /// reclaims a dead instance.
+    ///
+    /// Sweep reads `get(type_id).destructor`, so the `entries` slot is the
+    /// dispatch source. After `freeze_types` the published `TypeEntry` also
+    /// carries `T_HAS_DESTRUCTOR` and `customdata`; rematerialize that row so
+    /// a late attach cannot leave the group describing a type without a
+    /// destructor.
     pub fn set_destructor(&mut self, type_id: u32, destructor: DestructorFn) {
         self.entries[type_id as usize].destructor = Some(destructor);
+        if self.frozen_layout_table.is_some() {
+            self.rematerialize_type_entry(type_id as usize);
+        }
+    }
+
+    /// Rebuild one frozen `type_info_group` row from the live `TypeInfo`.
+    /// Offsets stay where `freeze_types` published them; only `infobits` and
+    /// `customdata` can change when a destructor is attached later.
+    fn rematerialize_type_entry(&mut self, index: usize) {
+        let info = &self.entries[index];
+        let existing = self
+            .frozen_layout_table
+            .as_ref()
+            .expect("rematerialize_type_entry after freeze_types")[index];
+        let need_custom = info.custom_trace.is_some()
+            || info.destructor.is_some()
+            || info.old_style_finalizer.is_some()
+            || info.memory_pressure_offset.is_some();
+        let customfunc = info
+            .custom_trace
+            .map(|f| f as usize)
+            .or_else(|| info.old_style_finalizer.map(|f| f as usize))
+            .or_else(|| info.destructor.map(|f| f as usize))
+            .unwrap_or(0);
+        let pressure = info.memory_pressure_offset.unwrap_or(0) as isize;
+        let item_size = info.item_size;
+        let customdata = if need_custom {
+            if existing.type_info.customdata != 0 {
+                // The Box in `custom_data` owns this row for the registry
+                // lifetime; rewrite the fields in place rather than allocating
+                // a second CUSTOM_DATA_STRUCT the old address would abandon.
+                let data =
+                    unsafe { &mut *(existing.type_info.customdata as *mut CustomDataLayout) };
+                data.customfunc = customfunc;
+                data.memory_pressure_offset = pressure;
+                existing.type_info.customdata
+            } else {
+                let data = Box::new(CustomDataLayout {
+                    customfunc,
+                    memory_pressure_offset: pressure,
+                });
+                let address = (&*data) as *const CustomDataLayout as usize;
+                self.custom_data.push(data);
+                address
+            }
+        } else {
+            0
+        };
+        let fixed_offsets = existing.type_info.ofstoptrs;
+        let var_offsets = if item_size > 0 {
+            unsafe { existing.tail.varsize.varofstoptrs }
+        } else {
+            0
+        };
+        let info = &self.entries[index];
+        let table = self
+            .frozen_layout_table
+            .as_mut()
+            .expect("rematerialize_type_entry after freeze_types");
+        table[index] =
+            TypeEntry::from_type_info(info, index as u32, customdata, fixed_offsets, var_offsets);
     }
 
     /// `gctypelayout.encode_type_shapes_now` parity
@@ -1438,6 +1504,29 @@ mod tests {
         assert_eq!(
             custom.customfunc,
             materialized_old_style_finalizer as *const () as usize
+        );
+    }
+
+    #[test]
+    fn set_destructor_after_freeze_rematerializes_type_entry() {
+        let mut reg = TypeRegistry::new();
+        let type_id = reg.register(TypeInfo::simple(16));
+        reg.freeze_types();
+
+        let row = &reg.type_info_table()[type_id as usize];
+        assert_eq!(row.type_info.infobits & TypeInfoLayout::T_HAS_DESTRUCTOR, 0);
+        assert_eq!(row.type_info.customdata, 0);
+
+        reg.set_destructor(type_id, materialized_destructor);
+
+        assert!(reg.get(type_id).destructor.is_some());
+        let row = &reg.type_info_table()[type_id as usize];
+        assert_ne!(row.type_info.infobits & TypeInfoLayout::T_HAS_DESTRUCTOR, 0);
+        assert_ne!(row.type_info.customdata, 0);
+        let custom = unsafe { &*(row.type_info.customdata as *const CustomDataLayout) };
+        assert_eq!(
+            custom.customfunc,
+            materialized_destructor as *const () as usize
         );
     }
 

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -233,18 +233,17 @@ pub fn do_combine_starstarargs_wrapped(
     // that uses it.  The two output slices are written from the published
     // pairs once the loop is done.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(w_starstararg);
-    let _ = pyre_object::gc_roots::pin_root(w_function);
-    let existing_base = pyre_object::gc_roots::shadow_stack_len();
     let existing_len = existingkeywords_w.map_or(0, |existing| existing.len());
-    for &w_name in existingkeywords_w.unwrap_or_default() {
-        let _ = pyre_object::gc_roots::pin_root(w_name);
+    let mut live = Vec::with_capacity(2 + existing_len + keys_w.len());
+    live.push(w_starstararg);
+    live.push(w_function);
+    if let Some(existing) = existingkeywords_w {
+        live.extend_from_slice(existing);
     }
-    let keys_base = pyre_object::gc_roots::shadow_stack_len();
-    for &key in keys_w {
-        let _ = pyre_object::gc_roots::pin_root(key);
-    }
+    live.extend_from_slice(keys_w);
+    let root_base = pyre_object::gc_roots::pin_roots(&live);
+    let existing_base = root_base + 2;
+    let keys_base = existing_base + existing_len;
     let pairs_base = pyre_object::gc_roots::shadow_stack_len();
     for _ in 0..2 * keys_w.len() {
         let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
@@ -366,9 +365,7 @@ pub fn combine_starargs_wrapped(
     // after it.
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::pin_roots(&arguments_w[..]);
-    let star_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(w_stararg);
-    let _ = pyre_object::gc_roots::pin_root(w_function);
+    let star_slot = pyre_object::gc_roots::pin_roots(&[w_stararg, w_function]);
     let w_stararg = || pyre_object::gc_roots::shadow_stack_get(star_slot);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(star_slot + 1);
     match crate::baseobjspace::fixedview(w_stararg(), -1) {
@@ -452,9 +449,7 @@ pub fn combine_starstarargs_wrapped(
     // afterwards to fetch each value.  Publish the mapping and the callable so
     // that later read is of the live object, not the address they had on entry.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(w_starstararg);
-    let _ = pyre_object::gc_roots::pin_root(w_function);
+    let root_base = pyre_object::gc_roots::pin_roots(&[w_starstararg, w_function]);
     let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     // The pairs the caller already accepted are in the same position: native
@@ -770,9 +765,11 @@ impl Arguments {
         // `arguments_w` are published here and read back where the second arm
         // uses them; none of the three sits in storage a root walker updates.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(w_starstararg.unwrap_or(pyre_object::PY_NULL));
-        let w_function = pyre_object::gc_roots::pin_root(w_function);
+        let root_base = pyre_object::gc_roots::pin_roots(&[
+            w_starstararg.unwrap_or(pyre_object::PY_NULL),
+            w_function,
+        ]);
+        let w_function = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         // argument.py — `if w_stararg is not None: self._combine_starargs_wrapped(...)`.
         if let Some(w_star) = w_stararg {
             let w_function = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
@@ -1109,20 +1106,15 @@ impl Arguments {
         // buffer or `Arguments`' own vectors are, so each word is pinned here,
         // ahead of the first allocation, and read back where it is used.
         let _roots = pyre_object::gc_roots::push_roots();
-        let kw_defs_slot = pyre_object::gc_roots::shadow_stack_len();
-        let w_kw_defs = pyre_object::gc_roots::pin_root(w_kw_defs);
-        let keywords_base = pyre_object::gc_roots::shadow_stack_len();
-        if let Some(values) = self.keywords_w.as_ref() {
-            for &w_value in values {
-                let _ = pyre_object::gc_roots::pin_root(w_value);
-            }
-        }
-        let names_base = pyre_object::gc_roots::shadow_stack_len();
-        if let Some(names) = self.keyword_names_w.as_ref() {
-            for &w_name in names {
-                let _ = pyre_object::gc_roots::pin_root(w_name);
-            }
-        }
+        let keywords_w = self.keywords_w.as_deref().unwrap_or(&[]);
+        let names_w = self.keyword_names_w.as_deref().unwrap_or(&[]);
+        let mut live = Vec::with_capacity(1 + keywords_w.len() + names_w.len());
+        live.push(w_kw_defs);
+        live.extend_from_slice(keywords_w);
+        live.extend_from_slice(names_w);
+        let kw_defs_slot = pyre_object::gc_roots::pin_roots(&live);
+        let w_kw_defs = pyre_object::gc_roots::shadow_stack_get(kw_defs_slot);
+        let keywords_base = kw_defs_slot + 1;
         // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
         // reaches here through a borrow, and a gateway builds its own array —
         // so the collector rewrites neither, while the run is read out one
@@ -1534,11 +1526,12 @@ impl Arguments {
         {
             // `zip` stops at the shorter side; the pinned pairs match it.
             let npairs = names.len().min(values.len());
-            let pairs_base = pyre_object::gc_roots::shadow_stack_len();
-            for (w_key, w_value) in names.iter().zip(values.iter()) {
-                let _ = pyre_object::gc_roots::pin_root(*w_key);
-                let _ = pyre_object::gc_roots::pin_root(*w_value);
+            let mut pairs = Vec::with_capacity(npairs * 2);
+            for (w_key, w_value) in names.iter().zip(values.iter()).take(npairs) {
+                pairs.push(*w_key);
+                pairs.push(*w_value);
             }
+            let pairs_base = pyre_object::gc_roots::pin_roots(&pairs);
             for i in 0..npairs {
                 let w_key = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i);
                 let w_value = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i + 1);
@@ -1710,16 +1703,17 @@ pub fn collect_keyword_args(
     let _roots = pyre_object::gc_roots::push_roots();
     let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_kwds);
-    let pairs_base = pyre_object::gc_roots::shadow_stack_len();
+    let mut pairs = Vec::with_capacity(keyword_names_w.len() * 2);
     for i in 0..keyword_names_w.len() {
         if mapping_contains(kwds_mapping, i as isize) {
-            let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
-            let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+            pairs.push(pyre_object::PY_NULL);
+            pairs.push(pyre_object::PY_NULL);
             continue;
         }
-        let _ = pyre_object::gc_roots::pin_root(keyword_names_w[i]);
-        let _ = pyre_object::gc_roots::pin_root(keywords_w[i]);
+        pairs.push(keyword_names_w[i]);
+        pairs.push(keywords_w[i]);
     }
+    let pairs_base = pyre_object::gc_roots::pin_roots(&pairs);
     for i in 0..keyword_names_w.len() {
         if mapping_contains(kwds_mapping, i as isize) {
             continue;

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1115,6 +1115,7 @@ impl Arguments {
         let kw_defs_slot = pyre_object::gc_roots::pin_roots(&live);
         let w_kw_defs = pyre_object::gc_roots::shadow_stack_get(kw_defs_slot);
         let keywords_base = kw_defs_slot + 1;
+        let names_base = keywords_base + keywords_w.len();
         // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
         // reaches here through a borrow, and a gateway builds its own array —
         // so the collector rewrites neither, while the run is read out one
@@ -1173,12 +1174,15 @@ impl Arguments {
             let mapping_len = co_argcount + co_kwonlyargcount - input_argcount;
             let mut mapping = vec![-1isize; mapping_len];
             // argument.py:259-262 — match keyword names to argnames.
+            let names_w: Vec<PyObjectRef> = (0..keyword_names_w.unwrap().len())
+                .map(|i| pyre_object::gc_roots::shadow_stack_get(names_base + i))
+                .collect();
             num_remainingkwds = match_keywords(
                 signature,
                 blindargs,
                 co_posonlyargcount,
                 input_argcount,
-                keyword_names_w.unwrap(),
+                &names_w,
                 &mut mapping,
             )?;
             if num_remainingkwds > 0 {
@@ -1191,7 +1195,7 @@ impl Arguments {
                         .map(|i| pyre_object::gc_roots::shadow_stack_get(keywords_base + i))
                         .collect();
                     collect_keyword_args(
-                        keyword_names_w.unwrap(),
+                        &names_w,
                         &values_w,
                         pyre_object::gc_roots::shadow_stack_get(kwds_slot),
                         &mapping,
@@ -1207,8 +1211,7 @@ impl Arguments {
                     // than silently substituting an empty string.
                     let mut name = String::new();
                     if num_remainingkwds == 1 {
-                        let names = keyword_names_w.unwrap();
-                        for (i, &w_n) in names.iter().enumerate() {
+                        for (i, &w_n) in names_w.iter().enumerate() {
                             if !mapping_contains(&mapping, i as isize) {
                                 if unsafe { pyre_object::is_str(w_n) } {
                                     name = unsafe { pyre_object::w_str_get_value(w_n).to_string() };

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -993,7 +993,7 @@ pub unsafe extern "C" fn PyBuffer_SizeFromFormat(format: *const c_char) -> isize
     let format = format_of(format);
     let sized = super::import_::import_module("_struct").and_then(|module| {
         let roots = pyre_object::gc_roots::push_roots();
-        let base = pyre_object::gc_roots::shadow_stack_len();
+        let base = roots.base();
         let _ = roots.pin_root(module);
         let _ = roots.pin_root(pyre_object::w_str_new(&format));
         let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -635,9 +635,7 @@ pub unsafe extern "C" fn PyDict_Merge(
         return -1;
     };
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(target);
-    let _ = roots.pin_root(source);
+    let base = roots.pin_roots(&[target, source]);
     let target = || pyre_object::gc_roots::shadow_stack_get(base);
     let source_now = pyre_object::gc_roots::shadow_stack_get(base + 1);
 
@@ -751,9 +749,8 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
         return -1;
     };
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(target);
-    let sequence = roots.pin_root(sequence);
+    let base = roots.pin_roots(&[target, sequence]);
+    let sequence = roots.get(base + 1);
     let target = || pyre_object::gc_roots::shadow_stack_get(base);
 
     let Some(pairs) = trap(unpack_all(pyre_object::gc_roots::shadow_stack_get(

--- a/pyre/pyre-interpreter/src/cpyext/iterator.rs
+++ b/pyre/pyre-interpreter/src/cpyext/iterator.rs
@@ -195,9 +195,7 @@ pub unsafe extern "C" fn PyIter_Send(
         crate::baseobjspace::next(w_iterator)
     } else {
         let roots = pyre_object::gc_roots::push_roots();
-        let base = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(w_iterator);
-        let _ = roots.pin_root(sent);
+        let base = roots.pin_roots(&[w_iterator, sent]);
         let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
         crate::baseobjspace::getattr_str(reload(0), "send")
             .and_then(|send| crate::call::call_function_impl_result(send, &[reload(1)]))

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -464,9 +464,7 @@ pub(super) fn remember_weakref_lifeline(w_obj: PyObjectRef, lifeline: PyObjectRe
         return;
     }
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(w_obj);
-    let _ = roots.pin_root(lifeline);
+    let base = roots.pin_roots(&[w_obj, lifeline]);
     let lifeline_raw = make_ref(pyre_object::gc_roots::shadow_stack_get(base + 1));
     let mut blocks = BLOCK_SIZES.lock();
     let Some(block) = blocks.get_mut(&(raw as usize)) else {

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -968,14 +968,13 @@ fn call_slot_method(
     arguments: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(w_self);
-    for &argument in arguments {
-        let _ = roots.pin_root(argument);
-    }
+    let mut live = Vec::with_capacity(arguments.len() + 2);
+    live.push(w_self);
+    live.extend_from_slice(arguments);
+    live.push(w_owner);
+    let base = roots.pin_roots(&live);
     // Last, so the indices above keep naming what they named.
-    let owner_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(w_owner);
+    let owner_slot = base + arguments.len() + 1;
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let function = slot_method(
         pyre_object::gc_roots::shadow_stack_get(owner_slot),
@@ -1314,10 +1313,7 @@ fn call_slot_arguments(
     kwds: *mut CPyObject,
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(callable);
-    let _ = roots.pin_root(w_self);
-    let _ = roots.pin_root(unsafe { pyobject::from_ref(kwds) });
+    let base = roots.pin_roots(&[callable, w_self, unsafe { pyobject::from_ref(kwds) }]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     // Minted last, so nothing pinned above it is a pre-move address.
     let starargs = match args.is_null() {
@@ -3466,13 +3462,12 @@ impl Drop for TernaryArgs {
 
 fn ternary_args(positional: &[PyObjectRef], keywords: &[(String, PyObjectRef)]) -> TernaryArgs {
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    for &argument in positional {
-        let _ = roots.pin_root(argument);
-    }
+    let mut live = Vec::with_capacity(positional.len() + keywords.len());
+    live.extend_from_slice(positional);
     for (_, value) in keywords {
-        let _ = roots.pin_root(*value);
+        live.push(*value);
     }
+    let base = roots.pin_roots(&live);
     let value_slot = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let items: Vec<PyObjectRef> = (0..positional.len()).map(value_slot).collect();
     let tuple = pyre_object::tupleobject::w_tuple_new(items);
@@ -4021,10 +4016,7 @@ fn power(
     };
     let modulus = args.get(2).copied().unwrap_or_else(pyre_object::w_none);
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(first);
-    let _ = roots.pin_root(second);
-    let _ = roots.pin_root(modulus);
+    let base = roots.pin_roots(&[first, second, modulus]);
     let owned =
         |index: usize| pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(base + index));
     let (left, right, third) = (owned(0), owned(1), owned(2));
@@ -4070,10 +4062,7 @@ fn call_ternary(
     third: Option<PyObjectRef>,
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(first);
-    let _ = roots.pin_root(second);
-    let _ = roots.pin_root(third.unwrap_or_else(pyre_object::w_none));
+    let base = roots.pin_roots(&[first, second, third.unwrap_or_else(pyre_object::w_none)]);
     let owned =
         |index: usize| pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(base + index));
     let (left, right, modulus) = (owned(0), owned(1), owned(2));
@@ -4923,10 +4912,7 @@ fn set_attribute(
         ));
     }
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(w_self);
-    let _ = roots.pin_root(name);
-    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let base = roots.pin_roots(&[w_self, name, value.unwrap_or_else(pyre_object::w_none)]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let receiver = pyobject::make_ref(reload(0));
     let key = pyobject::make_ref(reload(1));
@@ -4994,9 +4980,7 @@ fn set_attribute_legacy(
 ) -> Result<PyObjectRef, crate::PyError> {
     let name = legacy_attribute_name(name)?;
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(w_self);
-    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let base = roots.pin_roots(&[w_self, value.unwrap_or_else(pyre_object::w_none)]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let receiver = pyobject::make_ref(reload(0));
     let item = match value {
@@ -5040,10 +5024,7 @@ fn slot_descr_get(
         return Ok(args[0]);
     }
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(args[0]);
-    let _ = roots.pin_root(args[1]);
-    let _ = roots.pin_root(args[2]);
+    let base = roots.pin_roots(&[args[0], args[1], args[2]]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let none = |value: PyObjectRef| unsafe { pyre_object::is_none(value) };
     let descriptor = pyobject::make_ref(reload(0));
@@ -5085,10 +5066,11 @@ fn descr_assign(
         ));
     }
     let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    let descriptor = roots.pin_root(descriptor);
-    let _ = roots.pin_root(instance);
-    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let base = roots.pin_roots(&[
+        descriptor,
+        instance,
+        value.unwrap_or_else(pyre_object::w_none),
+    ]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let owner = pyobject::make_ref(reload(0));
     let target = pyobject::make_ref(reload(1));

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -4919,10 +4919,11 @@ pub fn wrap_oserror2(
     let filename = w_filename.unwrap_or_else(pyre_object::w_none);
     let filename2 = w_filename2.unwrap_or_else(pyre_object::w_none);
     let live_base = _roots.pin_roots(&[w_exc, filename, filename2]);
-    let extra = _roots.pin_roots(&[
-        pyre_object::w_int_new(errno as i64),
-        pyre_object::w_str_new_managed(&msg),
-    ]);
+    // `error.py _wrap_oserror2_impl` builds `w_errno` before `w_msg`.
+    // Evaluating both allocators in one `pin_roots` leaves the int
+    // unrooted across `w_str_new_managed`.
+    let extra = _roots.pin_roots(&[pyre_object::w_int_new(errno as i64)]);
+    let _ = _roots.pin_roots(&[pyre_object::w_str_new_managed(&msg)]);
     // The five the constructor takes, in `_wrap_oserror2_impl`'s order.  A
     // subclass reading `filename2` sees the argument it declares rather than a
     // short call.

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -969,9 +969,7 @@ impl PyError {
             return;
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        let base = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(self.exc_object);
-        let _ = pyre_object::gc_roots::pin_root(w_filename);
+        let base = pyre_object::gc_roots::pin_roots(&[self.exc_object, w_filename]);
         let storage = unsafe {
             pyre_object::interp_exceptions::w_exception_get_args_storage(
                 pyre_object::gc_roots::shadow_stack_get(base),
@@ -4918,24 +4916,25 @@ pub fn wrap_oserror2(
     // allocation rewrites the root SLOT and not this frame's copy of the
     // pointer.
     let _roots = pyre_object::gc_roots::push_roots();
-    let base = _roots.base();
-    let _ = _roots.pin_root(w_exc);
-    let _ = _roots.pin_root(pyre_object::w_int_new(errno as i64));
-    let _ = _roots.pin_root(pyre_object::w_str_new_managed(&msg));
-    let _ = _roots.pin_root(w_filename.unwrap_or_else(pyre_object::w_none));
-    let _ = _roots.pin_root(w_filename2.unwrap_or_else(pyre_object::w_none));
+    let filename = w_filename.unwrap_or_else(pyre_object::w_none);
+    let filename2 = w_filename2.unwrap_or_else(pyre_object::w_none);
+    let live_base = _roots.pin_roots(&[w_exc, filename, filename2]);
+    let extra = _roots.pin_roots(&[
+        pyre_object::w_int_new(errno as i64),
+        pyre_object::w_str_new_managed(&msg),
+    ]);
     // The five the constructor takes, in `_wrap_oserror2_impl`'s order.  A
     // subclass reading `filename2` sees the argument it declares rather than a
     // short call.
     let args = [
-        _roots.get(base + 1),
-        _roots.get(base + 2),
-        _roots.get(base + 3),
+        _roots.get(extra),
+        _roots.get(extra + 1),
+        _roots.get(live_base + 1),
         pyre_object::w_none(),
-        _roots.get(base + 4),
+        _roots.get(live_base + 2),
     ];
     operation_error_from_instance(
-        crate::call::call_function_impl_result(_roots.get(base), &args),
+        crate::call::call_function_impl_result(_roots.get(live_base), &args),
         || PyError::os_error_syscall(errno, pyre_object::PY_NULL),
     )
 }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3925,12 +3925,11 @@ pub fn funccall_valuestack(
         // `[code, w_obj, ...rest]` set has to be published here and read back
         // for the call.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = _roots.base();
-        let _ = _roots.pin_root(code as PyObjectRef);
-        let _ = _roots.pin_root(w_obj);
-        for &w_arg in &rest {
-            let _ = _roots.pin_root(w_arg);
-        }
+        let mut live = Vec::with_capacity(2 + rest.len());
+        live.push(code as PyObjectRef);
+        live.push(w_obj);
+        live.extend_from_slice(&rest);
+        let root_base = _roots.pin_roots(&live);
         frame.dropvalues(dropvalues);
         let args_w: Vec<PyObjectRef> = (0..nargs).map(|i| _roots.get(root_base + 1 + i)).collect();
         return match unsafe { crate::builtin_code_call(_roots.get(root_base), &args_w) } {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -6269,9 +6269,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     fn scandir_iter_mark_closed(self_obj: PyObjectRef) {
         // `W_ScandirIterator._close` clears the state inspected by
         // `_finalize_`, whether closure is explicit or due to exhaustion.
+        // `dirp` is already gone on this eager iterator, so the queued
+        // finalizer is a no-op; `may_ignore_finalizer` is the same answer
+        // the prompt-finalization census needs so `gen.close()` does not
+        // collect the whole heap for an already-closed scandir.
         let _ = with_scandir_iter(self_obj, |iterator| {
             iterator.open = false;
         });
+        crate::executioncontext::may_ignore_finalizer(self_obj);
     }
     fn scandir_iter_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         scandir_iter_mark_closed(args[0]);

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -9,8 +9,8 @@ use crate::executioncontext::{
 };
 use crate::pyframe::PyFrame;
 use pyre_object::PyObjectRef;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// The signal numbers and names `<signal.h>` supplies elsewhere.
 ///
@@ -420,6 +420,28 @@ pub struct CheckSignalAction {
 }
 
 impl CheckSignalAction {
+    /// interp_signal.py `CheckSignalAction._after_thread_switch`.
+    ///
+    /// `rgc.no_collect`: only reads the current EC and arms the ticker.
+    fn after_thread_switch() {
+        let action = check_signal_action();
+        if action.is_null() {
+            return;
+        }
+        let ec = crate::call::getexecutioncontext();
+        if !ec.is_null() && !unsafe { (*ec).w_async_exception_type }.is_null() {
+            signalstate::rearm_ticker();
+            return;
+        }
+        if unsafe { (*action).fire_in_another_thread }
+            && !ec.is_null()
+            && unsafe { (*ec).signals_enabled } != 0
+        {
+            unsafe { (*action).fire_in_another_thread = false };
+            signalstate::rearm_ticker();
+        }
+    }
+
     /// interp_signal.py `CheckSignalAction.__init__`.
     pub fn new(space: PyObjectRef) -> Box<Self> {
         Box::new(Self {
@@ -522,9 +544,10 @@ fn report_signal(ec: &mut ExecutionContext, n: i32) -> Result<(), crate::PyError
         &[w_n, pyre_object::gc_roots::shadow_stack_get(frame_slot)],
     );
     if res.is_null()
-        && let Some(err) = crate::call::take_call_error() {
-            return Err(err);
-        }
+        && let Some(err) = crate::call::take_call_error()
+    {
+        return Err(err);
+    }
     Ok(())
 }
 
@@ -551,15 +574,17 @@ fn report_wakeup_fd_error(errno_val: i32) {
 }
 
 impl AsyncActionOps for CheckSignalAction {
-    /// interp_signal.py `perform`.  The
-    /// `w_async_exception_type` arm only fires across threads, which pyre
-    /// does not have, so it stays a no-op guard and we proceed straight
-    /// to polling.
+    /// interp_signal.py `perform`.
     fn perform(
         &mut self,
         ec: &mut ExecutionContext,
         _frame: *mut PyFrame,
     ) -> Result<AsyncActionControl, crate::PyError> {
+        let w_exc = crate::module::thread::take_async_exception(ec as *mut ExecutionContext);
+        if !w_exc.is_null() {
+            let w_obj = crate::builtins::exc_exception_new(&[w_exc])?;
+            return Err(unsafe { crate::PyError::from_exc_object(w_obj) });
+        }
         self.poll_for_signals(ec)?;
         Ok(AsyncActionControl::Continue)
     }
@@ -588,9 +613,7 @@ fn check_signal_action() -> *mut CheckSignalAction {
 /// Trace the object-space-owned signal action's managed `space` slot.  PyPy's
 /// translated object graph reaches it through `space.check_signal_action`;
 /// pyre's process-owned Rust allocation needs that edge forwarded explicitly.
-pub(crate) fn walk_check_signal_action_roots(
-    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
-) {
+pub(crate) fn walk_check_signal_action_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     let action = check_signal_action();
     if action.is_null() {
         return;
@@ -614,11 +637,13 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
     let action_addr = *CHECK_SIGNAL_ACTION.get_or_init(|| {
         // moduledef.py:64-66 — construct and register the one signal action
         // owned by the process object space.
-        let action: &'static mut CheckSignalAction =
-            Box::leak(CheckSignalAction::new(ec.space));
+        let action: &'static mut CheckSignalAction = Box::leak(CheckSignalAction::new(ec.space));
         action.register_periodic_action(ec.actionflag.shared_mut(), false);
+        // CheckSignalAction.startup — register after a GIL switch so a
+        // signal seen on a worker rearms the main ticker promptly.
+        majit_gc::rgil::invoke_after_thread_switch(CheckSignalAction::after_thread_switch);
 
-        // Hand the ticker cell address to the OS handler (rsignal.py:31-32
+        // Hand the ticker cell address to the OS handler (rsignal.py:31-32)
         // `pypysig_getaddr_occurred`).  The handler itself only arms the
         // eval-breaker's async bit, which is a lock-free atomic RMW and so
         // async-signal-safe; `ExecutionContext::bytecode_trace` is what turns
@@ -719,10 +744,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             };
             // `PYPYSIG_USE_SEND` — set by the Windows probe below, which is
             // the only place a descriptor is asked whether it is a socket.
-            #[cfg_attr(
-                not(all(windows, not(feature = "sandbox"))),
-                expect(unused_mut)
-            )]
+            #[cfg_attr(not(all(windows, not(feature = "sandbox"))), expect(unused_mut))]
             let mut use_send = false;
             // interp_signal.py:343-360 — a real fd is validated with
             // `os.fstat` then `get_status_flags`: a bad fd is a ValueError
@@ -895,12 +917,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             checksignals_now()?;
                             Ok(pyre_object::w_none())
                         }
-                        Err(e) => {
-                            Err(crate::PyError::os_error_with_errno(
-                                e.raw_os_error().unwrap_or(0),
-                                format!("raise_signal: {e}"),
-                            ))
-                        }
+                        Err(e) => Err(crate::PyError::os_error_with_errno(
+                            e.raw_os_error().unwrap_or(0),
+                            format!("raise_signal: {e}"),
+                        )),
                     }
                 }
                 #[cfg(not(feature = "host_env"))]
@@ -970,10 +990,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     // The bound is `NSIG`, exclusive: `sigfillset` sets the
                     // bit for `NSIG - 1` and one past it too on darwin, so a
                     // wider bound answers with a signal that has no name.
-                    let sigs = rustpython_host_env::signal::valid_signals(
-                        signalstate::NSIG as usize,
-                    )
-                    .unwrap_or_default();
+                    let sigs =
+                        rustpython_host_env::signal::valid_signals(signalstate::NSIG as usize)
+                            .unwrap_or_default();
                     let items: Vec<pyre_object::PyObjectRef> = sigs
                         .into_iter()
                         .map(|n| pyre_object::w_int_new(n as i64))
@@ -1099,8 +1118,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             rustpython_host_env::signal::double_to_timeval(0.0)
                         },
                     };
-                    let old = rustpython_host_env::signal::setitimer(which, &new_value)
-                        .map_err(|e| {
+                    let old =
+                        rustpython_host_env::signal::setitimer(which, &new_value).map_err(|e| {
                             errno_exception("signal.ItimerError", e.raw_os_error().unwrap_or(0))
                         })?;
                     let (delay, interval) = rustpython_host_env::signal::itimerval_to_tuple(&old);
@@ -1232,13 +1251,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                                 "sigwait() takes exactly one argument (0 given)",
                             ));
                         }
-                        let mut set =
-                            rustpython_host_env::signal::sigemptyset().map_err(|e| {
-                                crate::PyError::os_error_with_errno(
-                                    e.raw_os_error().unwrap_or(0),
-                                    format!("sigemptyset: {e}"),
-                                )
-                            })?;
+                        let mut set = rustpython_host_env::signal::sigemptyset().map_err(|e| {
+                            crate::PyError::os_error_with_errno(
+                                e.raw_os_error().unwrap_or(0),
+                                format!("sigemptyset: {e}"),
+                            )
+                        })?;
                         for it in signal_set_items(args[0])? {
                             // Range-check before narrowing, or a number that
                             // aliases a valid signal in its low 32 bits passes.
@@ -1294,9 +1312,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         }
                         // interp_signal.py _sigset_to_signals
                         let items: Vec<pyre_object::PyObjectRef> = (1..signalstate::NSIG)
-                            .filter(|s| {
-                                rustpython_host_env::signal::sigset_contains(mask, *s)
-                            })
+                            .filter(|s| rustpython_host_env::signal::sigset_contains(mask, *s))
                             .map(|s| pyre_object::w_int_new(s as i64))
                             .collect();
                         Ok(pyre_object::w_set_from_items(&items))
@@ -1328,12 +1344,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                                 "pthread_kill() takes exactly 2 arguments",
                             ));
                         }
-                        let tid =
-                            (unsafe { pyre_object::w_int_get_value(args[0]) }) as u64;
-                        let signum =
-                            (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
-                        let ret =
-                            unsafe { libc::pthread_kill(tid as libc::pthread_t, signum) };
+                        let tid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u64;
+                        let signum = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                        let ret = unsafe { libc::pthread_kill(tid as libc::pthread_t, signum) };
                         if ret != 0 {
                             return Err(errno_exception("OSError", ret));
                         }
@@ -1429,9 +1442,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         // unblocked, their handlers may now be pending.
                         checksignals_now()?;
                         let out: Vec<pyre_object::PyObjectRef> = (1..=64)
-                            .filter(|s| {
-                                rustpython_host_env::signal::sigset_contains(prev, *s)
-                            })
+                            .filter(|s| rustpython_host_env::signal::sigset_contains(prev, *s))
                             .map(|s| pyre_object::w_int_new(s as i64))
                             .collect();
                         Ok(pyre_object::w_set_from_items(&out))

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -589,9 +589,10 @@ impl AsyncActionOps for CheckSignalAction {
             let cls_slot = pyre_object::gc_roots::pin_roots(&[w_exc]);
             let w_msg =
                 pyre_object::w_str_new("asynchronous exception triggered from another thread");
+            let msg_slot = pyre_object::gc_roots::pin_roots(&[w_msg]);
             let w_obj = crate::builtins::exc_exception_new(&[
                 pyre_object::gc_roots::shadow_stack_get(cls_slot),
-                w_msg,
+                pyre_object::gc_roots::shadow_stack_get(msg_slot),
             ])?;
             return Err(unsafe { crate::PyError::from_exc_object(w_obj) });
         }
@@ -653,8 +654,8 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
         // signal seen on a worker rearms the main ticker promptly.
         majit_gc::rgil::invoke_after_thread_switch(CheckSignalAction::after_thread_switch);
 
-        // Hand the ticker cell address to the OS handler (rsignal.py:31-32)
-        // `pypysig_getaddr_occurred`).  The handler itself only arms the
+        // Hand the ticker cell address to the OS handler
+        // (`pypysig_getaddr_occurred`).  The handler itself only arms the
         // eval-breaker's async bit, which is a lock-free atomic RMW and so
         // async-signal-safe; `ExecutionContext::bytecode_trace` is what turns
         // that request into a negative ticker, under the GIL.  Writing this

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -582,7 +582,17 @@ impl AsyncActionOps for CheckSignalAction {
     ) -> Result<AsyncActionControl, crate::PyError> {
         let w_exc = crate::module::thread::take_async_exception(ec as *mut ExecutionContext);
         if !w_exc.is_null() {
-            let w_obj = crate::builtins::exc_exception_new(&[w_exc])?;
+            // interp_signal.py `perform`: raise oefmt(w_exc, "asynchronous
+            // exception triggered from another thread"). Pin the type across
+            // the message allocation.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let cls_slot = pyre_object::gc_roots::pin_roots(&[w_exc]);
+            let w_msg =
+                pyre_object::w_str_new("asynchronous exception triggered from another thread");
+            let w_obj = crate::builtins::exc_exception_new(&[
+                pyre_object::gc_roots::shadow_stack_get(cls_slot),
+                w_msg,
+            ])?;
             return Err(unsafe { crate::PyError::from_exc_object(w_obj) });
         }
         self.poll_for_signals(ec)?;

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -654,9 +654,8 @@ pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError
             // below can write through a relocated (stale) pointer.  Its
             // digest keys the store, so the element is hashed once.
             let _roots = pyre_object::gc_roots::push_roots();
-            let sp = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(set);
-            let value = pyre_object::gc_roots::pin_root(value);
+            let sp = _roots.pin_roots(&[set, value]);
+            let value = _roots.get(sp + 1);
             let hash = crate::builtins::try_hash_value(value).map_err(|err| {
                 crate::baseobjspace::wrap_set_element_hash_error(
                     pyre_object::gc_roots::shadow_stack_get(sp + 1),
@@ -741,10 +740,8 @@ pub fn map_add_value(
         // user `__hash__`) and reload before the store, mirroring
         // `set_add_value`.
         let _roots = pyre_object::gc_roots::push_roots();
-        let sp = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(dict);
-        let key = pyre_object::gc_roots::pin_root(key);
-        let _ = pyre_object::gc_roots::pin_root(value);
+        let sp = _roots.pin_roots(&[dict, key, value]);
+        let key = _roots.get(sp + 1);
         let hash = crate::builtins::try_hash_value(key)
             .map_err(|err| crate::baseobjspace::wrap_dict_key_hash_error(key, err))?;
         let dict = pyre_object::gc_roots::shadow_stack_get(sp);
@@ -794,9 +791,7 @@ pub fn dict_update(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError
     // and `dict` is a `W_DictObject`, which relocates.  Pinning the pair below
     // the fetch published the words that were live before it.
     let _roots = pyre_object::gc_roots::push_roots();
-    let sp = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(dict);
-    let _ = pyre_object::gc_roots::pin_root(source);
+    let sp = _roots.pin_roots(&[dict, source]);
     let source_now = || pyre_object::gc_roots::shadow_stack_get(sp + 1);
     let keys_method = crate::baseobjspace::getattr_str(source_now(), "keys")?;
     let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
@@ -810,11 +805,8 @@ pub fn dict_update(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError
         // duration: `getitem` (arbitrary `__getitem__`) and
         // `try_hash_value` (arbitrary `__hash__`) both may allocate and
         // move them.
-        let key_base = pyre_object::gc_roots::shadow_stack_len();
-        for index in 0..keys.len() {
-            let _ = pyre_object::gc_roots::pin_root(keys[index]);
-        }
-        let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
+        let key_base = pyre_object::gc_roots::pin_roots(&keys);
+        let key_len = keys.len();
         for i in 0..key_len {
             let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
             let val = crate::baseobjspace::getitem(source_now(), key)?;
@@ -843,9 +835,7 @@ pub fn dict_update(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError
 /// `dict_update` and the JIT residual `bh_dict_update_fn`.
 pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), PyError> {
     let roots = pyre_object::gc_roots::push_roots();
-    let base = roots.base();
-    let _ = roots.pin_root(dict);
-    let _ = roots.pin_root(source);
+    let base = roots.pin_roots(&[dict, source]);
     match dict_update(roots.get(base), roots.get(base + 1)) {
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
             // The update ran Python, so the operand is named at the address it
@@ -880,10 +870,7 @@ pub fn dict_merge_value(
     // and a stale source is read as a mapping it no longer is.  `dict_update`
     // above brackets the same walk.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(dict);
-    let _ = pyre_object::gc_roots::pin_root(source);
-    let _ = pyre_object::gc_roots::pin_root(w_callable);
+    let root_base = _roots.pin_roots(&[dict, source, w_callable]);
     let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let source = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     let w_callable = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
@@ -921,11 +908,12 @@ pub fn dict_merge_value(
             // A store into the target allocates the storage it grows into, so
             // the snapshot has to be published too.
             let items = unsafe { pyre_object::w_dict_items(source()) };
-            let items_base = pyre_object::gc_roots::shadow_stack_len();
+            let mut live = Vec::with_capacity(items.len() * 2);
             for &(k, v) in &items {
-                let _ = pyre_object::gc_roots::pin_root(k);
-                let _ = pyre_object::gc_roots::pin_root(v);
+                live.push(k);
+                live.push(v);
             }
+            let items_base = pyre_object::gc_roots::pin_roots(&live);
             for index in 0..items.len() {
                 unsafe {
                     pyre_object::w_dict_store(

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -5174,9 +5174,10 @@ impl PyFrame {
         if !self.w_yielding_from.is_null() {
             released.push(majit_ir::GcRef(self.w_yielding_from as usize));
         }
-        if !self.f_backref.is_null() {
-            released.push(majit_ir::GcRef(self.f_backref as usize));
-        }
+        // `f_backref` is the caller frame, still on the stack.  CPython's
+        // refcount drop is only the generator frame's own locals;
+        // walking the caller here treats live test-method objects as
+        // released and forces a heap collect on every `close()`.
         if let Some(debug) = self.getdebug_data() {
             released.extend(
                 [debug.w_locals, debug.w_extra_locals, debug.w_f_trace]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -100,15 +100,17 @@ pub mod frame_locals_proxy {
     /// bounded by the green `locals_plus_names`.  `contains_loop` therefore
     /// declines this graph and the extras walk stays one residual call.
     fn pin_extra_locals_entries(extra: PyObjectRef) -> usize {
-        let mut count = 0;
-        // Nothing here allocates, so the pairs still queued in this native
-        // snapshot stay reachable through the dict itself.
-        for (key, value) in unsafe { pyre_object::dictmultiobject::w_dict_items(extra) } {
-            let _ = pyre_object::gc_roots::pin_root(key);
-            let _ = pyre_object::gc_roots::pin_root(value);
-            count += 1;
+        // `pin_root` itself is a forwarding query, so a sequential pin of
+        // the remaining pairs would leave them unrooted across that
+        // safepoint. Publish the whole snapshot first.
+        let items = unsafe { pyre_object::dictmultiobject::w_dict_items(extra) };
+        let mut live = Vec::with_capacity(items.len() * 2);
+        for (key, value) in items {
+            live.push(key);
+            live.push(value);
         }
-        count
+        let _ = pyre_object::gc_roots::pin_roots(&live);
+        live.len() / 2
     }
 
     impl FrameLocalsProxy {
@@ -1042,14 +1044,15 @@ fn merge_extra_locals(snapshot: PyObjectRef, extra: PyObjectRef) -> Result<(), c
     // queued in this native snapshot are published first and read back per
     // store.
     let roots = pyre_object::gc_roots::push_roots();
-    let snapshot_slot = roots.base();
-    let _ = roots.pin_root(snapshot);
-    let items_base = pyre_object::gc_roots::shadow_stack_len();
     let items = unsafe { pyre_object::dictmultiobject::w_dict_items(extra) };
+    let mut live = Vec::with_capacity(1 + items.len() * 2);
+    live.push(snapshot);
     for &(key, value) in &items {
-        let _ = roots.pin_root(key);
-        let _ = roots.pin_root(value);
+        live.push(key);
+        live.push(value);
     }
+    let snapshot_slot = roots.pin_roots(&live);
+    let items_base = snapshot_slot + 1;
     for index in 0..items.len() {
         let key = roots.get(items_base + index * 2);
         if crate::baseobjspace::contains(roots.get(snapshot_slot), key)? {
@@ -5981,13 +5984,12 @@ impl PyFrame {
         // values here; after a collection only the gcmap/shadow slots are
         // forwarded, so never carry the original slice across that call.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = _roots.base();
-        let _ = _roots.pin_root(code as PyObjectRef);
-        let _ = _roots.pin_root(w_globals);
-        let _ = _roots.pin_root(closure);
-        for &arg in args {
-            let _ = _roots.pin_root(arg);
-        }
+        let mut live = Vec::with_capacity(3 + args.len());
+        live.push(code as PyObjectRef);
+        live.push(w_globals);
+        live.push(closure);
+        live.extend_from_slice(args);
+        let root_base = _roots.pin_roots(&live);
         let w_builtin = crate::baseobjspace::frame_builtin_obj_checked(
             _roots.get(root_base + 1),
             execution_context,
@@ -6024,13 +6026,12 @@ impl PyFrame {
         allocation: FrameLocalsArrayAllocation,
     ) -> Self {
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = _roots.base();
-        let _ = _roots.pin_root(code as PyObjectRef);
-        let _ = _roots.pin_root(w_globals);
-        let _ = _roots.pin_root(closure);
-        for &arg in args {
-            let _ = _roots.pin_root(arg);
-        }
+        let mut live = Vec::with_capacity(3 + args.len());
+        live.push(code as PyObjectRef);
+        live.push(w_globals);
+        live.push(closure);
+        live.extend_from_slice(args);
+        let root_base = _roots.pin_roots(&live);
         let w_builtin =
             crate::baseobjspace::frame_builtin_obj(_roots.get(root_base + 1), execution_context);
         let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -146,11 +146,12 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
             let items = unsafe {
                 pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(dict_slot))
             };
-            let items_slot = pyre_object::gc_roots::shadow_stack_len();
+            let mut live = Vec::with_capacity(items.len() * 2);
             for (k, v) in &items {
-                let _ = pyre_object::gc_roots::pin_root(*k);
-                let _ = pyre_object::gc_roots::pin_root(*v);
+                live.push(*k);
+                live.push(*v);
             }
+            let items_slot = pyre_object::gc_roots::pin_roots(&live);
             let mut count = 0usize;
             for index in 0..items.len() {
                 let k = pyre_object::gc_roots::shadow_stack_get(items_slot + 2 * index);
@@ -326,10 +327,7 @@ fn reduce_2(
     // Same as `reduce_1`: boxing `proto` allocates, and here it would move
     // three already-copied references.
     let _roots = pyre_object::gc_roots::push_roots();
-    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(w_obj);
-    let _ = pyre_object::gc_roots::pin_root(w_args);
-    let _ = pyre_object::gc_roots::pin_root(w_kwargs);
+    let obj_slot = pyre_object::gc_roots::pin_roots(&[w_obj, w_args, w_kwargs]);
     let w_proto = pyre_object::w_int_new(proto);
     let proto_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_proto);
@@ -409,9 +407,7 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
             )));
         }
         let (hasargs, w_args, w_kwargs) = getnewargs(current_obj())?;
-        let args_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(w_args);
-        let _ = pyre_object::gc_roots::pin_root(w_kwargs);
+        let args_slot = pyre_object::gc_roots::pin_roots(&[w_args, w_kwargs]);
         // CPython 3.14 `object_getstate_default(required)`: when no
         // `__getnewargs__` supplied constructor state, a native layout whose
         // basicsize exceeds the plain object + managed dict/weakref/slots

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -952,8 +952,9 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     let w_code = w_code_value as PyObjectRef;
     let w_globals = w_globals_value as PyObjectRef;
     let _roots = pyre_object::gc_roots::push_roots();
-    let w_exc = pyre_object::gc_roots::pin_root(w_exc);
-    let w_code = pyre_object::gc_roots::pin_root(w_code);
+    let base = pyre_object::gc_roots::pin_roots(&[w_exc, w_code]);
+    let w_exc = pyre_object::gc_roots::shadow_stack_get(base);
+    let w_code = pyre_object::gc_roots::shadow_stack_get(base + 1);
     let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     // `record_application_traceback` requires the traceback's own frame
     // identity. The recording walker cannot force the optimizer's virtual
@@ -1033,8 +1034,9 @@ pub(crate) extern "C" fn record_discarded_level_traceback(
     let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
     let w_exc = exc_value as PyObjectRef;
     let _roots = pyre_object::gc_roots::push_roots();
-    let w_exc = pyre_object::gc_roots::pin_root(w_exc);
-    let w_code = pyre_object::gc_roots::pin_root(w_code);
+    let base = pyre_object::gc_roots::pin_roots(&[w_exc, w_code]);
+    let w_exc = pyre_object::gc_roots::shadow_stack_get(base);
+    let w_code = pyre_object::gc_roots::shadow_stack_get(base + 1);
     let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     let Ok(mut frame) = pyre_interpreter::createframe_obj(
         w_code as *const (),
@@ -5673,12 +5675,11 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     // rewrite these copied native parameters.  Root them immediately and
     // dispatch only values reloaded from the forwarded slots.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = _roots.base();
-    let _ = _roots.pin_root(callable);
-    let _ = _roots.pin_root(null_or_self);
-    for &arg in args {
-        let _ = _roots.pin_root(arg);
-    }
+    let mut live = Vec::with_capacity(2 + args.len());
+    live.push(callable);
+    live.push(null_or_self);
+    live.extend_from_slice(args);
+    let root_base = _roots.pin_roots(&live);
     // `eval.rs`'s `PyFrame::call` — a non-null null_or_self is the method receiver
     // (load_method_fast_path pushes `[w_descr, w_obj]`); the call proceeds
     // as `callable(null_or_self, *args)`.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7547,8 +7547,8 @@ fn drive_unpack_iterable_trace(
         // scope guard truncates both entries on the way out; `pin_root` without
         // one grows `ln`'s shadow stack by two per jd1 crossing.
         let _enter_roots = pyre_object::gc_roots::push_roots();
-        let _ = pyre_object::gc_roots::pin_root(w_iterator);
-        let items = pyre_object::gc_roots::pin_root(items);
+        let base = pyre_object::gc_roots::pin_roots(&[w_iterator, items]);
+        let items = pyre_object::gc_roots::shadow_stack_get(base + 1);
         let before = unsafe { pyre_object::listobject::w_list_len(items) };
         // A drain-time error that is not the loop-exit StopIteration has to
         // travel out of the unpack; `ln` cannot re-derive it, because calling

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5093,19 +5093,20 @@ fn walk_parked_exception_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// forwards, as one root source.
 ///
 /// Every holder here is `malloc_typed` or a plain static, so the marker skips
-/// it and this walk is the only path to its contents. All four are
+/// it and this walk is the only path to its contents. All three are
 /// process-global rather than per-mutator for the same reason: each outlives
 /// the thread that filled it. `w_globals` (`pycode.py:159-165
-/// frame_stores_global`) is first-store-wins, `_mapdict_caches[i].w_method`
-/// (mapdict.py:1418) is filled once, and a compiled `W_SRE_Pattern` outlives
-/// its compiling thread — as per-mutator areas their slots would lose their
-/// root at that thread's `unregister_mutator` while the holder stayed live.
+/// frame_stores_global`) is first-store-wins and `_mapdict_caches[i].w_method`
+/// (mapdict.py:1418) is filled once — as per-mutator areas their slots would
+/// lose their root at that thread's `unregister_mutator` while the holder
+/// stayed live. Compiled `W_SRE_Pattern` objects are ordinary managed
+/// instances (`interp_sre.py SRE_Pattern__new__`); their fields are traced
+/// from the object, not from a side table.
 fn walk_immortal_store_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     walk_rbigint_parts_cache(visitor);
     pyre_interpreter::module::_io::walk_autoflusher_roots(|slot| {
         visit_pyobject_root(slot, visitor)
     });
-    sre_pattern_root_walker(visitor);
     w_globals_stamped_code_root_walker(visitor);
     mapdict_method_cache_root_walker(visitor);
 }
@@ -6143,12 +6144,6 @@ fn pyre_interpreter_side_table_root_walker(visitor: &mut dyn FnMut(&mut majit_ir
 #[allow(dead_code)]
 fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots(|slot| {
-        visit_pyobject_root(slot, visitor);
-    });
-}
-
-fn sre_pattern_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    pyre_object::interp_sre::walk_sre_pattern_roots(|slot| {
         visit_pyobject_root(slot, visitor);
     });
 }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -522,6 +522,16 @@ impl RootScope {
         }
     }
 
+    /// Scope-local [`pin_roots`]: publish every live word, then normalize
+    /// the run. Sequential [`Self::pin_root`] would query after the first
+    /// write and leave later values invisible to a foreign collection.
+    #[majit_macros::dont_look_inside_cannot_raise]
+    pub fn pin_roots(&self, roots: &[PyObjectRef]) -> usize {
+        let base = self.publish(roots);
+        self.normalize(base, roots.len());
+        base
+    }
+
     /// Scope-local [`normalize_roots`] using the cached cell.
     #[majit_macros::dont_look_inside_cannot_raise]
     pub fn normalize(&self, base: usize, len: usize) {

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -33,12 +33,12 @@ pub struct W_SRE_Pattern {
 /// Every `W_SRE_Pattern` ever allocated.  PyPy's compiled patterns are normal
 /// interpreter objects, shared by all threads; the root owner must therefore
 /// be process-global too.  The addresses are stored as `usize` because the
-/// immortal raw pointer itself is not `Send`.
+/// raw pointer itself is not `Send`.
 ///
-/// Patterns are `malloc_typed` (immortal, off-GC), so the collector never
-/// traces into them: their GC-heap `w_pattern` / `w_groupindex` /
-/// `w_indexgroup` slots would otherwise be reclaimed or relocated without
-/// updating the slot.
+/// Allocation is `malloc_typed_stable` (old-gen, non-moving). The stable
+/// hook can still fall back to movable `malloc_typed`, so the side table
+/// must itself be a root: a minor that moves a nursery-born pattern has
+/// to rewrite the stored address before the field walk.
 static SRE_PATTERNS: std::sync::OnceLock<parking_lot::Mutex<Vec<usize>>> =
     std::sync::OnceLock::new();
 
@@ -46,15 +46,19 @@ fn sre_patterns() -> &'static parking_lot::Mutex<Vec<usize>> {
     SRE_PATTERNS.get_or_init(|| parking_lot::Mutex::new(Vec::new()))
 }
 
-/// Visit each immortal pattern's GC-heap `PyObjectRef` slots as roots.
+/// Visit each pattern object, then its GC-heap `PyObjectRef` slots.
 #[majit_macros::dont_look_inside]
 pub fn walk_sre_pattern_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let patterns = sre_patterns().lock();
-    for &addr in patterns.iter() {
-        if addr == 0 {
+    let mut patterns = sre_patterns().lock();
+    for addr in patterns.iter_mut() {
+        if *addr == 0 {
             continue;
         }
-        let pattern = addr as *mut W_SRE_Pattern;
+        visitor(unsafe { &mut *std::ptr::from_mut(addr).cast::<PyObjectRef>() });
+        if *addr == 0 {
+            continue;
+        }
+        let pattern = *addr as *mut W_SRE_Pattern;
         visitor(unsafe { &mut (*pattern).w_pattern });
         visitor(unsafe { &mut (*pattern).w_groupindex });
         visitor(unsafe { &mut (*pattern).w_indexgroup });

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -30,41 +30,6 @@ pub struct W_SRE_Pattern {
     pub w_indexgroup: PyObjectRef,
 }
 
-/// Every `W_SRE_Pattern` ever allocated.  PyPy's compiled patterns are normal
-/// interpreter objects, shared by all threads; the root owner must therefore
-/// be process-global too.  The addresses are stored as `usize` because the
-/// raw pointer itself is not `Send`.
-///
-/// Allocation is `malloc_typed_stable` (old-gen, non-moving). The stable
-/// hook can still fall back to movable `malloc_typed`, so the side table
-/// must itself be a root: a minor that moves a nursery-born pattern has
-/// to rewrite the stored address before the field walk.
-static SRE_PATTERNS: std::sync::OnceLock<parking_lot::Mutex<Vec<usize>>> =
-    std::sync::OnceLock::new();
-
-fn sre_patterns() -> &'static parking_lot::Mutex<Vec<usize>> {
-    SRE_PATTERNS.get_or_init(|| parking_lot::Mutex::new(Vec::new()))
-}
-
-/// Visit each pattern object, then its GC-heap `PyObjectRef` slots.
-#[majit_macros::dont_look_inside]
-pub fn walk_sre_pattern_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let mut patterns = sre_patterns().lock();
-    for addr in patterns.iter_mut() {
-        if *addr == 0 {
-            continue;
-        }
-        visitor(unsafe { &mut *std::ptr::from_mut(addr).cast::<PyObjectRef>() });
-        if *addr == 0 {
-            continue;
-        }
-        let pattern = *addr as *mut W_SRE_Pattern;
-        visitor(unsafe { &mut (*pattern).w_pattern });
-        visitor(unsafe { &mut (*pattern).w_groupindex });
-        visitor(unsafe { &mut (*pattern).w_indexgroup });
-    }
-}
-
 /// Allocate a `W_SRE_Pattern` — `SRE_Pattern__new__` field stamping
 /// (interp_sre.py:624-639).
 pub fn w_sre_pattern_new(
@@ -93,10 +58,6 @@ pub fn w_sre_pattern_new(
         w_groupindex,
         w_indexgroup,
     });
-    // This is a prebuilt-family root store: make the collector rescan it after
-    // publishing a newly allocated pattern.
-    crate::gc_roots::mark_prebuilt_roots_dirty();
-    sre_patterns().lock().push(obj as usize);
     obj
 }
 


### PR DESCRIPTION
## Summary

- Old-gen births no longer inflate `size_objects_made_old`; `force_enabled` does not flip `enabled`; arena free-list link words are cleared; nursery rounding uses `MEMORY_ALIGNMENT`; `rgil.acquire` runs the after-thread-switch hook.
- Collecting large/varsize mallocs run `minor_collection_with_major_progress` with extrasize `totalsize + nursery/2` before the block exists. MARKING re-grays remembered and pinned-parent objects before the root walk.
- `set_destructor` after freeze rematerializes the published `TypeEntry`. `gc_step` runs a minor before each `major_collection_step`. rewrite consults `has_write_barrier_from_array`. Sequential `pin_root` of already-live objects publishes the whole set first.

## Test plan

- [x] `cargo test -p majit-gc --lib -- --test-threads=1` (353 passed, 11 ignored)
- [x] `cargo check -p pyre-interpreter --features dynasm`
- [ ] `python3 pyre/check.py` on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage collection during external-memory allocation, major collection progress, and deferred cleanup.
  - Fixed delivery of pending asynchronous exceptions after thread switches.
  - Improved object lifetime and memory safety for reused allocations, interior roots, movable patterns, and late-registered destructors.
  - Improved cleanup handling for closed iterators and deferred callbacks.

- **Performance**
  - Streamlined garbage-collection root handling across interpreter and JIT operations.
  - Improved write-barrier selection, allocation alignment, and deferred cleanup processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->