### PR TITLE
metainterp: write live snapshots from the framestack

### DIFF
--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5699,7 +5699,7 @@ impl TraceCtx {
     /// `header_pc` identifies the header on its own here: a merge point's
     /// `green_key` is derived from `(code, header_pc)`, so the reverse scan's
     /// first hit is the same entry [`Self::get_merge_point_at`] would return.
-    /// Only entries recorded during the walk (`position > 0`) answer here.
+    /// Only entries recorded during the walk (`has_prefix_ops`) answer here.
     /// The entry at position 0 is the synthetic trace-start seed, whose boxes
     /// were built from the trace's own `inputarg_types()`; leaving it out lets
     /// callers keep their existing fallback for a head close and reserves this
@@ -5709,7 +5709,9 @@ impl TraceCtx {
         self.current_merge_points
             .iter()
             .rev()
-            .find(|mp| mp.header_pc == header_pc && mp.position._pos > 0)
+            .find(|mp| {
+                mp.header_pc == header_pc && mp.position.has_prefix_ops(self.num_inputargs())
+            })
             .map(|mp| mp.green_boxes.iter().map(|green| green.ty).collect())
     }
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2736,7 +2736,12 @@ impl TraceCtx {
     /// frame state. Returns a snapshot_id for use as rd_resume_position.
     pub fn capture_resumedata(&mut self, snapshot: crate::recorder::Snapshot) -> i32 {
         if self.recorder.has_byte_buffer() {
-            return self.recorder.encode_captured_snapshot(&snapshot);
+            let id = self.recorder.encode_captured_snapshot(&snapshot);
+            // A later `snapshots()` / `take_snapshots` must see this
+            // capture. RPython has no cache: it always reads
+            // `_snapshot_data`. Drop any earlier decode.
+            self.snapshots.clear();
+            return id;
         }
         let id = self.snapshots.len() as i32;
         self.snapshots.push(snapshot);

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2748,6 +2748,29 @@ impl TraceCtx {
         id
     }
 
+    /// opencoder.py `history.trace.capture_resumedata(framestack, ...)`.
+    pub fn capture_resumedata_from_framestack(
+        &mut self,
+        framestack: &mut [crate::pyjitpl::MIFrame],
+        after_residual_call: bool,
+    ) -> i32 {
+        let op_live = self.metainterp_sd.op_live as u8;
+        let recorder = &mut self.recorder;
+        let vable = self.virtualizable_boxes.as_deref().unwrap_or(&[]);
+        let vref = self.virtualref_boxes.as_slice();
+        let liveness = self.metainterp_sd.liveness_info.as_slice();
+        let id = recorder.capture_resumedata_from_framestack(
+            framestack,
+            vable,
+            vref,
+            after_residual_call,
+            op_live,
+            liveness,
+        );
+        self.snapshots.clear();
+        id
+    }
+
     /// Look up a captured snapshot by id.
     pub fn get_snapshot(&self, id: i32) -> Option<&crate::recorder::Snapshot> {
         if id >= 0 {

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -2190,6 +2190,8 @@ impl Trace {
         all_liveness: &[u8],
         after_residual_call: bool,
         is_last: bool,
+        unique_to_box: Option<&[u32]>,
+        patch_guard_descr: bool,
     ) -> i64 {
         self._total_snapshots += 1;
         // opencoder.py:769 frame.get_list_of_active_boxes(False, ...).
@@ -2202,6 +2204,7 @@ impl Trace {
             op_live,
             all_liveness,
             after_residual_call,
+            unique_to_box,
         );
         // opencoder.py:771-780 — write vable / vref arrays, then the
         // snapshot record. `s` captures the snapshot_data offset
@@ -2215,7 +2218,11 @@ impl Trace {
         let jitcode_index = frame.jitcode.try_index().map(|i| i as i64).unwrap_or(-1);
         let pc = frame.pc as i64;
         self._encode_snapshot(jitcode_index, pc, array, is_last);
-        self.patch_last_guard_descr_slot(s);
+        // Live pyre keeps the sequential resume id on FrontendSlot
+        // and must not grow the guard's 2-byte 0-placeholder.
+        if patch_guard_descr {
+            self.patch_last_guard_descr_slot(s);
+        }
         s
     }
 
@@ -2241,6 +2248,7 @@ impl Trace {
         op_live: u8,
         all_liveness: &[u8],
         is_last: bool,
+        unique_to_box: Option<&[u32]>,
     ) -> i64 {
         self._total_snapshots += 1;
         let array = frame.get_list_of_active_boxes(
@@ -2250,6 +2258,7 @@ impl Trace {
             op_live,
             all_liveness,
             /* after_residual_call */ false,
+            unique_to_box,
         );
         self.snapshot_add_prev(SNAPSHOT_PREV_COMES_NEXT);
         let jitcode_index = frame.jitcode.try_index().map(|i| i as i64).unwrap_or(-1);
@@ -2279,6 +2288,35 @@ impl Trace {
         all_liveness: &[u8],
         after_residual_call: bool,
     ) -> i64 {
+        self.capture_resumedata_mapped(
+            framestack,
+            virtualizable_boxes,
+            virtualref_boxes,
+            clear_result_register,
+            op_live,
+            all_liveness,
+            after_residual_call,
+            None,
+            true,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython metainterpreter routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and frame ownership"
+    )]
+    pub(crate) fn capture_resumedata_mapped(
+        &mut self,
+        framestack: &mut [crate::pyjitpl::MIFrame],
+        virtualizable_boxes: &[Box],
+        virtualref_boxes: &[Box],
+        clear_result_register: bool,
+        op_live: u8,
+        all_liveness: &[u8],
+        after_residual_call: bool,
+        unique_to_box: Option<&[u32]>,
+        patch_guard_descr: bool,
+    ) -> i64 {
         // opencoder.py `n = len(framestack) - 1`.
         let framestack_len = framestack.len();
         if framestack_len >= 1 {
@@ -2297,6 +2335,8 @@ impl Trace {
                     all_liveness,
                     after_residual_call,
                     /* is_last */ n == 0,
+                    unique_to_box,
+                    patch_guard_descr,
                 )
             };
             // opencoder.py self._ensure_parent_resumedata(framestack, n).
@@ -2308,13 +2348,18 @@ impl Trace {
                 clear_result_register,
                 op_live,
                 all_liveness,
+                unique_to_box,
             );
             result
         } else {
             // opencoder.py:829-831 — empty framestack → empty top
             // snapshot.
             let _ = clear_result_register;
-            self.create_empty_top_snapshot_from_boxes(virtualizable_boxes, virtualref_boxes)
+            self.create_empty_top_snapshot_from_boxes(
+                virtualizable_boxes,
+                virtualref_boxes,
+                patch_guard_descr,
+            )
         }
     }
 
@@ -2335,6 +2380,7 @@ impl Trace {
         clear_result_register: bool,
         op_live: u8,
         all_liveness: &[u8],
+        unique_to_box: Option<&[u32]>,
     ) {
         let mut n = n;
         while n > 0 {
@@ -2354,6 +2400,7 @@ impl Trace {
                     op_live,
                     all_liveness,
                     is_last,
+                    unique_to_box,
                 )
             };
             // opencoder.py `target.parent_snapshot = s`.
@@ -2396,6 +2443,7 @@ impl Trace {
         &mut self,
         vable_boxes: &[Box],
         vref_boxes: &[Box],
+        patch_guard_descr: bool,
     ) -> i64 {
         self._total_snapshots += 1;
         let s = self._snapshot_data.len() as i64;
@@ -2405,7 +2453,9 @@ impl Trace {
         self.append_snapshot_data_int(vable_array);
         self.append_snapshot_data_int(vref_array);
         self._encode_snapshot(-1, 0, empty_array, true);
-        self.patch_last_guard_descr_slot(s);
+        if patch_guard_descr {
+            self.patch_last_guard_descr_slot(s);
+        }
         s
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4791,7 +4791,7 @@ impl<M: Clone> MetaInterp<M> {
         // compile.py:269: cross-loop cut uses the inner loop's merge point.
         // Lookup by inner_key (not ctx.green_key which is the outer loop).
         ctx.get_merge_point_at(inner_key, ctx.header_pc)
-            .filter(|mp| mp.position._pos > 0)
+            .filter(|mp| mp.position.has_prefix_ops(ctx.num_inputargs()))
             .map(|mp| (mp.header_pc, mp.green_boxes.clone()))
     }
 
@@ -9145,9 +9145,9 @@ impl<M: Clone> MetaInterp<M> {
                 );
                 return false;
             };
-            let retrace_merge_point = ctx
-                .get_merge_point_at(green_key, header_pc)
-                .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0);
+            let retrace_merge_point = ctx.get_merge_point_at(green_key, header_pc).filter(|mp| {
+                mp.position == retrace_pos && mp.position.has_prefix_ops(ctx.num_inputargs())
+            });
             // compile.py:347 `trace = metainterp.history.trace.cut_trace_from(
             // start, inputargs)` is UNCONDITIONAL. `start` is read once, at the
             // caller's single merge-point selection (pyjitpl.py:3019), and

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1835,13 +1835,29 @@ where
         let n = sym
             .int_identity_slots_end()
             .min(self.frames.frames[0].int_regs.len());
-        let saved_int_regs: Vec<Option<OpRef>> = self.frames.frames[0].int_regs[..n].to_vec();
-        let saved_int_values: Vec<Option<i64>> = self.frames.frames[0].int_values[..n].to_vec();
+        let saved_int_regs: smallvec::SmallVec<[Option<OpRef>; 8]> = self.frames.frames[0].int_regs
+            [..n]
+            .iter()
+            .copied()
+            .collect();
+        let saved_int_values: smallvec::SmallVec<[Option<i64>; 8]> = self.frames.frames[0]
+            .int_values[..n]
+            .iter()
+            .copied()
+            .collect();
         let rn = sym
             .ref_identity_slots_end()
             .min(self.frames.frames[0].ref_regs.len());
-        let saved_ref_regs: Vec<Option<OpRef>> = self.frames.frames[0].ref_regs[..rn].to_vec();
-        let saved_ref_values: Vec<Option<i64>> = self.frames.frames[0].ref_values[..rn].to_vec();
+        let saved_ref_regs: smallvec::SmallVec<[Option<OpRef>; 8]> = self.frames.frames[0].ref_regs
+            [..rn]
+            .iter()
+            .copied()
+            .collect();
+        let saved_ref_values: smallvec::SmallVec<[Option<i64>; 8]> = self.frames.frames[0]
+            .ref_values[..rn]
+            .iter()
+            .copied()
+            .collect();
         let root_inflight_int_result =
             if self.frames.frames.len() > 1 && self.frames.frames[0]._result_argcode == b'i' {
                 self.frames.frames[0].result_arg_index.or_else(|| {
@@ -1865,16 +1881,9 @@ where
                 None
             };
         sym.populate_frame_int_regs(&mut self.frames.frames[0]);
-        let op_live = ctx.metainterp_sd().op_live as u8;
-        let all_liveness = ctx.metainterp_sd().liveness_info.clone();
-        // `pyjitpl.py:2610` `_snapshot_box_list` — clone the per-trace
-        // virtualizable / virtualref boxes so the snapshot builder
-        // can read them without keeping a `&TraceCtx` borrow alive.
-        // Both vectors are short (one per live `@jit.virtualizable`,
-        // two per live vref).
-        let virtualizable_snapshot = ctx.virtualizable_boxes.clone().unwrap_or_default();
-        let virtualref_snapshot = ctx.virtualref_boxes.clone();
         if crate::callee_rca_enabled() {
+            let virtualizable_snapshot = ctx.virtualizable_boxes.clone().unwrap_or_default();
+            let virtualref_snapshot = ctx.virtualref_boxes.clone();
             let vable_payload: Vec<_> = virtualizable_snapshot
                 .iter()
                 .enumerate()
@@ -1898,18 +1907,30 @@ where
             );
             eprintln!("[callee-rca][record-guard-vable] {:?}", vable_payload);
         }
-        let snapshot = build_state_field_snapshot(
-            self.frames,
-            op_live,
-            &all_liveness,
-            after_residual_call,
-            &virtualizable_snapshot,
-            &virtualref_snapshot,
-            Some((
-                sym.int_identity_slots_base(),
-                sym.int_identity_reserved_end(),
-            )),
-        );
+        // opencoder.py capture_resumedata writes `_snapshot_data` from
+        // the framestack. The Vec<Snapshot> path stays for unit tests
+        // that never attach the byte buffer.
+        let snapshot_id = if ctx.recorder.has_byte_buffer() {
+            ctx.capture_resumedata_from_framestack(&mut self.frames.frames, after_residual_call)
+        } else {
+            let op_live = ctx.metainterp_sd().op_live as u8;
+            let all_liveness = ctx.metainterp_sd().liveness_info.clone();
+            let virtualizable_snapshot = ctx.virtualizable_boxes.clone().unwrap_or_default();
+            let virtualref_snapshot = ctx.virtualref_boxes.clone();
+            let snapshot = build_state_field_snapshot(
+                self.frames,
+                op_live,
+                &all_liveness,
+                after_residual_call,
+                &virtualizable_snapshot,
+                &virtualref_snapshot,
+                Some((
+                    sym.int_identity_slots_base(),
+                    sym.int_identity_reserved_end(),
+                )),
+            );
+            ctx.capture_resumedata(snapshot)
+        };
         for idx in 0..n {
             // RPython pyjitpl.py:180-193 leaves the parent frame's
             // in-flight int result slot cleared after get_list_of_active_boxes(True).
@@ -1933,7 +1954,6 @@ where
             }
         }
         self.frames.frames[top_idx].pc = saved_top_pc;
-        let snapshot_id = ctx.capture_resumedata(snapshot);
         match target {
             GuardStampTarget::LastOp => ctx.set_last_guard_resume_position(snapshot_id),
             GuardStampTarget::GuardFromEnd(from_end) => {

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -21,11 +21,30 @@ use crate::recorder::SnapshotTagged;
 /// `self.registers_i[index]` (which is already a `ConstInt` /
 /// `InputArg` / `AbstractResOp`).
 #[inline]
-fn register_to_box_int(opref: OpRef, value: i64) -> OpBox {
+/// Map a live `OpRef.raw()` onto the opencoder TAGBOX `_index`.
+/// `None` keeps `raw()` — TRB-only tests mint boxes in `_index` order.
+fn remap_resop(opref: OpRef, unique_to_box: Option<&[u32]>) -> u32 {
+    let raw = opref.raw();
+    match unique_to_box {
+        None => raw,
+        Some(map) => {
+            let mapped = *map.get(raw as usize).unwrap_or_else(|| {
+                panic!("get_list_of_active_boxes: OpRef {opref:?} has no TAGBOX index")
+            });
+            assert!(
+                mapped != u32::MAX,
+                "get_list_of_active_boxes: void op {opref:?} used as a value box"
+            );
+            mapped
+        }
+    }
+}
+
+fn register_to_box_int(opref: OpRef, value: i64, unique_to_box: Option<&[u32]>) -> OpBox {
     if opref.is_constant() {
         OpBox::ConstInt(value)
     } else {
-        OpBox::ResOp(opref.raw())
+        OpBox::ResOp(remap_resop(opref, unique_to_box))
     }
 }
 
@@ -33,7 +52,7 @@ fn register_to_box_int(opref: OpRef, value: i64) -> OpBox {
 /// `value` stores the raw address of the GC ref (cast to i64 at write
 /// time).
 #[inline]
-fn register_to_box_ref(opref: OpRef, value: i64) -> OpBox {
+fn register_to_box_ref(opref: OpRef, value: i64, unique_to_box: Option<&[u32]>) -> OpBox {
     if opref.is_constant() {
         // history.py `ConstPtr.value` is the single object field. The
         // forwarded gcref lives in the inline `OpRef::ConstPtr` payload
@@ -46,18 +65,18 @@ fn register_to_box_ref(opref: OpRef, value: i64) -> OpBox {
         };
         OpBox::ConstPtr(bits)
     } else {
-        OpBox::ResOp(opref.raw())
+        OpBox::ResOp(remap_resop(opref, unique_to_box))
     }
 }
 
 /// Map a float register (OpRef, raw bits) to an `OpBox`.
 /// `value` stores the bit-casted `f64` payload.
 #[inline]
-fn register_to_box_float(opref: OpRef, value: i64) -> OpBox {
+fn register_to_box_float(opref: OpRef, value: i64, unique_to_box: Option<&[u32]>) -> OpBox {
     if opref.is_constant() {
         OpBox::ConstFloat(value as u64)
     } else {
-        OpBox::ResOp(opref.raw())
+        OpBox::ResOp(remap_resop(opref, unique_to_box))
     }
 }
 
@@ -744,6 +763,7 @@ impl MIFrame {
         op_live: u8,
         all_liveness: &[u8],
         after_residual_call: bool,
+        unique_to_box: Option<&[u32]>,
     ) -> i64 {
         const SIZE_LIVE_OP: usize = majit_translate::liveness::OFFSET_SIZE + 1;
         use majit_translate::liveness::{LivenessIterator, decode_offset};
@@ -866,7 +886,7 @@ impl MIFrame {
                         .expect("get_list_of_active_boxes: int register uninitialized");
                     let value = self.int_values[idx]
                         .expect("get_list_of_active_boxes: int value uninitialized");
-                    register_to_box_int(opref, value)
+                    register_to_box_int(opref, value, unique_to_box)
                 } else {
                     // pyjitpl.py `copy_constants(..., constants_i, ...,
                     // ConstInt)` — constants live in the `[num_regs_i ..
@@ -894,7 +914,7 @@ impl MIFrame {
                         .expect("get_list_of_active_boxes: ref register uninitialized");
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_boxes: ref value uninitialized");
-                    register_to_box_ref(opref, value)
+                    register_to_box_ref(opref, value, unique_to_box)
                 } else {
                     // pyjitpl.py `copy_constants(..., constants_r, ...,
                     // ConstPtrJitCode)` — constants_r store raw GC
@@ -919,7 +939,7 @@ impl MIFrame {
                         .expect("get_list_of_active_boxes: float register uninitialized");
                     let value = self.float_values[idx]
                         .expect("get_list_of_active_boxes: float value uninitialized");
-                    register_to_box_float(opref, value)
+                    register_to_box_float(opref, value, unique_to_box)
                 } else {
                     // pyjitpl.py `copy_constants(..., constants_f,
                     // ..., ConstFloat)` — `constants_f[i]` stores the
@@ -1507,6 +1527,7 @@ mod tests {
             LIVE_OP,
             &all_liveness,
             /* after_residual_call */ true,
+            None,
         );
 
         // Two boxes pushed → array length prefix + 2 varints.
@@ -1588,6 +1609,7 @@ mod tests {
             OP_LIVE,
             &all_liveness,
             /* after_residual_call */ false,
+            None,
         );
 
         // pyjitpl.py:193 — `_result_argcode` flips to `b'?'` after
@@ -1643,6 +1665,7 @@ mod tests {
             OP_LIVE,
             &all_liveness,
             /* after_residual_call */ false,
+            None,
         );
 
         // Register slot now holds the zero ConstInt inline-Const OpRef,
@@ -1697,6 +1720,7 @@ mod tests {
             OP_LIVE,
             &all_liveness,
             false,
+            None,
         );
         assert_eq!(frame._result_argcode, b'?');
 
@@ -1757,6 +1781,7 @@ mod tests {
             OP_LIVE,
             &all_liveness,
             false,
+            None,
         );
 
         let (length, consumed) =

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -298,8 +298,9 @@ pub struct Trace {
     snapshot_offsets: Vec<usize>,
     /// Per-snapshot `py_pc` words, outermost-first. RPython's
     /// `_encode_snapshot` has no twin; resume still reads this pyre
-    /// extra after decode.
-    snapshot_py_pcs: Vec<Vec<u32>>,
+    /// extra after decode. Inline capacity covers the usual 1-frame
+    /// portal (regex) plus a few inlines without a heap `Vec`.
+    snapshot_py_pcs: Vec<smallvec::SmallVec<[u32; 4]>>,
 }
 
 impl Trace {
@@ -489,7 +490,8 @@ impl Trace {
     /// `rd_resume_position`; the byte offset lives in `snapshot_offsets`.
     pub fn encode_captured_snapshot(&mut self, snapshot: &Snapshot) -> i32 {
         let id = self.snapshot_offsets.len() as i32;
-        let py_pcs: Vec<u32> = snapshot.frames.iter().map(|f| f.py_pc).collect();
+        let py_pcs: smallvec::SmallVec<[u32; 4]> =
+            snapshot.frames.iter().map(|f| f.py_pc).collect();
 
         // Write `_snapshot_data` only. `create_top_snapshot` also patches
         // the last op's descr slot (`opencoder.py`); that slot is the
@@ -546,6 +548,56 @@ impl Trace {
         id
     }
 
+    /// opencoder.py `Trace.capture_resumedata(framestack, ...)`.
+    /// Writes `_snapshot_data` from the live framestack — no
+    /// `Vec<Snapshot>` / `SnapshotTagged` on the record path.
+    pub fn capture_resumedata_from_framestack(
+        &mut self,
+        framestack: &mut [crate::pyjitpl::MIFrame],
+        virtualizable_boxes: &[OpRef],
+        virtualref_boxes: &[(OpRef, usize)],
+        after_residual_call: bool,
+        op_live: u8,
+        all_liveness: &[u8],
+    ) -> i32 {
+        let id = self.snapshot_offsets.len() as i32;
+        let py_pcs: smallvec::SmallVec<[u32; 4]> = framestack.iter().map(|f| f.pc as u32).collect();
+        let vable: smallvec::SmallVec<[OcBox; 8]> = virtualizable_boxes
+            .iter()
+            .map(|r| self.arg_to_box(*r))
+            .collect();
+        let vref: smallvec::SmallVec<[OcBox; 8]> = virtualref_boxes
+            .iter()
+            .map(|(r, _)| self.arg_to_box(*r))
+            .collect();
+        // opencoder.Trace owns both `_index` and `_snapshot_data`.
+        // unique_to_box is not written during the snapshot walk.
+        let remap = self.unique_to_box.as_slice() as *const [u32];
+        let offset = {
+            let trb = self
+                .trb
+                .as_mut()
+                .expect("capture_resumedata_from_framestack requires attach_byte_buffer");
+            // SAFETY: `unique_to_box` and `trb` are sibling fields of
+            // the same Trace; capture does not push unique_to_box.
+            let remap = unsafe { &*remap };
+            trb.capture_resumedata_mapped(
+                framestack,
+                &vable,
+                &vref,
+                /* clear_result_register */ true,
+                op_live,
+                all_liveness,
+                after_residual_call,
+                Some(remap),
+                /* patch_guard_descr */ false,
+            )
+        };
+        self.snapshot_offsets.push(offset as usize);
+        self.snapshot_py_pcs.push(py_pcs);
+        id
+    }
+
     /// Rebuild `Vec<Snapshot>` from `_snapshot_data` in capture order.
     pub fn decode_captured_snapshots(&self) -> Option<Vec<Snapshot>> {
         let trb = self.trb.as_ref()?;
@@ -563,24 +615,25 @@ impl Trace {
         for (i, &offset) in self.snapshot_offsets.iter().enumerate() {
             let (vable_t, vref_t, frames_t) = {
                 let it = trb.get_snapshot_iter(offset);
-                let vable_t: Vec<i64> = it.iter_vable_array().collect();
-                let vref_t: Vec<i64> = it.iter_vref_array().collect();
-                let frames_t: Vec<(i64, i64, Vec<i64>)> = it
-                    .framestack
-                    .iter()
-                    .copied()
-                    .map(|snap_idx| {
-                        let (jc, pc) = it.unpack_jitcode_pc(snap_idx);
-                        let boxes: Vec<i64> = it.iter_array(snap_idx).collect();
-                        (jc, pc, boxes)
-                    })
-                    .collect();
+                let vable_t: smallvec::SmallVec<[i64; 8]> = it.iter_vable_array().collect();
+                let vref_t: smallvec::SmallVec<[i64; 8]> = it.iter_vref_array().collect();
+                let frames_t: smallvec::SmallVec<[(i64, i64, smallvec::SmallVec<[i64; 8]>); 4]> =
+                    it.framestack
+                        .iter()
+                        .copied()
+                        .map(|snap_idx| {
+                            let (jc, pc) = it.unpack_jitcode_pc(snap_idx);
+                            let boxes: smallvec::SmallVec<[i64; 8]> =
+                                it.iter_array(snap_idx).collect();
+                            (jc, pc, boxes)
+                        })
+                        .collect();
                 (vable_t, vref_t, frames_t)
             };
             let py_pcs = self
                 .snapshot_py_pcs
                 .get(i)
-                .map(Vec::as_slice)
+                .map(smallvec::SmallVec::as_slice)
                 .unwrap_or(&[]);
             let frames = frames_t
                 .into_iter()

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -465,88 +465,79 @@ impl Trace {
         }
     }
 
+    /// `_list_of_boxes` from tagged snapshot values, encoding each box
+    /// into `_snapshot_array_data` the way `opencoder.py _add_box_to_storage`
+    /// does — no intermediate `Vec<i64>`.
+    fn write_tagged_array(&mut self, boxes: &[SnapshotTagged]) -> i64 {
+        let res = self
+            .trb
+            .as_mut()
+            .expect("write_tagged_array requires attach_byte_buffer")
+            .new_array(boxes.len());
+        for &tagged in boxes {
+            let b = self.snapshot_tagged_to_box(tagged);
+            self.trb
+                .as_mut()
+                .expect("write_tagged_array requires attach_byte_buffer")
+                ._add_box_to_storage_box(b);
+        }
+        res
+    }
+
     /// `opencoder.py create_top_snapshot` / `create_snapshot` from a
     /// structured `Snapshot`. Sequential id is the live
     /// `rd_resume_position`; the byte offset lives in `snapshot_offsets`.
     pub fn encode_captured_snapshot(&mut self, snapshot: &Snapshot) -> i32 {
         let id = self.snapshot_offsets.len() as i32;
         let py_pcs: Vec<u32> = snapshot.frames.iter().map(|f| f.py_pc).collect();
-        let vable: Vec<OcBox> = snapshot
-            .vable_boxes
-            .iter()
-            .copied()
-            .map(|t| self.snapshot_tagged_to_box(t))
-            .collect();
-        let vref: Vec<OcBox> = snapshot
-            .vref_boxes
-            .iter()
-            .copied()
-            .map(|t| self.snapshot_tagged_to_box(t))
-            .collect();
-        let frame_boxes: Vec<Vec<OcBox>> = snapshot
-            .frames
-            .iter()
-            .map(|f| {
-                f.boxes
-                    .iter()
-                    .copied()
-                    .map(|t| self.snapshot_tagged_to_box(t))
-                    .collect()
-            })
-            .collect();
-        let frame_meta: Vec<(i64, i64)> = snapshot
-            .frames
-            .iter()
-            .map(|f| (Self::encode_jitcode_index(f.jitcode_index), i64::from(f.pc)))
-            .collect();
-
-        let trb = self
-            .trb
-            .as_mut()
-            .expect("encode_captured_snapshot requires attach_byte_buffer");
-        let encode_boxes = |trb: &mut TraceRecordBuffer, boxes: &[OcBox]| -> Vec<i64> {
-            boxes.iter().copied().map(|b| trb._encode(b)).collect()
-        };
 
         // Write `_snapshot_data` only. `create_top_snapshot` also patches
         // the last op's descr slot (`opencoder.py`); that slot is the
         // RPython resume position. Live pyre keeps the sequential id on
         // `FrontendSlot.resume` and must not rewrite a later non-guard's
         // trailing bytes as if they were the placeholder.
-        let offset = if frame_meta.is_empty() {
-            let vable_t = encode_boxes(trb, &vable);
-            let vref_t = encode_boxes(trb, &vref);
+        let offset = if snapshot.frames.is_empty() {
+            let empty_array = self.write_tagged_array(&[]);
+            let vable_array = self.write_tagged_array(&snapshot.vable_boxes);
+            let vref_array = self.write_tagged_array(&snapshot.vref_boxes);
+            let trb = self
+                .trb
+                .as_mut()
+                .expect("encode_captured_snapshot requires attach_byte_buffer");
             trb._total_snapshots += 1;
             let s = trb._snapshot_data.len() as i64;
-            let empty_array = trb._list_of_boxes(&[]);
-            let vable_array = trb._list_of_boxes_virtualizable(&vable_t);
-            let vref_array = trb._list_of_boxes(&vref_t);
             trb.append_snapshot_data_int(vable_array);
             trb.append_snapshot_data_int(vref_array);
             trb._encode_snapshot(-1, 0, empty_array, true);
             s
         } else {
-            let last = frame_meta.len() - 1;
-            let inner = encode_boxes(trb, &frame_boxes[last]);
-            let array = trb._list_of_boxes(&inner);
-            let vable_t = encode_boxes(trb, &vable);
-            let vref_t = encode_boxes(trb, &vref);
-            trb._total_snapshots += 1;
-            let s = trb._snapshot_data.len() as i64;
-            let vable_array = trb._list_of_boxes(&vable_t);
-            let vref_array = trb._list_of_boxes(&vref_t);
-            trb.append_snapshot_data_int(vable_array);
-            trb.append_snapshot_data_int(vref_array);
-            trb._encode_snapshot(
-                frame_meta[last].0,
-                frame_meta[last].1,
-                array,
-                frame_meta.len() == 1,
-            );
+            let last = snapshot.frames.len() - 1;
+            let array = self.write_tagged_array(&snapshot.frames[last].boxes);
+            let vable_array = self.write_tagged_array(&snapshot.vable_boxes);
+            let vref_array = self.write_tagged_array(&snapshot.vref_boxes);
+            let jitcode = Self::encode_jitcode_index(snapshot.frames[last].jitcode_index);
+            let pc = i64::from(snapshot.frames[last].pc);
+            let is_last = snapshot.frames.len() == 1;
+            let s = {
+                let trb = self
+                    .trb
+                    .as_mut()
+                    .expect("encode_captured_snapshot requires attach_byte_buffer");
+                trb._total_snapshots += 1;
+                let s = trb._snapshot_data.len() as i64;
+                trb.append_snapshot_data_int(vable_array);
+                trb.append_snapshot_data_int(vref_array);
+                trb._encode_snapshot(jitcode, pc, array, is_last);
+                s
+            };
             for i in (0..last).rev() {
-                let tagged = encode_boxes(trb, &frame_boxes[i]);
-                let array = trb._list_of_boxes(&tagged);
-                trb.create_snapshot(frame_meta[i].0, frame_meta[i].1, array, i == 0);
+                let array = self.write_tagged_array(&snapshot.frames[i].boxes);
+                let jitcode = Self::encode_jitcode_index(snapshot.frames[i].jitcode_index);
+                let pc = i64::from(snapshot.frames[i].pc);
+                self.trb
+                    .as_mut()
+                    .expect("encode_captured_snapshot requires attach_byte_buffer")
+                    .create_snapshot(jitcode, pc, array, i == 0);
             }
             s
         };

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -420,33 +420,30 @@ impl Trace {
         }
     }
 
-    fn box_index_to_opref(&self, box_index: u32) -> OpRef {
+    fn box_index_to_opref(&self, box_index: u32, box_to_unique: &[u32]) -> OpRef {
         let n = self.inputargs.len() as u32;
         if box_index < n {
             return OpRef::input_arg_typed(box_index, self.inputargs[box_index as usize].tp);
         }
-        for (unique, &mapped) in self.unique_to_box.iter().enumerate() {
-            if mapped != box_index {
-                continue;
-            }
-            let unique = unique as u32;
-            if unique < n {
-                return OpRef::input_arg_typed(unique, self.inputargs[unique as usize].tp);
-            }
-            let slot = &self.slots[(unique - n) as usize];
-            return OpRef::op_typed(unique, slot.opcode.result_type());
+        let unique = *box_to_unique.get(box_index as usize).unwrap_or(&u32::MAX);
+        if unique == u32::MAX {
+            panic!("decode snapshot: TAGBOX({box_index}) has no unique OpRef");
         }
-        panic!("decode snapshot: TAGBOX({box_index}) has no unique OpRef")
+        if unique < n {
+            return OpRef::input_arg_typed(unique, self.inputargs[unique as usize].tp);
+        }
+        let slot = &self.slots[(unique - n) as usize];
+        OpRef::op_typed(unique, slot.opcode.result_type())
     }
 
-    fn untag_snapshot(&self, tagged: i64) -> SnapshotTagged {
+    fn untag_snapshot(&self, tagged: i64, box_to_unique: &[u32]) -> SnapshotTagged {
         use crate::opencoder::{TAG_MASK, TAG_SHIFT, TAGBOX, TAGCONSTOTHER, TAGCONSTPTR, TAGINT};
         let tag = (tagged & TAG_MASK as i64) as u8;
         let v = tagged >> TAG_SHIFT;
         match tag {
             TAGBOX => {
                 debug_assert!(v >= 0, "TAGBOX value must be non-negative, got {v}");
-                let opref = self.box_index_to_opref(v as u32);
+                let opref = self.box_index_to_opref(v as u32, box_to_unique);
                 SnapshotTagged::Box(opref, opref.ty().unwrap_or(Type::Int))
             }
             TAGINT => SnapshotTagged::Const(v, Type::Int),
@@ -561,6 +558,16 @@ impl Trace {
     /// Rebuild `Vec<Snapshot>` from `_snapshot_data` in capture order.
     pub fn decode_captured_snapshots(&self) -> Option<Vec<Snapshot>> {
         let trb = self.trb.as_ref()?;
+        let mut box_to_unique = Vec::new();
+        for (unique, &mapped) in self.unique_to_box.iter().enumerate() {
+            if mapped == u32::MAX {
+                continue;
+            }
+            if box_to_unique.len() <= mapped as usize {
+                box_to_unique.resize(mapped as usize + 1, u32::MAX);
+            }
+            box_to_unique[mapped as usize] = unique as u32;
+        }
         let mut out = Vec::with_capacity(self.snapshot_offsets.len());
         for (i, &offset) in self.snapshot_offsets.iter().enumerate() {
             let (vable_t, vref_t, frames_t) = {
@@ -591,16 +598,22 @@ impl Trace {
                     jitcode_index: Self::decode_jitcode_index(jc),
                     pc: pc as u32,
                     py_pc: py_pcs.get(fi).copied().unwrap_or(pc as u32),
-                    boxes: boxes.into_iter().map(|t| self.untag_snapshot(t)).collect(),
+                    boxes: boxes
+                        .into_iter()
+                        .map(|t| self.untag_snapshot(t, &box_to_unique))
+                        .collect(),
                 })
                 .collect();
             out.push(Snapshot {
                 frames,
                 vable_boxes: vable_t
                     .into_iter()
-                    .map(|t| self.untag_snapshot(t))
+                    .map(|t| self.untag_snapshot(t, &box_to_unique))
                     .collect(),
-                vref_boxes: vref_t.into_iter().map(|t| self.untag_snapshot(t)).collect(),
+                vref_boxes: vref_t
+                    .into_iter()
+                    .map(|t| self.untag_snapshot(t, &box_to_unique))
+                    .collect(),
             });
         }
         Some(out)


### PR DESCRIPTION
Follow-up to #1720. Live guards now write `_snapshot_data` the way `opencoder.py capture_resumedata` does — from the framestack — instead of allocating a `Vec<Snapshot>` per guard and encoding it afterwards.

- `publish_last_guard_resume_snapshot` calls `capture_resumedata_from_framestack` when the byte buffer is attached.
- Frame boxes are remapped through `unique_to_box` so TAGBOX indices stay aligned with the live `OpRef` namespace.
- The last-guard descr slot is not patched; sequential resume ids stay on `FrontendSlot.resume`.
- Snapshot decode and the `py_pc` side table use `SmallVec` so typical one-frame snapshots stay off-heap.
- `write_tagged_array` (already on the branch) encodes tagged boxes without an intermediate `Vec<i64>`.

Census on `and`/`or` (1 MiB, row 2, `dynasm,alloc-census,fast-alloc`): 4.5 → 4.1 allocs/char after these cuts. Remaining 256 B/char is compile-time `Rc<Op>` materialization (`TraceIterator.next` / `ResOperation`).

`cargo test --all --no-default-features --features dynasm` passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-point detection during tracing and retracing.
  * Improved resume-data capture for byte-buffer and framestack-based execution paths.
  * Preserved correct guard metadata when creating snapshots.
  * Improved handling of active values during snapshot creation and restoration.
* **Performance**
  * Reduced temporary allocations while encoding and decoding snapshot data.
  * Streamlined snapshot processing for more efficient tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->