### PR TITLE
blackhole: emit raw field/array ops for Int-bank bases

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5907,14 +5907,13 @@ mod tests {
         }
 
         #[test]
-        fn wire_bhimpl_handlers_wires_non_vable_int_base_access_aliases() {
-            // setfield/array int-base forms still exist (FieldWrite /
-            // ArrayRead emit has not been rehomed).  getfield_gc is
-            // Ref-bank only — an Int-bank base is getfield_raw.
+        fn wire_bhimpl_handlers_wires_raw_int_base_access() {
+            // Int-bank field/array access is the raw family, not a
+            // getfield_gc/setfield_gc alias.
             let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
-            insns.insert("setfield_gc_i/iid".to_string(), 0u8);
-            insns.insert("setfield_gc_r/ird".to_string(), 1u8);
-            insns.insert("getarrayitem_gc_i/iid>i".to_string(), 2u8);
+            insns.insert("getfield_raw_i/id>i".to_string(), 0u8);
+            insns.insert("setfield_raw_i/iid".to_string(), 1u8);
+            insns.insert("getarrayitem_raw_i/iid>i".to_string(), 2u8);
 
             let mut builder = BlackholeInterpBuilder::new();
             builder.setup_insns(&insns);
@@ -5934,9 +5933,12 @@ mod tests {
             let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
             insns.insert("getfield_gc_i/id>i".to_string(), 0u8);
             insns.insert("getfield_gc_r/id>r".to_string(), 1u8);
-            insns.insert("getfield_vable_i/id>i".to_string(), 2u8);
-            insns.insert("setfield_vable_i/iid".to_string(), 3u8);
-            insns.insert("setfield_vable_r/ird".to_string(), 4u8);
+            insns.insert("setfield_gc_i/iid".to_string(), 2u8);
+            insns.insert("setfield_gc_r/ird".to_string(), 3u8);
+            insns.insert("getarrayitem_gc_i/iid>i".to_string(), 4u8);
+            insns.insert("getfield_vable_i/id>i".to_string(), 5u8);
+            insns.insert("setfield_vable_i/iid".to_string(), 6u8);
+            insns.insert("setfield_vable_r/ird".to_string(), 7u8);
 
             let mut builder = BlackholeInterpBuilder::new();
             builder.setup_insns(&insns);
@@ -5947,6 +5949,9 @@ mod tests {
                 vec![
                     "getfield_gc_i/id>i",
                     "getfield_gc_r/id>r",
+                    "setfield_gc_i/iid",
+                    "setfield_gc_r/ird",
+                    "getarrayitem_gc_i/iid>i",
                     "getfield_vable_i/id>i",
                     "setfield_vable_i/iid",
                     "setfield_vable_r/ird",
@@ -8584,36 +8589,12 @@ fn handler_setfield_gc_i_c(
     cpu.bh_setfield_gc_i(struct_ptr, value, descr);
     Ok(pos)
 }
-fn handler_setfield_gc_i_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let struct_ptr = bh.registers_i[code[position] as usize];
-    let value = bh.registers_i[code[position + 1] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 2);
-    let cpu = bh.cpu();
-    cpu.bh_setfield_gc_i(struct_ptr, value, descr);
-    Ok(pos)
-}
 fn handler_setfield_gc_r(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     position: usize,
 ) -> Result<usize, DispatchError> {
     let struct_ptr = bh.registers_r[code[position] as usize];
-    let value = bh.registers_r[code[position + 1] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 2);
-    let cpu = bh.cpu();
-    cpu.bh_setfield_gc_r(struct_ptr, majit_ir::GcRef(value as usize), descr);
-    Ok(pos)
-}
-fn handler_setfield_gc_r_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let struct_ptr = bh.registers_i[code[position] as usize];
     let value = bh.registers_r[code[position + 1] as usize];
     let (descr, pos) = read_descr(bh, code, position + 2);
     let cpu = bh.cpu();
@@ -8672,18 +8653,6 @@ fn handler_getarrayitem_gc_i_c(
     let (descr, pos) = read_descr(bh, code, position + 2);
     let result = bh.cpu().bh_getarrayitem_gc_i(array, index, descr);
     bh.registers_i[code[pos] as usize] = result;
-    Ok(pos + 1)
-}
-fn handler_getarrayitem_gc_i_intbase(
-    bh: &mut BlackholeInterpreter,
-    code: &[u8],
-    position: usize,
-) -> Result<usize, DispatchError> {
-    let array = bh.registers_i[code[position] as usize];
-    let index = bh.registers_i[code[position + 1] as usize];
-    let (descr, pos) = read_descr(bh, code, position + 2);
-    let cpu = bh.cpu();
-    bh.registers_i[code[pos] as usize] = cpu.bh_getarrayitem_gc_i(array, index, descr);
     Ok(pos + 1)
 }
 fn handler_getarrayitem_gc_r(
@@ -9967,9 +9936,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // (an int field store, `setfield_gc_i/rid` = BC_SETFIELD_GC_I 0xac)
     // landed on the unwired-opcode placeholder.
     // Canonical `rd`/`r{i,r,f}d` argcodes only (these access fields off a
-    // ref base).  `getfield_gc` intbase (`id`) is no longer a handler;
+    // ref base).  GC intbase (`id`/`iid`) is no longer a handler;
     // `promote_gc_field_bases` rehomes a Signed GC pointer so the
-    // assembler emits `/rd>X`.  Additive: every byte is currently unwired.
+    // assembler emits `/rd>X` / `/rid`.  An Int-bank leftover is the
+    // raw family.  Additive: every byte is currently unwired.
     for (key, byte) in [
         (
             "getfield_gc_i/rd>i",
@@ -10735,19 +10705,15 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("setfield_gc_i/rcd", handler_setfield_gc_i_c);
     builder.wire_handler("setfield_gc_r/rrd", handler_setfield_gc_r);
     builder.wire_handler("setfield_gc_f/rfd", handler_setfield_gc_f);
-    builder.wire_handler("setfield_gc_i/iid", handler_setfield_gc_i_intbase);
-    builder.wire_handler("setfield_gc_r/ird", handler_setfield_gc_r_intbase);
     builder.wire_handler("arraylen_gc/rd>i", handler_arraylen_gc);
 
-    // Array item operations (blackhole.py:1329-1365). The `/iid>i` variant
-    // carries a pyre tagged-int base in an int register — same backend
-    // primitive as the canonical `/rid>i` form, only the base's register
-    // class differs.
+    // Array item operations (`bhimpl_getarrayitem_gc_*`).
+    // The GC form takes the array in the Ref bank.
+    // An Int-bank base is `getarrayitem_raw_*`.
     builder.wire_handler("getarrayitem_gc_i/rid>i", handler_getarrayitem_gc_i);
     builder.wire_handler("getarrayitem_gc_r/rid>r", handler_getarrayitem_gc_r);
     builder.wire_handler("getarrayitem_gc_i/rcd>i", handler_getarrayitem_gc_i_c);
     builder.wire_handler("getarrayitem_gc_r/rcd>r", handler_getarrayitem_gc_r_c);
-    builder.wire_handler("getarrayitem_gc_i/iid>i", handler_getarrayitem_gc_i_intbase);
     builder.wire_handler("getarrayitem_gc_i_pure/rid>i", handler_getarrayitem_gc_i);
     builder.wire_handler("getarrayitem_gc_r_pure/rid>r", handler_getarrayitem_gc_r);
     builder.wire_handler("setarrayitem_gc_i/riid", handler_setarrayitem_gc_i);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1667,13 +1667,12 @@ impl Assembler {
                 pure,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
-                assert_eq!(
-                    kc, 'r',
-                    "getfield_gc base must use the Ref register bank \
-                     (blackhole.py bhimpl_getfield_gc_* @arguments(\"cpu\", \"r\", \"d\", returns=\"X\")); \
-                     an Int-bank base is getfield_raw — graph {:?}",
+                assert!(
+                    kc == 'r' || kc == 'i',
+                    "getfield base must be Ref (gc) or Int (raw), got {kc:?} — graph {:?}",
                     self.current_graph_name,
                 );
+                let is_gc = kc == 'r';
                 state.code.push(reg);
                 argcodes.push(kc);
                 let descr_idx = self.emit_ready_descr(fielddescrof(field, ty, callcontrol));
@@ -1696,8 +1695,22 @@ impl Assembler {
                 } else {
                     'v'
                 };
-                let mut opname = format!("getfield_gc_{result_kind}");
-                if *pure {
+                // `jtransform.py rewrite_op_getfield`: `_gckind == 'raw'`
+                // emits `getfield_raw_*` and strips `_pure`.  A non-pure
+                // `getfield_raw_r` is refused.
+                if !is_gc && result_kind == 'r' && !*pure {
+                    panic!(
+                        "getfield_raw_r (without _pure) not supported \
+                         (jtransform.py rewrite_op_getfield) — graph {:?}",
+                        self.current_graph_name,
+                    );
+                }
+                let mut opname = if is_gc {
+                    format!("getfield_gc_{result_kind}")
+                } else {
+                    format!("getfield_raw_{result_kind}")
+                };
+                if is_gc && *pure {
                     opname.push_str("_pure");
                 }
                 let key = format!("{opname}/{argcodes}");
@@ -2013,6 +2026,12 @@ impl Assembler {
                 ty,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
+                assert!(
+                    kc == 'r' || kc == 'i',
+                    "setfield base must be Ref (gc) or Int (raw), got {kc:?} — graph {:?}",
+                    self.current_graph_name,
+                );
+                let is_gc = kc == 'r';
                 state.code.push(reg);
                 argcodes.push(kc);
                 // RPython `bhimpl_setfield_gc_{i,r,f}` canonical keys key
@@ -2028,6 +2047,7 @@ impl Assembler {
                 // (`/rid`) when wide (`assembler.py:99-107`, `setfield_gc`
                 // ∈ USE_C_FORM at `assembler.py`); a ref/float Constant
                 // takes its pooled `r`/`f` byte (`assembler.py:168`).
+                // `setfield_raw_*` is not in USE_C_FORM.
                 let value_kind = match value {
                     crate::model::LinkArg::Value(var) => {
                         let (reg, kc) = self.lookup_reg_with_kind_var(var, regallocs);
@@ -2040,7 +2060,11 @@ impl Assembler {
                         if kind == 'i' {
                             let (byte, argcode) = self.emit_const_i_from_const_allow_short(
                                 &c.value,
-                                use_c_form("setfield_gc_i"),
+                                use_c_form(if is_gc {
+                                    "setfield_gc_i"
+                                } else {
+                                    "setfield_raw_i"
+                                }),
                                 state,
                                 callcontrol,
                             );
@@ -2054,11 +2078,22 @@ impl Assembler {
                         kind
                     }
                 };
+                if !is_gc && value_kind == 'r' {
+                    panic!(
+                        "setfield_raw_r not supported (jtransform.py rewrite_op_setfield) \
+                         — graph {:?}",
+                        self.current_graph_name,
+                    );
+                }
                 let descr_idx = self.emit_ready_descr(fielddescrof(field, ty, callcontrol));
                 state.code.push((descr_idx & 0xFF) as u8);
                 state.code.push((descr_idx >> 8) as u8);
                 argcodes.push('d');
-                let opname = format!("setfield_gc_{value_kind}");
+                let opname = if is_gc {
+                    format!("setfield_gc_{value_kind}")
+                } else {
+                    format!("setfield_raw_{value_kind}")
+                };
                 let key = format!("{opname}/{argcodes}");
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
@@ -2172,6 +2207,12 @@ impl Assembler {
                 pure,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
+                assert!(
+                    kc == 'r' || kc == 'i',
+                    "getarrayitem base must be Ref (gc) or Int (raw), got {kc:?} — graph {:?}",
+                    self.current_graph_name,
+                );
+                let is_gc = kc == 'r';
                 state.code.push(reg);
                 argcodes.push(kc);
                 let (reg, kc) = self.lookup_reg_with_kind_var(index, regallocs);
@@ -2221,15 +2262,27 @@ impl Assembler {
                 } else {
                     'v'
                 };
+                // `jtransform.py rewrite_op_getarrayitem`: `_gckind != 'gc'`
+                // emits `getarrayitem_raw_*` and strips `_pure`.  A
+                // `getarrayitem_raw_r` is refused.
+                if !is_gc && result_kind == 'r' {
+                    panic!(
+                        "getarrayitem_raw_r not supported \
+                         (jtransform.py rewrite_op_getarrayitem) — graph {:?}",
+                        self.current_graph_name,
+                    );
+                }
                 // `getarrayitem_gc_{i,r,f}_pure` for a foldable/immutable
                 // element load (`ll_getitem_foldable_nonneg`, rlist.py);
                 // `blackhole.py:1339-1341` aliases `bhimpl_getarrayitem_gc_*_pure
                 // = bhimpl_getarrayitem_gc_*`, so the `rid>X` argcodes are
                 // identical to the non-pure form — only the opname differs.
-                let opname = if *pure {
+                let opname = if is_gc && *pure {
                     format!("getarrayitem_gc_{result_kind}_pure")
-                } else {
+                } else if is_gc {
                     format!("getarrayitem_gc_{result_kind}")
+                } else {
+                    format!("getarrayitem_raw_{result_kind}")
                 };
                 let key = format!("{opname}/{argcodes}");
                 let opnum = self.get_opnum(&key);
@@ -2244,6 +2297,12 @@ impl Assembler {
                 nolength,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
+                assert!(
+                    kc == 'r' || kc == 'i',
+                    "setarrayitem base must be Ref (gc) or Int (raw), got {kc:?} — graph {:?}",
+                    self.current_graph_name,
+                );
+                let is_gc = kc == 'r';
                 state.code.push(reg);
                 argcodes.push(kc);
                 let (reg, kc) = self.lookup_reg_with_kind_var(index, regallocs);
@@ -2279,7 +2338,11 @@ impl Assembler {
                         if kind == 'i' {
                             let (byte, argcode) = self.emit_const_i_from_const_allow_short(
                                 &c.value,
-                                use_c_form("setarrayitem_gc_i"),
+                                use_c_form(if is_gc {
+                                    "setarrayitem_gc_i"
+                                } else {
+                                    "setarrayitem_raw_i"
+                                }),
                                 state,
                                 callcontrol,
                             );
@@ -2310,9 +2373,20 @@ impl Assembler {
                 state.code.push((descr_idx & 0xFF) as u8);
                 state.code.push((descr_idx >> 8) as u8);
                 argcodes.push('d');
+                if !is_gc && value_kind == 'r' {
+                    panic!(
+                        "setarrayitem_raw_r not supported \
+                         (jtransform.py rewrite_op_setarrayitem) — graph {:?}",
+                        self.current_graph_name,
+                    );
+                }
                 // RPython `bhimpl_setarrayitem_gc_{i,r,f}` keys off the
                 // value register's kind — same rationale as setfield_gc_*.
-                let opname = format!("setarrayitem_gc_{value_kind}");
+                let opname = if is_gc {
+                    format!("setarrayitem_gc_{value_kind}")
+                } else {
+                    format!("setarrayitem_raw_{value_kind}")
+                };
                 let key = format!("{opname}/{argcodes}");
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
@@ -2328,6 +2402,16 @@ impl Assembler {
                 nolength,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
+                // `jtransform.py rewrite_op_getarraysize` asserts
+                // `ARRAY._gckind == 'gc'`.  An Int-bank base is not
+                // `arraylen_gc`.
+                assert_eq!(
+                    kc, 'r',
+                    "arraylen_gc base must use the Ref register bank \
+                     (blackhole.py bhimpl_arraylen_gc @arguments(\"cpu\", \"r\", \"d\", returns=\"i\")) \
+                     — graph {:?}",
+                    self.current_graph_name,
+                );
                 state.code.push(reg);
                 argcodes.push(kc);
                 let len_offset = if *nolength { None } else { Some(0) };
@@ -7722,11 +7806,10 @@ mod tests {
         }
     }
 
-    /// `bhimpl_getfield_gc_*` declares the struct as `r`.  An Int-bank
-    /// base is `getfield_raw`, not a GC field load.
+    /// An Int-bank FieldRead is `getfield_raw`, matching
+    /// `jtransform.py rewrite_op_getfield` `_gckind == 'raw'`.
     #[test]
-    #[should_panic(expected = "getfield_gc base must use the Ref register bank")]
-    fn assemble_rejects_int_bank_getfield_gc_base() {
+    fn assemble_int_bank_field_read_emits_getfield_raw() {
         use crate::flatten::flatten_graph;
         use crate::model::{FieldDescriptor, FunctionGraph, OpKind, ValueType};
 
@@ -7759,6 +7842,16 @@ mod tests {
         let mut flat = flatten_graph(&graph, &mut regallocs);
         let mut asm = Assembler::new();
         let _ = asm.assemble(&mut flat, &regallocs);
+        assert!(
+            asm.insns.contains_key("getfield_raw_i/id>i"),
+            "Int-bank FieldRead must assemble as getfield_raw_i/id>i, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !asm.insns.keys().any(|k| k.starts_with("getfield_gc_")),
+            "Int-bank FieldRead must not emit getfield_gc, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
     }
 
     /// `promote_gc_field_bases` rehomes a Signed GC FieldRead base so

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -195,16 +195,22 @@ pub(crate) fn authoritative_result_types(graph: &FunctionGraph) -> HashMap<Varia
 /// address-sized word).  The assembler then keys the first argcode off
 /// that bank and emits the pyre-only `getfield_gc_*/id>X` form.
 ///
-/// Walk every surviving `FieldRead`/`FieldWrite` of a GC owner
-/// (unknown owner defaults to `_gckind='gc'`, matching
-/// `jtransform.py rewrite_op_getfield`'s `getattr(STRUCT, '_gckind',
-/// 'gc')`) and publish `GcRef` on a `Signed`/`Unknown`/`Void` base.
+/// Walk every surviving GC field/array access (unknown owner defaults
+/// to `_gckind='gc'`, matching `jtransform.py rewrite_op_getfield`'s
+/// `getattr(STRUCT, '_gckind', 'gc')`) and publish `GcRef` on a
+/// `Signed`/`Unknown`/`Void` base.
 ///
 /// Raw owners (`CallControl::struct_storage_for` →
 /// `is_gc_managed=false`) are left alone: a `Signed` base stays an
-/// address, a `GcRef` base stays a Ref-banked raw struct (`PyType` /
-/// `CLASSTYPE` travels through the Ref bank even though its storage
-/// is not a GC object).
+/// address (`getfield_raw` / `setfield_raw`), a `GcRef` base stays a
+/// Ref-banked raw struct (`PyType` / `CLASSTYPE` travels through the
+/// Ref bank even though its storage is not a GC object).
+///
+/// `ArrayRead` / `ArrayWrite` / `ArrayLen` are the GC-array family
+/// (`jtransform.py` emits `getarrayitem_gc` / `arraylen_gc` only when
+/// `ARRAY._gckind == 'gc'`; raw arrays go through `raw_load` /
+/// `getarrayitem_raw`).  A Signed base on those ops is the same
+/// mis-banked GC pointer FieldRead had.
 pub(crate) fn promote_gc_field_bases(
     graph: &FunctionGraph,
     callcontrol: Option<&crate::call::CallControl>,
@@ -215,25 +221,33 @@ pub(crate) fn promote_gc_field_bases(
                 OpKind::FieldRead { base, field, .. } | OpKind::FieldWrite { base, field, .. } => {
                     (base, field_owner_is_gc(field, callcontrol))
                 }
-                OpKind::VableFieldRead { base, .. } | OpKind::VableFieldWrite { base, .. } => {
-                    (base, true)
-                }
+                OpKind::VableFieldRead { base, .. }
+                | OpKind::VableFieldWrite { base, .. }
+                | OpKind::ArrayRead { base, .. }
+                | OpKind::ArrayWrite { base, .. }
+                | OpKind::ArrayLen { base, .. }
+                | OpKind::VableArrayRead { base, .. }
+                | OpKind::VableArrayWrite { base, .. }
+                | OpKind::VableArrayLen { base, .. } => (base, true),
                 _ => continue,
             };
             if !force_gc {
                 continue;
             }
-            match FunctionGraph::concretetype_of(base) {
-                ConcreteType::GcRef => {}
-                ConcreteType::Float => panic!(
-                    "GC field base {base:?} has Float concretetype — \
-                     history.getkind(Ptr(GC)) is 'ref' (graph {})",
-                    graph.name
-                ),
-                ConcreteType::Signed | ConcreteType::Unknown | ConcreteType::Void => {
-                    FunctionGraph::set_concretetype_of_inline(base, ConcreteType::GcRef);
-                }
-            }
+            stamp_gc_ref_base(base, &graph.name);
+        }
+    }
+}
+
+fn stamp_gc_ref_base(base: &crate::flowspace::model::Variable, graph_name: &str) {
+    match FunctionGraph::concretetype_of(base) {
+        ConcreteType::GcRef => {}
+        ConcreteType::Float => panic!(
+            "GC field/array base {base:?} has Float concretetype — \
+             history.getkind(Ptr(GC)) is 'ref' (graph {graph_name})"
+        ),
+        ConcreteType::Signed | ConcreteType::Unknown | ConcreteType::Void => {
+            FunctionGraph::set_concretetype_of_inline(base, ConcreteType::GcRef);
         }
     }
 }
@@ -301,6 +315,37 @@ mod tests {
             FunctionGraph::concretetype_of(&base),
             ConcreteType::GcRef,
             "a GC FieldRead base that arrived as Signed must be published as GcRef"
+        );
+    }
+
+    #[test]
+    fn promote_gc_field_bases_lifts_a_signed_array_read_base() {
+        let mut graph = FunctionGraph::new("int_base_getarrayitem");
+        let base = push_input(&mut graph, "arr", ValueType::Int);
+        let index = push_input(&mut graph, "i", ValueType::Int);
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::ArrayRead {
+                    base: base.clone(),
+                    index,
+                    item_ty: ValueType::Int,
+                    array_type_id: None,
+                    nolength: false,
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(result));
+        FunctionGraph::set_concretetype_of_inline(&base, ConcreteType::Signed);
+
+        promote_gc_field_bases(&graph, None);
+
+        assert_eq!(
+            FunctionGraph::concretetype_of(&base),
+            ConcreteType::GcRef,
+            "a GC ArrayRead base that arrived as Signed must be published as GcRef"
         );
     }
 


### PR DESCRIPTION
## Summary

- promote GC `ArrayRead`/`ArrayWrite`/`ArrayLen` bases to `GcRef` before regalloc
- assemble leftover Int-bank field/array accesses as `getfield_raw_*` / `setfield_raw_*` / `getarrayitem_raw_*` (`jtransform.py` `_gckind == 'raw'`)
- drop the `setfield_gc` / `getarrayitem_gc` intbase handlers

## Validation

- `cargo test --all --no-default-features --features dynasm`