### PR TITLE
metainterp: take extra-ops and skip serialize Vecs

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -74,7 +74,7 @@ pub fn serialize_optimizer_knowledge(
     // membership set (values are always None). Pyre uses a Vec scanned
     // linearly: the no-HashMap rule precludes a hash-backed mirror, and
     // available_boxes per bridge is bounded by the live-box set.
-    let available_boxes: Vec<OpRef> = liveboxes
+    let available_boxes: smallvec::SmallVec<[OpRef; 16]> = liveboxes
         .iter()
         .filter_map(|opt| *opt)
         // #160: liveboxes is box-keyed; resolve each backend position to
@@ -149,61 +149,66 @@ pub fn serialize_optimizer_knowledge(
         return Ok(());
     };
     // bridgeopt.py:93: triples_struct = optimizer.optheap.serialize_optheap(available_boxes)
-    let filtered_fields: Vec<(OpRef, i32, OpRef)> = knowledge
-        .heap_fields
-        .iter()
-        .copied()
-        .filter(|&(obj, _, val)| {
-            let obj_ok = env.is_const(obj) || available_boxes.contains(&obj);
-            let val_ok = env.is_const(val) || available_boxes.contains(&val);
-            obj_ok && val_ok
-        })
-        .collect();
-    numb_state.append_int(filtered_fields.len() as i64);
-    for (obj, descr_idx, val) in &filtered_fields {
-        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
+    let field_ok = |obj: OpRef, val: OpRef| {
+        (env.is_const(obj) || available_boxes.contains(&obj))
+            && (env.is_const(val) || available_boxes.contains(&val))
+    };
+    numb_state.append_int(
+        knowledge
+            .heap_fields
+            .iter()
+            .filter(|&&(obj, _, val)| field_ok(obj, val))
+            .count() as i64,
+    );
+    for &(obj, descr_idx, val) in &knowledge.heap_fields {
+        if !field_ok(obj, val) {
+            continue;
+        }
+        let obj_tag = tag_box(obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(obj_tag as i32);
-        numb_state.append_int(*descr_idx as i64);
-        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
+        numb_state.append_int(descr_idx as i64);
+        let val_tag = tag_box(val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(val_tag as i32);
     }
     // bridgeopt.py:102-108: array items
-    let filtered_arrayitems: Vec<(OpRef, i64, i32, OpRef)> = knowledge
-        .heap_arrayitems
-        .iter()
-        .copied()
-        .filter(|&(obj, _, _, val)| {
-            let obj_ok = env.is_const(obj) || available_boxes.contains(&obj);
-            let val_ok = env.is_const(val) || available_boxes.contains(&val);
-            obj_ok && val_ok
-        })
-        .collect();
-    numb_state.append_int(filtered_arrayitems.len() as i64);
-    for (obj, index, descr_idx, val) in &filtered_arrayitems {
-        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
+    numb_state.append_int(
+        knowledge
+            .heap_arrayitems
+            .iter()
+            .filter(|&&(obj, _, _, val)| field_ok(obj, val))
+            .count() as i64,
+    );
+    for &(obj, index, descr_idx, val) in &knowledge.heap_arrayitems {
+        if !field_ok(obj, val) {
+            continue;
+        }
+        let obj_tag = tag_box(obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(obj_tag as i32);
         // bridgeopt.py:106 numb_state.append_int(index) — pass the original
         // index unchanged; resumecode.py:90-93 enforces SHORT range on the
         // i64 value, panicking instead of silently wrapping a too-large
         // index into an i32.
-        numb_state.append_int(*index);
-        numb_state.append_int(*descr_idx as i64);
-        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
+        numb_state.append_int(index);
+        numb_state.append_int(descr_idx as i64);
+        let val_tag = tag_box(val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(val_tag as i32);
     }
 
     // bridgeopt.py:113-122: loopinvariant results
-    let filtered_loopinvariant: Vec<(i64, OpRef)> = knowledge
-        .loopinvariant_results
-        .iter()
-        .copied()
-        .filter(|&(_, result)| env.is_const(result) || available_boxes.contains(&result))
-        .collect();
-    numb_state.append_int(filtered_loopinvariant.len() as i64);
-    for (const_ptr, result) in &filtered_loopinvariant {
-        let const_tag = memo.getconst_int(*const_ptr)?;
+    numb_state.append_int(
+        knowledge
+            .loopinvariant_results
+            .iter()
+            .filter(|&&(_, result)| env.is_const(result) || available_boxes.contains(&result))
+            .count() as i64,
+    );
+    for &(const_ptr, result) in &knowledge.loopinvariant_results {
+        if !(env.is_const(result) || available_boxes.contains(&result)) {
+            continue;
+        }
+        let const_tag = memo.getconst_int(const_ptr)?;
         numb_state.writer.append_short(const_tag as i32);
-        let result_tag = tag_box(*result, &numb_state.liveboxes, memo, env, new_liveboxes)?;
+        let result_tag = tag_box(result, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(result_tag as i32);
     }
     Ok(())

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4669,10 +4669,9 @@ impl Optimizer {
         _start_pass: usize,
         ctx: &mut OptContext,
     ) -> Result<(), crate::optimize::InvalidLoop> {
-        let mut pending = std::collections::VecDeque::new();
-        while let Some((start, op)) = ctx.extra_operations_after.pop_front() {
-            pending.push_back((start, op));
-        }
+        // RPython `send_extra_operation` walks the list in place. Take the
+        // queued deque instead of copying each entry into a fresh one.
+        let pending = std::mem::take(&mut ctx.extra_operations_after);
         // The level is parked on the context so `flush_queued_producer` can
         // pull one entry out of it; this function runs nested inside itself
         // (`propagate_from_pass_range` drains after every pass), and only the

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -373,6 +373,10 @@ impl Trace {
             trb.record_input_arg(ia.tp);
         }
         self.unique_to_box = (0..n).collect();
+        // Bridge traces are tens of ops; grow the maps once instead of
+        // doubling through the 16/32/64-byte size classes on every record.
+        self.unique_to_box.reserve(128);
+        self.slots.reserve(128);
         self.trb = Some(Box::new(trb));
     }
 


### PR DESCRIPTION
Follow-up to #1746. The optimizer drain copied `extra_operations_after` into a fresh `VecDeque` on every pass; RPython `send_extra_operation` walks the list in place. `serialize_optimizer_knowledge` now walks heap/loopinvariant lists without intermediate `Vec`s (`bridgeopt.py`). The live byte recorder reserves slot maps so they do not double through the 16/32/64-byte size classes on every recorded op.

Census on `and`/`or` (1 MiB, row 2): 64 B 0.58 → 0.54 allocs/char. Total still 4.1 allocs / ~780 B/char; the remaining 256 B class is compile-time `Rc<Op>` (`TraceIterator.next`).

`cargo test -p majit-metainterp --no-default-features --features dynasm --lib -- extra_operations serialize_optimizer snapshot` and braininterp (8) passed locally.