### PR TITLE
wasm: zero recycled CA frames on the bump path

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2434,8 +2434,9 @@ fn emit_ca_malloc_cond_varsize_frame(
     alloc_size_local: u32,
 ) {
     use majit_backend::jitframe::{
-        FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
-        JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JITFRAME_FIXED_SIZE, SIZEOFSIGNED,
+        FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_INFO_OFS,
+        JF_FRAME_OFS, JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JITFRAME_FIXED_SIZE,
+        SIZEOFSIGNED,
     };
     let word = SIZEOFSIGNED as i32;
     let ss_word = std::mem::size_of::<usize>() as i32;
@@ -2511,9 +2512,15 @@ fn emit_ca_malloc_cond_varsize_frame(
     sink.i32_const(hdr);
     sink.i32_add();
     sink.local_set(alloc_scratch_local);
+    // Recycled nursery bytes do not start null. `JitFrame::init` and
+    // `wasm_jit_ca_alloc_frame` write a null `jf_frame_info`; PyPy's
+    // `handle_call_assembler` then stores `llfi`. This path has no
+    // frame-info pointer on the dispatch entry, so write null.
+    sink.local_get(alloc_scratch_local);
+    sink.i64_const(0);
+    emit_word_store(sink, JF_FRAME_INFO_OFS as u64);
     // rewrite.py `gen_malloc_frame`: zero the GCREF fields because of
-    // the unusual malloc pattern. `jf_frame_info` is raw and stays
-    // null here the way `JitFrame::init` leaves it.
+    // the unusual malloc pattern.
     for ofs in [
         JF_SAVEDATA_OFS,
         JF_FORCE_DESCR_OFS,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2391,10 +2391,6 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
     sink.i32_add();
 }
 
-fn emit_word_zero(sink: &mut PeepSink<'_, '_>) {
-    sink.i64_const(0);
-}
-
 fn emit_word_store(sink: &mut PeepSink<'_, '_>, offset: u64) {
     if majit_backend::jitframe::SIZEOFSIGNED == 4 {
         sink.i32_wrap_i64();
@@ -2437,10 +2433,7 @@ fn emit_ca_malloc_cond_varsize_frame(
     alloc_scratch_local: u32,
     alloc_size_local: u32,
 ) {
-    use majit_backend::jitframe::{
-        JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_INFO_OFS, JF_FRAME_OFS,
-        JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JITFRAME_FIXED_SIZE, SIZEOFSIGNED,
-    };
+    use majit_backend::jitframe::{JF_FRAME_OFS, JF_GCMAP_OFS, JITFRAME_FIXED_SIZE, SIZEOFSIGNED};
     let word = SIZEOFSIGNED as i32;
     let ss_word = std::mem::size_of::<usize>() as i32;
     let hdr = GcHeader::SIZE as i32;
@@ -2515,21 +2508,20 @@ fn emit_ca_malloc_cond_varsize_frame(
     sink.i32_const(hdr);
     sink.i32_add();
     sink.local_set(alloc_scratch_local);
-    // rewrite.rs after `gen_malloc_nursery_varsize_frame`: tid is already
-    // in the header; zero the GCREF fields `jitframe_allocate` leaves
-    // empty, write `jf_frame_info` / length / `jf_gcmap`.
-    for ofs in [
-        JF_FRAME_INFO_OFS,
-        JF_DESCR_OFS,
-        JF_FORCE_DESCR_OFS,
-        JF_SAVEDATA_OFS,
-        JF_GUARD_EXC_OFS,
-        JF_FORWARD_OFS,
-    ] {
-        sink.local_get(alloc_scratch_local);
-        emit_word_zero(sink);
-        emit_word_store(sink, ofs as u64);
-    }
+    // The bump returns recycled nursery bytes. We install `jf_gcmap`
+    // before the callee writes its homes, so those slots must be null
+    // or `jitframe_trace` walks leftover pointers
+    // (`invalid type_id` in `copy_nursery_object`). rewrite.py
+    // `clear_gc_fields` plus a zero `jf_frame` cover that; the helper
+    // path gets the same from `alloc_with_type` on a reset nursery.
+    sink.local_get(alloc_scratch_local);
+    sink.i32_const(0);
+    sink.local_get(alloc_size_local);
+    sink.i32_const(hdr);
+    sink.i32_sub();
+    sink.memory_fill(0);
+    // rewrite.rs after `gen_malloc_nursery_varsize_frame`: write
+    // `jf_frame` length and `jf_gcmap` over the cleared payload.
     sink.local_get(alloc_scratch_local);
     sink.local_get(ca_target_local);
     sink.i64_load32_u(memarg(crate::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS, 2));

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2433,7 +2433,10 @@ fn emit_ca_malloc_cond_varsize_frame(
     alloc_scratch_local: u32,
     alloc_size_local: u32,
 ) {
-    use majit_backend::jitframe::{JF_FRAME_OFS, JF_GCMAP_OFS, JITFRAME_FIXED_SIZE, SIZEOFSIGNED};
+    use majit_backend::jitframe::{
+        FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
+        JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JITFRAME_FIXED_SIZE, SIZEOFSIGNED,
+    };
     let word = SIZEOFSIGNED as i32;
     let ss_word = std::mem::size_of::<usize>() as i32;
     let hdr = GcHeader::SIZE as i32;
@@ -2508,20 +2511,22 @@ fn emit_ca_malloc_cond_varsize_frame(
     sink.i32_const(hdr);
     sink.i32_add();
     sink.local_set(alloc_scratch_local);
-    // The bump returns recycled nursery bytes. We install `jf_gcmap`
-    // before the callee writes its homes, so those slots must be null
-    // or `jitframe_trace` walks leftover pointers
-    // (`invalid type_id` in `copy_nursery_object`). rewrite.py
-    // `clear_gc_fields` plus a zero `jf_frame` cover that; the helper
-    // path gets the same from `alloc_with_type` on a reset nursery.
-    sink.local_get(alloc_scratch_local);
-    sink.i32_const(0);
-    sink.local_get(alloc_size_local);
-    sink.i32_const(hdr);
-    sink.i32_sub();
-    sink.memory_fill(0);
+    // rewrite.py `gen_malloc_frame`: zero the GCREF fields because of
+    // the unusual malloc pattern. `jf_frame_info` is raw and stays
+    // null here the way `JitFrame::init` leaves it.
+    for ofs in [
+        JF_SAVEDATA_OFS,
+        JF_FORCE_DESCR_OFS,
+        JF_DESCR_OFS,
+        JF_GUARD_EXC_OFS,
+        JF_FORWARD_OFS,
+    ] {
+        sink.local_get(alloc_scratch_local);
+        sink.i64_const(0);
+        emit_word_store(sink, ofs as u64);
+    }
     // rewrite.rs after `gen_malloc_nursery_varsize_frame`: write
-    // `jf_frame` length and `jf_gcmap` over the cleared payload.
+    // `jf_frame` length and `jf_gcmap`.
     sink.local_get(alloc_scratch_local);
     sink.local_get(ca_target_local);
     sink.i64_load32_u(memarg(crate::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS, 2));
@@ -2534,6 +2539,20 @@ fn emit_ca_malloc_cond_varsize_frame(
     sink.local_get(ca_target_local);
     sink.i64_load(mem64(crate::failguard::WASM_CA_TARGET_GCMAP_PTR_OFS));
     emit_word_store(sink, JF_GCMAP_OFS as u64);
+    // `build_callee_gcmap` is installed now, before the callee prologue
+    // writes homes. Host MiniMarkGC reset does not zero
+    // (`malloc_zero_filled = False`; the wasm32 fill is guest-only), so
+    // `jitframe_trace` would walk leftover item pointers. PyPy never
+    // does this fill: its assembler writes `jf_gcmap` at safepoints
+    // once those slots are live.
+    sink.local_get(alloc_scratch_local);
+    sink.i32_const(FIRST_ITEM_OFFSET as i32);
+    sink.i32_add();
+    sink.i32_const(0);
+    sink.local_get(ca_target_local);
+    sink.i64_load32_u(memarg(crate::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS, 2));
+    sink.i32_wrap_i64();
+    sink.memory_fill(0);
     // assembler.py `_call_header_shadowstack`: [is_minor=1, jf_ptr], then
     // advance top by 2*WORD.
     sink.i32_const(inline.jf_top_addr as i32);

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -136,10 +136,9 @@ fn stat_value(stderr: &str, name: &str) -> u64 {
 ///
 /// - Entry prologues clear the current frame's GC Ref homes. #1683
 ///   coalesces those stores into `memory.fill` on local 0.
-/// - The inline `malloc_cond_varsize_frame` bump returns recycled
-///   nursery bytes, so it `memory.fill`s `total - HDR` at the payload
-///   (rewrite.py `clear_gc_fields` plus a zero `jf_frame`). The helper
-///   path still arrives already zero from a reset nursery.
+/// - The inline bump installs `build_callee_gcmap` before the callee
+///   writes homes, so it `memory.fill`s the `jf_frame` items. rewrite.py
+///   `gen_malloc_frame` only nulls the five GCREF header fields.
 #[track_caller]
 fn assert_no_call_assembler_frame_fill(stderr: &str) {
     let lines: Vec<_> = stderr.lines().map(str::trim).collect();
@@ -153,13 +152,16 @@ fn assert_no_call_assembler_frame_fill(stderr: &str) {
             && lines[index - 3] == "i32.add"
             && lines[index - 2] == "i32.const 0"
             && lines[index - 1].starts_with("i32.const ");
-        let is_ca_payload_zero = index >= 4
+        let is_ca_item_zero = index >= 7
+            && lines[index - 7].starts_with("local.get ")
+            && lines[index - 6].starts_with("i32.const ")
+            && lines[index - 5] == "i32.add"
             && lines[index - 4] == "i32.const 0"
             && lines[index - 3].starts_with("local.get ")
-            && lines[index - 2] == "i32.const 8"
-            && lines[index - 1] == "i32.sub";
+            && lines[index - 2].starts_with("i64.load32_u")
+            && lines[index - 1] == "i32.wrap_i64";
         assert!(
-            is_entry_home_clear || is_ca_payload_zero,
+            is_entry_home_clear || is_ca_item_zero,
             "recursive CA refilled a nursery frame instead of relying on its zeroed payload:\n{stderr}"
         );
     }
@@ -2091,7 +2093,7 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
     );
     assert!(
         saw_payload_fill,
-        "malloc_cond_varsize_frame must memory.fill the recycled payload"
+        "malloc_cond_varsize_frame must memory.fill the jf_frame items"
     );
 }
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -131,10 +131,15 @@ fn stat_value(stderr: &str, name: &str) -> u64 {
         .unwrap_or_else(|err| panic!("invalid {name}= in wasm JIT stats: {err}\n{stderr}"))
 }
 
-/// The CALL_ASSEMBLER frame allocator returns a zeroed payload, so codegen
-/// must not clear that fresh frame again.  Entry prologues separately clear
-/// the current frame's GC Ref homes; #1683 deliberately coalesces those stores
-/// into `memory.fill`, identified by their local-0 (current frame) base.
+/// CALL_ASSEMBLER must not refill a frame the allocator already zeroed.
+/// Two fills are expected:
+///
+/// - Entry prologues clear the current frame's GC Ref homes. #1683
+///   coalesces those stores into `memory.fill` on local 0.
+/// - The inline `malloc_cond_varsize_frame` bump returns recycled
+///   nursery bytes, so it `memory.fill`s `total - HDR` at the payload
+///   (rewrite.py `clear_gc_fields` plus a zero `jf_frame`). The helper
+///   path still arrives already zero from a reset nursery.
 #[track_caller]
 fn assert_no_call_assembler_frame_fill(stderr: &str) {
     let lines: Vec<_> = stderr.lines().map(str::trim).collect();
@@ -148,8 +153,13 @@ fn assert_no_call_assembler_frame_fill(stderr: &str) {
             && lines[index - 3] == "i32.add"
             && lines[index - 2] == "i32.const 0"
             && lines[index - 1].starts_with("i32.const ");
+        let is_ca_payload_zero = index >= 4
+            && lines[index - 4] == "i32.const 0"
+            && lines[index - 3].starts_with("local.get ")
+            && lines[index - 2] == "i32.const 8"
+            && lines[index - 1] == "i32.sub";
         assert!(
-            is_entry_home_clear,
+            is_entry_home_clear || is_ca_payload_zero,
             "recursive CA refilled a nursery frame instead of relying on its zeroed payload:\n{stderr}"
         );
     }
@@ -2066,14 +2076,22 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
         .0;
     validate_wasm(&bytes);
     let mut saw_nursery_free = false;
+    let mut saw_payload_fill = false;
     count_operators(&bytes, |op| {
         if matches!(op, wasmparser::Operator::I32Const { value } if *value == nursery_free as i32) {
             saw_nursery_free = true;
+        }
+        if matches!(op, wasmparser::Operator::MemoryFill { .. }) {
+            saw_payload_fill = true;
         }
     });
     assert!(
         saw_nursery_free,
         "malloc_cond_varsize_frame must load nursery_free"
+    );
+    assert!(
+        saw_payload_fill,
+        "malloc_cond_varsize_frame must memory.fill the recycled payload"
     );
 }
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -152,13 +152,20 @@ fn assert_no_call_assembler_frame_fill(stderr: &str) {
             && lines[index - 3] == "i32.add"
             && lines[index - 2] == "i32.const 0"
             && lines[index - 1].starts_with("i32.const ");
+        // Guest traces are wasm32: JitFrame is seven pointer fields plus
+        // the Signed length word, so FIRST_ITEM_OFFSET is 32. The length
+        // load is `WasmCaRuntimeTarget.callee_frame_bytes`.
+        let frame_bytes_load = format!(
+            "i64.load32_u offset={}",
+            majit_backend_wasm::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS
+        );
         let is_ca_item_zero = index >= 7
             && lines[index - 7].starts_with("local.get ")
-            && lines[index - 6].starts_with("i32.const ")
+            && lines[index - 6] == "i32.const 32"
             && lines[index - 5] == "i32.add"
             && lines[index - 4] == "i32.const 0"
             && lines[index - 3].starts_with("local.get ")
-            && lines[index - 2].starts_with("i64.load32_u")
+            && lines[index - 2] == frame_bytes_load
             && lines[index - 1] == "i32.wrap_i64";
         assert!(
             is_entry_home_clear || is_ca_item_zero,
@@ -2078,13 +2085,29 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
         .0;
     validate_wasm(&bytes);
     let mut saw_nursery_free = false;
-    let mut saw_payload_fill = false;
+    let mut saw_first_item = false;
+    let mut saw_frame_bytes_load = false;
+    let mut saw_item_fill = false;
     count_operators(&bytes, |op| {
         if matches!(op, wasmparser::Operator::I32Const { value } if *value == nursery_free as i32) {
             saw_nursery_free = true;
         }
+        if matches!(
+            op,
+            wasmparser::Operator::I32Const { value }
+                if *value == majit_backend::jitframe::FIRST_ITEM_OFFSET as i32
+        ) {
+            saw_first_item = true;
+        }
+        if matches!(
+            op,
+            wasmparser::Operator::I64Load32U { memarg }
+                if memarg.offset == majit_backend_wasm::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS
+        ) {
+            saw_frame_bytes_load = true;
+        }
         if matches!(op, wasmparser::Operator::MemoryFill { .. }) {
-            saw_payload_fill = true;
+            saw_item_fill = true;
         }
     });
     assert!(
@@ -2092,8 +2115,8 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
         "malloc_cond_varsize_frame must load nursery_free"
     );
     assert!(
-        saw_payload_fill,
-        "malloc_cond_varsize_frame must memory.fill the jf_frame items"
+        saw_first_item && saw_frame_bytes_load && saw_item_fill,
+        "malloc_cond_varsize_frame must memory.fill jf_frame items from FIRST_ITEM_OFFSET for frame_bytes"
     );
 }
 


### PR DESCRIPTION
## Summary

#1743 inlined `malloc_cond_varsize_frame` for CALL_ASSEMBLER frames. The helper path (`wasm_jit_ca_alloc_frame` / `alloc_nursery_typed`) still arrives on a reset nursery, so leftover GCREF words are already null. The bump returns recycled nursery bytes, and we install `jf_gcmap` before the callee writes homes. `jitframe_trace` then walks leftover pointers and `copy_nursery_object` panics with `invalid type_id`.

rewrite.py `clear_gc_fields` plus a zero `jf_frame` cover that. This PR `memory.fill`s `total - HDR` at the payload before writing length and `jf_gcmap`. Fill uses `alloc_size_local` before the shadow-stack push overwrites it.

## Tests

- `cargo test -p majit-backend-wasm` (21 lib + 119 codegen + 2 bridge)
- `cargo test -p majit-backend-wasm -- --ignored` (6/6, including `recursive_call_assembler_does_not_refill_zeroed_nursery_frames`)
- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/check.py --backend dynasm,wasm` — wasm 542/542, no GC panic. `fib_recursive` dynasm 0.30s / wasm 1.21s (4.1×, under the 5.5× header). dynasm `synth/global_reassign` 0.9× floor flake; rerun 1.1× pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of dynamically allocated runtime call frames to ensure frame data starts in a clean state.
  * Prevented stale references from being incorrectly traced during garbage collection, improving runtime stability for variable-sized inline frames.

* **Tests**
  * Expanded regression coverage for frame initialization and call-assembler behavior.
  * Added validation that frame payload memory is cleared before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->