### PR TITLE
Root tracing frame storage through scoped owned areas

### DIFF
--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -277,7 +277,7 @@ struct MutatorEntry {
     bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
     bh_interp_roots: *const RefCell<Vec<BhInterpEntry>>,
     resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
-    extra_areas: Vec<MutatorExtraArea>,
+    extra_areas: Vec<Option<MutatorExtraArea>>,
     pruners: Vec<MutatorPruner>,
 }
 
@@ -295,6 +295,7 @@ struct MutatorExtraArea {
     /// root that fails validation reports the bare `extra_area`, which names
     /// the mechanism and not the registrar — and there are fifteen of them.
     name: &'static str,
+    scoped: bool,
 }
 
 std::thread_local! {
@@ -402,15 +403,75 @@ pub unsafe fn register_mutator_extra_area(
     data: *const (),
     name: &'static str,
 ) {
+    register_extra_area(walk, data, name, false);
+}
+
+fn register_extra_area(
+    walk: MutatorExtraWalkFn,
+    data: *const (),
+    name: &'static str,
+    scoped: bool,
+) -> usize {
     let thread_id = std::thread::current().id();
     let mut registry = MUTATOR_REGISTRY.lock();
     let entry = registry
         .iter_mut()
         .find(|entry| entry.thread_id == thread_id)
         .expect("register_mutator_extra_area called before register_mutator");
-    entry
-        .extra_areas
-        .push(MutatorExtraArea { walk, data, name });
+    let index = entry.extra_areas.len();
+    entry.extra_areas.push(Some(MutatorExtraArea {
+        walk,
+        data,
+        name,
+        scoped,
+    }));
+    index
+}
+
+/// Scoped translated-root publication, corresponding to
+/// ShadowStackFrameworkGCTransformer.push_roots/pop_roots. Unlike permanent
+/// mutator areas, a frame-owned area must retire before its storage is freed.
+/// Slots stay fixed so independently owned frames may retire out of order.
+pub struct MutatorExtraAreaGuard {
+    index: usize,
+    // An area belongs to its acquiring mutator; prevent Send/Sync.
+    _owner: std::marker::PhantomData<*const ()>,
+}
+
+impl MutatorExtraAreaGuard {
+    /// # Safety
+    /// `data` must remain valid until this guard is dropped. The callback
+    /// must obey MutatorExtraWalkFn's STW/owner-thread contract, including
+    /// Rust aliasing rules. Drop the guard before unregistering the mutator.
+    pub unsafe fn new(walk: MutatorExtraWalkFn, data: *const (), name: &'static str) -> Self {
+        Self {
+            index: register_extra_area(walk, data, name, true),
+            _owner: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for MutatorExtraAreaGuard {
+    fn drop(&mut self) {
+        let thread_id = std::thread::current().id();
+        let mut registry = MUTATOR_REGISTRY.lock();
+        let entry = registry
+            .iter_mut()
+            .find(|entry| entry.thread_id == thread_id)
+            .expect("scoped root area outlived its registered mutator");
+        let area = entry
+            .extra_areas
+            .get_mut(self.index)
+            .and_then(Option::take)
+            .expect("releasing an inactive scoped root area");
+        assert!(
+            area.scoped,
+            "releasing a permanent root area through a scope"
+        );
+        while entry.extra_areas.last().is_some_and(Option::is_none) {
+            entry.extra_areas.pop();
+        }
+    }
 }
 
 /// Append an owner-keyed-table pruner to the current registered mutator.
@@ -487,7 +548,7 @@ pub fn walk_all_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
     );
     let registry = MUTATOR_REGISTRY.lock();
     for mutator in registry.iter() {
-        for area in mutator.extra_areas.iter() {
+        for area in mutator.extra_areas.iter().flatten() {
             // SAFETY: gc_sync has quiesced every registered owner, and each
             // area remains valid until its MutatorEntry is removed.
             walk_one_extra_area(area, &mut visitor);
@@ -505,7 +566,7 @@ pub fn walk_my_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
     let Some(mutator) = registry.iter().find(|entry| entry.thread_id == thread_id) else {
         return;
     };
-    for area in mutator.extra_areas.iter() {
+    for area in mutator.extra_areas.iter().flatten() {
         // SAFETY: this is the owning thread's synchronous collection path.
         walk_one_extra_area(area, &mut visitor);
     }
@@ -523,6 +584,14 @@ pub fn unregister_mutator() {
         .iter()
         .position(|entry| entry.thread_id == thread_id)
         .expect("unregistering an unregistered mutator thread");
+    assert!(
+        registry[index]
+            .extra_areas
+            .iter()
+            .flatten()
+            .all(|area| !area.scoped),
+        "unregistering a mutator with live scoped root areas"
+    );
     registry.swap_remove(index);
 }
 
@@ -1939,6 +2008,56 @@ mod tests {
         walk_my_extra_areas(|gcref| gcref.0 += 0x100);
         unregister_mutator();
         assert_eq!(root, GcRef(0x1100));
+    }
+
+    #[test]
+    fn scoped_extra_areas_keep_outer_roots_and_retire_by_owner() {
+        unsafe fn walk_cell(data: *const (), visitor: &mut dyn FnMut(&mut GcRef)) {
+            let slot = unsafe { &*(data as *const Cell<GcRef>) };
+            let mut value = slot.get();
+            visitor(&mut value);
+            slot.set(value);
+        }
+        let _lock = TEST_MUTEX.lock();
+        let outer = Cell::new(GcRef(0x1000));
+        let inner = Cell::new(GcRef(0x2000));
+        register_mutator();
+        let outer_guard = unsafe {
+            MutatorExtraAreaGuard::new(walk_cell, &outer as *const _ as *const (), "outer")
+        };
+        let inner_guard = unsafe {
+            MutatorExtraAreaGuard::new(walk_cell, &inner as *const _ as *const (), "inner")
+        };
+        let mut seen = Vec::new();
+        walk_my_extra_areas(|root| {
+            seen.push(root.0);
+            root.0 += 0x80;
+        });
+        assert_eq!(seen, [0x1000, 0x2000]);
+        assert_eq!(outer.get(), GcRef(0x1080));
+        assert_eq!(inner.get(), GcRef(0x2080));
+        drop(outer_guard);
+        seen.clear();
+        walk_my_extra_areas(|root| seen.push(root.0));
+        assert_eq!(seen, [0x2080]);
+        drop(inner_guard);
+        walk_my_extra_areas(|_| panic!("retired root still visible"));
+        unregister_mutator();
+    }
+
+    #[test]
+    fn scoped_extra_area_unwinds_before_owner_storage_dies() {
+        unsafe fn no_roots(_: *const (), _: &mut dyn FnMut(&mut GcRef)) {}
+        let _lock = TEST_MUTEX.lock();
+        register_mutator();
+        let result = std::panic::catch_unwind(|| {
+            let _guard =
+                unsafe { MutatorExtraAreaGuard::new(no_roots, std::ptr::null(), "unwind") };
+            panic!("test unwind");
+        });
+        assert!(result.is_err());
+        // Teardown asserts that no scoped area remains registered.
+        unregister_mutator();
     }
 
     /// A thread that unregisters leaves nothing behind for the all-mutator

--- a/majit/majit-macros/src/virtualizable/derive.rs
+++ b/majit/majit-macros/src/virtualizable/derive.rs
@@ -397,25 +397,27 @@ pub fn expand_sym(input: DeriveInput) -> TokenStream {
     let collect_locals = locals_field
         .map(|f| {
             if let Some(nl) = nlocals_field {
-                quote! { __args.extend_from_slice(&self.#f[..self.#nl.min(self.#f.len())]); }
+                quote! { __args.extend(self.#f.iter().take(self.#nl).map(|opref| *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&opref))); }
             } else {
-                quote! { __args.extend_from_slice(&self.#f); }
+                quote! { __args.extend(self.#f.iter().map(|opref| *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&opref))); }
             }
         })
         .unwrap_or_default();
 
-    let collect_stack =
-        if let (Some(lf), Some(_vsd), Some(nl)) = (locals_field, vsd_field, nlocals_field) {
-            quote! {
-                let __stack_only = self.__vable_stack_only_depth();
-                let __nlocals = self.#nl;
-                let __avail = self.#lf.len().saturating_sub(__nlocals);
-                let __stack_len = __stack_only.min(__avail);
-                __args.extend_from_slice(&self.#lf[__nlocals..__nlocals + __stack_len]);
-            }
-        } else {
-            quote! {}
-        };
+    let collect_stack = if let (Some(lf), Some(_vsd), Some(nl)) =
+        (locals_field, vsd_field, nlocals_field)
+    {
+        quote! {
+            let __stack_only = self.__vable_stack_only_depth();
+            let __nlocals = self.#nl;
+            assert!(__nlocals <= self.#lf.len(), "locals window exceeds register storage");
+            let __avail = self.#lf.len().saturating_sub(__nlocals);
+            let __stack_len = __stack_only.min(__avail);
+            __args.extend(self.#lf.iter().skip(__nlocals).take(__stack_len).map(|opref| *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&opref)));
+        }
+    } else {
+        quote! {}
+    };
 
     // Stage 3.4 Phase C: typed emission mirrors the locals+stack
     // window of `locals_field`. The `stack_types_field` side table
@@ -427,14 +429,16 @@ pub fn expand_sym(input: DeriveInput) -> TokenStream {
         if let Some(nl) = nlocals_field {
             quote! {
                 let __locals_len = self.#nl.min(self.#lf.len());
-                for (__i, &__opref) in self.#lf[..__locals_len].iter().enumerate() {
+                for (__i, __opref) in self.#lf.iter().take(__locals_len).enumerate() {
+                    let __opref = *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&__opref);
                     let __tp = self.#ltf.get(__i).copied().unwrap_or(majit_ir::Type::Ref);
                     __args.push((__opref, __tp));
                 }
             }
         } else {
             quote! {
-                for (__i, &__opref) in self.#lf.iter().enumerate() {
+                for (__i, __opref) in self.#lf.iter().enumerate() {
+                    let __opref = *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&__opref);
                     let __tp = self.#ltf.get(__i).copied().unwrap_or(majit_ir::Type::Ref);
                     __args.push((__opref, __tp));
                 }
@@ -450,9 +454,11 @@ pub fn expand_sym(input: DeriveInput) -> TokenStream {
         quote! {
             let __stack_only = self.__vable_stack_only_depth();
             let __nlocals = self.#nl;
+            assert!(__nlocals <= self.#lf.len(), "locals window exceeds register storage");
             let __avail = self.#lf.len().saturating_sub(__nlocals);
             let __stack_len = __stack_only.min(__avail);
-            for (__i, &__opref) in self.#lf[__nlocals..__nlocals + __stack_len].iter().enumerate() {
+            for (__i, __opref) in self.#lf.iter().skip(__nlocals).take(__stack_len).enumerate() {
+                let __opref = *std::borrow::Borrow::<majit_ir::OpRef>::borrow(&__opref);
                 let __tp = self.#stf.get(__i).copied().unwrap_or(majit_ir::Type::Ref);
                 __args.push((__opref, __tp));
             }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -420,7 +420,7 @@ pub struct PreambleCompileData<'a> {
     pub base: CompileData<'a>,
     #[allow(dead_code)]
     pub runtime_boxes: &'a [OpRef],
-    pub call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+    pub call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
     #[allow(dead_code)]
     pub enable_opts: &'a [String],
 }
@@ -429,7 +429,7 @@ impl<'a> PreambleCompileData<'a> {
     pub fn new(
         trace: &'a TreeLoop,
         runtime_boxes: &'a [OpRef],
-        call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+        call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
         enable_opts: &'a [String],
     ) -> Self {
         Self {
@@ -446,7 +446,7 @@ pub struct SimpleCompileData<'a> {
     pub base: CompileData<'a>,
     #[allow(dead_code)]
     pub resumestorage: Option<&'a ResumeStorage>,
-    pub call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+    pub call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
     #[allow(dead_code)]
     pub enable_opts: &'a [String],
 }
@@ -455,7 +455,7 @@ impl<'a> SimpleCompileData<'a> {
     pub fn new(
         trace: &'a TreeLoop,
         resumestorage: Option<&'a ResumeStorage>,
-        call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+        call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
         enable_opts: &'a [String],
     ) -> Self {
         Self {
@@ -474,7 +474,7 @@ pub struct BridgeCompileData<'a> {
     pub runtime_boxes: &'a [OpRef],
     #[allow(dead_code)]
     pub resumestorage: Option<&'a ResumeStorage>,
-    pub call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+    pub call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
     pub inline_short_preamble: bool,
     #[allow(dead_code)]
     pub enable_opts: &'a [String],
@@ -485,7 +485,7 @@ impl<'a> BridgeCompileData<'a> {
         trace: &'a TreeLoop,
         runtime_boxes: &'a [OpRef],
         resumestorage: Option<&'a ResumeStorage>,
-        call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+        call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
         inline_short_preamble: bool,
         enable_opts: &'a [String],
     ) -> Self {
@@ -508,7 +508,7 @@ pub struct UnrolledLoopData<'a> {
     #[allow(dead_code)]
     pub state: &'a crate::optimizeopt::unroll::ExportedState,
     #[allow(dead_code)]
-    pub call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+    pub call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
     #[allow(dead_code)]
     pub enable_opts: &'a [String],
 }
@@ -518,7 +518,7 @@ impl<'a> UnrolledLoopData<'a> {
         trace: &'a TreeLoop,
         celltoken: &'a Arc<JitCellToken>,
         state: &'a crate::optimizeopt::unroll::ExportedState,
-        call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+        call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
         enable_opts: &'a [String],
     ) -> Self {
         Self {

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -3812,13 +3812,14 @@ impl TraceCtx {
     /// `CallPure*` (or a `Const` when all args fold) AND the
     /// `call_pure_results` cache is populated for cross-trace
     /// constant folding by the optimizer's pure pass
-    /// (`pyjitpl.py:2397 + compile.py:221 take_call_pure_results`).
+    /// (`pyjitpl.py MetaInterp.record_result_of_call_pure` and
+    /// `compile.py PreambleCompileData.optimize`).
     ///
     /// `concrete_arg_values` must be parallel to `args` and start with
     /// the funcbox's concrete value (i.e., one entry for the funcbox
     /// followed by one per real arg) — same shape as
     /// `_build_allboxes(funcbox, argboxes, descr)` in
-    /// `pyjitpl.py:1960-1993`. `concrete_result` is the value returned
+    /// `pyjitpl.py MIFrame._build_allboxes`. `concrete_result` is the value returned
     /// by executing the helper with the concrete operand values; the
     /// caller is responsible for invoking the helper (the runtime
     /// tracer already has the concrete operands available before the
@@ -4028,12 +4029,6 @@ impl TraceCtx {
         self.recorder.cut(patch_pos);
         self.recorder
             .record_op_with_descr(pure_opcode, argboxes, descr)
-    }
-
-    /// pyjitpl.py:2397 + compile.py:221: take call_pure_results for
-    /// passing to the optimizer.
-    pub fn take_call_pure_results(&mut self) -> indexmap::IndexMap<Vec<Value>, Value> {
-        std::mem::take(&mut self.call_pure_results)
     }
 
     // ── conditional_call / record_known_result (jtransform.py:1665, 292) ──

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -96,11 +96,7 @@ pub trait Optimization {
 
     /// optimizer.py propagate_all_forward(trace, call_pure_results, flush).
     /// Only OptPure consumes this; other passes ignore it.
-    fn set_call_pure_results(
-        &mut self,
-        _results: &indexmap::IndexMap<Vec<majit_ir::Value>, majit_ir::Value>,
-    ) {
-    }
+    fn set_call_pure_results(&mut self, _results: &crate::optimizeopt::util::ArgsDict) {}
 
     /// Name of this pass (for debugging).
     fn name(&self) -> &'static str;
@@ -340,7 +336,7 @@ pub struct Optimizer {
     /// (via get_constant_box) → result value, carried across
     /// loop iterations so the optimizer can constant-fold repeated
     /// pure calls. RPython uses value-based equality for keys.
-    pub call_pure_results: indexmap::IndexMap<Vec<majit_ir::Value>, majit_ir::Value>,
+    pub call_pure_results: crate::optimizeopt::util::ArgsDict,
     /// optimizer.py: `_last_guard_op` — tracks the last emitted guard
     /// for guard sharing and descriptor fusion.
     ///
@@ -1508,7 +1504,7 @@ impl Optimizer {
             passes: Vec::new(),
             pureop_historylength: crate::jit::PARAMETERS.pureop_historylength as usize,
             final_num_inputs: 0,
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             last_guard_op_idx: None,
             replaces_guard: indexmap::IndexMap::new(),
             pendingfields: Vec::new(),
@@ -1566,11 +1562,8 @@ impl Optimizer {
     }
 
     /// Look up a previously recorded CALL_PURE result.
-    pub fn get_call_pure_result(&self, args: &[majit_ir::Value]) -> Option<&majit_ir::Value> {
-        self.call_pure_results
-            .iter()
-            .find(|(k, _)| k.as_slice() == args)
-            .map(|(_, v)| v)
+    pub fn get_call_pure_result(&self, args: &[majit_ir::Value]) -> Option<majit_ir::Value> {
+        self.call_pure_results.get(args)
     }
 
     /// bridgeopt.py: deserialize_optimizer_knowledge
@@ -7348,7 +7341,7 @@ mod tests {
         opt.record_call_pure_result(vec![Value::Int(10), Value::Int(20)], Value::Int(42));
         assert_eq!(
             opt.get_call_pure_result(&[Value::Int(10), Value::Int(20)]),
-            Some(&Value::Int(42))
+            Some(Value::Int(42))
         );
         assert_eq!(
             opt.get_call_pure_result(&[Value::Int(10), Value::Int(99)]),

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -337,7 +337,7 @@ pub struct OptPure {
     /// optimizer.py: call_pure_results passed into propagate_all_forward.
     /// RPython keys are lists of constant boxes (value-based equality).
     /// Keys are the constant Values that _can_optimize_call_pure builds.
-    call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
+    call_pure_results: crate::optimizeopt::util::ArgsDict,
     /// shortpreamble.py: PureOp.produce_op stores PreambleOp in
     /// optpure's cache. In majit, PreambleOp entries stored here are
     /// searched with forwarding-aware matching (force_preamble_op pattern).
@@ -370,7 +370,7 @@ impl OptPure {
             last_emitted_was_removed: false,
             known_result_call_pure: Vec::new(),
             extra_call_pure: Vec::new(),
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             preamble_pure_ops: Vec::new(),
         }
     }
@@ -842,10 +842,7 @@ impl OptPure {
                 .and_then(|b| ctx.get_constant_box(&b))?;
             arg_consts.push(const_value);
         }
-        self.call_pure_results
-            .iter()
-            .find(|(k, _)| k.as_slice() == arg_consts.as_slice())
-            .map(|(_, v)| *v)
+        self.call_pure_results.get(&arg_consts)
     }
 }
 
@@ -1276,7 +1273,7 @@ impl Optimization for OptPure {
         // preamble_pure_ops also NOT cleared — populated during import.
     }
 
-    fn set_call_pure_results(&mut self, results: &indexmap::IndexMap<Vec<Value>, Value>) {
+    fn set_call_pure_results(&mut self, results: &crate::optimizeopt::util::ArgsDict) {
         self.call_pure_results = results.clone();
     }
 
@@ -1890,7 +1887,7 @@ mod tests {
             last_emitted_was_removed: false,
             known_result_call_pure: Vec::new(),
             extra_call_pure: Vec::new(),
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             preamble_pure_ops: Vec::new(),
         }));
         let result = opt

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -407,7 +407,7 @@ pub struct UnrollOptimizer {
     pub callinfocollection: Option<std::sync::Arc<majit_ir::CallInfoCollection>>,
     /// compile.py:221 + optimizer.py:530: call_pure_results from tracing.
     /// Passed through to the inner Optimizer for cross-iteration CALL_PURE folding.
-    pub call_pure_results: indexmap::IndexMap<Vec<majit_ir::Value>, majit_ir::Value>,
+    pub call_pure_results: crate::optimizeopt::util::ArgsDict,
     /// `optimizer.cpu` (model.py `AbstractCPU`) backref, carried into
     /// the inner phase-1/phase-2 `Optimizer.cpu` at spawn time so
     /// `cpu.cls_of_box(runtime_box)` reads (virtualstate.py:601/:608/:620)
@@ -559,7 +559,7 @@ impl UnrollOptimizer {
             phase1_patchguardop: None,
             next_global_opref: 0,
             callinfocollection: None,
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             cpu: crate::cpu::default_cpu(),
             phase2_input_ops_seed: None,
             compile_snapshot_root_slots: None,
@@ -1191,8 +1191,8 @@ impl UnrollOptimizer {
         // function (no `self.`-qualified read past this point on any path —
         // the imported_state path writes `phase1_emit_ops` above then reads it
         // here; the non-peeled early-return arm returns before reaching here),
-        // and the caller never reads `unroll_opt.{snapshot_*,phase1_emit_ops,
-        // call_pure_results}` after the optimize call (the InvalidLoop retry
+        // and the caller never reads `unroll_opt.{snapshot_*,phase1_emit_ops}`
+        // after the optimize call (the InvalidLoop retry
         // moves the caller's own `snapshot_map` locals, not these fields). A
         // `Vec` move copies only the (ptr,len,cap) header and leaves the inner
         // buffers — and the `*mut OpRef` const-ptr root slots collected into
@@ -1205,7 +1205,8 @@ impl UnrollOptimizer {
         opt_p2.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
         opt_p2.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
         opt_p2.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
-        opt_p2.call_pure_results = std::mem::take(&mut self.call_pure_results);
+        // compile.py / optimizer.py share the attempt's args_dict itself.
+        opt_p2.call_pure_results = self.call_pure_results.clone();
         // RPython: same Optimizer instance keeps patchguardop across phases.
         // Phase 1 processes GUARD_FUTURE_CONDITION (from close_loop_args_at)
         // which sets patchguardop. optimizer.py:294 parity — no synthetic

--- a/majit/majit-metainterp/src/optimizeopt/util.rs
+++ b/majit/majit-metainterp/src/optimizeopt/util.rs
@@ -8,7 +8,112 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+use majit_gc::shadow_stack::OwnerRootGuard;
+use majit_ir::Value;
 use majit_ir::operand::Operand;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `history.py ConstPtr.value` is traced storage. Native cached constants
+/// retain their own collector-updated slot instead of copying an address.
+/// The guard never retains the dictionary, so its final owner retires roots.
+enum CachedConst {
+    Scalar(Value),
+    Ref(OwnerRootGuard),
+}
+
+impl CachedConst {
+    fn new(value: Value) -> Self {
+        match value {
+            Value::Ref(root) => Self::Ref(OwnerRootGuard::new(root)),
+            value => Self::Scalar(value),
+        }
+    }
+
+    fn value(&self) -> Value {
+        match self {
+            Self::Scalar(value) => *value,
+            Self::Ref(root) => Value::Ref(root.get()),
+        }
+    }
+}
+
+struct ArgsKey(Vec<CachedConst>);
+
+impl ArgsKey {
+    fn new(args: impl IntoIterator<Item = Value>) -> Self {
+        // Root every argument before hashing any: identityhash may reserve an
+        // old-generation shadow for a nursery object (minimark.find_shadow).
+        Self(args.into_iter().map(CachedConst::new).collect())
+    }
+}
+
+impl PartialEq for ArgsKey {
+    fn eq(&self, other: &Self) -> bool {
+        // util.py args_eq / history.py Const.same_box: typed value equality,
+        // including bitwise Float equality and CURRENT Ref pointer identity.
+        self.0.len() == other.0.len()
+            && self
+                .0
+                .iter()
+                .zip(&other.0)
+                .all(|(a, b)| a.value() == b.value())
+    }
+}
+
+impl Eq for ArgsKey {}
+
+impl Hash for ArgsKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Native Hash encoding of util.py args_hash (hash numbers themselves
+        // are not a wire format). Ref hash must be stable across forwarding, like
+        // history.py ConstPtr._get_hash_; raw Value::hash hashes its address.
+        let mut hash = 0x345678_u64;
+        for arg in &self.0 {
+            let word = match arg.value() {
+                Value::Int(value) => value as u64,
+                Value::Float(value) => value.to_bits(),
+                Value::Ref(root) => majit_gc::gc_id_or_identityhash(root.0) as u64,
+                Value::Void => 17,
+            };
+            hash = hash.wrapping_mul(1000003) ^ word;
+        }
+        hash.hash(state);
+    }
+}
+
+/// `util.py args_dict`, specialized to CALL_PURE's constant argument lists.
+/// `compile.py` and `optimizer.py` share the metainterpreter's dictionary,
+/// not independent snapshots. Clone retains that identity and its roots.
+/// Collection updates only the independently owned Const slots, never this
+/// map through a borrowed TraceCtx/Optimizer. No GC-time clear or rehash.
+#[derive(Clone, Default)]
+pub struct ArgsDict(Rc<RefCell<indexmap::IndexMap<ArgsKey, CachedConst>>>);
+
+impl std::fmt::Debug for ArgsDict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArgsDict")
+            .field("len", &self.0.borrow().len())
+            .finish()
+    }
+}
+
+pub fn args_dict() -> ArgsDict {
+    ArgsDict::default()
+}
+
+impl ArgsDict {
+    pub fn insert(&self, args: Vec<Value>, value: Value) {
+        let key = ArgsKey::new(args);
+        let value = CachedConst::new(value);
+        self.0.borrow_mut().insert(key, value);
+    }
+
+    pub fn get(&self, args: &[Value]) -> Option<Value> {
+        let key = ArgsKey::new(args.iter().copied());
+        self.0.borrow().get(&key).map(CachedConst::value)
+    }
+}
 
 /// util.py `args_eq`.
 ///
@@ -72,5 +177,28 @@ mod tests {
         let a = Some(Operand::bound_from_opref(OpRef::int_op(0)));
         let b = Some(Operand::bound_from_opref(OpRef::int_op(0)));
         assert!(!args_eq(&[a], &[b]));
+    }
+
+    #[test]
+    fn args_dict_shares_identity_and_uses_typed_constant_equality() {
+        use majit_ir::Value;
+        let dict = super::args_dict();
+        let compiler = dict.clone();
+        dict.insert(vec![Value::Float(0.0)], Value::Int(1));
+        dict.insert(vec![Value::Float(-0.0)], Value::Int(2));
+        dict.insert(vec![Value::Int(0)], Value::Int(3));
+        let nan = f64::from_bits(0x7ff8000000000001);
+        dict.insert(vec![Value::Float(nan)], Value::Int(4));
+        assert_eq!(compiler.get(&[Value::Float(0.0)]), Some(Value::Int(1)));
+        assert_eq!(compiler.get(&[Value::Float(-0.0)]), Some(Value::Int(2)));
+        assert_eq!(compiler.get(&[Value::Int(0)]), Some(Value::Int(3)));
+        assert_eq!(compiler.get(&[Value::Float(nan)]), Some(Value::Int(4)));
+        assert_eq!(
+            compiler.get(&[Value::Float(f64::from_bits(nan.to_bits() + 1))]),
+            None
+        );
+        compiler.insert(vec![], Value::Int(5));
+        assert_eq!(dict.get(&[]), Some(Value::Int(5)));
+        assert_eq!(super::args_dict().get(&[]), None);
     }
 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -480,7 +480,7 @@ struct SimpleCompileViews<'a> {
 
 fn make_simple_compile_views<'a>(
     trace: &'a TreeLoop,
-    call_pure_results: &'a indexmap::IndexMap<Vec<Value>, Value>,
+    call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
     enable_opts: &'a [String],
 ) -> SimpleCompileViews<'a> {
     let data = compile::SimpleCompileData::new(trace, None, call_pure_results, enable_opts);
@@ -3014,18 +3014,13 @@ impl<M: Clone> MetaInterp<M> {
         // consts (history.py `ConstPtr.value`) those value slots can be
         // `ConstPtr(GcRef)`; they are returned on cache hits and
         // emitted into the op-graph, so a stale gcref is a use-after-move.
-        // Forward them in place. (Cache *keys* are intentionally left stale —
-        // a forwarded lookup key misses and repopulates, like
-        // `call_pure_results` below.)
+        // Forward them in place. Heapcache key ownership is a separate census
+        // from the independently rooted CALL_PURE constants below.
         trace_ctx.heap_cache_mut().walk_const_ptr_refs(&mut visitor);
-        // NOTE: `trace_ctx.call_pure_results: IndexMap<Vec<Value>, Value>`
-        // (pyjitpl.py:3572-3573) also stores Ref slots. RPython's
-        // args_dict stores Const boxes and the GC traces their gcrefs
-        // through the Python object graph. Pyre stores concrete
-        // `Value::Ref(GcRef)` entries in a linear IndexMap; this active
-        // trace walker does not rewrite that cache yet. Stale entries
-        // miss after a moving collection and are repopulated by the next
-        // CALL_PURE recording.
+        // util.py args_dict / history.py ConstPtr.value: CALL_PURE's keys and
+        // results own collector-updated Const slots. Compile/optimizer handles
+        // share that same dictionary; its roots survive even after this trace
+        // is detached, without a callback borrowing TraceCtx during collection.
 
         // Non-constant Ref registers name the recorder's `RefFrontendOp` /
         // `InputArgRef`, whose attached concrete value was forwarded above.
@@ -7350,7 +7345,7 @@ impl<M: Clone> MetaInterp<M> {
         });
 
         // compile.py:221: call_pure_results = metainterp.call_pure_results
-        let call_pure_results = ctx.take_call_pure_results();
+        let call_pure_results = ctx.call_pure_results.clone();
 
         let snapshots = ctx.take_snapshots();
         let mut recorder = ctx.recorder;
@@ -9328,7 +9323,7 @@ impl<M: Clone> MetaInterp<M> {
             // ConstantPool to snapshot — this typed-constant map starts fresh.
             let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
             let initial_inputarg_consts = ctx.initial_inputarg_consts.clone();
-            let call_pure_results = ctx.take_call_pure_results();
+            let call_pure_results = ctx.call_pure_results.clone();
 
             // compile.py:358-362 records the closing JUMP on the same history
             // that `cut_trace_from` views. Rust materializes TreeLoop eagerly,
@@ -10425,7 +10420,8 @@ impl<M: Clone> MetaInterp<M> {
             .compile_tracing
             .as_mut()
             .unwrap()
-            .take_call_pure_results();
+            .call_pure_results
+            .clone();
         // `pyjitpl.py:3216-3217` / `pyjitpl.py:3241`:
         //   `token = sd.done_with_this_frame_descr_<type>` (normal) or
         //   `token = sd.exit_frame_with_exception_descr_ref` (raising),
@@ -10944,7 +10940,7 @@ impl<M: Clone> MetaInterp<M> {
         let orig_vable_ptr_simple =
             self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
 
-        let call_pure_results = ctx.take_call_pure_results();
+        let call_pure_results = ctx.call_pure_results.clone();
         let snapshots = ctx.take_snapshots();
         let recorder = ctx.recorder;
         // Snapshots live on TraceCtx; rebuild the TreeLoop with them so
@@ -14574,7 +14570,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vable_boxes: SnapshotBoxes,
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
-        call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
+        call_pure_results: crate::optimizeopt::util::ArgsDict,
     ) -> bool {
         self.remember_compiled_graph_write();
         self.last_compiled_artifact_token = None;

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -606,10 +606,10 @@ pub struct TraceCtx {
     /// TraceCtx because TraceCtx is freshly created per trace and the
     /// MetaInterp is reused across traces.
     forced_virtualizable: Option<OpRef>,
-    /// pyjitpl.py:2397: call_pure_results — maps constant argument tuples
-    /// to their concrete result values, recorded during tracing.
-    /// Passed to the optimizer for cross-iteration CALL_PURE folding.
-    pub(crate) call_pure_results: indexmap::IndexMap<Vec<Value>, Value>,
+    /// pyjitpl.py MetaInterp.__init__ creates one args_dict per attempt.
+    /// TraceCtx is the native attempt owner; compilation and optimization
+    /// share this dictionary and its rooted constants, not address snapshots.
+    pub(crate) call_pure_results: crate::optimizeopt::util::ArgsDict,
     /// Cached `warmstate.trace_limit` snapshot for this tracing session.
     /// pyjitpl.py:2789 reads `self.jitdriver_sd.warmstate.trace_limit` each
     /// call; pyre snapshots it at `setup_tracing` time (warmstate owns the
@@ -1869,7 +1869,7 @@ impl TraceCtx {
             merge_point_resumed: false,
             walk_resume_pc: None,
             callinfocollection: None,
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             trace_limit: DEFAULT_TRACE_LIMIT,
             snapshots: Vec::new(),
             resumekey_original_loop_token: None,
@@ -1970,7 +1970,7 @@ impl TraceCtx {
             merge_point_resumed: false,
             walk_resume_pc: None,
             callinfocollection: None,
-            call_pure_results: indexmap::IndexMap::new(),
+            call_pure_results: crate::optimizeopt::util::args_dict(),
             trace_limit: DEFAULT_TRACE_LIMIT,
             snapshots: Vec::new(),
             resumekey_original_loop_token: None,

--- a/majit/majit-metainterp/tests/call_pure_roots.rs
+++ b/majit/majit-metainterp/tests/call_pure_roots.rs
@@ -1,0 +1,90 @@
+//! `util.py args_dict` / `history.py ConstPtr`: real moving-GC coverage.
+//! A separate process isolates the active collector and identity-hash hooks.
+
+use majit_gc::{GcAllocator, TypeInfo, collector::MiniMarkGC, gc_sync, shadow_stack};
+use majit_ir::{GcRef, Value};
+use majit_metainterp::optimizeopt::{optimizer::Optimizer, util::args_dict};
+
+fn root_count() -> usize {
+    let mut count = 0;
+    shadow_stack::walk_roots(|_| count += 1);
+    count
+}
+
+fn as_ref(value: Option<Value>) -> GcRef {
+    match value {
+        Some(Value::Ref(root)) => root,
+        other => panic!("expected cached Ref, got {other:?}"),
+    }
+}
+
+#[test]
+fn cache_constants_survive_movement_handoff_and_retire_with_the_last_owner() {
+    let mut gc = MiniMarkGC::new();
+    let tid = gc.register_type(TypeInfo::simple(16));
+    gc_sync::store_singleton(Box::new(gc));
+    shadow_stack::register_mutator();
+    gc_sync::register_thread();
+    majit_gc::set_active_gc_id_or_identityhash(Some(|addr| {
+        gc_sync::gc_op(|gc| gc.id_or_identityhash(addr))
+    }));
+    let initial_roots = root_count();
+
+    let key = gc_sync::gc_op(|gc| gc.alloc_with_type(tid, 16));
+    let result = gc_sync::gc_op(|gc| gc.alloc_with_type(tid, 16));
+    unsafe {
+        *(key.0 as *mut usize) = 42;
+        *(result.0 as *mut usize) = 99;
+    }
+    let cache = args_dict();
+    cache.insert(vec![Value::Int(7)], Value::Ref(result));
+    cache.insert(vec![Value::Ref(key)], Value::Ref(result));
+    cache.insert(vec![Value::Int(8)], Value::Ref(key));
+    let stable_hash = majit_gc::gc_id_or_identityhash(key.0);
+    assert_eq!(root_count(), initial_roots + 4);
+    let mut optimizer = Optimizer::new();
+    optimizer.call_pure_results = cache.clone();
+    let compile_owner = cache.clone();
+    drop(cache);
+    assert_eq!(
+        root_count(),
+        initial_roots + 4,
+        "handoff must share Const roots"
+    );
+
+    // Neither raw local pointer is a root: only the dictionary retains them.
+    gc_sync::gc_op(|gc| gc.collect_generation(-1));
+    let moved_key = as_ref(compile_owner.get(&[Value::Int(8)]));
+    let moved_result = as_ref(optimizer.get_call_pure_result(&[Value::Int(7)]));
+    assert_ne!(moved_key, key);
+    assert_ne!(moved_result, result);
+    assert_eq!(majit_gc::gc_id_or_identityhash(moved_key.0), stable_hash);
+    assert_eq!(
+        compile_owner.get(&[Value::Ref(moved_key)]),
+        Some(Value::Ref(moved_result))
+    );
+    assert_eq!(unsafe { *(moved_key.0 as *const usize) }, 42);
+    assert_eq!(unsafe { *(moved_result.0 as *const usize) }, 99);
+
+    // Equal keys after forwarding replace the original entry, not a duplicate
+    // under a new address hash. Both compiler and optimizer see the update.
+    compile_owner.insert(vec![Value::Ref(moved_key)], Value::Int(123));
+    assert_eq!(
+        optimizer.get_call_pure_result(&[Value::Ref(moved_key)]),
+        Some(Value::Int(123))
+    );
+    assert_eq!(root_count(), initial_roots + 3);
+    drop(compile_owner);
+    assert_eq!(root_count(), initial_roots + 3);
+    drop(optimizer);
+    assert_eq!(root_count(), initial_roots);
+    assert_eq!(
+        args_dict().get(&[Value::Int(7)]),
+        None,
+        "new attempt starts empty"
+    );
+
+    majit_gc::set_active_gc_id_or_identityhash(None);
+    shadow_stack::unregister_mutator();
+    gc_sync::unregister_thread();
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -655,18 +655,7 @@ pub(crate) fn guard_value_record<Sym: WalkSym>(
     ctx.trace_ctx
         .record_guard(OpCode::GuardValue, &[value, expected], 0);
     walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    ctx.trace_ctx.replace_box(value, expected);
-    match bank {
-        GuardValueBank::Int => {
-            ctx.registers_i.replace_active_box(value, expected);
-        }
-        GuardValueBank::Ref => {
-            ctx.registers_r.replace_active_box(value, expected);
-        }
-        GuardValueBank::Float => {
-            ctx.registers_f.replace_active_box(value, expected);
-        }
-    }
+    super::vable_ops::walker_replace_box(ctx, value, expected);
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/arith.rs
@@ -658,25 +658,13 @@ pub(crate) fn guard_value_record<Sym: WalkSym>(
     ctx.trace_ctx.replace_box(value, expected);
     match bank {
         GuardValueBank::Int => {
-            for slot in ctx.registers_i.iter_mut() {
-                if *slot == value {
-                    *slot = expected;
-                }
-            }
+            ctx.registers_i.replace_active_box(value, expected);
         }
         GuardValueBank::Ref => {
-            for slot in ctx.registers_r.iter_mut() {
-                if *slot == value {
-                    *slot = expected;
-                }
-            }
+            ctx.registers_r.replace_active_box(value, expected);
         }
         GuardValueBank::Float => {
-            for slot in ctx.registers_f.iter_mut() {
-                if *slot == value {
-                    *slot = expected;
-                }
-            }
+            ctx.registers_f.replace_active_box(value, expected);
         }
     }
     Ok((DispatchOutcome::Continue, op.next_pc))
@@ -822,16 +810,16 @@ pub(crate) fn unop_cast_record<Sym: WalkSym>(
                 result
             };
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         // `cast_int_to_ptr/i>r`: Int-bank → Ref-bank. Bit-cast the
         // operand's Box.value (`BoxInt(n)` → `BoxRef(n as ptr)`).
@@ -896,16 +884,16 @@ pub(crate) fn binop_float_record<Sym: WalkSym>(
         let result = ctx.trace_ctx.const_float(bits);
         let dst = code[op.pc + 3] as usize;
         let len = ctx.registers_f.len();
-        let slot = ctx
+        let _ = ctx
             .registers_f
-            .get_mut(dst)
+            .get(dst)
             .ok_or(DispatchError::RegisterOutOfRange {
                 pc: op.pc,
                 reg: dst,
                 len,
                 bank: "f",
             })?;
-        *slot = result;
+        ctx.registers_f.set(dst, result);
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     count_ops_recorded(ctx, opcode);
@@ -921,16 +909,16 @@ pub(crate) fn binop_float_record<Sym: WalkSym>(
     }
     let dst = code[op.pc + 3] as usize;
     let len = ctx.registers_f.len();
-    let slot = ctx
+    let _ = ctx
         .registers_f
-        .get_mut(dst)
+        .get(dst)
         .ok_or(DispatchError::RegisterOutOfRange {
             pc: op.pc,
             reg: dst,
             len,
             bank: "f",
         })?;
-    *slot = result;
+    ctx.registers_f.set(dst, result);
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
@@ -954,16 +942,16 @@ pub(crate) fn unop_float_record<Sym: WalkSym>(
         let result = ctx.trace_ctx.const_float(bits);
         let dst = code[op.pc + 2] as usize;
         let len = ctx.registers_f.len();
-        let slot = ctx
+        let _ = ctx
             .registers_f
-            .get_mut(dst)
+            .get(dst)
             .ok_or(DispatchError::RegisterOutOfRange {
                 pc: op.pc,
                 reg: dst,
                 len,
                 bank: "f",
             })?;
-        *slot = result;
+        ctx.registers_f.set(dst, result);
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     count_ops_recorded(ctx, opcode);
@@ -977,16 +965,16 @@ pub(crate) fn unop_float_record<Sym: WalkSym>(
     }
     let dst = code[op.pc + 2] as usize;
     let len = ctx.registers_f.len();
-    let slot = ctx
+    let _ = ctx
         .registers_f
-        .get_mut(dst)
+        .get(dst)
         .ok_or(DispatchError::RegisterOutOfRange {
             pc: op.pc,
             reg: dst,
             len,
             bank: "f",
         })?;
-    *slot = result;
+    ctx.registers_f.set(dst, result);
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -351,11 +351,9 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
 
     let result = {
         let mut wc = WalkContext {
-            callee_shadow: None,
-            inline_callee_consts: None,
-            inline_poison_pcs: None,
-            fbw_mode: FbwWalkMode {
-                snapshot_sym: sym_ptr,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: None,
+                concrete_registers_r: top_concrete_r,
                 current_exception_seed: (trace_ctx.is_bridge_trace
                     && !sym.last_exc_box().is_none())
                 .then_some(sym.last_exc_box()),
@@ -364,6 +362,17 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
                 } else {
                     pyre_object::PY_NULL
                 },
+                outer_active_boxes: Vec::new(),
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
+                ..Default::default()
+            }),
+            inline_callee_consts: None,
+            inline_poison_pcs: None,
+            fbw_mode: FbwWalkMode {
+                snapshot_sym: sym_ptr,
+
                 class_of_last_exc_is_const: sym.class_of_last_exc_is_const(),
                 // A guard-failure bridge resumes at the opcode boundary, so
                 // its first `jit_merge_point` crossing at this python-pc is
@@ -380,7 +389,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             registers_r: &top_regs_r,
             registers_i: &RegisterBank::with_constants(top_regs_i, top_num_regs_i),
             registers_f: &RegisterBank::with_constants(top_regs_f, top_num_regs_f),
-            concrete_registers_r: &mut top_concrete_r,
+
             concrete_registers_i: &mut top_concrete_i,
             descr_refs: &descr_refs,
             raw_descrs,
@@ -391,7 +400,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             entry_py_pc,
             outer_resume_marker_jit_pc: None,
             outer_jitcode_index: 0,
-            outer_active_boxes: Vec::new(),
+
             // This entry (test/fixture) hard-codes
             // `outer_jitcode_index = 0` and an empty `outer_active_boxes`
             // rather than seeding them from `sym.jitcode` /
@@ -400,17 +409,18 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // `walker_capture_snapshot_for_last_guard` would attach
             // resume data pointing at the wrong frame.
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
         };
+        let _frame_state_root = crate::trace::InlineFrameStateGuard::enter(&wc.frame_state);
         // #73: seed the walk-level operand-stack box mirror
         // at entry.  The mirror is only enabled when the outer sym owns the
         // virtualizable shadow (the production full-body loop trace) — the
@@ -659,7 +669,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             Err(DispatchError::BranchGuardUnrestorableKeptStackPermanent { .. })
                 | Err(DispatchError::BranchGuardKeptStackUnsupported { .. })
         ) && wc.vstack_valid
-            && wc.vstack_depth <= wc.vstack_boxes.len()
+            && wc.vstack_depth <= wc.frame_state.borrow().vstack_boxes.len()
         {
             // `MIFrame.registers_r` is the authoritative source upstream when
             // an abort converts the metainterp framestack to blackholes
@@ -668,7 +678,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // the decoded abort resume pc before it mutates the live frame.
             fbw_branch_abort_stack_latch(
                 wc.vstack_cur_pypc as usize,
-                wc.vstack_boxes[..wc.vstack_depth].to_vec(),
+                wc.frame_state.borrow().vstack_boxes[..wc.vstack_depth].to_vec(),
             );
         }
         // Read final last_exc_value before wc drops so the borrow
@@ -1313,16 +1323,27 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
 
     let outcome = {
         let mut sub_wc = WalkContext {
-            callee_shadow: Some(super::CalleeLocalsShadow {
-                code_ptr: callee_pjc.code_ptr,
-                // `resume.py:1042-1057` rebuilds one concrete frame for every
-                // resumed MIFrame.  Keep that identity on this callee's own
-                // walk context so residual execution can enter precisely this
-                // frame on the ExecutionContext chain.  It deliberately does
-                // not use `InlineConcreteFrameGuard`: that TLS also selects
-                // the standard-virtualizable heap-sync target, which remains
-                // the bridge root for a reconstructed carrier.
-                concrete_frame: concrete_callee_frame,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: Some(super::CalleeLocalsShadow {
+                    code_ptr: callee_pjc.code_ptr,
+                    // `resume.py rebuild_from_resumedata` rebuilds a frame for every
+                    // resumed MIFrame.  Keep that identity on this callee's own
+                    // walk context so residual execution can enter precisely this
+                    // frame on the ExecutionContext chain.  It deliberately does
+                    // not use `InlineConcreteFrameGuard`: that TLS also selects
+                    // the standard-virtualizable heap-sync target, which remains
+                    // the bridge root for a reconstructed carrier.
+                    concrete_frame: concrete_callee_frame,
+                    ..Default::default()
+                }),
+                concrete_registers_r: concrete_r,
+                current_exception_seed: (!root_sym.last_exc_box().is_none())
+                    .then_some(root_sym.last_exc_box()),
+                current_exception_seed_concrete: root_sym.last_exc_value(),
+                outer_active_boxes: outer_active_boxes,
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
                 ..Default::default()
             }),
             inline_callee_consts: Some(consts),
@@ -1336,9 +1357,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
                 snapshot_sym: root_sym_ptr,
                 inline_subwalk: true,
                 carrier_resume: true,
-                current_exception_seed: (!root_sym.last_exc_box().is_none())
-                    .then_some(root_sym.last_exc_box()),
-                current_exception_seed_concrete: root_sym.last_exc_value(),
+
                 class_of_last_exc_is_const: root_sym.class_of_last_exc_is_const(),
                 ..Default::default()
             },
@@ -1346,7 +1365,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             registers_r: &regs_r,
             registers_i: &RegisterBank::with_constants(regs_i, num_regs_i),
             registers_f: &RegisterBank::with_constants(regs_f, num_regs_f),
-            concrete_registers_r: &mut concrete_r,
+
             concrete_registers_i: &mut concrete_i,
             descr_refs: &perfn_descr_refs,
             raw_descrs: RawDescrPool::PerFn(perfn_descrs),
@@ -1364,13 +1383,13 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             // first and only concrete execution.
             is_authoritative_executor: true,
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -1381,8 +1400,8 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             entry_py_pc: EntryPyPc::Jit(root_pc),
             outer_resume_marker_jit_pc: root_frame.resume_marker_jit_pc,
             outer_jitcode_index,
-            outer_active_boxes,
         };
+        let _frame_state_root = crate::trace::InlineFrameStateGuard::enter(&sub_wc.frame_state);
         let mut callee_parents = vec![parent_for_current];
         callee_parents.extend(pending_ctor_tail.take());
         let _inline_frame = InlineFrameGuard::enter(session, callee_w_code, false, callee_parents);
@@ -1408,17 +1427,21 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         // folds to `CALL_ASSEMBLER` instead of declining.
         for (slot, &opref) in local_oprefs.iter().enumerate() {
             sub_wc
+                .frame_state
+                .borrow_mut()
                 .callee_shadow
                 .as_mut()
                 .unwrap()
                 .set_opref(slot as i64, opref);
         }
         for (slot, &v) in local_concretes.iter().enumerate() {
-            sub_wc.callee_shadow.as_mut().unwrap().set_concrete(
-                callee_pjc.metadata.portal_frame_reg,
-                slot as i64,
-                v,
-            );
+            sub_wc
+                .frame_state
+                .borrow_mut()
+                .callee_shadow
+                .as_mut()
+                .unwrap()
+                .set_concrete(callee_pjc.metadata.portal_frame_reg, slot as i64, v);
         }
         // The decoded multi-frame recipe carries this callee's semantic
         // operand stack after its locals/cells prefix.  Preserve that red
@@ -1428,17 +1451,25 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         let stack_base = local_oprefs.len();
         for (s, &opref) in resumed_stack_oprefs.iter().enumerate() {
             sub_wc
+                .frame_state
+                .borrow_mut()
                 .callee_shadow
                 .as_mut()
                 .unwrap()
                 .set_opref((stack_base + s) as i64, opref);
         }
         for (s, &value) in resumed_stack_concretes.iter().enumerate() {
-            sub_wc.callee_shadow.as_mut().unwrap().set_concrete(
-                callee_pjc.metadata.portal_frame_reg,
-                (stack_base + s) as i64,
-                value,
-            );
+            sub_wc
+                .frame_state
+                .borrow_mut()
+                .callee_shadow
+                .as_mut()
+                .unwrap()
+                .set_concrete(
+                    callee_pjc.metadata.portal_frame_reg,
+                    (stack_base + s) as i64,
+                    value,
+                );
         }
         if let Some(frame) = ActiveResumeFrame::current(session, root_sym_ptr)
             && frame.0.jitcode.code.as_ptr() == callee_code.as_ptr()
@@ -1446,7 +1477,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             && let Some((py_pc, _code_ptr, depth)) = frame.vstack_coordinate_for_jitcode_pc(entry)
             && depth == resumed_stack_oprefs.len()
         {
-            sub_wc.vstack_boxes = resumed_stack_oprefs.to_vec();
+            sub_wc.frame_state.borrow_mut().vstack_boxes = resumed_stack_oprefs.to_vec();
             sub_wc.vstack_depth = depth;
             sub_wc.vstack_cur_pypc = py_pc;
             sub_wc.vstack_valid = true;
@@ -1460,7 +1491,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         // box with no runtime value, and an effectful sub-walk replays from the
         // guard (the framed-pickle stream is consumed twice).
         if !sub_wc.vstack_valid {
-            sub_wc.vstack_boxes = resumed_stack_oprefs.to_vec();
+            sub_wc.frame_state.borrow_mut().vstack_boxes = resumed_stack_oprefs.to_vec();
             sub_wc.vstack_depth = resumed_stack_oprefs.len();
             sub_wc.vstack_cur_pypc =
                 crate::py_coord::resume_py_pc_for_jitcode_word(consts.jitcode_index, entry as i32)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -194,7 +194,8 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
     let total_r = top_num_regs_r + top_constants_r.len();
     let total_i = top_num_regs_i + top_constants_i.len();
     let total_f = top_num_regs_f + top_constants_f.len();
-    let mut top_regs_r = vec![OpRef::NONE; total_r];
+    let top_regs_r = RegisterBank::with_constants(vec![OpRef::NONE; total_r], top_num_regs_r);
+    let _setup_bank_guard = crate::trace::InlineRegisterBankGuard::enter(&top_regs_r);
     let mut top_regs_i = vec![OpRef::NONE; total_i];
     let mut top_regs_f = vec![OpRef::NONE; total_f];
     let mut top_concrete_r = vec![ConcreteValue::Null; total_r];
@@ -217,7 +218,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
     // slot).
     for (i, v) in top_constants_r.iter().enumerate() {
         let v = v.get();
-        top_regs_r[top_num_regs_r + i] = trace_ctx.const_ref(v);
+        top_regs_r.set(top_num_regs_r + i, trace_ctx.const_ref(v));
         top_concrete_r[top_num_regs_r + i] = ConcreteValue::Ref(v as pyre_object::PyObjectRef);
     }
     for (i, &v) in top_constants_f.iter().enumerate() {
@@ -260,7 +261,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         });
     }
     for (i, &box_ref) in argboxes_r.iter().enumerate() {
-        top_regs_r[i] = box_ref;
+        top_regs_r.set(i, box_ref);
         if let Some(majit_ir::Value::Ref(majit_ir::GcRef(ptr))) = trace_ctx.box_value(box_ref) {
             top_concrete_r[i] = ConcreteValue::Ref(ptr as pyre_object::PyObjectRef);
         }
@@ -376,9 +377,9 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
                 ..Default::default()
             },
             session,
-            registers_r: &mut top_regs_r,
-            registers_i: &mut top_regs_i,
-            registers_f: &mut top_regs_f,
+            registers_r: &top_regs_r,
+            registers_i: &RegisterBank::with_constants(top_regs_i, top_num_regs_i),
+            registers_f: &RegisterBank::with_constants(top_regs_f, top_num_regs_f),
             concrete_registers_r: &mut top_concrete_r,
             concrete_registers_i: &mut top_concrete_i,
             descr_refs: &descr_refs,
@@ -650,8 +651,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // `sym.registers_r`, so publish it for the length of the walk or a
             // fold's freshly minted `ConstPtr` sits in a bank no root area
             // reaches.
-            let _bank_guard =
-                crate::trace::InlineRegisterBankGuard::enter(&raw mut *wc.registers_r);
+            let _bank_guard = crate::trace::InlineRegisterBankGuard::enter(wc.registers_r);
             walk(jitcode_code, walk_position, &mut wc)
         };
         if matches!(
@@ -803,7 +803,7 @@ pub(crate) fn compute_bridge_root_parent_frame<Sym: WalkSym>(
     // non-bridge callers (`bridge_registers_r == None`).
     let mut regs_r = root_sym
         .bridge_registers_r()
-        .cloned()
+        .map(|regs| regs.to_vec())
         .unwrap_or_else(|| root_sym.registers_r().to_vec());
     let result_color = unsafe { &(*root_sym.jitcode()).payload }
         .result_color_trivia_for_jitcode_pc(root_pc)
@@ -1165,7 +1165,8 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     let total_r = num_regs_r + jc.constants_r.len();
     let total_i = num_regs_i + jc.constants_i.len();
     let total_f = num_regs_f + jc.constants_f.len();
-    let mut regs_r = vec![OpRef::NONE; total_r];
+    let regs_r = RegisterBank::with_constants(vec![OpRef::NONE; total_r], num_regs_r);
+    let _setup_bank_guard = crate::trace::InlineRegisterBankGuard::enter(&regs_r);
     let mut regs_i = vec![OpRef::NONE; total_i];
     let mut regs_f = vec![OpRef::NONE; total_f];
     let mut concrete_r = vec![ConcreteValue::Null; total_r];
@@ -1178,7 +1179,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     // reading as the top-level seeding above and as `build_callee_banks`.
     for (i, v) in jc.constants_r.iter().enumerate() {
         let v = v.get();
-        regs_r[num_regs_r + i] = ctx.const_ref(v);
+        regs_r.set(num_regs_r + i, ctx.const_ref(v));
         concrete_r[num_regs_r + i] = ConcreteValue::Ref(v as pyre_object::PyObjectRef);
     }
     for (i, &v) in jc.constants_f.iter().enumerate() {
@@ -1192,7 +1193,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         }));
     }
     for (i, &box_ref) in argboxes_r.iter().enumerate() {
-        regs_r[i] = box_ref;
+        regs_r.set(i, box_ref);
         if let Some(majit_ir::Value::Ref(majit_ir::GcRef(ptr))) = ctx.box_value(box_ref) {
             concrete_r[i] = ConcreteValue::Ref(ptr as pyre_object::PyObjectRef);
         }
@@ -1230,7 +1231,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
                 callee_num_regs_r: regs_r.len(),
             }));
         }
-        regs_r[call_dst_reg] = result;
+        regs_r.set(call_dst_reg, result);
         if let Some(majit_ir::Value::Ref(majit_ir::GcRef(ptr))) = ctx.box_value(result) {
             concrete_r[call_dst_reg] = ConcreteValue::Ref(ptr as pyre_object::PyObjectRef);
         }
@@ -1342,9 +1343,9 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
                 ..Default::default()
             },
             session,
-            registers_r: &mut regs_r,
-            registers_i: &mut regs_i,
-            registers_f: &mut regs_f,
+            registers_r: &regs_r,
+            registers_i: &RegisterBank::with_constants(regs_i, num_regs_i),
+            registers_f: &RegisterBank::with_constants(regs_f, num_regs_f),
             concrete_registers_r: &mut concrete_r,
             concrete_registers_i: &mut concrete_i,
             descr_refs: &perfn_descr_refs,
@@ -1467,7 +1468,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             sub_wc.vstack_valid = true;
         }
         // As above: the callee bank is a local of this frame.
-        let bank_guard = crate::trace::InlineRegisterBankGuard::enter(&raw mut *sub_wc.registers_r);
+        let bank_guard = crate::trace::InlineRegisterBankGuard::enter(sub_wc.registers_r);
         let outcome = walk(callee_code, entry, &mut sub_wc);
         drop(bank_guard);
         // `pyjitpl.py handle_guard_failure` wraps `_handle_guard_failure`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -169,7 +169,9 @@ mod recursion_depth_policy_tests {
 /// The innermost inline level's strict-fold frame register (`u16::MAX` when
 /// inactive / no inline level).
 pub(crate) fn fbw_strict_fold_frame_reg<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> u16 {
-    ctx.callee_shadow
+    ctx.frame_state
+        .borrow()
+        .callee_shadow
         .as_ref()
         .map_or(u16::MAX, |shadow| shadow.fold_frame_reg)
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -507,8 +507,8 @@ pub(crate) fn fbw_built_exc_insert(op: OpRef) {
 /// `true` if it was present — i.e. the raised value was built inline by
 /// [`try_walker_trace_exception_new`].  Removed (not just read) so a
 /// second raise of the same object (whose `w_context` is now stamped)
-/// takes the residual path, matching the trait's
-/// `trace_built_exc.remove(&exc_val.opref)`.
+/// takes the residual path. This set tracks symbolic freshness only; the
+/// exception's concrete value remains attached to its recorder box.
 pub(crate) fn fbw_built_exc_take(op: OpRef) -> bool {
     FBW_BUILT_EXC.with(|s| s.borrow_mut().remove(&op))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/frame_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/frame_state.rs
@@ -148,6 +148,42 @@ impl WalkFrameState {
         self.0.borrow_mut()
     }
 
+    /// `virtualizable.py write_boxes`: validate the sparse native shadow, then
+    /// read each live value immediately before its write. The writer may box
+    /// Int/Float values and collect; neither a borrow nor a copied Ref list may
+    /// span that allocation. Ref values themselves require no boxing allocation.
+    pub(crate) fn write_callee_locals(
+        &self,
+        nlocals: usize,
+        frame_reg: u16,
+        mut write: impl FnMut(usize, Value),
+    ) -> bool {
+        {
+            let data = self.borrow();
+            let Some(shadow) = data.callee_shadow.as_ref() else {
+                return false;
+            };
+            if !super::callee_locals_region_is_publishable(shadow, nlocals, frame_reg) {
+                return false;
+            }
+        }
+        for slot in 0..nlocals {
+            let value = {
+                let data = self.borrow();
+                data.callee_shadow
+                    .as_ref()
+                    .expect("callee shadow retired during writeback")
+                    .concrete
+                    .get(&(slot as i64))
+                    .map(|entry| entry.value)
+            };
+            if let Some(value) = value {
+                write(slot, value);
+            }
+        }
+        true
+    }
+
     pub(crate) fn replace_active_box(&self, oldbox: OpRef, newbox: OpRef) {
         let mut data = self.borrow_mut();
         let replace = |slot: &mut OpRef| {
@@ -338,6 +374,60 @@ mod tests {
         assert_refs(&paused, 0x1080);
         assert_refs(&inner, 0x2100);
         drop(inner_root);
+    }
+
+    #[test]
+    fn callee_writeback_releases_borrows_and_reads_forwarded_later_slots() {
+        let _runtime = crate::trace_ctx_for_test(0);
+        let _stw = majit_gc::gc_sync::quiesce_mutators();
+        let mut shadow = CalleeLocalsShadow::default();
+        shadow.set_concrete(1, 0, Value::Int(1000));
+        shadow.set_concrete(1, 1, Value::Ref(GcRef(0x1000)));
+        shadow.set_concrete(1, 2, Value::Float(2.5));
+        shadow.set_concrete(1, 3, Value::Ref(GcRef(0x2000)));
+        let state = WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: Some(shadow),
+            ..WalkFrameStateData::default()
+        });
+        let _root = state.root();
+        let published = state.clone();
+        let mut written = Vec::new();
+        assert!(published.write_callee_locals(5, 1, |slot, value| {
+            // Boxing a scalar can collect before a later Ref is loaded. Walk
+            // the real registered owner, so a retained borrow panics here and
+            // an unrooted shadow copy returns a stale later value.
+            if matches!(value, Value::Int(_) | Value::Float(_)) {
+                majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+                    if (0x1000..0x3000).contains(&root.0) {
+                        root.0 += 0x80;
+                    }
+                });
+            }
+            written.push((slot, value));
+        }));
+        assert_eq!(
+            written,
+            vec![
+                (0, Value::Int(1000)),
+                (1, Value::Ref(GcRef(0x1080))),
+                (2, Value::Float(2.5)),
+                (3, Value::Ref(GcRef(0x2100))),
+            ]
+        );
+    }
+
+    #[test]
+    fn callee_writeback_validates_all_slots_before_writing() {
+        let mut shadow = CalleeLocalsShadow::default();
+        shadow.set_concrete(1, 0, Value::Int(1000));
+        shadow.set_opref(1, OpRef::ref_op(7));
+        let state = WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: Some(shadow),
+            ..WalkFrameStateData::default()
+        });
+        assert!(!state.write_callee_locals(2, 1, |_, _| panic!("partial write")));
+        assert!(!state.write_callee_locals(1, 2, |_, _| panic!("wrong frame")));
+        assert!(!WalkFrameState::default().write_callee_locals(1, 1, |_, _| panic!("no shadow")));
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/frame_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/frame_state.rs
@@ -1,0 +1,403 @@
+//! Shared frame-owned state for the walker's remaining semantic mirrors.
+//!
+//! `pyjitpl.py MIFrame` owns its live values; `MetaInterp.replace_box` updates
+//! every frame synchronously. Until the semantic/color mirrors disappear,
+//! they must share that ownership and GC lifetime instead of being copied
+//! between a suspended SubWalkFrame and its active WalkContext.
+
+use super::{CalleeLocalsShadow, ConcreteValue};
+use majit_ir::{GcRef, OpRef, Value};
+use std::cell::{Ref, RefCell, RefMut};
+use std::rc::Rc;
+
+pub struct WalkFrameStateData {
+    /// Present only for an inlined-callee sub-walk. Top-level and other walks
+    /// have no callee shadow, preserving the former empty-stack no-op behavior.
+    pub callee_shadow: Option<CalleeLocalsShadow>,
+    /// Frozen `PyFrame` state at the outer Python opcode boundary —
+    /// `sym.registers_r ∪ sym.registers_i.opref ∪ sym.registers_f.opref`
+    /// captured at walk entry (the retired per-opcode arm entry did
+    /// this; inline sub-walks seed it from the CALL-site capture; the
+    /// full-body root leaves it empty and collects at guard capture),
+    /// filtered by `OpRef::is_none()`.  This is what
+    /// [`super::walker_capture_snapshot_for_last_guard`] passes as the
+    /// snapshot frame's active boxes on the arm path.
+    ///
+    /// Sub-walks clone the parent's Vec — outer active-box count is
+    /// small (a Python frame's live locals + stack tail) and walker
+    /// nesting depth is shallow (2–3 levels), so the per-sub-walk
+    /// clone cost is negligible.
+    pub outer_active_boxes: Vec<OpRef>,
+    /// PyPy-faithful kept-operand-stack snapshot: the walk-level
+    /// symbolic operand stack, indexed by ABSOLUTE operand-stack depth
+    /// (slot `s`, `s in 0..vstack_depth`).  The Python operand stack is
+    /// all-Ref (`W_Root`), so a single `Vec<OpRef>` (Ref bank) suffices.
+    /// This is the walker analog of PyPy's `MIFrame.registers_r`
+    /// valuestack array snapshotted by `get_list_of_active_boxes`
+    /// (`pyjitpl.py`) — the authoritative per-slot box source the
+    /// `stack_sync` vable overlay reads at a branch guard instead of the
+    /// unreliable `registers_r[stack_slot_color_map[s]]` static-color read.
+    ///
+    /// Maintained ONLY when `sym.owns_virtualizable_shadow()`; on any
+    /// unmodeled stack effect the maintenance sets `vstack_valid = false`
+    /// and `stack_sync` omits every operand slot, which resume
+    /// re-materializes (zero regression).
+    ///
+    /// The mirror is the SOLE kept-stack source at a branch guard: the
+    /// flat `stack_slot_color_map` static-color read it once fell back to
+    /// is retired, so a slot the mirror does not cover is omitted rather
+    /// than read from the flat map.  `PYRE_VSTACK_DIAG` logs the per-op
+    /// reconcile trace.
+    pub vstack_boxes: Vec<OpRef>,
+    /// #73: the last Ref box written via [`super::write_ref_reg`] during the
+    /// CURRENT Python opcode — the box a value-producing opcode lands on
+    /// the operand-stack TOS.  Reset to `OpRef::NONE` at every opcode
+    /// boundary; read by [`super::reconcile_vstack_at_boundary`] for the
+    /// RESULT-TO-TOS class.
+    pub vstack_last_ref: OpRef,
+    /// The `(py_pc, depth, boxes)` the mirror held when `vstack_reorder_ceiling`
+    /// was armed.  A layout excursion that returns to that exact coordinate has
+    /// retired no Python opcode, so the operand stack it left is still the
+    /// operand stack it comes back to and the saved boxes are restored verbatim
+    /// — the shadow reseed cannot reconstruct them, because mid-expression the
+    /// virtualizable's stack region holds the NULLs the in-flight opcode's
+    /// `popvalue_maybe_none` wrote.  `None` outside a region.
+    ///
+    /// There is nothing to snapshot upstream: `pyjitpl.py`
+    /// `MIFrame.run_one_step` steps a live frame whose `registers_r` survive
+    /// the step.  This mirror is instead reconstructed from source pcs, and
+    /// that reconstruction is exactly what an excursion can lose.
+    pub vstack_reorder_saved: Option<(u32, usize, Vec<OpRef>, Vec<bool>)>,
+    /// The exception a bridge resumes with, and after a walked
+    /// `set_current_exception` the value that store published.  Read by the
+    /// nullary bare-reraise folds, and by the PUSH_EXC_INFO `prev` save only
+    /// under [`super::FbwWalkMode::current_exception_seed_from_walk_store`].
+    pub current_exception_seed: Option<OpRef>,
+    /// Concrete shadow paired with [`WalkFrameStateData::current_exception_seed`].
+    pub current_exception_seed_concrete: pyre_object::PyObjectRef,
+    /// Concrete shadow mirror for `registers_r`.
+    ///
+    /// Semantic-slot indexed, length equals `registers_r.len()`. At
+    /// `dispatch_via_miframe` entry, populated by concatenating
+    /// `PyreSym.concrete_locals` + `PyreSym.concrete_stack`; sub-walks
+    /// allocate a fresh `Vec<ConcreteValue>` sized to the callee's
+    /// `num_regs_r` and fill arg slots from the parent's slice at the
+    /// arg byte indices.
+    ///
+    /// **Mutable invariant**: every walker handler that
+    /// writes `registers_r[dst]` MUST also write `concrete_registers_r
+    /// [dst]` in lock-step.  Use the [`super::write_ref_reg`] helper which
+    /// enforces this contract.  Sites that don't know the result's
+    /// concrete pass `ConcreteValue::Null` — downstream consumers
+    /// (e.g. `raise/r` GUARD_CLASS gate) treat `Null` as "no info,
+    /// skip the guard", same as slots the snapshot never populated.
+    /// Copy-style handlers (`ref_copy/r>r`,
+    /// `last_exc_value/>r`) propagate the source's concrete.
+    ///
+    /// The slice is mutable so the concrete shadow tracks the symbolic
+    /// register in lock-step. If it were immutable, sibling handlers
+    /// like `last_exc_value/>r` could rewrite the symbolic register
+    /// without touching the concrete snapshot, so a follow-on `raise/r`
+    /// would read a stale concrete and silently skip the GUARD_CLASS
+    /// gate; the lock-step contract keeps walker-side GUARD_CLASS sound.
+    ///
+    /// **Companion bank** `super::WalkContext::concrete_registers_i` carries the same
+    /// contract for the Int bank.  Production entries size and seed it:
+    /// `dispatch_via_miframe` from `top_constants_i` and `argboxes_i`,
+    /// and both inline-callee entries; only the test fixtures pass
+    /// `&mut []`.
+    ///
+    /// `goto_if_not/iL` and `switch/id` read neither bank: both resolve
+    /// their branch value through `TraceCtx::concrete_of_opref` and
+    /// surface `GotoIfNotValueNotConcrete` rather than guess a
+    /// direction.
+    pub concrete_registers_r: Vec<ConcreteValue>,
+}
+
+impl Default for WalkFrameStateData {
+    fn default() -> Self {
+        Self {
+            callee_shadow: None,
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            current_exception_seed: None,
+            current_exception_seed_concrete: pyre_object::PY_NULL,
+            concrete_registers_r: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct WalkFrameState(Rc<RefCell<WalkFrameStateData>>);
+
+impl WalkFrameState {
+    pub fn new(data: WalkFrameStateData) -> Self {
+        Self(Rc::new(RefCell::new(data)))
+    }
+
+    /// A short field access only: release before executing/allocating guest
+    /// objects. The collector's checked borrow detects violations.
+    pub fn borrow(&self) -> Ref<'_, WalkFrameStateData> {
+        self.0.borrow()
+    }
+
+    /// As with `borrow`, no borrow may span a collecting call.
+    pub fn borrow_mut(&self) -> RefMut<'_, WalkFrameStateData> {
+        self.0.borrow_mut()
+    }
+
+    pub(crate) fn replace_active_box(&self, oldbox: OpRef, newbox: OpRef) {
+        let mut data = self.borrow_mut();
+        let replace = |slot: &mut OpRef| {
+            if *slot == oldbox {
+                *slot = newbox;
+            }
+        };
+        for slot in &mut data.outer_active_boxes {
+            replace(slot);
+        }
+        for slot in &mut data.vstack_boxes {
+            replace(slot);
+        }
+        replace(&mut data.vstack_last_ref);
+        if let Some((_, _, boxes, _)) = &mut data.vstack_reorder_saved {
+            for slot in boxes {
+                replace(slot);
+            }
+        }
+        if let Some(shadow) = &mut data.callee_shadow {
+            replace(&mut shadow.frame_box);
+            for slot in shadow.opref.values_mut() {
+                replace(slot);
+            }
+        }
+        if let Some(slot) = &mut data.current_exception_seed {
+            replace(slot);
+        }
+    }
+
+    pub(crate) fn root(&self) -> WalkFrameStateRoot {
+        let area = unsafe {
+            majit_gc::shadow_stack::MutatorExtraAreaGuard::new(
+                walk_frame_state_roots,
+                Rc::as_ptr(&self.0).cast(),
+                "miframe_state",
+            )
+        };
+        WalkFrameStateRoot {
+            _area: area,
+            _owner: self.clone(),
+        }
+    }
+}
+
+pub(crate) struct WalkFrameStateRoot {
+    _area: majit_gc::shadow_stack::MutatorExtraAreaGuard,
+    _owner: WalkFrameState,
+}
+
+unsafe fn walk_frame_state_roots(data: *const (), visitor: &mut dyn FnMut(&mut GcRef)) {
+    let cell = unsafe { &*(data as *const RefCell<WalkFrameStateData>) };
+    let mut data = cell
+        .try_borrow_mut()
+        .expect("walk frame state borrow held across collection");
+    for value in &mut data.outer_active_boxes {
+        value.walk_const_ptr_refs_mut(visitor);
+    }
+    for value in &mut data.vstack_boxes {
+        value.walk_const_ptr_refs_mut(visitor);
+    }
+    data.vstack_last_ref.walk_const_ptr_refs_mut(visitor);
+    if let Some((_, _, boxes, _)) = &mut data.vstack_reorder_saved {
+        for value in boxes {
+            value.walk_const_ptr_refs_mut(visitor);
+        }
+    }
+    if let Some(shadow) = &mut data.callee_shadow {
+        shadow.frame_box.walk_const_ptr_refs_mut(visitor);
+        for value in shadow.opref.values_mut() {
+            value.walk_const_ptr_refs_mut(visitor);
+        }
+        for entry in shadow.concrete.values_mut() {
+            if let Value::Ref(root) = &mut entry.value {
+                visitor(root);
+            }
+        }
+        // FrameBox frames are currently nonmoving, but the owning reference
+        // is still a GC edge (call_jit.rs walk_jit_callee_frame_roots_area).
+        let mut frame = GcRef(shadow.concrete_frame);
+        visitor(&mut frame);
+        shadow.concrete_frame = frame.0;
+        // code_ptr is a Rust CodeObject address, not a PyObject GC pointer.
+        // The JitCode code-root publication traces that code's GC fields.
+    }
+    if let Some(value) = &mut data.current_exception_seed {
+        value.walk_const_ptr_refs_mut(visitor);
+    }
+    let mut exception = GcRef(data.current_exception_seed_concrete as usize);
+    visitor(&mut exception);
+    data.current_exception_seed_concrete = exception.0 as pyre_object::PyObjectRef;
+    if !data.current_exception_seed_concrete.is_null() {
+        // Native exception carriers also need their young child slots walked.
+        unsafe {
+            pyre_interpreter::eval::walk_raw_exception_roots(
+                data.current_exception_seed_concrete,
+                visitor,
+            )
+        };
+    }
+    for value in &mut data.concrete_registers_r {
+        if let ConcreteValue::Ref(ptr) = value {
+            let mut root = GcRef(*ptr as usize);
+            visitor(&mut root);
+            *ptr = root.0 as pyre_object::PyObjectRef;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with_refs(word: usize) -> WalkFrameState {
+        let op = OpRef::const_ptr(GcRef(word));
+        let mut shadow = CalleeLocalsShadow {
+            frame_box: op,
+            concrete_frame: word,
+            ..Default::default()
+        };
+        shadow.set_opref(0, op);
+        shadow.set_concrete(1, 0, Value::Ref(GcRef(word)));
+        WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: Some(shadow),
+            outer_active_boxes: vec![op],
+            vstack_boxes: vec![op],
+            vstack_last_ref: op,
+            vstack_reorder_saved: Some((0, 1, vec![op], vec![true])),
+            current_exception_seed: Some(op),
+            // Only the symbolic seed may use a sentinel: concrete exceptions
+            // have their real children traversed by the callback.
+            current_exception_seed_concrete: pyre_object::PY_NULL,
+            concrete_registers_r: vec![
+                ConcreteValue::Ref(word as pyre_object::PyObjectRef),
+                ConcreteValue::Int(word as i64),
+            ],
+        })
+    }
+
+    fn assert_refs(state: &WalkFrameState, word: usize) {
+        let state = state.borrow();
+        let op = OpRef::const_ptr(GcRef(word));
+        assert_eq!(state.outer_active_boxes, [op]);
+        assert_eq!(state.vstack_boxes, [op]);
+        assert_eq!(state.vstack_last_ref, op);
+        assert_eq!(state.vstack_reorder_saved.as_ref().unwrap().2, [op]);
+        assert_eq!(state.current_exception_seed, Some(op));
+        assert!(
+            matches!(state.concrete_registers_r[0], ConcreteValue::Ref(p) if p as usize == word)
+        );
+        let shadow = state.callee_shadow.as_ref().unwrap();
+        assert_eq!(shadow.frame_box, op);
+        assert_eq!(shadow.concrete_frame, word);
+        assert_eq!(shadow.opref.get(&0), Some(&op));
+        assert_eq!(
+            shadow.concrete.get(&0).unwrap().value,
+            Value::Ref(GcRef(word))
+        );
+    }
+
+    #[test]
+    fn nested_scoped_roots_forward_every_frame_mirror_and_retire_independently() {
+        let _runtime = crate::trace_ctx_for_test(0);
+        let _stw = majit_gc::gc_sync::quiesce_mutators();
+        let outer = state_with_refs(0x1000);
+        let inner = state_with_refs(0x2000);
+        let paused = outer.clone();
+        let outer_root = outer.root();
+        let inner_root = inner.root();
+        drop(outer);
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            if root.0 == 0x1000 || root.0 == 0x2000 {
+                root.0 += 0x80;
+            }
+        });
+        assert_refs(&paused, 0x1080);
+        assert_refs(&inner, 0x2080);
+        assert!(matches!(
+            paused.borrow().concrete_registers_r[1],
+            ConcreteValue::Int(0x1000)
+        ));
+        drop(outer_root);
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            if root.0 == 0x1080 || root.0 == 0x2080 {
+                root.0 += 0x80;
+            }
+        });
+        assert_refs(&paused, 0x1080);
+        assert_refs(&inner, 0x2100);
+        drop(inner_root);
+    }
+
+    #[test]
+    fn replacement_is_immediate_before_a_collection_or_resume() {
+        let state = state_with_refs(0x1000);
+        let paused = state.clone();
+        let old = OpRef::const_ptr(GcRef(0x1000));
+        let new = OpRef::input_arg_ref(0);
+        paused.replace_active_box(old, new);
+        let state = state.borrow();
+        assert_eq!(state.outer_active_boxes, [new]);
+        assert_eq!(state.vstack_boxes, [new]);
+        assert_eq!(state.vstack_last_ref, new);
+        assert_eq!(state.vstack_reorder_saved.as_ref().unwrap().2, [new]);
+        assert_eq!(state.current_exception_seed, Some(new));
+        let shadow = state.callee_shadow.as_ref().unwrap();
+        assert_eq!(shadow.frame_box, new);
+        assert_eq!(shadow.opref.get(&0), Some(&new));
+    }
+
+    #[test]
+    #[should_panic(expected = "walk frame state borrow held across collection")]
+    fn collecting_with_a_live_field_borrow_is_rejected() {
+        let state = WalkFrameState::default();
+        let _borrow = state.borrow();
+        // Direct invocation keeps the expected panic outside the global root
+        // traversal; no registry borrow is poisoned by this diagnostic.
+        unsafe { walk_frame_state_roots(Rc::as_ptr(&state.0).cast(), &mut |_| {}) };
+    }
+
+    #[test]
+    fn standing_exception_seed_keeps_its_young_children() {
+        use pyre_object::interp_exceptions::{ExcKind, W_BaseException, w_exception_new_empty};
+        pyre_interpreter::typedef::init_typeobjects();
+        let _pins = pyre_object::gc_roots::push_roots();
+        let exception =
+            pyre_object::gc_roots::pin_root(w_exception_new_empty(ExcKind::UnicodeTranslateError));
+        let child = pyre_object::gc_roots::pin_root(pyre_object::unicodeobject::w_str_new("child"));
+        let replacement =
+            pyre_object::gc_roots::pin_root(pyre_object::unicodeobject::w_str_new("forwarded"));
+        let _stw = majit_gc::gc_sync::quiesce_mutators();
+        unsafe {
+            (*(exception as *mut W_BaseException)).w_object = child;
+        }
+        let state = WalkFrameState::new(WalkFrameStateData {
+            current_exception_seed_concrete: exception,
+            ..Default::default()
+        });
+        let _root = state.root();
+        let mut seen = false;
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            seen |= root.0 == exception as usize;
+            if root.0 == child as usize {
+                root.0 = replacement as usize;
+            }
+        });
+        assert!(seen);
+        assert_eq!(
+            unsafe { (*(exception as *const W_BaseException)).w_object },
+            replacement
+        );
+    }
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -78,7 +78,7 @@ pub(crate) fn getarrayitem_gc_via_heapcache<Sym: WalkSym>(
                         'r' => write_ref_reg(ctx, op.pc, dst, folded, concrete)?,
                         _ => {
                             let len = ctx.registers_f.len();
-                            let slot = ctx.registers_f.get_mut(dst).ok_or(
+                            let _ = ctx.registers_f.get(dst).ok_or(
                                 DispatchError::RegisterOutOfRange {
                                     pc: op.pc,
                                     reg: dst,
@@ -86,7 +86,7 @@ pub(crate) fn getarrayitem_gc_via_heapcache<Sym: WalkSym>(
                                     bank: "f",
                                 },
                             )?;
-                            *slot = folded;
+                            ctx.registers_f.set(dst, folded);
                         }
                     }
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -183,16 +183,16 @@ pub(crate) fn getarrayitem_gc_via_heapcache<Sym: WalkSym>(
         }
         'f' => {
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     }
@@ -670,16 +670,16 @@ pub(crate) fn getfield_gc_via_heapcache<Sym: WalkSym>(
         }
         'f' => {
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -6974,6 +6974,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         None
     };
     let caller_replacements = FrameBoxReplacements::new(ctx.session);
+    caller_replacements.bind_banks(ctx.registers_r, ctx.registers_i, ctx.registers_f);
     let (callee_outcome, callee_class_of_last_exc_is_const) = {
         let mut sub_wc = WalkContext {
             callee_shadow: Some(super::CalleeLocalsShadow {
@@ -12104,7 +12105,7 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         exchange.next_frame_id += 1;
         id
     };
-    let frame = SubWalkFrame {
+    let mut frame = SubWalkFrame {
         box_replacements: FrameBoxReplacements::new(ctx.session),
         id: frame_id,
         caller_pc: pc,
@@ -12148,6 +12149,11 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
     };
+    frame.box_replacements.bind_banks(
+        &mut frame.registers_r,
+        &mut frame.registers_i,
+        &mut frame.registers_f,
+    );
 
     if !driver_pointer.is_null() {
         // Nested descent: publish the heap frame and yield the parent at its
@@ -12163,6 +12169,7 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
     let mut driver = SubWalkDriver::new(frame);
     let _driver_guard = SubWalkDriverGuard::install(&mut driver.exchange);
     let caller_replacements = FrameBoxReplacements::new(ctx.session);
+    caller_replacements.bind_banks(ctx.registers_r, ctx.registers_i, ctx.registers_f);
     let result = driver.drive(ctx.trace_ctx);
     caller_replacements.apply(ctx);
     drop(caller_replacements);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1495,9 +1495,9 @@ pub(crate) fn exception_string_override_has_nested_call(
 /// to abort the multi-frame inline and interpret rather than
 /// encode a NONE box.  `PYRE_FBW_MF_DIAG` dumps the missing color.
 pub(crate) fn collect_callee_active_boxes(
-    regs_i: &[OpRef],
-    regs_r: &[OpRef],
-    regs_f: &[OpRef],
+    regs_i: &(impl RegisterValues + ?Sized),
+    regs_r: &(impl RegisterValues + ?Sized),
+    regs_f: &(impl RegisterValues + ?Sized),
     callee_jitcode_index: u32,
     callee_op_pc: usize,
     carried_jitcode_pc: i32,
@@ -1520,38 +1520,54 @@ pub(crate) fn collect_callee_active_boxes(
     );
     let mut active = Vec::with_capacity(banks.int.len() + banks.ref_.len() + banks.float.len());
     let diag = fbw_mf_diag_enabled();
-    let read = |bank: &[OpRef], idx: u32, name: &str| -> Result<OpRef, DispatchError> {
-        match bank.get(idx as usize).copied() {
-            Some(v) if v != OpRef::NONE => Ok(v),
-            other => {
-                if diag {
-                    eprintln!(
-                        "[fbw-mf-diag] decline: callee {name} reg {idx} {} \
+    let read =
+        |value: Option<OpRef>, len: usize, idx: u32, name: &str| -> Result<OpRef, DispatchError> {
+            match value {
+                Some(v) if v != OpRef::NONE => Ok(v),
+                other => {
+                    if diag {
+                        eprintln!(
+                            "[fbw-mf-diag] decline: callee {name} reg {idx} {} \
                          (callee_jitcode_index={callee_jitcode_index}, \
                          bank_len={}, live_i={:?} live_r={:?} live_f={:?})",
-                        if other.is_none() {
-                            "out-of-range"
-                        } else {
-                            "holds OpRef::NONE"
-                        },
-                        bank.len(),
-                        banks.int,
-                        banks.ref_,
-                        banks.float,
-                    );
+                            if other.is_none() {
+                                "out-of-range"
+                            } else {
+                                "holds OpRef::NONE"
+                            },
+                            len,
+                            banks.int,
+                            banks.ref_,
+                            banks.float,
+                        );
+                    }
+                    Err(DispatchError::callee_inline_unsupported(callee_op_pc))
                 }
-                Err(DispatchError::callee_inline_unsupported(callee_op_pc))
             }
-        }
-    };
+        };
     for &idx in &banks.int {
-        active.push(read(regs_i, idx, "int")?);
+        active.push(read(
+            regs_i.get_box(idx as usize),
+            regs_i.len(),
+            idx,
+            "int",
+        )?);
     }
     for &idx in &banks.ref_ {
-        active.push(read(regs_r, idx, "ref")?);
+        active.push(read(
+            regs_r.get_box(idx as usize),
+            regs_r.len(),
+            idx,
+            "ref",
+        )?);
     }
     for &idx in &banks.float {
-        active.push(read(regs_f, idx, "float")?);
+        active.push(read(
+            regs_f.get_box(idx as usize),
+            regs_f.len(),
+            idx,
+            "float",
+        )?);
     }
     Ok(active)
 }
@@ -6387,6 +6403,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         mut callee_concrete_r,
         mut callee_concrete_i,
     ) = allocate_callee_register_banks(&body, ctx.trace_ctx);
+    let callee_regs_r = RegisterBank::with_constants(callee_regs_r, body.num_regs_r);
+    let _setup_bank_guard = crate::trace::InlineRegisterBankGuard::enter(&callee_regs_r);
     // Fast-path arg seeding: positional args land in the callee's
     // param registers with their concrete shadow (mirror of
     // `dispatch_inline_call_dr_kind`).  The canonical splice regalloc does
@@ -6429,7 +6447,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         if reg >= callee_regs_r.len() {
             return resolved_inline_decline(op.pc, line!());
         }
-        callee_regs_r[reg] = callee_args[i];
+        callee_regs_r.set(reg, callee_args[i]);
         callee_concrete_r[reg] = callee_arg_concretes[i];
     }
 
@@ -6679,7 +6697,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             return resolved_inline_decline(op.pc, line!());
         };
 
-        callee_regs_r[frame_reg as usize] = callee_frame;
+        callee_regs_r.set(frame_reg as usize, callee_frame);
         // `perform_call` creates one concrete frame per MIFrame before
         // `setup_call` installs the argument boxes (pyjitpl.py,
         // 1862-1874).  Mirror that recording-time object.  `setup_call`
@@ -6740,7 +6758,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // GC-managed FrameBox::drop intentionally relinquishes only the
         // host handle; the frontend op above keeps the frame reachable.
         drop(frame);
-        callee_regs_r[ec_reg as usize] = callee_ec;
+        callee_regs_r.set(ec_reg as usize, callee_ec);
         // `perform_call` threads the same concrete ExecutionContext into
         // every MIFrame.  The symbolic second red above and its concrete
         // shadow are one value; leaving only the shadow unknown makes
@@ -7002,9 +7020,9 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 ..ctx.fbw_mode
             },
             session: ctx.session,
-            registers_r: &mut callee_regs_r,
-            registers_i: &mut callee_regs_i,
-            registers_f: &mut callee_regs_f,
+            registers_r: &callee_regs_r,
+            registers_i: &RegisterBank::with_constants(callee_regs_i, body.num_regs_i),
+            registers_f: &RegisterBank::with_constants(callee_regs_f, body.num_regs_f),
             concrete_registers_r: &mut callee_concrete_r,
             concrete_registers_i: &mut callee_concrete_i,
             descr_refs: &callee_descr_refs,
@@ -7097,7 +7115,10 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             {
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
                 shadow.concrete_frame = concrete_callee_frame as usize;
-                shadow.frame_box = sub_wc.registers_r[callee_portal_frame_reg as usize];
+                shadow.frame_box = sub_wc
+                    .registers_r
+                    .get(callee_portal_frame_reg as usize)
+                    .expect("ref register in range");
             }
             if !try_multiframe {
                 let shadow = sub_wc.callee_shadow.as_mut().unwrap();
@@ -7206,7 +7227,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             // `ConstPtr` into `sub_wc.registers_r`, which is not the anchored
             // `sym.registers_r`.
             let _callee_bank_guard =
-                crate::trace::InlineRegisterBankGuard::enter(&raw mut *sub_wc.registers_r);
+                crate::trace::InlineRegisterBankGuard::enter(sub_wc.registers_r);
             walk(body.code, 0, &mut sub_wc)
         };
         if let Some(jd_no) = subwalk_jd_no {
@@ -8360,7 +8381,7 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
-        let result = ctx.registers_r[dst];
+        let result = ctx.registers_r.get(dst).expect("ref register in range");
         let str_type = &pyre_object::pyobject::STR_TYPE as *const _ as i64;
         let str_type_const = ctx.trace_ctx.const_int(str_type);
         ctx.trace_ctx
@@ -8499,7 +8520,7 @@ pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
-        let result = ctx.registers_r[dst];
+        let result = ctx.registers_r.get(dst).expect("ref register in range");
         let concrete_result = walker_concrete_ref_object(ctx, result);
         let live = concrete_result.and_then(walker_machine_int_value);
         // The inline unbox is guard-free only against a known-class or
@@ -10153,7 +10174,7 @@ pub(crate) fn try_walker_specialize_instance_iter<Sym: WalkSym>(
     // back the very box the receiver guard pins, so the class the check reads
     // is that guard's class on every entry.  Any other result reaches the
     // residual, which runs the check itself.
-    if ctx.registers_r[dst] != obj_op {
+    if ctx.registers_r.get(dst).expect("ref register in range") != obj_op {
         if fbw_executed_effect_count() != executed_effects_before {
             return Err(DispatchError::callee_inline_unsupported(op.pc));
         }
@@ -10325,7 +10346,7 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
         return Ok(Some((DispatchOutcome::Continue, inline_resume_pc)));
     }
 
-    let item_op = ctx.registers_r[dst];
+    let item_op = ctx.registers_r.get(dst).expect("ref register in range");
     let Some(concrete_item) = walker_concrete_ref_object(ctx, item_op) else {
         return Err(DispatchError::callee_inline_unsupported(op.pc));
     };
@@ -11090,7 +11111,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
-        let result = ctx.registers_r[dst];
+        let result = ctx.registers_r.get(dst).expect("ref register in range");
         if matches!(
             concrete_from_recorded_opref(ctx, result),
             ConcreteValue::Ref(obj)
@@ -11337,7 +11358,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
-        let result = ctx.registers_r[dst];
+        let result = ctx.registers_r.get(dst).expect("ref register in range");
         if matches!(
             concrete_from_recorded_opref(ctx, result),
             ConcreteValue::Ref(obj)
@@ -11548,7 +11569,7 @@ pub(crate) fn try_walker_inline_format<Sym: WalkSym>(
         // exact str and each accepted str subclass get their own guarded
         // version, while a later non-string result deopts to the residual that
         // raises the faithful TypeError.
-        let result = ctx.registers_r[dst];
+        let result = ctx.registers_r.get(dst).expect("ref register in range");
         let concrete_result = match concrete_from_recorded_opref(ctx, result) {
             ConcreteValue::Ref(obj) => obj,
             other => unreachable!("accepted __format__ result is not a Ref: {other:?}"),
@@ -11674,9 +11695,9 @@ struct SubWalkFrame<'a, Sym: WalkSym> {
     pc: usize,
     body: SubJitCodeBody,
     seed_from_active_resume: bool,
-    registers_r: Vec<OpRef>,
-    registers_i: Vec<OpRef>,
-    registers_f: Vec<OpRef>,
+    registers_r: RegisterBank,
+    registers_i: RegisterBank,
+    registers_f: RegisterBank,
     concrete_registers_r: Vec<ConcreteValue>,
     concrete_registers_i: Vec<ConcreteValue>,
     callee_shadow: Option<CalleeLocalsShadow>,
@@ -11716,9 +11737,9 @@ impl<'a, Sym: WalkSym> SubWalkFrame<'a, Sym> {
             inline_poison_pcs: self.inline_poison_pcs.take(),
             fbw_mode: self.fbw_mode,
             session: self.session,
-            registers_r: &mut self.registers_r,
-            registers_i: &mut self.registers_i,
-            registers_f: &mut self.registers_f,
+            registers_r: &self.registers_r,
+            registers_i: &self.registers_i,
+            registers_f: &self.registers_f,
             concrete_registers_r: &mut self.concrete_registers_r,
             concrete_registers_i: &mut self.concrete_registers_i,
             descr_refs: self.descr_refs,
@@ -11851,20 +11872,16 @@ impl<'a, Sym: WalkSym> SubWalkDriver<'a, Sym> {
     /// `inline_register_banks` already held every live bank at once — its only
     /// reader walks the whole list (`trace.rs walk_active_sym_register_area`).
     ///
-    /// `InlineRegisterBankGuard::drop` pops whatever entry is on top, so the
-    /// entries have to retire in reverse order; pairing them with `frames`
-    /// is what gives that.  The address published is the `Vec`'s heap buffer,
-    /// so it survives a `frames` realloc moving the `SubWalkFrame` itself, and
-    /// the walk cannot reallocate the bank because `WalkContext` borrows it as
-    /// `&mut [OpRef]`.
+    /// Each registration retains the frame's actual shared slots. A `frames`
+    /// realloc cannot move those slots, and guard retirement finds its bank
+    /// by identity, including when setup and driver registrations overlap.
     fn push_frame(&mut self, frame: SubWalkFrame<'a, Sym>) {
         self.frames.push(frame);
-        let bank: *mut [OpRef] = self
+        let bank = &self
             .frames
-            .last_mut()
+            .last()
             .expect("the frame just pushed")
-            .registers_r
-            .as_mut_slice();
+            .registers_r;
         self.bank_guards
             .push(crate::trace::InlineRegisterBankGuard::enter(bank));
     }
@@ -12028,6 +12045,8 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         mut callee_concrete_r,
         mut callee_concrete_i,
     ) = allocate_callee_register_banks(sub_body, ctx.trace_ctx);
+    let callee_regs_r = RegisterBank::with_constants(callee_regs_r, sub_body.num_regs_r);
+    let _setup_bank_guard = crate::trace::InlineRegisterBankGuard::enter(&callee_regs_r);
 
     if int_args.len() > sub_body.num_regs_i {
         return Err(DispatchError::InlineCallIntArityMismatch {
@@ -12054,7 +12073,7 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         callee_regs_i[i] = *arg;
     }
     for (i, arg) in ref_args.iter().enumerate() {
-        callee_regs_r[i] = *arg;
+        callee_regs_r.set(i, *arg);
     }
     for (i, arg) in float_args.iter().enumerate() {
         callee_regs_f[i] = *arg;
@@ -12113,8 +12132,8 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         body: sub_body.clone(),
         seed_from_active_resume: true,
         registers_r: callee_regs_r,
-        registers_i: callee_regs_i,
-        registers_f: callee_regs_f,
+        registers_i: RegisterBank::with_constants(callee_regs_i, sub_body.num_regs_i),
+        registers_f: RegisterBank::with_constants(callee_regs_f, sub_body.num_regs_f),
         concrete_registers_r: callee_concrete_r,
         concrete_registers_i: callee_concrete_i,
         callee_shadow: None,
@@ -12149,11 +12168,9 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
     };
-    frame.box_replacements.bind_banks(
-        &mut frame.registers_r,
-        &mut frame.registers_i,
-        &mut frame.registers_f,
-    );
+    frame
+        .box_replacements
+        .bind_banks(&frame.registers_r, &frame.registers_i, &frame.registers_f);
 
     if !driver_pointer.is_null() {
         // Nested descent: publish the heap frame and yield the parent at its
@@ -12674,15 +12691,16 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
                     }
                     'f' => {
                         let len = ctx.registers_f.len();
-                        let slot = ctx.registers_f.get_mut(dst).ok_or(
-                            DispatchError::RegisterOutOfRange {
-                                pc: op.pc,
-                                reg: dst,
-                                len,
-                                bank: "f",
-                            },
-                        )?;
-                        *slot = value;
+                        let _ =
+                            ctx.registers_f
+                                .get(dst)
+                                .ok_or(DispatchError::RegisterOutOfRange {
+                                    pc: op.pc,
+                                    reg: dst,
+                                    len,
+                                    bank: "f",
+                                })?;
+                        ctx.registers_f.set(dst, value);
                     }
                     _ => unreachable!(
                         "dispatch_inline_call_dirf_kind dst_bank must be 'i', 'r', 'f' or 'v'"

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1797,8 +1797,13 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // The loopless `fib` shape keeps only within-iteration temps (a prior call
     // result), no InputArg, and was foldable either way.
     if ctx.vstack_valid {
-        let kept_below = ctx.vstack_boxes.len().saturating_sub(r_args.len());
-        if ctx.vstack_boxes[..kept_below]
+        let kept_below = ctx
+            .frame_state
+            .borrow()
+            .vstack_boxes
+            .len()
+            .saturating_sub(r_args.len());
+        if ctx.frame_state.borrow().vstack_boxes[..kept_below]
             .iter()
             .any(|slot| slot.is_input_arg() && !loop_carried_slot_keeps_fold_profitable(ctx, *slot))
         {
@@ -2172,14 +2177,20 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         } else {
             raw_depth()
         };
-        ctx.vstack_boxes.truncate(resume_depth);
-        ctx.vstack_boxes.resize(resume_depth, OpRef::NONE);
+        ctx.frame_state
+            .borrow_mut()
+            .vstack_boxes
+            .truncate(resume_depth);
+        ctx.frame_state
+            .borrow_mut()
+            .vstack_boxes
+            .resize(resume_depth, OpRef::NONE);
         if resume_depth > 0 {
-            ctx.vstack_boxes[resume_depth - 1] = ca_result;
+            ctx.frame_state.borrow_mut().vstack_boxes[resume_depth - 1] = ca_result;
         }
         ctx.vstack_cur_pypc = resume_py_pc;
         ctx.vstack_depth = resume_depth;
-        ctx.vstack_last_ref = OpRef::NONE;
+        ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
         super::vstack_mirror::disarm_vstack_reorder_region(ctx);
     }
 
@@ -2610,12 +2621,16 @@ pub(crate) fn reconstructed_all_ref_call_stack<Sym: WalkSym>(
     // an enclosing FOR_ITER).  RPython resumes the complete MIFrame stack, so
     // retain that prefix from the authoritative vstack mirror.
     let prefix_len = if ctx.vstack_valid {
-        ctx.vstack_boxes.len().checked_sub(fresh.len())?
+        ctx.frame_state
+            .borrow()
+            .vstack_boxes
+            .len()
+            .checked_sub(fresh.len())?
     } else {
         0
     };
     let mut stack = Vec::with_capacity(prefix_len + fresh.len());
-    for &value in &ctx.vstack_boxes[..prefix_len] {
+    for &value in &ctx.frame_state.borrow().vstack_boxes[..prefix_len] {
         match concrete_from_recorded_opref(ctx, value) {
             ConcreteValue::Ref(r) if !r.is_null() => stack.push(r),
             _ => return None,
@@ -4168,7 +4183,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     // leaves the caller's trace exactly as the ordinary residual call found it.
     let pre_fold_pos = ctx.trace_ctx.get_trace_position();
     let call_site_active = if nested_helper_entry.is_some() {
-        ctx.outer_active_boxes.clone()
+        ctx.frame_state.borrow().outer_active_boxes.clone()
     } else {
         let call_site_word = call_site_marker
             .map(|marker| marker as i32)
@@ -4343,7 +4358,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     let saved_entry = ctx.entry_py_pc;
     let saved_marker = ctx.outer_resume_marker_jit_pc;
     let saved_oji = ctx.outer_jitcode_index;
-    let saved_active = std::mem::take(&mut ctx.outer_active_boxes);
+    let saved_active = std::mem::take(&mut ctx.frame_state.borrow_mut().outer_active_boxes);
     let saved_descr_refs = ctx.descr_refs;
     let saved_raw_descrs = ctx.raw_descrs;
     let saved_lookup = ctx.sub_jitcode_lookup;
@@ -4357,7 +4372,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     ctx.entry_py_pc = EntryPyPc::Jit(op.pc);
     ctx.outer_resume_marker_jit_pc = call_site_marker;
     ctx.outer_jitcode_index = outer_jitcode_index;
-    ctx.outer_active_boxes = call_site_active;
+    ctx.frame_state.borrow_mut().outer_active_boxes = call_site_active;
     ctx.descr_refs = crate::jitcode_runtime::descr_ref_table();
     ctx.raw_descrs = RawDescrPool::Global;
     ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
@@ -4402,7 +4417,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     ctx.entry_py_pc = saved_entry;
     ctx.outer_resume_marker_jit_pc = saved_marker;
     ctx.outer_jitcode_index = saved_oji;
-    ctx.outer_active_boxes = saved_active;
+    ctx.frame_state.borrow_mut().outer_active_boxes = saved_active;
     ctx.descr_refs = saved_descr_refs;
     ctx.raw_descrs = saved_raw_descrs;
     ctx.sub_jitcode_lookup = saved_lookup;
@@ -4584,7 +4599,7 @@ fn reconstructed_call_stack_from_resume_sources<Sym: WalkSym>(
                  depth={depth} vstack_valid={} vstack_depth={} vstack_len={}",
                 ctx.vstack_valid,
                 ctx.vstack_depth,
-                ctx.vstack_boxes.len(),
+                ctx.frame_state.borrow().vstack_boxes.len(),
             );
         }
         return None;
@@ -4597,7 +4612,7 @@ fn reconstructed_call_stack_from_resume_sources<Sym: WalkSym>(
             overrides.iter().map(|&(slot, _)| slot).collect::<Vec<_>>(),
             ctx.vstack_valid,
             ctx.vstack_depth,
-            ctx.vstack_boxes.len(),
+            ctx.frame_state.borrow().vstack_boxes.len(),
         );
     }
     let mut ordered = vec![None; depth];
@@ -6405,6 +6420,13 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     ) = allocate_callee_register_banks(&body, ctx.trace_ctx);
     let callee_regs_r = RegisterBank::with_constants(callee_regs_r, body.num_regs_r);
     let _setup_bank_guard = crate::trace::InlineRegisterBankGuard::enter(&callee_regs_r);
+    // MIFrame.setup_call owns the concrete halves before frame construction
+    // can allocate. The later WalkContext uses these same slots.
+    let callee_state = WalkFrameState::new(WalkFrameStateData {
+        concrete_registers_r: callee_concrete_r,
+        ..Default::default()
+    });
+    let _setup_state_guard = crate::trace::InlineFrameStateGuard::enter(&callee_state);
     // Fast-path arg seeding: positional args land in the callee's
     // param registers with their concrete shadow (mirror of
     // `dispatch_inline_call_dr_kind`).  The canonical splice regalloc does
@@ -6448,7 +6470,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             return resolved_inline_decline(op.pc, line!());
         }
         callee_regs_r.set(reg, callee_args[i]);
-        callee_concrete_r[reg] = callee_arg_concretes[i];
+        callee_state.borrow_mut().concrete_registers_r[reg] = callee_arg_concretes[i];
     }
 
     // #68: seed the callee's `frame` / `ec` reds that the codewriter
@@ -6736,7 +6758,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         drop(arg_roots);
         let concrete_frame_ptr = frame.as_mut_ptr();
         concrete_callee_frame = concrete_frame_ptr;
-        callee_concrete_r[frame_reg as usize] =
+        callee_state.borrow_mut().concrete_registers_r[frame_reg as usize] =
             ConcreteValue::Ref(concrete_frame_ptr as pyre_object::PyObjectRef);
         ctx.trace_ctx.set_opref_concrete(
             callee_frame,
@@ -6765,7 +6787,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // `build_single_frame_miframe` reject an otherwise complete
         // callee image during an escape, after which the legacy caller
         // replay resumes past CALL without its result.
-        callee_concrete_r[ec_reg as usize] =
+        callee_state.borrow_mut().concrete_registers_r[ec_reg as usize] =
             ConcreteValue::Ref(concrete_ec as pyre_object::PyObjectRef);
 
         // Retain for a possible `SubLoopCalleeCallAssembler` emit.
@@ -6864,11 +6886,11 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         inline_outer_jc_index,
         inline_outer_resume_marker_jit_pc,
         inline_caller_py_pc,
-    ) = if ctx.outer_active_boxes.is_empty() {
+    ) = if ctx.frame_state.borrow().outer_active_boxes.is_empty() {
         let sym_ptr = ctx.fbw_mode.snapshot_sym;
         if sym_ptr.is_null() {
             (
-                ctx.outer_active_boxes.clone(),
+                ctx.frame_state.borrow().outer_active_boxes.clone(),
                 ctx.entry_py_pc,
                 ctx.outer_jitcode_index,
                 ctx.outer_resume_marker_jit_pc,
@@ -6878,7 +6900,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             let sym = unsafe { &*sym_ptr };
             if sym.jitcode().is_null() {
                 (
-                    ctx.outer_active_boxes.clone(),
+                    ctx.frame_state.borrow().outer_active_boxes.clone(),
                     ctx.entry_py_pc,
                     ctx.outer_jitcode_index,
                     ctx.outer_resume_marker_jit_pc,
@@ -6945,7 +6967,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // (e.g. an inline CALL inside a carrier sub-walk whose outer
         // coordinate is the paused root).
         (
-            ctx.outer_active_boxes.clone(),
+            ctx.frame_state.borrow().outer_active_boxes.clone(),
             ctx.entry_py_pc,
             ctx.outer_jitcode_index,
             ctx.outer_resume_marker_jit_pc,
@@ -6993,12 +7015,21 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     };
     let caller_replacements = FrameBoxReplacements::new(ctx.session);
     caller_replacements.bind_banks(ctx.registers_r, ctx.registers_i, ctx.registers_f);
+    caller_replacements.bind_frame_state(&ctx.frame_state);
     let (callee_outcome, callee_class_of_last_exc_is_const) = {
-        let mut sub_wc = WalkContext {
-            callee_shadow: Some(super::CalleeLocalsShadow {
+        {
+            let parent_state = ctx.frame_state.borrow();
+            let mut state = callee_state.borrow_mut();
+            state.callee_shadow = Some(super::CalleeLocalsShadow {
                 code_ptr: raw_callee_code,
                 ..Default::default()
-            }),
+            });
+            state.current_exception_seed = parent_state.current_exception_seed;
+            state.current_exception_seed_concrete = parent_state.current_exception_seed_concrete;
+            state.outer_active_boxes = inline_outer_active_boxes;
+        }
+        let mut sub_wc = WalkContext {
+            frame_state: callee_state,
             // Path-1: resolve scalar static-field reads off this callee's own
             // unseeded portal frame to its compile-time constants.
             inline_callee_consts: Some(inline_consts),
@@ -7023,19 +7054,19 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             registers_r: &callee_regs_r,
             registers_i: &RegisterBank::with_constants(callee_regs_i, body.num_regs_i),
             registers_f: &RegisterBank::with_constants(callee_regs_f, body.num_regs_f),
-            concrete_registers_r: &mut callee_concrete_r,
+
             concrete_registers_i: &mut callee_concrete_i,
             descr_refs: &callee_descr_refs,
             raw_descrs: RawDescrPool::PerFn(callee_perfn_descrs),
             is_authoritative_executor: ctx.is_authoritative_executor,
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -7045,7 +7076,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             entry_py_pc: inline_outer_entry_py_pc,
             outer_resume_marker_jit_pc: inline_outer_resume_marker_jit_pc,
             outer_jitcode_index: inline_outer_jc_index,
-            outer_active_boxes: inline_outer_active_boxes,
         };
         // Track this callee for the lifetime of the sub-walk so nested
         // self-calls see the correct recursion depth.
@@ -7113,7 +7143,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // unresolved).
         if callee_portal_frame_reg != u16::MAX {
             {
-                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                let mut state = sub_wc.frame_state.borrow_mut();
+                let shadow = state.callee_shadow.as_mut().unwrap();
                 shadow.concrete_frame = concrete_callee_frame as usize;
                 shadow.frame_box = sub_wc
                     .registers_r
@@ -7121,7 +7152,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     .expect("ref register in range");
             }
             if !try_multiframe {
-                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                let mut state = sub_wc.frame_state.borrow_mut();
+                let shadow = state.callee_shadow.as_mut().unwrap();
                 shadow.fold_frame_reg = callee_portal_frame_reg;
                 // The fold's premise (`setarrayitem_vable_via_metainterp`) is
                 // that it writes away from an UNSEEDED portal frame — a pure
@@ -7152,7 +7184,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     .trace_ctx
                     .concrete_of_opref(callee_args[i])
                     .unwrap_or(majit_ir::Value::Void);
-                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                let mut state = sub_wc.frame_state.borrow_mut();
+                let shadow = state.callee_shadow.as_mut().unwrap();
                 shadow.set_opref(slot, value);
                 shadow.set_concrete(callee_portal_frame_reg, slot, concrete);
             }
@@ -7170,7 +7203,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 .enumerate()
             {
                 let slot = (callee_code.varnames.len() + i) as i64;
-                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                let mut state = sub_wc.frame_state.borrow_mut();
+                let shadow = state.callee_shadow.as_mut().unwrap();
                 shadow.set_opref(slot, value);
                 shadow.set_concrete(
                     callee_portal_frame_reg,
@@ -7386,13 +7420,20 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                         let semantic_slot = nlocals + rel;
                         let register_value =
                             crate::state::semantic_slot_color_for_ref_slot(&entries, semantic_slot)
-                                .and_then(|color| sub_wc.concrete_registers_r.get(color).copied());
+                                .and_then(|color| {
+                                    sub_wc
+                                        .frame_state
+                                        .borrow()
+                                        .concrete_registers_r
+                                        .get(color)
+                                        .copied()
+                                });
                         let value = register_value
                             .or_else(|| {
                                 (metadata.built_as_portal && abort_kind == MidBodyAbortKind::Marker)
                                     .then(|| {
                                         callee_vable_ref_at(
-                                            sub_wc.callee_shadow.as_ref(),
+                                            sub_wc.frame_state.borrow().callee_shadow.as_ref(),
                                             metadata.portal_frame_reg,
                                             semantic_slot,
                                         )
@@ -7415,6 +7456,8 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                             continue;
                         }
                         let value = sub_wc
+                            .frame_state
+                            .borrow()
                             .callee_shadow
                             .as_ref()
                             .and_then(|shadow| shadow.concrete.get(&(slot as i64)).copied())
@@ -7481,7 +7524,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         let class_of_last_exc_is_const = sub_wc.fbw_mode.class_of_last_exc_is_const;
         (result, class_of_last_exc_is_const)
     };
-    caller_replacements.apply(ctx);
     drop(caller_replacements);
     // `executioncontext.py leave`, in the original's `finally`
     // position: the sub-walk block above is an expression that always
@@ -10182,7 +10224,7 @@ pub(crate) fn try_walker_specialize_instance_iter<Sym: WalkSym>(
         ctx.trace_ctx.heap_cache_mut().reset();
         return Ok(None);
     }
-    ctx.vstack_last_ref = obj_op;
+    ctx.frame_state.borrow_mut().vstack_last_ref = obj_op;
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
 
@@ -10351,7 +10393,7 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
         return Err(DispatchError::callee_inline_unsupported(op.pc));
     };
     fbw_foriter_inflight_capture(concrete_item, body_coord);
-    ctx.vstack_last_ref = item_op;
+    ctx.frame_state.borrow_mut().vstack_last_ref = item_op;
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
 
@@ -11698,9 +11740,10 @@ struct SubWalkFrame<'a, Sym: WalkSym> {
     registers_r: RegisterBank,
     registers_i: RegisterBank,
     registers_f: RegisterBank,
-    concrete_registers_r: Vec<ConcreteValue>,
+
     concrete_registers_i: Vec<ConcreteValue>,
-    callee_shadow: Option<CalleeLocalsShadow>,
+    /// The active and paused adapters share the same frame-owned slots.
+    frame_state: WalkFrameState,
     inline_callee_consts: Option<InlineCalleeConsts>,
     inline_poison_pcs: Option<std::sync::Arc<[usize]>>,
     fbw_mode: FbwWalkMode<Sym>,
@@ -11712,15 +11755,15 @@ struct SubWalkFrame<'a, Sym: WalkSym> {
     entry_py_pc: EntryPyPc,
     outer_resume_marker_jit_pc: Option<usize>,
     outer_jitcode_index: u32,
-    outer_active_boxes: Vec<OpRef>,
+
     pending_guard_snapshot_error: Option<DispatchError>,
-    vstack_boxes: Vec<OpRef>,
+
     vstack_depth: usize,
     vstack_cur_pypc: u32,
     vstack_valid: bool,
-    vstack_last_ref: OpRef,
+
     vstack_reorder_ceiling: u32,
-    vstack_reorder_saved: Option<(u32, usize, Vec<OpRef>, Vec<bool>)>,
+
     vstack_handler_landing_py: Option<u32>,
     live_before_jit_pc: usize,
     live_after_jit_pc: usize,
@@ -11732,7 +11775,7 @@ impl<'a, Sym: WalkSym> SubWalkFrame<'a, Sym> {
         trace_ctx: &mut TraceCtx,
     ) -> Result<(DispatchOutcome, usize), DispatchError> {
         let mut walk_ctx = WalkContext {
-            callee_shadow: self.callee_shadow.take(),
+            frame_state: self.frame_state.clone(),
             inline_callee_consts: self.inline_callee_consts,
             inline_poison_pcs: self.inline_poison_pcs.take(),
             fbw_mode: self.fbw_mode,
@@ -11740,7 +11783,7 @@ impl<'a, Sym: WalkSym> SubWalkFrame<'a, Sym> {
             registers_r: &self.registers_r,
             registers_i: &self.registers_i,
             registers_f: &self.registers_f,
-            concrete_registers_r: &mut self.concrete_registers_r,
+
             concrete_registers_i: &mut self.concrete_registers_i,
             descr_refs: self.descr_refs,
             raw_descrs: self.raw_descrs,
@@ -11751,22 +11794,19 @@ impl<'a, Sym: WalkSym> SubWalkFrame<'a, Sym> {
             entry_py_pc: self.entry_py_pc,
             outer_resume_marker_jit_pc: self.outer_resume_marker_jit_pc,
             outer_jitcode_index: self.outer_jitcode_index,
-            outer_active_boxes: std::mem::take(&mut self.outer_active_boxes),
+
             pending_guard_snapshot_error: self.pending_guard_snapshot_error.take(),
-            vstack_boxes: std::mem::take(&mut self.vstack_boxes),
+
             vstack_depth: self.vstack_depth,
             vstack_cur_pypc: self.vstack_cur_pypc,
             vstack_valid: self.vstack_valid,
-            vstack_last_ref: self.vstack_last_ref,
+
             vstack_reorder_ceiling: self.vstack_reorder_ceiling,
-            vstack_reorder_saved: self.vstack_reorder_saved.take(),
+
             vstack_handler_landing_py: self.vstack_handler_landing_py,
             live_before_jit_pc: self.live_before_jit_pc,
             live_after_jit_pc: self.live_after_jit_pc,
         };
-        // This owner survives SubWalkSuspended, unlike an invocation of walk.
-        // Synchronize the paused frame before resuming its CALL continuation.
-        self.box_replacements.apply(&mut walk_ctx);
         if self.seed_from_active_resume {
             self.seed_from_active_resume = false;
             if let Some(frame) =
@@ -11781,22 +11821,22 @@ impl<'a, Sym: WalkSym> SubWalkFrame<'a, Sym> {
         self.box_replacements.set_listening(false);
         let result = walk(self.body.code, self.pc, &mut walk_ctx);
         self.box_replacements.set_listening(true);
-        self.callee_shadow = walk_ctx.callee_shadow.take();
+
         self.inline_callee_consts = walk_ctx.inline_callee_consts;
         self.inline_poison_pcs = walk_ctx.inline_poison_pcs.take();
         self.fbw_mode = walk_ctx.fbw_mode;
         self.entry_py_pc = walk_ctx.entry_py_pc;
         self.outer_resume_marker_jit_pc = walk_ctx.outer_resume_marker_jit_pc;
         self.outer_jitcode_index = walk_ctx.outer_jitcode_index;
-        self.outer_active_boxes = std::mem::take(&mut walk_ctx.outer_active_boxes);
+
         self.pending_guard_snapshot_error = walk_ctx.pending_guard_snapshot_error.take();
-        self.vstack_boxes = std::mem::take(&mut walk_ctx.vstack_boxes);
+
         self.vstack_depth = walk_ctx.vstack_depth;
         self.vstack_cur_pypc = walk_ctx.vstack_cur_pypc;
         self.vstack_valid = walk_ctx.vstack_valid;
-        self.vstack_last_ref = walk_ctx.vstack_last_ref;
+
         self.vstack_reorder_ceiling = walk_ctx.vstack_reorder_ceiling;
-        self.vstack_reorder_saved = walk_ctx.vstack_reorder_saved.take();
+
         self.vstack_handler_landing_py = walk_ctx.vstack_handler_landing_py;
         self.live_before_jit_pc = walk_ctx.live_before_jit_pc;
         self.live_after_jit_pc = walk_ctx.live_after_jit_pc;
@@ -11837,6 +11877,7 @@ struct SubWalkDriver<'a, Sym: WalkSym> {
     frames: Vec<SubWalkFrame<'a, Sym>>,
     /// One entry per live frame, pushed and dropped with `frames`.
     bank_guards: Vec<crate::trace::InlineRegisterBankGuard>,
+    state_guards: Vec<crate::trace::InlineFrameStateGuard>,
     exchange: SubWalkExchange<'a, Sym>,
 }
 
@@ -11846,6 +11887,7 @@ impl<'a, Sym: WalkSym> SubWalkDriver<'a, Sym> {
         let mut driver = Self {
             frames: Vec::new(),
             bank_guards: Vec::new(),
+            state_guards: Vec::new(),
             exchange: SubWalkExchange {
                 pending: None,
                 completed: None,
@@ -11884,11 +11926,22 @@ impl<'a, Sym: WalkSym> SubWalkDriver<'a, Sym> {
             .registers_r;
         self.bank_guards
             .push(crate::trace::InlineRegisterBankGuard::enter(bank));
+        self.state_guards
+            .push(crate::trace::InlineFrameStateGuard::enter(
+                &self
+                    .frames
+                    .last()
+                    .expect("the frame just pushed")
+                    .frame_state,
+            ));
     }
 
     /// Pop a frame, retiring its bank root first so the two stacks stay in
     /// step.
     fn pop_frame(&mut self) -> SubWalkFrame<'a, Sym> {
+        self.state_guards
+            .pop()
+            .expect("a live sub-walk frame lost its state root");
         self.bank_guards
             .pop()
             .expect("a live sub-walk frame lost its register-bank root");
@@ -12134,9 +12187,22 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         registers_r: callee_regs_r,
         registers_i: RegisterBank::with_constants(callee_regs_i, sub_body.num_regs_i),
         registers_f: RegisterBank::with_constants(callee_regs_f, sub_body.num_regs_f),
-        concrete_registers_r: callee_concrete_r,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: callee_concrete_r,
+            current_exception_seed: ctx.frame_state.borrow().current_exception_seed,
+            current_exception_seed_concrete: ctx
+                .frame_state
+                .borrow()
+                .current_exception_seed_concrete,
+            outer_active_boxes: ctx.frame_state.borrow().outer_active_boxes.clone(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         concrete_registers_i: callee_concrete_i,
-        callee_shadow: None,
+
         inline_callee_consts: None,
         inline_poison_pcs: None,
         // `op_pc` belongs to the callee JitCode.  A canonical helper has no
@@ -12155,15 +12221,15 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
         entry_py_pc: ctx.entry_py_pc,
         outer_resume_marker_jit_pc: ctx.outer_resume_marker_jit_pc,
         outer_jitcode_index: ctx.outer_jitcode_index,
-        outer_active_boxes: ctx.outer_active_boxes.clone(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12171,6 +12237,7 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
     frame
         .box_replacements
         .bind_banks(&frame.registers_r, &frame.registers_i, &frame.registers_f);
+    frame.box_replacements.bind_frame_state(&frame.frame_state);
 
     if !driver_pointer.is_null() {
         // Nested descent: publish the heap frame and yield the parent at its
@@ -12187,8 +12254,8 @@ pub(crate) fn run_sub_jitcode_walk<'frame, 'a: 'frame, Sym: WalkSym>(
     let _driver_guard = SubWalkDriverGuard::install(&mut driver.exchange);
     let caller_replacements = FrameBoxReplacements::new(ctx.session);
     caller_replacements.bind_banks(ctx.registers_r, ctx.registers_i, ctx.registers_f);
+    caller_replacements.bind_frame_state(&ctx.frame_state);
     let result = driver.drive(ctx.trace_ctx);
-    caller_replacements.apply(ctx);
     drop(caller_replacements);
     match result {
         Ok((outcome, class_state)) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -245,6 +245,13 @@ mod vstack_mirror;
 pub use vstack_mirror::*;
 mod vable_ops;
 use vable_ops::FrameBoxReplacements;
+mod register_bank;
+mod register_list;
+pub use register_bank::RegisterBank;
+pub(crate) use register_bank::RegisterBankRoot;
+use register_bank::RegisterValues;
+pub use register_list::RegisterList;
+pub(crate) use register_list::RegisterListRoot;
 pub use vable_ops::*;
 mod heapcache_ops;
 pub use heapcache_ops::*;
@@ -858,7 +865,6 @@ fn record_top_level_application_traceback<Sym: WalkSym>(
         .and_then(|jitcode| {
             ctx.registers_r
                 .get(jitcode.metadata.portal_frame_reg as usize)
-                .copied()
         })
         .unwrap_or(OpRef::NONE);
     if emit_runtime && !hook.is_null() && !exc.is_none() && !frame.is_none() {
@@ -1014,7 +1020,6 @@ fn record_inline_application_traceback<Sym: WalkSym>(
         .and_then(|jitcode| {
             ctx.registers_r
                 .get(jitcode.metadata.portal_frame_reg as usize)
-                .copied()
         })
         .unwrap_or(OpRef::NONE);
     let frame_hook = majit_metainterp::record_application_traceback_hook_address();
@@ -1183,11 +1188,7 @@ fn finish_current_frame_execution<Sym: WalkSym>(
         let mut concrete = std::ptr::null_mut();
         if let Some(jitcode) = crate::state::pyjitcode_for_jitcode_index(jitcode_index) {
             let frame_reg = jitcode.metadata.portal_frame_reg as usize;
-            frame = ctx
-                .registers_r
-                .get(frame_reg)
-                .copied()
-                .unwrap_or(OpRef::NONE);
+            frame = ctx.registers_r.get(frame_reg).unwrap_or(OpRef::NONE);
             concrete = match ctx.concrete_registers_r.get(frame_reg).copied() {
                 Some(ConcreteValue::Ref(frame_ptr)) => frame_ptr as *mut pyre_interpreter::PyFrame,
                 _ => std::ptr::null_mut(),
@@ -1333,7 +1334,6 @@ fn traceback_node_site<Sym: WalkSym>(
     let frame = ctx
         .registers_r
         .get(jitcode.metadata.portal_frame_reg as usize)
-        .copied()
         .unwrap_or(OpRef::NONE);
     // Storing this box into the node's `frame` field lets the traceback
     // outlive the frame, so folded inline-callee locals have to reach the
@@ -1762,20 +1762,17 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// Symbolic Ref-bank register file. Indexing matches RPython
     /// `MIFrame.registers_r` (`pyjitpl.py`); the byte after a
     /// `r`-coded operand opcode indexes directly into this slice.
-    /// Mutable so handlers writing `>r` results (currently
-    /// `residual_call_r_r/iRd>r`) can land their dst.
-    pub registers_r: &'frame mut [OpRef],
+    /// Shared frame-owned slots permit result stores and GC forwarding without
+    /// an exclusive slice surviving a descendant call.
+    pub registers_r: &'frame RegisterBank,
     /// Symbolic Int-bank register file. Indexing matches RPython
-    /// `MIFrame.registers_i` (`pyjitpl.py`). Pyre's PyreSym is
-    /// mid-migration to a 3-bank typed model — production callers may
-    /// pass an empty slice today (the assembler only emits `i`-coded
-    /// operands once the codewriter wires Int kind). Mutable so
-    /// `int_copy/i>i` can land its dst.
-    pub registers_i: &'frame mut [OpRef],
+    /// `MIFrame.registers_i` (`pyjitpl.py`). Result stores update shared
+    /// frame-owned slots, just as `int_copy/i>i` writes the MIFrame list.
+    pub registers_i: &'frame RegisterBank,
     /// Symbolic Float-bank register file. Indexing matches RPython
     /// `MIFrame.registers_f` (`pyjitpl.py`). Mutable so
     /// `float_<binop>/ff>f` and `float_neg/f>f` can land their dst.
-    pub registers_f: &'frame mut [OpRef],
+    pub registers_f: &'frame RegisterBank,
     /// Concrete shadow mirror for `registers_r`.
     ///
     /// Semantic-slot indexed, length equals `registers_r.len()`. At
@@ -4061,7 +4058,6 @@ fn read_ref_reg_raw<Sym: WalkSym>(
     let reg = code[byte_pc] as usize;
     ctx.registers_r
         .get(reg)
-        .copied()
         .ok_or(DispatchError::RegisterOutOfRange {
             pc: op.pc,
             reg,
@@ -4083,7 +4079,6 @@ fn read_int_reg<Sym: WalkSym>(
     let reg = code[byte_pc] as usize;
     ctx.registers_i
         .get(reg)
-        .copied()
         .ok_or(DispatchError::RegisterOutOfRange {
             pc: op.pc,
             reg,
@@ -4105,7 +4100,6 @@ fn read_float_reg<Sym: WalkSym>(
     let reg = code[byte_pc] as usize;
     ctx.registers_f
         .get(reg)
-        .copied()
         .ok_or(DispatchError::RegisterOutOfRange {
             pc: op.pc,
             reg,
@@ -4581,7 +4575,6 @@ fn read_ref_var_list<Sym: WalkSym>(
         let opref = ctx
             .registers_r
             .get(reg)
-            .copied()
             .ok_or(DispatchError::RegisterOutOfRange {
                 pc: op.pc,
                 reg,
@@ -4640,16 +4633,16 @@ fn write_ref_reg<Sym: WalkSym>(
     concrete: ConcreteValue,
 ) -> Result<(), DispatchError> {
     let len = ctx.registers_r.len();
-    let slot = ctx
+    let _ = ctx
         .registers_r
-        .get_mut(dst)
+        .get(dst)
         .ok_or(DispatchError::RegisterOutOfRange {
             pc,
             reg: dst,
             len,
             bank: "r",
         })?;
-    *slot = value;
+    ctx.registers_r.set(dst, value);
     // Snapshot is sized to `registers_r.len()` at dispatch entry, so
     // a dst-in-bounds OpRef write implies in-bounds for the shadow.
     // `get_mut` defensively to tolerate sub-walk shadows that lag the
@@ -4777,7 +4770,7 @@ pub(crate) fn read_float_reg_concrete<Sym: WalkSym>(
     let reg = code[byte_pc] as usize;
     ctx.registers_f
         .get(reg)
-        .and_then(|&value| ctx.trace_ctx.concrete_of_opref(value))
+        .and_then(|value| ctx.trace_ctx.concrete_of_opref(value))
         .map_or(ConcreteValue::Null, |value| match value {
             Value::Float(v) => ConcreteValue::Float(v),
             _ => ConcreteValue::Null,
@@ -4823,16 +4816,16 @@ fn write_int_reg<Sym: WalkSym>(
     concrete: ConcreteValue,
 ) -> Result<(), DispatchError> {
     let len = ctx.registers_i.len();
-    let slot = ctx
+    let _ = ctx
         .registers_i
-        .get_mut(dst)
+        .get(dst)
         .ok_or(DispatchError::RegisterOutOfRange {
             pc,
             reg: dst,
             len,
             bank: "i",
         })?;
-    *slot = value;
+    ctx.registers_i.set(dst, value);
     // Mirror `write_ref_reg`'s defensive get_mut.  Test fixtures pass
     // an empty `concrete_registers_i` slice; production callers
     // (Concrete shadow seeding) size it to `registers_i.len()` at dispatch entry.
@@ -4995,7 +4988,6 @@ fn read_int_var_list<Sym: WalkSym>(
         let opref = ctx
             .registers_i
             .get(reg)
-            .copied()
             .ok_or(DispatchError::RegisterOutOfRange {
                 pc: op.pc,
                 reg,
@@ -5023,7 +5015,6 @@ fn read_float_var_list<Sym: WalkSym>(
         let opref = ctx
             .registers_f
             .get(reg)
-            .copied()
             .ok_or(DispatchError::RegisterOutOfRange {
                 pc: op.pc,
                 reg,
@@ -5065,11 +5056,7 @@ fn dispatch_switch_id<Sym: WalkSym>(
                 .record_guard(OpCode::GuardValue, &[valuebox, expected], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
             ctx.trace_ctx.replace_box(valuebox, expected);
-            for slot in ctx.registers_i.iter_mut() {
-                if *slot == valuebox {
-                    *slot = expected;
-                }
-            }
+            ctx.registers_i.replace_active_box(valuebox, expected);
         }
         return Ok((DispatchOutcome::Continue, target));
     }
@@ -5402,11 +5389,7 @@ fn guard_current_frame_globals_identity<Sym: WalkSym>(
         .record_guard(OpCode::GuardValue, &[w_globals_op, expected], 0);
     walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
     ctx.trace_ctx.replace_box(w_globals_op, expected);
-    for slot in ctx.registers_r.iter_mut() {
-        if *slot == w_globals_op {
-            *slot = expected;
-        }
-    }
+    ctx.registers_r.replace_active_box(w_globals_op, expected);
     Ok(true)
 }
 
@@ -5437,7 +5420,6 @@ fn replace_movable_load_global_namespace_with_frame_globals<Sym: WalkSym>(
         let Some(frame) = ctx
             .registers_r
             .get(jitcode.metadata.portal_frame_reg as usize)
-            .copied()
             .filter(|frame| !frame.is_none())
         else {
             // The old single-frame inline path has no callee red to read.  Do
@@ -5951,9 +5933,9 @@ fn snapshot_diag_enabled() -> bool {
 fn collect_outer_active_boxes<Sym: WalkSym>(
     sym: &Sym,
     trace_ctx: &mut TraceCtx,
-    regs_i: &[OpRef],
-    regs_r: &[OpRef],
-    regs_f: &[OpRef],
+    regs_i: &(impl RegisterValues + ?Sized),
+    regs_r: &(impl RegisterValues + ?Sized),
+    regs_f: &(impl RegisterValues + ?Sized),
     outer_jitcode_index: u32,
     guard_present: bool,
     // The resume-carried coordinate remains the bank-liveness source. Entry
@@ -6148,8 +6130,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
     };
     for &idx in &banks.int {
         let v = regs_i
-            .get(idx as usize)
-            .copied()
+            .get_box(idx as usize)
             .unwrap_or_else(|| panic!("{}", dump_ctx("int", idx)));
         if v == OpRef::NONE {
             panic!("{}", dump_ctx("int", idx));
@@ -6306,8 +6287,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
         }
         let fallback = || {
             regs_r
-                .get(color)
-                .copied()
+                .get_box(color)
                 .unwrap_or_else(|| panic!("{}", dump_ctx("ref", idx)))
         };
         let semantic_idx = crate::state::semantic_ref_slot_for_reg_color(
@@ -6338,8 +6318,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
                 || (color as u16 == portal_ec_reg && portal_ec_reg != u16::MAX));
         let value = if is_portal_red_scratch {
             let live_reg = regs_r
-                .get(color)
-                .copied()
+                .get_box(color)
                 .filter(|&v| v != OpRef::NONE && !opref_is_null_const_ptr(v));
             let red_field = if color as u16 == portal_frame_reg {
                 sym.frame()
@@ -6357,7 +6336,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
                 Some(s_idx) if s_idx < nlocals + valid_stack_only => {
                     let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                     let vbox = trace_ctx.virtualizable_box_at(nvs + s_idx);
-                    let walk_box = regs_r.get(color).copied();
+                    let walk_box = regs_r.get_box(color);
                     if s_idx >= nlocals {
                         // Operand-stack slot.  `pyjitpl.py` snapshots
                         // `self.registers_r[index]`, but pyre's stack
@@ -6445,7 +6424,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
                 // this read is the same `get_list_of_active_boxes` parity the
                 // mapped arm above uses.  Under the walker (gate-off) each PC
                 // owns a depth-narrowed marker, so this arm never fires.
-                None => match regs_r.get(color).copied() {
+                None => match regs_r.get_box(color) {
                     Some(v) if v != OpRef::NONE => v,
                     _ => OpRef::const_ptr(majit_ir::GcRef(0)),
                 },
@@ -6464,7 +6443,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
         // preference decided otherwise — the resume value and the register the
         // resumed bytecode reads then disagree.
         if snapshot_diag_enabled() {
-            let walk = regs_r.get(color).copied().unwrap_or(OpRef::NONE);
+            let walk = regs_r.get_box(color).unwrap_or(OpRef::NONE);
             if walk != OpRef::NONE && walk != value {
                 eprintln!(
                     "[snap] jc={outer_jitcode_index} carried={carried_jitcode_pc} \
@@ -6478,8 +6457,7 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
     }
     for &idx in &banks.float {
         let v = regs_f
-            .get(idx as usize)
-            .copied()
+            .get_box(idx as usize)
             .unwrap_or_else(|| panic!("{}", dump_ctx("float", idx)));
         if v == OpRef::NONE {
             panic!("{}", dump_ctx("float", idx));
@@ -6707,6 +6685,79 @@ pub(crate) fn ctor_continuation_parent_frame(instance: OpRef) -> Option<InlinePa
 /// sub-walks unwind to the caller's level.
 struct InlineFrameGuard<'a>(&'a std::cell::RefCell<WalkSession>);
 
+/// The translated stack root of this attempt's MetaInterp/framestack
+/// (warmstate.py WarmEnterState.make_entry_point.bound_reached). Borrow the
+/// stable RefCell for the whole attempt, including empty-stack intervals and
+/// post-walk snapshots. Frame guards may be stored in a Vec and retired in
+/// insertion order; none of them owns this publication's lifetime.
+pub(crate) struct WalkSessionRoots<'a> {
+    _area: majit_gc::shadow_stack::MutatorExtraAreaGuard,
+    _session: &'a std::cell::RefCell<WalkSession>,
+}
+
+impl<'a> WalkSessionRoots<'a> {
+    pub(crate) fn new(session: &'a std::cell::RefCell<WalkSession>) -> Self {
+        let area = unsafe {
+            // The returned guard's borrow prevents moving/dropping the cell
+            // before retirement. Collectors visit it only under mutator STW
+            // or synchronously on its owner; no session borrow spans a
+            // collecting call. The checked callback enforces that last rule.
+            majit_gc::shadow_stack::MutatorExtraAreaGuard::new(
+                walk_session_roots,
+                (session as *const std::cell::RefCell<WalkSession>).cast(),
+                "walk_session",
+            )
+        };
+        Self {
+            _area: area,
+            _session: session,
+        }
+    }
+}
+
+unsafe fn walk_session_roots(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let cell = unsafe { &*(data as *const std::cell::RefCell<WalkSession>) };
+    let mut session = cell
+        .try_borrow_mut()
+        .expect("WalkSession borrow held across collection");
+    let walk_ptr = |ptr: &mut pyre_object::PyObjectRef,
+                    visitor: &mut dyn FnMut(&mut majit_ir::GcRef)| {
+        let mut root = majit_ir::GcRef(*ptr as usize);
+        visitor(&mut root);
+        *ptr = root.0 as pyre_object::PyObjectRef;
+    };
+    // MetaInterp.last_exc_value and blackhole.py tmpreg_r are owner fields,
+    // not merely roots when an inline frame happens to be on the stack.
+    if let Some(value) = session.last_exc_value.as_mut() {
+        value.walk_const_ptr_refs_mut(visitor);
+    }
+    if let ConcreteValue::Ref(value) = &mut session.last_exc_value_concrete {
+        walk_ptr(value, visitor);
+        unsafe { pyre_interpreter::eval::walk_raw_exception_roots(*value, visitor) };
+    }
+    session.tmpreg_r.walk_const_ptr_refs_mut(visitor);
+    if let ConcreteValue::Ref(value) = &mut session.tmpreg_r_concrete {
+        walk_ptr(value, visitor);
+    }
+    for frame in session.framestack.iter_mut() {
+        for parent in frame.parents.iter_mut() {
+            // history.py ConstPtr.value remains reachable through each
+            // paused frame's active boxes, including constructor tails.
+            for value in &mut parent.boxes {
+                value.walk_const_ptr_refs_mut(visitor);
+            }
+            for (_, value) in &mut parent.call_stack_overrides {
+                walk_ptr(value, visitor);
+            }
+            if let Some(blackhole) = parent.blackhole.as_mut() {
+                for (_, value) in &mut blackhole.ref_values {
+                    walk_ptr(value, visitor);
+                }
+            }
+        }
+    }
+}
+
 thread_local! {
     /// Top-level caller CALL native JitCode coordinate and concrete
     /// operand-stack slots stashed by
@@ -6719,15 +6770,6 @@ thread_local! {
         const { std::cell::Cell::new(None) };
     static FBW_ABORT_OUTER_STACK_OVERRIDES: std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>> =
         const { std::cell::RefCell::new(Vec::new()) };
-    /// Raw pointer to the walk session whose framestack currently holds
-    /// inline frames, for [`fbw_store_journal_root_walker`]: the session
-    /// lives on the walk driver's Rust stack, which the GC cannot scan, and
-    /// each `InlineParentFrame::call_stack_overrides` slot holds a
-    /// nursery-resident ref across residual-call allocations.  Set by
-    /// [`InlineFrameGuard::enter`] and restored on drop; null outside any
-    /// inline sub-walk.
-    static ACTIVE_WALK_SESSION: std::cell::Cell<*const std::cell::RefCell<WalkSession>> =
-        const { std::cell::Cell::new(std::ptr::null()) };
 }
 
 impl<'a> InlineFrameGuard<'a> {
@@ -6762,7 +6804,6 @@ impl<'a> InlineFrameGuard<'a> {
         if fbw_depth_census_enabled() {
             fbw_depth_census_record(&session.borrow().framestack);
         }
-        ACTIVE_WALK_SESSION.with(|c| c.set(session as *const _));
         InlineFrameGuard(session)
     }
 }
@@ -6771,9 +6812,6 @@ impl Drop for InlineFrameGuard<'_> {
     fn drop(&mut self) {
         let mut session = self.0.borrow_mut();
         session.framestack.pop();
-        if session.framestack.is_empty() {
-            ACTIVE_WALK_SESSION.with(|c| c.set(std::ptr::null()));
-        }
     }
 }
 
@@ -7316,7 +7354,6 @@ struct FbwStoreJournalRootArea {
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     bridge_iter: *const std::cell::RefCell<Vec<BridgeIterJournalEntry>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
-    active_session: *const std::cell::Cell<*const std::cell::RefCell<WalkSession>>,
     escape_flush_undo: *const std::cell::RefCell<Option<EscapeFlushUndo>>,
     locals_mirror_undo: *const std::cell::RefCell<Vec<FbwLocalsMirrorUndo>>,
     single_frame_blackhole: *const std::cell::RefCell<Option<LatchedSingleFrameBlackhole>>,
@@ -7336,7 +7373,6 @@ thread_local! {
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
         bridge_iter: FBW_BRIDGE_ITER_JOURNAL.with(|value| value as *const _),
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
-        active_session: ACTIVE_WALK_SESSION.with(|value| value as *const _),
         escape_flush_undo: escape_flush_undo_cell_ptr(),
         locals_mirror_undo: locals_mirror_undo_cell_ptr(),
         single_frame_blackhole: single_frame_blackhole_cell_ptr(),
@@ -7648,28 +7684,6 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     let abort_overrides = unsafe { &mut *(*area.abort_overrides).as_ptr() };
     for (_slot, value) in abort_overrides.iter_mut() {
         visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
-    }
-    // Inline parent-frame stack overrides on the active walk session's
-    // framestack. The session lives on the walk driver's Rust stack (which the
-    // GC cannot scan) and each override slot holds a nursery-resident ref.
-    let session_ptr = unsafe { (*area.active_session).get() };
-    if !session_ptr.is_null() {
-        // SAFETY: `ACTIVE_WALK_SESSION` is set by `InlineFrameGuard::enter` and
-        // cleared when the last frame pops, so a non-null pointer refers to a
-        // session that is live for the duration of this quiesced walk.
-        let session = unsafe { &mut *(*session_ptr).as_ptr() };
-        for frame in session.framestack.iter_mut() {
-            for parent in frame.parents.iter_mut() {
-                for (_slot, value) in parent.call_stack_overrides.iter_mut() {
-                    visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
-                }
-                if let Some(blackhole) = parent.blackhole.as_mut() {
-                    for (_color, value) in blackhole.ref_values.iter_mut() {
-                        visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
-                    }
-                }
-            }
-        }
     }
     // Cell-store journal: the cell is immovable (`malloc_typed`) so no
     // forwarding happens, but a mid-walk rebind can drop the module dict's
@@ -11156,7 +11170,7 @@ fn guarded_branch_core<Sym: WalkSym>(
         let resolved_recovered: Option<Vec<(u16, OpRef)>> = kept_recovered.as_ref().map(|mv| {
             mv.iter()
                 .filter_map(|&(dst, src)| {
-                    let v = ctx.registers_r.get(src as usize).copied()?;
+                    let v = ctx.registers_r.get(src as usize)?;
                     (v != OpRef::NONE).then_some((dst, v))
                 })
                 .collect()
@@ -12482,16 +12496,16 @@ fn handle<Sym: WalkSym>(
                     .record_op_with_descr(OpCode::RawLoadF, &[base, offset], descr);
             let dst = code[op.pc + 5] as usize;
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         // `_opimpl_raw_store` delegates to `execute_raw_store`:
@@ -12941,16 +12955,16 @@ fn handle<Sym: WalkSym>(
             let src_val = read_float_reg(code, op, 0, ctx)?;
             let dst = code[op.pc + 2] as usize;
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = src_val;
+            ctx.registers_f.set(dst, src_val);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "ref_push/r" => {
@@ -13031,16 +13045,16 @@ fn handle<Sym: WalkSym>(
             let val = ctx.session.borrow().tmpreg_f;
             let dst = code[op.pc + 1] as usize;
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = val;
+            ctx.registers_f.set(dst, val);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "ref_copy/r>r" => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1105,11 +1105,7 @@ fn flush_callee_locals_region_to_frame<Sym: WalkSym>(
     frame: *mut pyre_interpreter::PyFrame,
     frame_reg: u16,
 ) -> bool {
-    let state = ctx.frame_state.borrow();
-    let Some(shadow) = state.callee_shadow.as_ref() else {
-        return false;
-    };
-    flush_callee_locals_region(shadow, frame, frame_reg)
+    flush_callee_locals_region(&ctx.frame_state, frame, frame_reg)
 }
 
 /// [`flush_callee_locals_region_to_frame`] against a shadow reached without a
@@ -1117,7 +1113,7 @@ fn flush_callee_locals_region_to_frame<Sym: WalkSym>(
 /// the `TraceCtx`, so the level's shadow is published for the duration of the
 /// residual instead (`residual_call.rs`).
 pub(crate) fn flush_callee_locals_region(
-    shadow: &CalleeLocalsShadow,
+    state: &WalkFrameState,
     frame: *mut pyre_interpreter::PyFrame,
     frame_reg: u16,
 ) -> bool {
@@ -1129,9 +1125,6 @@ pub(crate) fn flush_callee_locals_region(
     };
     // Validation pass first: it allocates nothing, so a decline leaves the
     // frame untouched (same all-or-nothing discipline as the top-level twin).
-    if !callee_locals_region_is_publishable(shadow, nlocals, frame_reg) {
-        return false;
-    }
     let frame_ptr = frame as *const u8;
     let arr_ptr = unsafe {
         *(frame_ptr.add(crate::frame_layout::PYFRAME_LOCALS_CELLS_STACK_OFFSET)
@@ -1140,19 +1133,22 @@ pub(crate) fn flush_callee_locals_region(
     if arr_ptr.is_null() || unsafe { &*arr_ptr }.as_slice().len() < nlocals {
         return false;
     }
-    for abs in 0..nlocals {
-        let Some(concrete) = shadow.concrete.get(&(abs as i64)) else {
-            continue;
-        };
-        let boxed = crate::state::boxed_slot_value_for_type(Type::Ref, &concrete.value);
+    // `virtualizable.py write_boxes` keeps the source boxes and destination
+    // array live throughout writeback. Native boxing can collect: retain roots
+    // for both destinations and read each source from its shared owner after
+    // the preceding allocation, with no frame-state borrow across boxing.
+    let frame_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame as usize));
+    let array_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(arr_ptr as usize));
+    state.write_callee_locals(nlocals, frame_reg, |abs, value| {
+        let boxed = crate::state::boxed_slot_value_for_type(Type::Ref, &value);
+        let arr_ptr = array_root.get().0 as *mut pyre_object::FixedObjectArray;
         unsafe {
             (*arr_ptr).as_mut_slice()[abs] = boxed;
         }
         // Boxing an Int/Float slot allocates, and each minor collection
         // consumes the array's remembered-set entry, so re-arm per store.
-        crate::state::frame_array_write_barrier(frame as *mut u8, arr_ptr);
-    }
-    true
+        crate::state::frame_array_write_barrier(frame_root.get().0 as *mut u8, arr_ptr);
+    })
 }
 
 /// Publish `PyFrame.frame_finished_execution = True` on the current

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -245,8 +245,11 @@ mod vstack_mirror;
 pub use vstack_mirror::*;
 mod vable_ops;
 use vable_ops::FrameBoxReplacements;
+mod frame_state;
 mod register_bank;
 mod register_list;
+pub(crate) use frame_state::WalkFrameStateRoot;
+pub use frame_state::{WalkFrameState, WalkFrameStateData};
 pub use register_bank::RegisterBank;
 pub(crate) use register_bank::RegisterBankRoot;
 use register_bank::RegisterValues;
@@ -1047,6 +1050,8 @@ fn concrete_portal_frame<Sym: WalkSym>(
 ) -> Option<*mut pyre_interpreter::PyFrame> {
     let jitcode = crate::state::pyjitcode_for_jitcode_index(jitcode_index)?;
     let ConcreteValue::Ref(frame) = ctx
+        .frame_state
+        .borrow()
         .concrete_registers_r
         .get(jitcode.metadata.portal_frame_reg as usize)
         .copied()?
@@ -1100,7 +1105,8 @@ fn flush_callee_locals_region_to_frame<Sym: WalkSym>(
     frame: *mut pyre_interpreter::PyFrame,
     frame_reg: u16,
 ) -> bool {
-    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+    let state = ctx.frame_state.borrow();
+    let Some(shadow) = state.callee_shadow.as_ref() else {
         return false;
     };
     flush_callee_locals_region(shadow, frame, frame_reg)
@@ -1189,7 +1195,13 @@ fn finish_current_frame_execution<Sym: WalkSym>(
         if let Some(jitcode) = crate::state::pyjitcode_for_jitcode_index(jitcode_index) {
             let frame_reg = jitcode.metadata.portal_frame_reg as usize;
             frame = ctx.registers_r.get(frame_reg).unwrap_or(OpRef::NONE);
-            concrete = match ctx.concrete_registers_r.get(frame_reg).copied() {
+            concrete = match ctx
+                .frame_state
+                .borrow()
+                .concrete_registers_r
+                .get(frame_reg)
+                .copied()
+            {
                 Some(ConcreteValue::Ref(frame_ptr)) => frame_ptr as *mut pyre_interpreter::PyFrame,
                 _ => std::ptr::null_mut(),
             };
@@ -1200,7 +1212,7 @@ fn finish_current_frame_execution<Sym: WalkSym>(
         // an unescaped concrete, and finishing that other box leaves the
         // returned object with only `FLAG_ESCAPED`.  `frame.clear()` then
         // refuses a frame that has already returned.
-        if let Some(shadow) = ctx.callee_shadow.as_ref() {
+        if let Some(shadow) = ctx.frame_state.borrow().callee_shadow.as_ref() {
             let shadow_concrete = if shadow.concrete_frame == 0 {
                 std::ptr::null_mut()
             } else {
@@ -1604,14 +1616,8 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// `CALL_ASSEMBLER` (`opimpl_recursive_call_assembler`) rather than
     /// re-unrolling the call tree to the multi-frame depth cap.
     pub carrier_resume: bool,
-    /// The exception a bridge resumes with, and after a walked
-    /// `set_current_exception` the value that store published.  Read by the
-    /// nullary bare-reraise folds, and by the PUSH_EXC_INFO `prev` save only
-    /// under [`FbwWalkMode::current_exception_seed_from_walk_store`].
-    pub current_exception_seed: Option<OpRef>,
-    /// Concrete shadow paired with [`FbwWalkMode::current_exception_seed`].
-    pub current_exception_seed_concrete: pyre_object::PyObjectRef,
-    /// Whether [`FbwWalkMode::current_exception_seed`] names a value this walk
+
+    /// Whether [`WalkFrameStateData::current_exception_seed`] names a value this walk
     /// stored into `ExecutionContext.sys_exc_value`, as opposed to the
     /// exception the bridge is resuming with.  Only the former answers "what
     /// does that field hold": the bridge's in-flight exception is the one a
@@ -1713,8 +1719,6 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
             transparent_helper_subwalk: false,
             transparent_helper_jitcode_index: None,
             carrier_resume: false,
-            current_exception_seed: None,
-            current_exception_seed_concrete: pyre_object::PY_NULL,
             current_exception_seed_from_walk_store: false,
             class_of_last_exc_is_const: false,
             bridge_entry_merge_pc: None,
@@ -1734,9 +1738,8 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
 ///   lookup. These flow unchanged from caller into callee, so they
 ///   keep their original (longer) lifetime.
 pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
-    /// Present only for an inlined-callee sub-walk. Top-level and other walks
-    /// have no callee shadow, preserving the former empty-stack no-op behavior.
-    pub callee_shadow: Option<CalleeLocalsShadow>,
+    /// The active and paused adapters share the same frame-owned slots.
+    pub frame_state: WalkFrameState,
     /// Compile-time-constant frame fields of this inlined callee's own
     /// unseeded portal frame. This is the walk-time equivalent of the
     /// codewriter's non-portal branch (`codewriter.rs`),
@@ -1773,43 +1776,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// `MIFrame.registers_f` (`pyjitpl.py`). Mutable so
     /// `float_<binop>/ff>f` and `float_neg/f>f` can land their dst.
     pub registers_f: &'frame RegisterBank,
-    /// Concrete shadow mirror for `registers_r`.
-    ///
-    /// Semantic-slot indexed, length equals `registers_r.len()`. At
-    /// `dispatch_via_miframe` entry, populated by concatenating
-    /// `PyreSym.concrete_locals` + `PyreSym.concrete_stack`; sub-walks
-    /// allocate a fresh `Vec<ConcreteValue>` sized to the callee's
-    /// `num_regs_r` and fill arg slots from the parent's slice at the
-    /// arg byte indices.
-    ///
-    /// **Mutable invariant**: every walker handler that
-    /// writes `registers_r[dst]` MUST also write `concrete_registers_r
-    /// [dst]` in lock-step.  Use the [`write_ref_reg`] helper which
-    /// enforces this contract.  Sites that don't know the result's
-    /// concrete pass `ConcreteValue::Null` — downstream consumers
-    /// (e.g. `raise/r` GUARD_CLASS gate) treat `Null` as "no info,
-    /// skip the guard", same as slots the snapshot never populated.
-    /// Copy-style handlers (`ref_copy/r>r`,
-    /// `last_exc_value/>r`) propagate the source's concrete.
-    ///
-    /// The slice is mutable so the concrete shadow tracks the symbolic
-    /// register in lock-step. If it were immutable, sibling handlers
-    /// like `last_exc_value/>r` could rewrite the symbolic register
-    /// without touching the concrete snapshot, so a follow-on `raise/r`
-    /// would read a stale concrete and silently skip the GUARD_CLASS
-    /// gate; the lock-step contract keeps walker-side GUARD_CLASS sound.
-    ///
-    /// **Companion bank** `concrete_registers_i` below carries the same
-    /// contract for the Int bank.  Production entries size and seed it:
-    /// `dispatch_via_miframe` from `top_constants_i` and `argboxes_i`,
-    /// and both inline-callee entries; only the test fixtures pass
-    /// `&mut []`.
-    ///
-    /// `goto_if_not/iL` and `switch/id` read neither bank: both resolve
-    /// their branch value through `TraceCtx::concrete_of_opref` and
-    /// surface `GotoIfNotValueNotConcrete` rather than guess a
-    /// direction.
-    pub concrete_registers_r: &'frame mut [ConcreteValue],
+
     /// Concrete shadow mirror for `registers_i`.  Color-indexed (not
     /// semantic-slot indexed like `concrete_registers_r`) because pyre's
     /// Int bank has no "semantic-slot" abstraction — Int registers are
@@ -1907,20 +1874,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// `0` — the full-body guard capture reads `sym.jitcode` directly
     /// instead of this field.
     pub outer_jitcode_index: u32,
-    /// Frozen `PyFrame` state at the outer Python opcode boundary —
-    /// `sym.registers_r ∪ sym.registers_i.opref ∪ sym.registers_f.opref`
-    /// captured at walk entry (the retired per-opcode arm entry did
-    /// this; inline sub-walks seed it from the CALL-site capture; the
-    /// full-body root leaves it empty and collects at guard capture),
-    /// filtered by `OpRef::is_none()`.  This is what
-    /// [`walker_capture_snapshot_for_last_guard`] passes as the
-    /// snapshot frame's active boxes on the arm path.
-    ///
-    /// Sub-walks clone the parent's Vec — outer active-box count is
-    /// small (a Python frame's live locals + stack tail) and walker
-    /// nesting depth is shallow (2–3 levels), so the per-sub-walk
-    /// clone cost is negligible.
-    pub outer_active_boxes: Vec<OpRef>,
+
     /// Snapshot-capture failure latched by the `WalkerFrameOps`
     /// `generate_guard` impl, whose `()` trait signature (shared with
     /// `MIFrame`) has no error channel.  The residual-call dispatcher
@@ -1928,27 +1882,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// recorded without a resume snapshot aborts the walk instead of
     /// compiling.
     pub pending_guard_snapshot_error: Option<DispatchError>,
-    /// PyPy-faithful kept-operand-stack snapshot: the walk-level
-    /// symbolic operand stack, indexed by ABSOLUTE operand-stack depth
-    /// (slot `s`, `s in 0..vstack_depth`).  The Python operand stack is
-    /// all-Ref (`W_Root`), so a single `Vec<OpRef>` (Ref bank) suffices.
-    /// This is the walker analog of PyPy's `MIFrame.registers_r`
-    /// valuestack array snapshotted by `get_list_of_active_boxes`
-    /// (`pyjitpl.py`) — the authoritative per-slot box source the
-    /// `stack_sync` vable overlay reads at a branch guard instead of the
-    /// unreliable `registers_r[stack_slot_color_map[s]]` static-color read.
-    ///
-    /// Maintained ONLY when `sym.owns_virtualizable_shadow()`; on any
-    /// unmodeled stack effect the maintenance sets `vstack_valid = false`
-    /// and `stack_sync` omits every operand slot, which resume
-    /// re-materializes (zero regression).
-    ///
-    /// The mirror is the SOLE kept-stack source at a branch guard: the
-    /// flat `stack_slot_color_map` static-color read it once fell back to
-    /// is retired, so a slot the mirror does not cover is omitted rather
-    /// than read from the flat map.  `PYRE_VSTACK_DIAG` logs the per-op
-    /// reconcile trace.
-    pub vstack_boxes: Vec<OpRef>,
+
     /// #73: the absolute operand-stack depth `vstack_boxes` currently
     /// reflects — the depth ON ENTRY to the Python opcode at
     /// `vstack_cur_pypc` (i.e. AFTER the previous opcode's stack effect
@@ -1964,12 +1898,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// `false` permanently on the first unmodeled stack effect so the
     /// `stack_sync` overlay declines to use it.
     pub vstack_valid: bool,
-    /// #73: the last Ref box written via [`write_ref_reg`] during the
-    /// CURRENT Python opcode — the box a value-producing opcode lands on
-    /// the operand-stack TOS.  Reset to `OpRef::NONE` at every opcode
-    /// boundary; read by [`reconcile_vstack_at_boundary`] for the
-    /// RESULT-TO-TOS class.
-    pub vstack_last_ref: OpRef,
+
     /// #389(b): the py_pc the walk backed off FROM when it entered the
     /// codewriter's out-of-order FOR_ITER-entry permutation lowering
     /// (`SWAP`/`BUILD_LIST`/`SWAP` before a `FOR_ITER`, lowered non-monotonically
@@ -1979,19 +1908,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// the virtualizable shadow instead of replaying stack effects.  Cleared once
     /// the walk advances past this ceiling (py-pc order is monotonic again).
     pub vstack_reorder_ceiling: u32,
-    /// The `(py_pc, depth, boxes)` the mirror held when `vstack_reorder_ceiling`
-    /// was armed.  A layout excursion that returns to that exact coordinate has
-    /// retired no Python opcode, so the operand stack it left is still the
-    /// operand stack it comes back to and the saved boxes are restored verbatim
-    /// — the shadow reseed cannot reconstruct them, because mid-expression the
-    /// virtualizable's stack region holds the NULLs the in-flight opcode's
-    /// `popvalue_maybe_none` wrote.  `None` outside a region.
-    ///
-    /// There is nothing to snapshot upstream: `pyjitpl.py:1892`
-    /// `MIFrame.run_one_step` steps a live frame whose `registers_r` survive
-    /// the step.  This mirror is instead reconstructed from source pcs, and
-    /// that reconstruction is exactly what an excursion can lose.
-    pub vstack_reorder_saved: Option<(u32, usize, Vec<OpRef>, Vec<bool>)>,
+
     /// The py_pc the walk's floor lookup reports while it is inside an
     /// out-of-line exception LANDING block — the unwind bookkeeping the
     /// codewriter emits per catch site, after the whole body, which then jumps
@@ -4602,7 +4519,9 @@ fn read_ref_reg_concrete<Sym: WalkSym>(
 ) -> ConcreteValue {
     let byte_pc = op.pc + 1 + operand_offset;
     let reg = code[byte_pc] as usize;
-    ctx.concrete_registers_r
+    ctx.frame_state
+        .borrow()
+        .concrete_registers_r
         .get(reg)
         .copied()
         .unwrap_or(ConcreteValue::Null)
@@ -4662,7 +4581,12 @@ fn write_ref_reg<Sym: WalkSym>(
             ConcreteValue::Null
         }
     };
-    if let Some(c_slot) = ctx.concrete_registers_r.get_mut(dst) {
+    if let Some(c_slot) = ctx
+        .frame_state
+        .borrow_mut()
+        .concrete_registers_r
+        .get_mut(dst)
+    {
         *c_slot = sanitized;
     }
     // #73: record the box just written as the candidate
@@ -4672,7 +4596,7 @@ fn write_ref_reg<Sym: WalkSym>(
     // `reconcile_vstack_at_boundary` reconstruct the new TOS without a
     // per-opcode hook.  Cheap unconditional write to a new side-field;
     // only consumed when the mirror is valid (never alters existing state).
-    ctx.vstack_last_ref = value;
+    ctx.frame_state.borrow_mut().vstack_last_ref = value;
     Ok(())
 }
 
@@ -4694,9 +4618,9 @@ fn write_vable_field_ref_reg<Sym: WalkSym>(
     value: OpRef,
     concrete: ConcreteValue,
 ) -> Result<(), DispatchError> {
-    let saved = ctx.vstack_last_ref;
+    let saved = ctx.frame_state.borrow().vstack_last_ref;
     write_ref_reg(ctx, pc, dst, value, concrete)?;
-    ctx.vstack_last_ref = saved;
+    ctx.frame_state.borrow_mut().vstack_last_ref = saved;
     Ok(())
 }
 
@@ -4936,7 +4860,9 @@ fn read_ref_var_list_concrete<Sym: WalkSym>(
     (0..len)
         .map(|i| {
             let reg = code[len_pc + 1 + i] as usize;
-            ctx.concrete_registers_r
+            ctx.frame_state
+                .borrow()
+                .concrete_registers_r
                 .get(reg)
                 .copied()
                 .unwrap_or(ConcreteValue::Null)
@@ -5055,8 +4981,7 @@ fn dispatch_switch_id<Sym: WalkSym>(
             ctx.trace_ctx
                 .record_guard(OpCode::GuardValue, &[valuebox, expected], 0);
             walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-            ctx.trace_ctx.replace_box(valuebox, expected);
-            ctx.registers_i.replace_active_box(valuebox, expected);
+            vable_ops::walker_replace_box(ctx, valuebox, expected);
         }
         return Ok((DispatchOutcome::Continue, target));
     }
@@ -5388,8 +5313,7 @@ fn guard_current_frame_globals_identity<Sym: WalkSym>(
     ctx.trace_ctx
         .record_guard(OpCode::GuardValue, &[w_globals_op, expected], 0);
     walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
-    ctx.trace_ctx.replace_box(w_globals_op, expected);
-    ctx.registers_r.replace_active_box(w_globals_op, expected);
+    vable_ops::walker_replace_box(ctx, w_globals_op, expected);
     Ok(true)
 }
 
@@ -7891,7 +7815,7 @@ pub unsafe fn fbw_store_journal_root_walker_area(
 }
 
 /// #73: classification of a Python opcode's effect on the walk-level
-/// symbolic operand stack ([`WalkContext::vstack_boxes`]), used by
+/// symbolic operand stack ([`WalkFrameStateData::vstack_boxes`]), used by
 /// [`reconcile_vstack_at_boundary`] to update `vstack_boxes` at an
 /// opcode boundary.  The depth delta is already known from
 /// `depth_at_py_pc`; this only decides WHERE the new boxes come from.
@@ -11094,7 +11018,9 @@ fn guarded_branch_core<Sym: WalkSym>(
         let mirror_covers_kept = ctx.vstack_valid
             && resume_depth.is_some_and(|d| {
                 (0..d).all(|s| {
-                    ctx.vstack_boxes
+                    ctx.frame_state
+                        .borrow()
+                        .vstack_boxes
                         .get(s as usize)
                         .copied()
                         .is_some_and(|b| b != OpRef::NONE)
@@ -11264,7 +11190,11 @@ fn guarded_branch_core<Sym: WalkSym>(
             // invalid-mirror walk.
             let kept_boxed_int = !ctx.vstack_valid
                 && gate_frame.as_ref().is_some_and(|f| {
-                    kept_stack_has_boxed_int_hazard(f, other_target, ctx.concrete_registers_r)
+                    kept_stack_has_boxed_int_hazard(
+                        f,
+                        other_target,
+                        &ctx.frame_state.borrow().concrete_registers_r,
+                    )
                 });
             // A not-taken arm resuming at an exception-handler-protected
             // PC carries the kept exception operand (`PUSH_EXC_INFO`'s
@@ -11430,10 +11360,16 @@ fn latch_taken_python_branch_abort_stack<Sym: WalkSym>(
     else {
         return;
     };
-    if !ctx.vstack_valid || depth > ctx.vstack_depth || depth > ctx.vstack_boxes.len() {
+    if !ctx.vstack_valid
+        || depth > ctx.vstack_depth
+        || depth > ctx.frame_state.borrow().vstack_boxes.len()
+    {
         return;
     }
-    fbw_branch_abort_stack_latch(successor, ctx.vstack_boxes[..depth].to_vec());
+    fbw_branch_abort_stack_latch(
+        successor,
+        ctx.frame_state.borrow().vstack_boxes[..depth].to_vec(),
+    );
 }
 
 fn goto_if_not_branch_on<Sym: WalkSym>(
@@ -11926,7 +11862,7 @@ fn establish_nullity<Sym: WalkSym>(
         walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardIsnull, &[boxref])?;
         // `constant_from_op` of a proven-null ref is the null constant.
         let promoted = ctx.trace_ctx.const_ref(0);
-        ctx.trace_ctx.replace_box(boxref, promoted);
+        vable_ops::walker_replace_box(ctx, boxref, promoted);
     }
     ctx.trace_ctx
         .heap_cache_mut()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/register_bank.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/register_bank.rs
@@ -1,0 +1,256 @@
+//! Storage for `pyjitpl.py MIFrame.registers_{i,r,f}`.
+//!
+//! A frame owns the list; execution and `MetaInterp.replace_box` share its
+//! identity, not a captured mutable slice. Slot access returns values so a
+//! caller cannot retain an exclusive slot borrow across a descendant call.
+//! Construction follows `MIFrame.copy_constants`/frame setup: the full
+//! register-and-constant list is seeded before publication. Its size stays
+//! fixed during execution; Cell permits shared access to the actual slots.
+
+use majit_ir::OpRef;
+use std::cell::Cell;
+use std::rc::Rc;
+
+/// Value-only access used while the remaining typed banks are migrated.
+pub trait RegisterValues {
+    fn len(&self) -> usize;
+    fn get_box(&self, index: usize) -> Option<OpRef>;
+}
+
+impl RegisterValues for [OpRef] {
+    fn len(&self) -> usize {
+        <[OpRef]>::len(self)
+    }
+    fn get_box(&self, index: usize) -> Option<OpRef> {
+        self.get(index).copied()
+    }
+}
+
+impl RegisterValues for Vec<OpRef> {
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+    fn get_box(&self, index: usize) -> Option<OpRef> {
+        self.as_slice().get(index).copied()
+    }
+}
+
+impl<const N: usize> RegisterValues for [OpRef; N] {
+    fn len(&self) -> usize {
+        N
+    }
+    fn get_box(&self, index: usize) -> Option<OpRef> {
+        self.as_slice().get(index).copied()
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct RegisterBank(Option<Rc<RegisterSlots>>, usize);
+
+#[derive(Debug)]
+struct RegisterSlots(Box<[Cell<OpRef>]>);
+
+impl std::ops::Deref for RegisterSlots {
+    type Target = [Cell<OpRef>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The translated stack root for MIFrame's register list. Publication owns
+/// the same list as execution, not a pointer into a borrowed PyreSym.
+pub(crate) struct RegisterBankRoot {
+    // Retire the area before releasing its owner (field drop order).
+    _area: Option<majit_gc::shadow_stack::MutatorExtraAreaGuard>,
+    _owner: RegisterBank,
+}
+
+unsafe fn walk_register_slots(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let slots = unsafe { &*(data as *const RegisterSlots) };
+    for slot in slots.iter() {
+        let mut value = slot.get();
+        value.walk_const_ptr_refs_mut(visitor);
+        slot.set(value);
+    }
+}
+
+impl RegisterValues for RegisterBank {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn get_box(&self, index: usize) -> Option<OpRef> {
+        self.get(index)
+    }
+}
+
+impl RegisterBank {
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (Some(a), Some(b)) => Rc::ptr_eq(a, b),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    pub fn new(values: impl IntoIterator<Item = OpRef>) -> Self {
+        let slots: Vec<_> = values.into_iter().map(Cell::new).collect();
+        let num_regs = slots.len();
+        Self::from_slots(slots, num_regs)
+    }
+
+    /// MIFrame.setup/copy_constants: only the prefix contains mutable
+    /// registers; the suffix holds the JitCode's constants.
+    pub fn with_constants(values: impl IntoIterator<Item = OpRef>, num_regs: usize) -> Self {
+        Self::from_slots(values.into_iter().map(Cell::new).collect(), num_regs)
+    }
+
+    fn from_slots(slots: Vec<Cell<OpRef>>, num_regs: usize) -> Self {
+        assert!(num_regs <= slots.len());
+        // MIFrame.setup leaves registers_f=None when there are no registers
+        // or constants. Do not allocate an empty shared bank for every call.
+        if slots.is_empty() {
+            Self::default()
+        } else {
+            Self(
+                Some(Rc::new(RegisterSlots(slots.into_boxed_slice()))),
+                num_regs,
+            )
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.as_ref().map_or(0, |slots| slots.len())
+    }
+
+    pub(crate) fn root(&self) -> RegisterBankRoot {
+        let area = self.0.as_ref().map(|slots| unsafe {
+            // The Rc allocation is stable and the returned guard retains it.
+            // The collector accesses only shared Cell slots, never a frame's
+            // exclusive borrow or Rc's reference count. Registry walks run
+            // synchronously on the owner or under foreign-mutator STW.
+            majit_gc::shadow_stack::MutatorExtraAreaGuard::new(
+                walk_register_slots,
+                Rc::as_ptr(slots).cast(),
+                "miframe_registers",
+            )
+        });
+        RegisterBankRoot {
+            _area: area,
+            _owner: self.clone(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&self, index: usize) -> Option<OpRef> {
+        self.0.as_ref()?.get(index).map(Cell::get)
+    }
+
+    pub fn set(&self, index: usize, value: OpRef) {
+        self.0.as_ref().expect("write to an empty register bank")[index].set(value);
+    }
+
+    pub fn to_vec(&self) -> Vec<OpRef> {
+        self.0
+            .iter()
+            .flat_map(|slots| slots.iter().map(Cell::get))
+            .collect()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = OpRef> + '_ {
+        self.0.iter().flat_map(|slots| slots.iter().map(Cell::get))
+    }
+
+    /// Trace the frame's actual slots, as RPython's GC traces MIFrame's list.
+    /// The root walker only calls this synchronously on the owner or while
+    /// all foreign mutators are quiesced. It never clones/drops the Rc owner.
+    pub(crate) fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+        for slot in self.0.iter().flat_map(|slots| slots.iter()) {
+            let mut value = slot.get();
+            value.walk_const_ptr_refs_mut(visitor);
+            slot.set(value);
+        }
+    }
+
+    pub fn replace_active_box(&self, old: OpRef, new: OpRef) {
+        // pyjitpl.py MIFrame.replace_active_box_in_frame stops at num_regs,
+        // not num_regs_and_consts: replacement must not rewrite constants.
+        for slot in self.0.iter().flat_map(|slots| slots.iter()).take(self.1) {
+            if slot.get() == old {
+                slot.set(new);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_replacement_preserves_the_constant_suffix() {
+        let old = OpRef::const_ptr(majit_ir::GcRef(0x1000));
+        let new = OpRef::input_arg_ref(0);
+        let bank = RegisterBank::with_constants([old, old], 1);
+        bank.clone().replace_active_box(old, new);
+        assert_eq!(bank.to_vec(), [new, old]);
+        let constants_only = RegisterBank::with_constants([old], 0);
+        constants_only.replace_active_box(old, new);
+        assert_eq!(constants_only.to_vec(), [old]);
+    }
+
+    #[test]
+    fn empty_bank_has_no_shared_allocation() {
+        let bank = RegisterBank::new([]);
+        assert!(bank.is_empty());
+        assert!(bank.0.is_none());
+        assert_eq!(bank.get(0), None);
+    }
+
+    #[test]
+    fn paused_and_active_access_share_the_frame_owned_slots() {
+        let old = OpRef::input_arg_float(0);
+        let new = OpRef::input_arg_float(1);
+        let owner = RegisterBank::new([old]);
+        let paused = owner.clone();
+        owner.set(0, new);
+        paused.replace_active_box(new, old);
+        assert_eq!(owner.get(0), Some(old));
+        drop(owner);
+        paused.replace_active_box(old, new);
+        assert_eq!(paused.get(0), Some(new));
+    }
+
+    #[test]
+    fn int_replacement_updates_each_live_alias_immediately() {
+        let old = OpRef::input_arg_int(0);
+        let new = OpRef::input_arg_int(1);
+        let frame = RegisterBank::new([old, old]);
+        let paused = frame.clone();
+        frame.set(1, new);
+        paused.replace_active_box(old, new);
+        assert_eq!(frame.to_vec(), vec![new, new]);
+        drop(frame);
+        paused.replace_active_box(new, old);
+        assert_eq!(paused.to_vec(), vec![old, old]);
+    }
+
+    #[test]
+    fn gc_root_forwards_shared_ref_slots_and_retains_their_owner() {
+        use majit_ir::GcRef;
+        let old = OpRef::const_ptr(GcRef(0x1000));
+        let frame = RegisterBank::new([old, OpRef::input_arg_ref(0)]);
+        let root = frame.clone();
+        assert!(frame.ptr_eq(&root));
+        assert!(!frame.ptr_eq(&RegisterBank::new([old])));
+        root.walk_const_ptr_refs(&mut |ptr| ptr.0 += 0x1000);
+        assert_eq!(frame.get(0), Some(OpRef::const_ptr(GcRef(0x2000))));
+        frame.set(0, old);
+        drop(frame);
+        root.walk_const_ptr_refs(&mut |ptr| ptr.0 += 0x1000);
+        assert_eq!(root.get(0), Some(OpRef::const_ptr(GcRef(0x2000))));
+        assert_eq!(root.get(1), Some(OpRef::input_arg_ref(0)));
+    }
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/register_list.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/register_list.rs
@@ -1,0 +1,125 @@
+//! Growable storage for the remaining MIFrame Ref-register mirrors.
+//!
+//! Like MIFrame.registers_r, the list has a stable owner even when its backing
+//! allocation grows. Only value access escapes: no slot borrow can survive a
+//! collection. This preserves the existing semantic-mirror layout while its
+//! consumers converge on the codewriter's register colors.
+
+use majit_ir::OpRef;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Clone, Default, Debug)]
+pub struct RegisterList(Rc<RefCell<Option<Vec<OpRef>>>>);
+
+impl From<Vec<OpRef>> for RegisterList {
+    fn from(values: Vec<OpRef>) -> Self {
+        Self(Rc::new(RefCell::new(Some(values))))
+    }
+}
+
+impl RegisterList {
+    pub fn len(&self) -> usize {
+        self.0.borrow().as_ref().map_or(0, Vec::len)
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn is_some(&self) -> bool {
+        self.0.borrow().is_some()
+    }
+    pub fn is_none(&self) -> bool {
+        !self.is_some()
+    }
+    pub fn as_ref(&self) -> Option<&Self> {
+        self.is_some().then_some(self)
+    }
+    pub fn as_mut(&self) -> Option<&Self> {
+        self.as_ref()
+    }
+    pub fn get_or_insert_with(&self, make: impl FnOnce() -> Vec<OpRef>) -> &Self {
+        if self.is_none() {
+            self.replace(make());
+        }
+        self
+    }
+    pub fn get(&self, index: usize) -> Option<OpRef> {
+        self.0.borrow().as_ref()?.get(index).copied()
+    }
+    pub fn set(&self, index: usize, value: OpRef) {
+        self.0.borrow_mut().as_mut().expect("absent register list")[index] = value;
+    }
+    pub fn resize(&self, len: usize, value: OpRef) {
+        self.0
+            .borrow_mut()
+            .get_or_insert_with(Vec::new)
+            .resize(len, value);
+    }
+    pub fn truncate(&self, len: usize) {
+        if let Some(values) = self.0.borrow_mut().as_mut() {
+            values.truncate(len);
+        }
+    }
+    pub fn swap(&self, a: usize, b: usize) {
+        self.0
+            .borrow_mut()
+            .as_mut()
+            .expect("absent register list")
+            .swap(a, b);
+    }
+    pub fn extend(&self, values: impl IntoIterator<Item = OpRef>) {
+        // Evaluate the producer before borrowing the list: producers may call
+        // back into the tracer (or allocate), just as RPython list extension
+        // cannot keep an exclusive Rust borrow over such a call.
+        for value in values {
+            self.0.borrow_mut().get_or_insert_with(Vec::new).push(value);
+        }
+    }
+    pub fn replace(&self, values: Vec<OpRef>) {
+        *self.0.borrow_mut() = Some(values);
+    }
+    pub fn iter(&self) -> impl Iterator<Item = OpRef> + '_ {
+        (0..self.len()).map(|i| self.get(i).expect("register list shrank during iteration"))
+    }
+    pub fn to_vec(&self) -> Vec<OpRef> {
+        self.0.borrow().clone().unwrap_or_default()
+    }
+    pub(crate) fn root(&self) -> RegisterListRoot {
+        let area = unsafe {
+            majit_gc::shadow_stack::MutatorExtraAreaGuard::new(
+                walk_register_list,
+                Rc::as_ptr(&self.0).cast(),
+                "miframe_ref_list",
+            )
+        };
+        RegisterListRoot {
+            _area: area,
+            _owner: self.clone(),
+        }
+    }
+}
+
+pub(crate) struct RegisterListRoot {
+    _area: majit_gc::shadow_stack::MutatorExtraAreaGuard,
+    _owner: RegisterList,
+}
+
+unsafe fn walk_register_list(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    // Registered storage is Rc-owned, not part of a borrowed PyreSym. All
+    // mutator methods release the list borrow before any collecting call.
+    let list = unsafe { &*(data as *const RefCell<Option<Vec<OpRef>>>) };
+    if let Some(values) = list.borrow_mut().as_mut() {
+        for value in values {
+            value.walk_const_ptr_refs_mut(visitor);
+        }
+    }
+}
+
+impl super::RegisterValues for RegisterList {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn get_box(&self, index: usize) -> Option<OpRef> {
+        self.get(index)
+    }
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1231,10 +1231,10 @@ thread_local! {
     /// A force inside the residual runs from `force_pyframe`, which reaches
     /// only the `TraceCtx`; `virtualizable.py write_boxes` writes the array of
     /// the virtualizable it forces, so the level's own slot source has to be
-    /// reachable there.  The pointer is valid exactly while the guard that set
-    /// it is alive, which brackets the residual.
-    static PUBLISHED_INLINE_SHADOW: std::cell::Cell<Option<(*const super::CalleeLocalsShadow, u16)>> =
-        const { std::cell::Cell::new(None) };
+    /// reachable there. Publish the shared owner, not a raw pointer into its
+    /// RefCell: writeback may collect and forward the same shadow's fields.
+    static PUBLISHED_INLINE_SHADOW: std::cell::RefCell<Option<(super::WalkFrameState, u16)>> =
+        const { std::cell::RefCell::new(None) };
 
     /// The frame a live [`LiveLastInstrGuard`] published the executing pc onto,
     /// with the resume coordinate it displaced.
@@ -1412,17 +1412,14 @@ struct ResidualFrameChainGuard {
     /// residual publishes across this scope.
     frame_root: majit_gc::shadow_stack::OwnerRootGuard,
     previous_published: *mut pyre_interpreter::PyFrame,
-    previous_shadow: Option<(*const super::CalleeLocalsShadow, u16)>,
+    previous_shadow: Option<(super::WalkFrameState, u16)>,
     /// Whether this guard performed the chain write, so `Drop` restores only
     /// what it changed.  False when the chain already named `frame`.
     entered: bool,
 }
 
 impl ResidualFrameChainGuard {
-    fn enter(
-        frame: usize,
-        shadow: Option<(*const super::CalleeLocalsShadow, u16)>,
-    ) -> Option<Self> {
+    fn enter(frame: usize, shadow: Option<(super::WalkFrameState, u16)>) -> Option<Self> {
         let frame = frame as *mut pyre_interpreter::PyFrame;
         if frame.is_null() {
             return None;
@@ -1492,7 +1489,7 @@ impl Drop for ResidualFrameChainGuard {
             // dropping that propagation would leave the escape recorded only on
             // a frame the walk owns privately.
             PUBLISHED_INLINE_FRAME.with(|slot| slot.set(self.previous_published));
-            PUBLISHED_INLINE_SHADOW.with(|slot| slot.set(self.previous_shadow));
+            PUBLISHED_INLINE_SHADOW.with(|slot| slot.replace(self.previous_shadow.take()));
             if self.entered {
                 // The value `enter` displaced, read back off the frame it was
                 // written to, so a collection during the residual forwarded it
@@ -1641,19 +1638,18 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
                         // suppression is scoped to this residual.
                         let written = PUBLISHED_INLINE_SHADOW
                             .with(|slot| slot.take())
-                            .is_some_and(|(shadow, frame_reg)| {
-                                // SAFETY: the pointer is published by
-                                // `ResidualFrameChainGuard`, which brackets the
-                                // residual this force runs inside of, and
-                                // restores the previous entry on drop.
-                                let shadow = unsafe { &*shadow };
+                            .is_some_and(|(state, frame_reg)| {
                                 // The shadow describes ONE level's frame.  Only
                                 // that frame may be written from it: a nested
                                 // residual publishes its own, and writing one
                                 // level's slots onto another's array would
                                 // replace live values with unrelated ones.
-                                shadow.concrete_frame == frame as usize
-                                    && super::flush_callee_locals_region(shadow, frame, frame_reg)
+                                let matches_frame =
+                                    state.borrow().callee_shadow.as_ref().is_some_and(|shadow| {
+                                        shadow.concrete_frame == frame as usize
+                                    });
+                                matches_frame
+                                    && super::flush_callee_locals_region(&state, frame, frame_reg)
                             });
                         if !written {
                             UNFLUSHED_ESCAPED_CALLEE.with(|slot| slot.set(frame as usize));
@@ -4179,14 +4175,14 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             .borrow()
             .callee_shadow
             .as_ref()
-            .and_then(|shadow| {
+            .and_then(|_| {
                 let frame_reg = ctx
                     .inline_callee_consts
                     .and_then(|consts| {
                         crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)
                     })
                     .map(|jitcode| jitcode.metadata.portal_frame_reg)?;
-                Some((shadow as *const super::CalleeLocalsShadow, frame_reg))
+                Some((ctx.frame_state.clone(), frame_reg))
             });
         let _frame_chain = ResidualFrameChainGuard::enter(concrete_inline_frame, published_shadow);
         let live_py_pc = if ctx.fbw_mode.inline_subwalk {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -294,7 +294,7 @@ macro_rules! latchdbg {
 /// unresolved.  A zero-effect walk may then use the legacy entry replay;
 /// an effectful walk must keep recording until a complete image can be built,
 /// because replaying it would apply the effect twice.
-/// Resolve `WalkContext::vstack_boxes` — the walker's counterpart of
+/// Resolve `WalkFrameStateData::vstack_boxes` — the walker's counterpart of
 /// `MIFrame.registers_r` snapshotted by `get_list_of_active_boxes`
 /// (`pyjitpl.py`) — into the concrete operand stack an abort image publishes.
 ///
@@ -316,8 +316,8 @@ fn capture_vstack_mirror_image<Sym: WalkSym>(
         latchdbg!("origin={origin} mirror-invalid");
         return None;
     }
-    let mut slots = Vec::with_capacity(ctx.vstack_boxes.len());
-    for &opref in ctx.vstack_boxes.iter() {
+    let mut slots = Vec::with_capacity(ctx.frame_state.borrow().vstack_boxes.len());
+    for &opref in ctx.frame_state.borrow().vstack_boxes.iter() {
         match ctx.trace_ctx.concrete_of_opref(opref) {
             Some(majit_ir::Value::Ref(value)) if value != majit_ir::GcRef::NO_CONCRETE => {
                 slots.push(value.as_usize() as pyre_object::PyObjectRef);
@@ -327,9 +327,9 @@ fn capture_vstack_mirror_image<Sym: WalkSym>(
                     "origin={origin} mirror-slot {}/{} unresolved opref={opref:?} \
                      concrete={other:?} pypc={} boxes={:?}",
                     slots.len(),
-                    ctx.vstack_boxes.len(),
+                    ctx.frame_state.borrow().vstack_boxes.len(),
                     ctx.vstack_cur_pypc,
-                    ctx.vstack_boxes,
+                    ctx.frame_state.borrow().vstack_boxes,
                 );
                 return None;
             }
@@ -763,7 +763,13 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         if miframe.ref_values.get(color).copied().flatten().is_some() {
             continue;
         }
-        let value = match ctx.concrete_registers_r.get(color).copied()? {
+        let value = match ctx
+            .frame_state
+            .borrow()
+            .concrete_registers_r
+            .get(color)
+            .copied()?
+        {
             ConcreteValue::Ref(value) => value as i64,
             // ConcreteValue::Null is the walker's "unknown" sentinel, not a
             // proven Python null.  The register shadow never held this color's
@@ -832,7 +838,12 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         // `ConcreteValue::Null` is the walker's "unknown" sentinel, not a proven
         // Python null, so it seeds nothing.
         if slot.is_none()
-            && let Some(ConcreteValue::Ref(value)) = ctx.concrete_registers_r.get(color).copied()
+            && let Some(ConcreteValue::Ref(value)) = ctx
+                .frame_state
+                .borrow()
+                .concrete_registers_r
+                .get(color)
+                .copied()
         {
             *slot = Some(value as i64);
         }
@@ -999,14 +1010,16 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
                     _ => None,
                 }
             });
-        let from_shadow =
-            ctx.concrete_registers_r
-                .get(color)
-                .copied()
-                .and_then(|value| match value {
-                    ConcreteValue::Ref(value) => Some(value as i64),
-                    _ => None,
-                });
+        let from_shadow = ctx
+            .frame_state
+            .borrow()
+            .concrete_registers_r
+            .get(color)
+            .copied()
+            .and_then(|value| match value {
+                ConcreteValue::Ref(value) => Some(value as i64),
+                _ => None,
+            });
         // Every bool a comparison leaves in a Ref register is now a real Ref —
         // either the `space.newbool` singleton behind its truth guard or the
         // residual box — so `forwarded` reads it directly.  A raw-truth Int was
@@ -2962,7 +2975,13 @@ pub(crate) fn probe_resid_decline_ctx<Sym: WalkSym>(
     // shadow (`concrete_registers_r`): a `Null` shadow at a found slot with a
     // `None` box_value is the bridge-resume seed gap (neither store populated).
     let reg_slot = ctx.registers_r.iter().position(|r| r == arg);
-    let shadow = reg_slot.and_then(|s| ctx.concrete_registers_r.get(s));
+    let shadow = reg_slot.and_then(|s| {
+        ctx.frame_state
+            .borrow()
+            .concrete_registers_r
+            .get(s)
+            .copied()
+    });
     eprintln!(
         "[fbw-resid-decline] {why} op_pc={op_pc} py_pc={py_pc:?} py_op={opcode:?} \
          arg_index={arg_index} arg={arg_id} box_value={box_v:?} reg_slot={reg_slot:?} \
@@ -3001,7 +3020,9 @@ fn carrier_stack_box_for_ref_arg<Sym: WalkSym>(
         color,
     )?;
     let stack_slot = semantic.checked_sub(nlocals)?;
-    ctx.vstack_boxes
+    ctx.frame_state
+        .borrow()
+        .vstack_boxes
         .get(stack_slot)
         .copied()
         .filter(|&value| value != OpRef::NONE)
@@ -3027,11 +3048,14 @@ fn repair_carrier_call_ref_args<Sym: WalkSym>(
             *arg = frame_box;
         }
     }
-    if !ctx.vstack_valid || ctx.vstack_boxes.len() < r_args.len() {
+    if !ctx.vstack_valid || ctx.frame_state.borrow().vstack_boxes.len() < r_args.len() {
         return;
     }
-    let start = ctx.vstack_boxes.len() - r_args.len();
-    for (arg, &frame_box) in r_args.iter_mut().zip(&ctx.vstack_boxes[start..]) {
+    let start = ctx.frame_state.borrow().vstack_boxes.len() - r_args.len();
+    for (arg, &frame_box) in r_args
+        .iter_mut()
+        .zip(&ctx.frame_state.borrow().vstack_boxes[start..])
+    {
         if ctx.trace_ctx.concrete_of_opref(*arg).is_none()
             && frame_box != OpRef::NONE
             && ctx.trace_ctx.concrete_of_opref(frame_box).is_some()
@@ -4126,7 +4150,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                     && !ctx.trace_ctx.is_bridge_trace
                     && escape_opcode_window_clean(*py_pc)
             })
-            .map(|_| ctx.vstack_boxes.clone());
+            .map(|_| ctx.frame_state.borrow().vstack_boxes.clone());
         let _frame_escape = ActiveFrameEscapeGuard::enter(escape_frame, escape_py_pc, escape_stack);
         // `executioncontext.py enter` for the inlined callee this residual
         // runs inside of.
@@ -4140,6 +4164,8 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // `sys._getframe()` onto the caller, retaining the TLS value only for
         // older non-shadow inline paths.
         let concrete_inline_frame = ctx
+            .frame_state
+            .borrow()
             .callee_shadow
             .as_ref()
             .map(|shadow| shadow.concrete_frame)
@@ -4148,13 +4174,20 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // The level's own slot source travels with the frame: a force inside
         // this residual reaches only the `TraceCtx`, and the frame it forces is
         // this callee, not the traced virtualizable.
-        let published_shadow = ctx.callee_shadow.as_ref().and_then(|shadow| {
-            let frame_reg = ctx
-                .inline_callee_consts
-                .and_then(|consts| crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index))
-                .map(|jitcode| jitcode.metadata.portal_frame_reg)?;
-            Some((shadow as *const super::CalleeLocalsShadow, frame_reg))
-        });
+        let published_shadow = ctx
+            .frame_state
+            .borrow()
+            .callee_shadow
+            .as_ref()
+            .and_then(|shadow| {
+                let frame_reg = ctx
+                    .inline_callee_consts
+                    .and_then(|consts| {
+                        crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)
+                    })
+                    .map(|jitcode| jitcode.metadata.portal_frame_reg)?;
+                Some((shadow as *const super::CalleeLocalsShadow, frame_reg))
+            });
         let _frame_chain = ResidualFrameChainGuard::enter(concrete_inline_frame, published_shadow);
         let live_py_pc = if ctx.fbw_mode.inline_subwalk {
             ctx.vstack_cur_pypc
@@ -4683,7 +4716,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                         // it a CALL returning None leaves a NULL hole at the
                         // following POP_TOP and an abort cannot flush past an
                         // already-executed mutation such as `seen.add(w)`.
-                        ctx.vstack_last_ref = recorded;
+                        ctx.frame_state.borrow_mut().vstack_last_ref = recorded;
                     }
                     majit_ir::Type::Float => {
                         ctx.trace_ctx.set_opref_concrete(
@@ -4734,7 +4767,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                 // TOS.  This runs for every `ForIterNext` residual once it
                 // returns, placing the item OpRef on the new TOS for the
                 // FOR_ITER `ResultToTos` boundary.
-                ctx.vstack_last_ref = recorded;
+                ctx.frame_state.borrow_mut().vstack_last_ref = recorded;
                 if fbw_debug_abort_enabled() {
                     let item = result_i64 as usize as pyre_object::PyObjectRef;
                     let intval = if unsafe { pyre_object::pyobject::is_int(item) } {
@@ -5103,7 +5136,13 @@ pub(super) fn maybe_publish_inline_callee_last_instr_concrete<Sym: WalkSym>(
     // gh#1444 either, whose wrong answer is a depth->=2 multi-frame blackhole
     // adopt (`PYRE_FBW_MULTIFRAME_DEPTH=1` answers correctly).  So the split is
     // a recorded gap rather than either one's cause.
-    if let Some(ConcreteValue::Ref(frame_ptr)) = ctx.concrete_registers_r.get(frame_reg).copied() {
+    if let Some(ConcreteValue::Ref(frame_ptr)) = ctx
+        .frame_state
+        .borrow()
+        .concrete_registers_r
+        .get(frame_reg)
+        .copied()
+    {
         if !frame_ptr.is_null() {
             unsafe {
                 (*(frame_ptr as *mut pyre_interpreter::PyFrame)).last_instr = callee_py_pc as isize;
@@ -5130,7 +5169,8 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
     let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index) else {
         return Ok(());
     };
-    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+    let state = ctx.frame_state.borrow();
+    let Some(shadow) = state.callee_shadow.as_ref() else {
         return Ok(());
     };
     if shadow.fold_frame_reg == u16::MAX || shadow.frame_box == OpRef::NONE {
@@ -5169,6 +5209,7 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
         })
         .collect();
     slots.sort_by_key(|(slot, _, _)| *slot);
+    drop(state);
 
     for (slot, value, concrete) in slots {
         let index = ctx.trace_ctx.const_int(slot);
@@ -5192,7 +5233,7 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
         };
         walker_capture_inline_nonstandard_vable_guard(ctx, pc, guards_before, write)?;
     }
-    if let Some(shadow) = ctx.callee_shadow.as_mut()
+    if let Some(shadow) = ctx.frame_state.borrow_mut().callee_shadow.as_mut()
         && shadow.frame_box == callee_frame
     {
         shadow.fold_frame_reg = u16::MAX;
@@ -7617,10 +7658,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && foldable_runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && r_args.is_empty()
-        && ctx.fbw_mode.current_exception_seed.is_some()
+        && ctx.frame_state.borrow().current_exception_seed.is_some()
     {
-        let seed = ctx.fbw_mode.current_exception_seed.unwrap();
-        let concrete = ctx.fbw_mode.current_exception_seed_concrete;
+        let seed = ctx.frame_state.borrow().current_exception_seed.unwrap();
+        let concrete = ctx.frame_state.borrow().current_exception_seed_concrete;
         if !concrete.is_null() && unsafe { pyre_object::is_exception(concrete) } {
             // `RAISE_VARARGS 0` may use the normalizing nullary helper rather
             // than the raw current-exception helper.  A bridge seed is already

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -751,7 +751,7 @@ fn build_single_frame_miframe<Sym: WalkSym>(
             continue;
         }
         let ConcreteValue::Int(value) = ctx.concrete_registers_i.get(color).copied()? else {
-            if ctx.registers_i.get(color).copied()?.is_none() {
+            if ctx.registers_i.get(color)?.is_none() {
                 continue;
             }
             return None;
@@ -772,7 +772,7 @@ fn build_single_frame_miframe<Sym: WalkSym>(
             // never concretized in this frame's shadow); decline only when even
             // that cannot resolve it.
             _ => {
-                let opref = ctx.registers_r.get(color).copied()?;
+                let opref = ctx.registers_r.get(color)?;
                 if opref.is_none() {
                     continue;
                 }
@@ -789,7 +789,7 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         if miframe.float_values.get(color).copied().flatten().is_some() {
             continue;
         }
-        let opref = ctx.registers_f.get(color).copied()?;
+        let opref = ctx.registers_f.get(color)?;
         if opref.is_none() {
             continue;
         }
@@ -844,7 +844,7 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         if miframe.float_values[color].is_some() {
             continue;
         }
-        let Some(&opref) = ctx.registers_f.get(color) else {
+        let Some(opref) = ctx.registers_f.get(color) else {
             continue;
         };
         if let Some(majit_ir::Value::Float(value)) = ctx.trace_ctx.concrete_of_opref(opref) {
@@ -971,7 +971,7 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
             continue;
         }
         if miframe.int_values[color].is_none() {
-            let Some(opref) = ctx.registers_i.get(color).copied() else {
+            let Some(opref) = ctx.registers_i.get(color) else {
                 continue;
             };
             if opref == OpRef::NONE {
@@ -986,7 +986,7 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
     }
 
     for color in 0..miframe.ref_values.len() {
-        let opref = ctx.registers_r.get(color).copied();
+        let opref = ctx.registers_r.get(color);
         let forwarded = opref
             .filter(|&value| value != OpRef::NONE)
             .and_then(|value| {
@@ -1026,7 +1026,7 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
         if miframe.float_values[color].is_some() {
             continue;
         }
-        let Some(opref) = ctx.registers_f.get(color).copied() else {
+        let Some(opref) = ctx.registers_f.get(color) else {
             continue;
         };
         if opref == OpRef::NONE {
@@ -2961,7 +2961,7 @@ pub(crate) fn probe_resid_decline_ctx<Sym: WalkSym>(
     // The declined arg's semantic register slot and its index-keyed concrete
     // shadow (`concrete_registers_r`): a `Null` shadow at a found slot with a
     // `None` box_value is the bridge-resume seed gap (neither store populated).
-    let reg_slot = ctx.registers_r.iter().position(|&r| r == arg);
+    let reg_slot = ctx.registers_r.iter().position(|r| r == arg);
     let shadow = reg_slot.and_then(|s| ctx.concrete_registers_r.get(s));
     eprintln!(
         "[fbw-resid-decline] {why} op_pc={op_pc} py_pc={py_pc:?} py_op={opcode:?} \
@@ -2984,7 +2984,7 @@ fn carrier_stack_box_for_ref_arg<Sym: WalkSym>(
         return None;
     }
     let consts = ctx.inline_callee_consts?;
-    let color = ctx.registers_r.iter().position(|&value| value == arg)?;
+    let color = ctx.registers_r.iter().position(|value| value == arg)?;
     let raw_code =
         unsafe { pyre_interpreter::w_code_get_ptr(consts.w_code as pyre_object::PyObjectRef) }
             as *const pyre_interpreter::CodeObject;
@@ -5050,7 +5050,7 @@ pub(crate) fn maybe_record_inline_callee_last_instr<Sym: WalkSym>(
         return;
     };
     let frame_reg = pjc.metadata.portal_frame_reg as usize;
-    let Some(&callee_frame) = ctx.registers_r.get(frame_reg) else {
+    let Some(callee_frame) = ctx.registers_r.get(frame_reg) else {
         return;
     };
     if callee_frame == OpRef::NONE {
@@ -5137,7 +5137,7 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
         return Ok(());
     }
     let frame_reg = pjc.metadata.portal_frame_reg as usize;
-    let Some(&callee_frame) = ctx.registers_r.get(frame_reg) else {
+    let Some(callee_frame) = ctx.registers_r.get(frame_reg) else {
         return Ok(());
     };
     if callee_frame != shadow.frame_box {
@@ -5240,16 +5240,16 @@ pub(crate) fn write_residual_call_result_to_dst<Sym: WalkSym>(
         }
         'f' => {
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         // Void variants (`pyjitpl.py opimpl_residual_call_*_v`):
         // the operand layout has no `>X` dst byte and no register slot to

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -602,7 +602,10 @@ fn prepare_force_quasi_immutable_abort<Sym: WalkSym>(
         reset_single_frame_blackhole();
         let _ = latch_abort_blackhole(ctx, resume_pc, "force-qmut");
     } else if ctx.vstack_valid && !ctx.trace_ctx.is_bridge_trace {
-        fbw_qmut_abort_stack_latch(ctx.vstack_cur_pypc as usize, ctx.vstack_boxes.clone());
+        fbw_qmut_abort_stack_latch(
+            ctx.vstack_cur_pypc as usize,
+            ctx.frame_state.borrow().vstack_boxes.clone(),
+        );
     }
     // The session flag survives recovered sub-walks; always overwrite it at
     // the raise site so a later root-frame abort cannot inherit `true`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -314,7 +314,7 @@ fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
         let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
         ctx.trace_ctx
             .capture_snapshot_for_last_guard_op_with_vable_vref(
-                &ctx.outer_active_boxes,
+                &ctx.frame_state.borrow().outer_active_boxes,
                 ctx.outer_jitcode_index,
                 nsvable_pc_word,
                 nsvable_py_pc,
@@ -842,7 +842,12 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 (0..depth)
                     .filter_map(|s| {
                         let v = if ctx.vstack_valid {
-                            ctx.vstack_boxes.get(s).copied().unwrap_or(OpRef::NONE)
+                            ctx.frame_state
+                                .borrow()
+                                .vstack_boxes
+                                .get(s)
+                                .copied()
+                                .unwrap_or(OpRef::NONE)
                         } else {
                             OpRef::NONE
                         };
@@ -1292,7 +1297,8 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 entry_jitcode_pc,
                 entry_twin,
                 entry_caller,
-                ctx.vstack_valid.then_some(ctx.vstack_boxes.as_slice()),
+                ctx.vstack_valid
+                    .then_some(ctx.frame_state.borrow().vstack_boxes.as_slice()),
                 scope.branch_guard_kept_recovered,
                 has_branch_guard.then_some(&mut unsourced_kept),
             );
@@ -1344,7 +1350,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
         return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
     };
     let arm_py_pc = forward_snapshot_py_pc(ctx.outer_jitcode_index, arm_pc_word)?;
-    let active = std::mem::take(&mut ctx.outer_active_boxes);
+    let active = std::mem::take(&mut ctx.frame_state.borrow_mut().outer_active_boxes);
     publish_single_frame_snapshot(
         ctx,
         scope.guard_stamp,
@@ -1357,7 +1363,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
         "carried",
         op_pc,
     );
-    ctx.outer_active_boxes = active;
+    ctx.frame_state.borrow_mut().outer_active_boxes = active;
     Ok(())
 }
 
@@ -1521,7 +1527,8 @@ pub(crate) fn concrete_ref_for_color<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     color: usize,
 ) -> Option<pyre_object::PyObjectRef> {
-    if let Some(ConcreteValue::Ref(ptr)) = ctx.concrete_registers_r.get(color) {
+    if let Some(ConcreteValue::Ref(ptr)) = ctx.frame_state.borrow().concrete_registers_r.get(color)
+    {
         if !ptr.is_null() {
             return Some(*ptr);
         }
@@ -1631,10 +1638,15 @@ pub(crate) fn collect_call_stack_overrides<Sym: WalkSym>(
         return Some(Vec::new());
     }
     let mut overrides = Vec::new();
-    if ctx.vstack_valid && ctx.vstack_depth == depth && ctx.vstack_boxes.len() >= depth {
+    if ctx.vstack_valid
+        && ctx.vstack_depth == depth
+        && ctx.frame_state.borrow().vstack_boxes.len() >= depth
+    {
         for d in 0..depth {
             let slot = nlocals + d;
-            if let Some(value) = concrete_ref_for_opref(ctx, ctx.vstack_boxes[d]) {
+            if let Some(value) =
+                concrete_ref_for_opref(ctx, ctx.frame_state.borrow().vstack_boxes[d])
+            {
                 overrides.push((slot, value));
             }
         }
@@ -1746,9 +1758,10 @@ pub(crate) fn collect_call_stack_overrides<Sym: WalkSym>(
             if overrides.iter().any(|&(present, _)| present == slot) {
                 continue;
             }
-            let vstack_box =
-                (ctx.vstack_valid && ctx.vstack_depth == depth && ctx.vstack_boxes.len() >= depth)
-                    .then(|| ctx.vstack_boxes[slot - nlocals]);
+            let vstack_box = (ctx.vstack_valid
+                && ctx.vstack_depth == depth
+                && ctx.frame_state.borrow().vstack_boxes.len() >= depth)
+                .then(|| ctx.frame_state.borrow().vstack_boxes[slot - nlocals]);
             let vstack_concrete =
                 vstack_box.map(|opref| concrete_ref_for_opref(ctx, opref).is_some());
             let pcdep_color = pcdep_entries
@@ -2030,7 +2043,12 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         // `set_stack_at` on a concrete PyFrame — a different index space.
         // Reading the shadow through it stamped whatever register happened to
         // live at the slot's number.
-        let got = ctx.concrete_registers_r.get(color).copied();
+        let got = ctx
+            .frame_state
+            .borrow()
+            .concrete_registers_r
+            .get(color)
+            .copied();
         let value = match got {
             Some(ConcreteValue::Ref(value)) => value,
             // The shadow holds `ConcreteValue::Null`, the walker's UNTRACKED
@@ -2065,7 +2083,7 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
                                 call_jit_pc,
                                 'r',
                                 color,
-                                ctx.concrete_registers_r.len(),
+                                ctx.frame_state.borrow().concrete_registers_r.len(),
                                 got,
                             );
                             report_caller_image_ref_box(ctx, color);
@@ -2078,7 +2096,7 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
                             call_jit_pc,
                             'r',
                             color,
-                            ctx.concrete_registers_r.len(),
+                            ctx.frame_state.borrow().concrete_registers_r.len(),
                             got,
                         );
                         report_caller_image_ref_box(ctx, color);
@@ -2098,7 +2116,13 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         }
         // `ConcreteValue::Null` is the walker's "unknown" sentinel rather than a
         // proven Python null, so it seeds nothing.
-        if let Some(ConcreteValue::Ref(value)) = ctx.concrete_registers_r.get(color).copied() {
+        if let Some(ConcreteValue::Ref(value)) = ctx
+            .frame_state
+            .borrow()
+            .concrete_registers_r
+            .get(color)
+            .copied()
+        {
             ref_values.push((color, value));
             swept[1] += 1;
         }
@@ -3139,7 +3163,7 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // stack slots.
     if scope.branch_guard_jitcode_pc.is_some()
         && ctx.vstack_valid
-        && ctx.vstack_depth <= ctx.vstack_boxes.len()
+        && ctx.vstack_depth <= ctx.frame_state.borrow().vstack_boxes.len()
     {
         for &(bank, color, slot) in &maps.pcdep_entries {
             if bank != 1 {
@@ -3152,7 +3176,7 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             if stack_slot >= ctx.vstack_depth {
                 continue;
             }
-            let value = ctx.vstack_boxes[stack_slot];
+            let value = ctx.frame_state.borrow().vstack_boxes[stack_slot];
             if value == OpRef::NONE || opref_is_null_const_ptr(value) {
                 continue;
             }
@@ -3162,7 +3186,7 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
         }
     }
     if recovered_regs_r.iter().any(|value| value.is_none()) && !callee_pjc.code_ptr.is_null() {
-        if let Some(shadow) = ctx.callee_shadow.as_ref() {
+        if let Some(shadow) = ctx.frame_state.borrow().callee_shadow.as_ref() {
             for (color, value) in recovered_regs_r.iter_mut().enumerate() {
                 if !value.is_none() {
                     continue;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -866,7 +866,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             // `pcdep_color_slots` map at the guard's own jitcode pc names the
             // Ref-bank color that holds operand-stack slot `nlocals + s` at THIS
             // guard PC (the same authoritative twin `collect_outer_active_boxes` reads),
-            // and `ctx.registers_r[color]` holds the live guard-state box.  This
+            // and `ctx.registers_r.get(color).expect("ref register in range")` holds the live guard-state box.  This
             // is the guard-PC color read (as `resolved_recovered` does for
             // `registers_r[src]`), NOT the retired stale merge-color read.
             // This ports `get_list_of_active_boxes`
@@ -906,7 +906,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     if let Some(color) =
                         crate::state::semantic_slot_color_for_ref_slot(&pcdep, nlocals + s)
                     {
-                        if let Some(&box_op) = ctx.registers_r.get(color) {
+                        if let Some(box_op) = ctx.registers_r.get(color) {
                             // Only a genuine Ref box may fill an operand-stack
                             // slot: the vable array is uniformly Ref-typed, and
                             // `build_vable_snapshot_boxes` reads each entry's
@@ -1198,7 +1198,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     {
                         continue;
                     }
-                    let Some(&value) = ctx.registers_r.get(color as usize) else {
+                    let Some(value) = ctx.registers_r.get(color as usize) else {
                         continue;
                     };
                     if value == OpRef::NONE || value.ty() != Some(majit_ir::Type::Ref) {
@@ -1526,7 +1526,7 @@ pub(crate) fn concrete_ref_for_color<Sym: WalkSym>(
             return Some(*ptr);
         }
     }
-    let opref = ctx.registers_r.get(color).copied()?;
+    let opref = ctx.registers_r.get(color)?;
     match ctx.trace_ctx.concrete_of_opref(opref) {
         Some(Value::Ref(r)) if !r.is_null() => Some(r.as_usize() as pyre_object::PyObjectRef),
         _ => None,
@@ -1923,7 +1923,7 @@ fn report_caller_image_ref_box<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, col
     if !fbw_debug_abort_enabled() {
         return;
     }
-    let opref = ctx.registers_r.get(color).copied();
+    let opref = ctx.registers_r.get(color);
     let box_is_none = opref.map(|o| o.is_none()).unwrap_or(true);
     let recovered = opref
         .filter(|o| !o.is_none())
@@ -2042,7 +2042,7 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
             // refusing the image; this site is the one copy that never received
             // those answers.
             _ => {
-                let opref = ctx.registers_r.get(color).copied();
+                let opref = ctx.registers_r.get(color);
                 match opref {
                     // No box at this color at all.  A `-live-` set is the union
                     // over the paths INTO its coordinate and the walk took one
@@ -2111,7 +2111,7 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         if result_bank == 'f' && result_color == Some(color) {
             continue;
         }
-        let got = ctx.registers_f.get(color).copied();
+        let got = ctx.registers_f.get(color);
         let Some(opref) = got.filter(|&opref| opref != OpRef::NONE) else {
             report_caller_image_decline(
                 jitcode_index,
@@ -2137,7 +2137,7 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         if float_seeded[color] || (result_bank == 'f' && result_color == Some(color)) {
             continue;
         }
-        let Some(opref) = ctx.registers_f.get(color).copied() else {
+        let Some(opref) = ctx.registers_f.get(color) else {
             continue;
         };
         if opref == OpRef::NONE {
@@ -2379,9 +2379,9 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     // list, then restore the caller's register (the inlined callee, not the
     // walk, produces the result; the inner frame supplies it on resume).
     let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
-    let saved = result_color.and_then(|color| ctx.registers_r.get(color).copied());
+    let saved = result_color.and_then(|color| ctx.registers_r.get(color));
     if let Some(result_color) = result_color.filter(|&color| color < ctx.registers_r.len()) {
-        ctx.registers_r[result_color] = null_ref;
+        ctx.registers_r.set(result_color, null_ref);
     }
     // Keep the caller at the immediate post-call `-live-`, matching the
     // paused `MIFrame.pc` used by RPython and the blackhole return ABI.
@@ -2409,7 +2409,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         result_color.filter(|&color| color < ctx.registers_r.len()),
         saved,
     ) {
-        ctx.registers_r[result_color] = saved;
+        ctx.registers_r.set(result_color, saved);
     }
     Ok(InlineParentFrame {
         jitcode_index,
@@ -2532,9 +2532,9 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     // walk, produces the result; the inner frame supplies it on resume) — same
     // as the top-level `in_a_call=true` shape.
     let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
-    let saved = result_color.and_then(|color| ctx.registers_r.get(color).copied());
+    let saved = result_color.and_then(|color| ctx.registers_r.get(color));
     if let Some(result_color) = result_color.filter(|&color| color < ctx.registers_r.len()) {
-        ctx.registers_r[result_color] = null_ref;
+        ctx.registers_r.set(result_color, null_ref);
     }
     // Keep the caller at the immediate post-call `-live-`, matching the
     // paused `MIFrame.pc` used by RPython and the blackhole return ABI.
@@ -2556,7 +2556,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         result_color.filter(|&color| color < ctx.registers_r.len()),
         saved,
     ) {
-        ctx.registers_r[result_color] = saved;
+        ctx.registers_r.set(result_color, saved);
     }
     let boxes = match boxes {
         Ok(b) => b,
@@ -2585,7 +2585,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         if caller_liveness_word != majit_ir::resumedata::NO_JITCODE_PC && depth > 1 {
             let (frame_reg, _) = crate::state::portal_red_regs_at(jitcode_index as i32);
             let frame_red = (frame_reg != u16::MAX)
-                .then(|| ctx.registers_r.get(frame_reg as usize).copied())
+                .then(|| ctx.registers_r.get(frame_reg as usize))
                 .flatten()
                 .filter(|&r| r != OpRef::NONE);
             let locals_idx = crate::descr::pyframe_locals_cells_stack_descr().index();
@@ -2635,7 +2635,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
                     if slot < nlocals || slot == pending_top_slot {
                         continue;
                     }
-                    let Some(&operand) = ctx.registers_r.get(color as usize) else {
+                    let Some(operand) = ctx.registers_r.get(color as usize) else {
                         continue;
                     };
                     if operand == OpRef::NONE {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -13239,7 +13239,7 @@ fn next_op_is_f_locals_for_getframe_result<Sym: WalkSym>(
     if obj_reg as usize != getframe_dst {
         return false;
     }
-    let (Some(&name_op), Some(&code_op)) = (
+    let (Some(name_op), Some(code_op)) = (
         ctx.registers_i.get(name_reg as usize),
         ctx.registers_r.get(code_reg as usize),
     ) else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2673,7 +2673,8 @@ fn walker_executing_frame_box<Sym: WalkSym>(
 ) -> Option<(OpRef, usize)> {
     let inline_frame = current_inline_concrete_frame();
     if inline_frame != 0 {
-        let shadow = ctx.callee_shadow.as_ref()?;
+        let state = ctx.frame_state.borrow();
+        let shadow = state.callee_shadow.as_ref()?;
         if shadow.concrete_frame != inline_frame || shadow.frame_box == OpRef::NONE {
             return None;
         }
@@ -2930,7 +2931,7 @@ fn try_walker_specialize_frame_lineno<Sym: WalkSym>(
 fn walker_bare_super_frame_slots<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<(OpRef, OpRef, bool)> {
-    if let Some(shadow) = ctx.callee_shadow.as_ref() {
+    if let Some(shadow) = ctx.frame_state.borrow().callee_shadow.as_ref() {
         // `u16::MAX` is the strict fresh-frame fold switched off and a `NONE`
         // frame box is a frame register that was never seeded; in neither case
         // is the shadow the authority for this level's slots.
@@ -3446,6 +3447,8 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     let is_inline_frame = inline_frame != 0
         && concrete_obj as usize == inline_frame
         && ctx
+            .frame_state
+            .borrow()
             .callee_shadow
             .as_ref()
             .is_some_and(|shadow| shadow.concrete_frame == inline_frame && shadow.frame_box == obj);
@@ -12674,7 +12677,8 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         decline!("subwalk-no-callee-resume");
     }
     let (fold_frame_reg, shadow_code_ptr) = {
-        let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        let state = ctx.frame_state.borrow();
+        let Some(shadow) = state.callee_shadow.as_ref() else {
             decline!("no-callee-shadow");
         };
         // `u16::MAX` is the strict fresh-frame fold switched off, and a
@@ -12789,7 +12793,8 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     };
     let mut slot_oprefs: Vec<Option<OpRef>> = Vec::with_capacity(nslots);
     {
-        let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        let state = ctx.frame_state.borrow();
+        let Some(shadow) = state.callee_shadow.as_ref() else {
             decline!("shadow-vanished");
         };
         for slot in 0..nslots as i64 {
@@ -13331,7 +13336,8 @@ pub(crate) fn try_walker_specialize_sys_getframe<Sym: WalkSym>(
         return Ok(None);
     };
     let (vable_op, vable_ptr) = if inline_level {
-        let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        let state = ctx.frame_state.borrow();
+        let Some(shadow) = state.callee_shadow.as_ref() else {
             return Ok(None);
         };
         if inline_ptr == 0 || shadow.concrete_frame != inline_ptr || shadow.frame_box == OpRef::NONE
@@ -16569,14 +16575,14 @@ fn run_orthodox_helper_subwalk<Sym: WalkSym>(
     let saved_entry = ctx.entry_py_pc;
     let saved_marker = ctx.outer_resume_marker_jit_pc;
     let saved_oji = ctx.outer_jitcode_index;
-    let saved_active = std::mem::take(&mut ctx.outer_active_boxes);
+    let saved_active = std::mem::take(&mut ctx.frame_state.borrow_mut().outer_active_boxes);
     let saved_descr_refs = ctx.descr_refs;
     let saved_raw_descrs = ctx.raw_descrs;
     let saved_lookup = ctx.sub_jitcode_lookup;
     ctx.entry_py_pc = EntryPyPc::Jit(op_pc);
     ctx.outer_resume_marker_jit_pc = call_site_marker;
     ctx.outer_jitcode_index = outer_jitcode_index;
-    ctx.outer_active_boxes = active;
+    ctx.frame_state.borrow_mut().outer_active_boxes = active;
     ctx.descr_refs = crate::jitcode_runtime::descr_ref_table();
     ctx.raw_descrs = RawDescrPool::Global;
     ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
@@ -16598,7 +16604,7 @@ fn run_orthodox_helper_subwalk<Sym: WalkSym>(
     ctx.entry_py_pc = saved_entry;
     ctx.outer_resume_marker_jit_pc = saved_marker;
     ctx.outer_jitcode_index = saved_oji;
-    ctx.outer_active_boxes = saved_active;
+    ctx.frame_state.borrow_mut().outer_active_boxes = saved_active;
     ctx.descr_refs = saved_descr_refs;
     ctx.raw_descrs = saved_raw_descrs;
     ctx.sub_jitcode_lookup = saved_lookup;
@@ -18641,11 +18647,15 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
         let seed_answers_this_read =
             ctx.fbw_mode.current_exception_seed_from_walk_store || is_covered_bare_raise_read;
         let (prev, prev_obj) = if let Some(seed) = ctx
-            .fbw_mode
+            .frame_state
+            .borrow()
             .current_exception_seed
             .filter(|_| seed_answers_this_read)
         {
-            (seed, ctx.fbw_mode.current_exception_seed_concrete)
+            (
+                seed,
+                ctx.frame_state.borrow().current_exception_seed_concrete,
+            )
         } else {
             let Some(ec) = walker_ensure_execution_context(ctx) else {
                 return Ok(None);
@@ -18762,8 +18772,8 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
     // exception into the next frame's `sys_exc_value`.
     fbw_sys_exc_journal_push(pyre_interpreter::eval::get_current_exception());
     pyre_interpreter::eval::set_current_exception(store_concrete);
-    ctx.fbw_mode.current_exception_seed = Some(store_op);
-    ctx.fbw_mode.current_exception_seed_concrete = store_concrete;
+    ctx.frame_state.borrow_mut().current_exception_seed = Some(store_op);
+    ctx.frame_state.borrow_mut().current_exception_seed_concrete = store_concrete;
     ctx.fbw_mode.current_exception_seed_from_walk_store = true;
     Ok(Some(()))
 }
@@ -19059,7 +19069,7 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
     } {
         walker_guard_class(ctx, op_pc, range_op, zip_type as i64)?;
         walker_guard_exact_w_class(ctx, op_pc, range_op, zip_class)?;
-        ctx.vstack_last_ref = range_op;
+        ctx.frame_state.borrow_mut().vstack_last_ref = range_op;
         return Ok(Some(range_op));
     }
 
@@ -19302,7 +19312,7 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
         new,
         majit_ir::Value::Ref(majit_ir::GcRef(real_iter as usize)),
     );
-    ctx.vstack_last_ref = new;
+    ctx.frame_state.borrow_mut().vstack_last_ref = new;
 
     Ok(Some(new))
 }
@@ -19630,7 +19640,7 @@ fn try_walker_specialize_zip_two_tuple_iters<Sym: WalkSym>(
         Value::Ref(majit_ir::GcRef(concrete_tuple as usize)),
     );
     fbw_foriter_inflight_capture(concrete_tuple, body);
-    ctx.vstack_last_ref = tuple_op;
+    ctx.frame_state.borrow_mut().vstack_last_ref = tuple_op;
     Ok(Some(tuple_op))
 }
 
@@ -19910,7 +19920,7 @@ fn try_walker_specialize_for_iter_list<Sym: WalkSym>(
     }
     unsafe { pyre_object::iterobject::w_list_iter_set_index(iter_obj, index + 1) };
     fbw_foriter_inflight_capture(concrete_item, body);
-    ctx.vstack_last_ref = item;
+    ctx.frame_state.borrow_mut().vstack_last_ref = item;
     Ok(Some(item))
 }
 
@@ -20041,7 +20051,7 @@ fn try_walker_specialize_for_iter_range_step_one<Sym: WalkSym>(
         fbw_bridge_iter_journal_push(iter_obj, concrete_current, concrete_remaining);
     }
     fbw_foriter_inflight_capture(concrete_item_ptr, body);
-    ctx.vstack_last_ref = item;
+    ctx.frame_state.borrow_mut().vstack_last_ref = item;
 
     Ok(Some(item))
 }
@@ -20263,7 +20273,7 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
     // Range iteration stays at the C level, so the operand-stack mirror
     // remains valid and must receive the item produced by FOR_ITER.  Its
     // virtual state is captured by subsequent body-guard snapshots.
-    ctx.vstack_last_ref = item;
+    ctx.frame_state.borrow_mut().vstack_last_ref = item;
 
     Ok(Some(item))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -7,6 +7,83 @@ static STATIC_REFUSAL_PREFIX_CALLS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 #[test]
+fn session_roots_cover_nested_attempts_and_vec_frame_retirement() {
+    let _runtime = crate::trace_ctx_for_test(0);
+    let _stw = majit_gc::gc_sync::quiesce_mutators();
+    let outer = std::cell::RefCell::new(WalkSession::default());
+    let inner = std::cell::RefCell::new(WalkSession::default());
+    let outer_roots = WalkSessionRoots::new(&outer);
+    let inner_roots = WalkSessionRoots::new(&inner);
+    let parent = |word: usize| InlineParentFrame {
+        jitcode_index: 0,
+        call_jitcode_pc: None,
+        call_stack_overrides: vec![(0, word as pyre_object::PyObjectRef)],
+        blackhole: Some(InlineParentBlackhole {
+            resume_pc: 0,
+            int_values: Vec::new(),
+            ref_values: vec![(0, (word + 0x10) as pyre_object::PyObjectRef)],
+            float_values: Vec::new(),
+        }),
+        resume_coord: ParentResumeCoord::Backxlat(0),
+        resume_marker_jit_pc: None,
+        boxes: vec![OpRef::const_ptr(majit_ir::GcRef(word + 0x20))],
+    };
+    let frames = vec![
+        InlineFrameGuard::enter(&outer, 0, false, vec![parent(0x1000)]),
+        InlineFrameGuard::enter(&outer, 0, false, vec![parent(0x2000)]),
+    ];
+    let inner_frame = InlineFrameGuard::enter(&inner, 0, false, vec![parent(0x3000)]);
+    let forward = || {
+        let mut seen = Vec::new();
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            if (0x1000..0x5000).contains(&root.0) {
+                seen.push(root.0);
+                root.0 += 0x80;
+            }
+        });
+        seen.sort_unstable();
+        seen
+    };
+    assert_eq!(
+        forward(),
+        [
+            0x1000, 0x1010, 0x1020, 0x2000, 0x2010, 0x2020, 0x3000, 0x3010, 0x3020
+        ]
+    );
+    drop(inner_frame);
+    drop(inner_roots);
+    assert_eq!(forward(), [0x1080, 0x1090, 0x10a0, 0x2080, 0x2090, 0x20a0]);
+    // Bridge reconstruction stores frame guards in a Vec; their drop order
+    // must not control the session owner's root registration lifetime.
+    drop(frames);
+    assert!(outer.borrow().framestack.is_empty());
+    outer.borrow_mut().tmpreg_r = OpRef::const_ptr(majit_ir::GcRef(0x4000));
+    assert_eq!(forward(), [0x4000]);
+    assert_eq!(
+        outer.borrow().tmpreg_r,
+        OpRef::const_ptr(majit_ir::GcRef(0x4080))
+    );
+    drop(outer_roots);
+    assert!(forward().is_empty());
+}
+
+#[test]
+fn session_root_callback_rejects_a_borrow_across_collection() {
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let held = session.borrow();
+    let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        // Check the borrow contract without unwinding through a global
+        // root traversal.
+        walk_session_roots(
+            (&session as *const std::cell::RefCell<WalkSession>).cast(),
+            &mut |_| {},
+        );
+    }));
+    assert!(failed.is_err());
+    drop(held);
+}
+
+#[test]
 fn finish_payload_root_walker_writes_back_forwarded_const_ptr() {
     fbw_finish_payload_reset();
     fbw_terminate_with_raise(
@@ -665,9 +742,9 @@ fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
         inline_poison_pcs: None,
         fbw_mode: mode,
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut concrete_r,
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
@@ -1218,9 +1295,9 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete,
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -1274,9 +1351,20 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         pc: 0,
         next_pc: 2,
     };
-    assert_eq!(wc.trace_ctx.concrete_of_opref(wc.registers_r[1]), None);
     assert_eq!(
-        super::vable_ops::vable_value_concrete(&code, &op, 0, &wc, 'r', wc.registers_r[1]),
+        wc.trace_ctx
+            .concrete_of_opref(wc.registers_r.get(1).expect("ref register in range")),
+        None
+    );
+    assert_eq!(
+        super::vable_ops::vable_value_concrete(
+            &code,
+            &op,
+            0,
+            &wc,
+            'r',
+            wc.registers_r.get(1).expect("ref register in range")
+        ),
         Some(Value::Ref(majit_ir::GcRef(exc_obj_ptr as usize))),
         "vable writes must preserve the concrete half of a non-constant register Box",
     );
@@ -1287,8 +1375,8 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
             0,
             &wc,
             'r',
-            wc.registers_r[1],
-            wc.registers_r[0],
+            wc.registers_r.get(1).expect("ref register in range"),
+            wc.registers_r.get(0).expect("ref register in range"),
         ),
         Some(Value::Ref(majit_ir::GcRef(0xC0DE_0000))),
         "a TOS override must resolve its own box instead of the stale encoded register shadow",
@@ -1301,7 +1389,7 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
             0,
             &wc,
             'r',
-            wc.registers_r[2],
+            wc.registers_r.get(2).expect("ref register in range"),
         ),
         Some(Value::Ref(majit_ir::GcRef(forwarded_obj_ptr))),
         "a forwarded recorder Box must win over the stale raw Ref shadow",
@@ -1471,9 +1559,9 @@ fn getfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -1527,9 +1615,9 @@ fn setfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -1601,9 +1689,9 @@ fn array_vable_handlers_with_none_obj_surface_vable_box_not_seeded() {
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
             session: &session,
-            registers_r: &mut regs_r,
-            registers_i: &mut regs_i,
-            registers_f: &mut [],
+            registers_r: &RegisterBank::new(regs_r.iter().copied()),
+            registers_i: &RegisterBank::new(regs_i.iter().copied()),
+            registers_f: &RegisterBank::default(),
             concrete_registers_r: &mut [],
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
@@ -1697,9 +1785,9 @@ fn array_vable_handlers_with_unpinned_index_surface_index_not_concrete() {
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
             session: &session,
-            registers_r: &mut regs_r,
-            registers_i: &mut regs_i,
-            registers_f: &mut [],
+            registers_r: &RegisterBank::new(regs_r.iter().copied()),
+            registers_i: &RegisterBank::new(regs_i.iter().copied()),
+            registers_f: &RegisterBank::default(),
             concrete_registers_r: &mut [],
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
@@ -1828,9 +1916,9 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
             session: &session,
-            registers_r: &mut regs_r,
-            registers_i: &mut regs_i,
-            registers_f: &mut [],
+            registers_r: &RegisterBank::new(regs_r.iter().copied()),
+            registers_i: &RegisterBank::new(regs_i.iter().copied()),
+            registers_f: &RegisterBank::default(),
             concrete_registers_r: &mut [],
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
@@ -2099,9 +2187,9 @@ fn drive_int_add_jump_if_ovf(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
@@ -2128,7 +2216,7 @@ fn drive_int_add_jump_if_ovf(
     };
     let (outcome, next_pc) = step(&code, 0, &mut wc).expect("int_add_jump_if_ovf must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
-    let dst = wc.registers_i[2];
+    let dst = wc.registers_i.get(2).expect("int register in range");
     drop(wc);
     let ops = tc.ops();
     let opcodes = ops.iter().map(|op| op.opcode).collect();
@@ -2256,9 +2344,9 @@ fn drive_alloc_with_descr(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete_r,
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -2286,7 +2374,7 @@ fn drive_alloc_with_descr(
     let (outcome, next_pc) =
         step(&code, 0, &mut wc).unwrap_or_else(|_| panic!("`{opname}` must dispatch"));
     assert_eq!(outcome, DispatchOutcome::Continue);
-    let dst = wc.registers_r[0];
+    let dst = wc.registers_r.get(0).expect("ref register in range");
     drop(wc);
 
     let ops = tc.ops();
@@ -2482,9 +2570,9 @@ fn run_hint_step_full(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: regs_r,
-        registers_i: regs_i,
-        registers_f: regs_f,
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: concrete_r,
         concrete_registers_i: concrete_i,
         descr_refs: &descr_pool,
@@ -2509,7 +2597,11 @@ fn run_hint_step_full(
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
     };
-    step(code, 0, &mut wc)
+    let result = step(code, 0, &mut wc);
+    regs_f.copy_from_slice(&wc.registers_f.to_vec());
+    regs_i.copy_from_slice(&wc.registers_i.to_vec());
+    regs_r.copy_from_slice(&wc.registers_r.to_vec());
+    result
 }
 
 #[test]
@@ -3070,9 +3162,9 @@ fn switch_id_hit_jumps_to_matching_target() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -3127,9 +3219,9 @@ fn switch_id_miss_falls_through() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -3183,9 +3275,9 @@ fn switch_id_requires_concrete_int_value() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -3248,9 +3340,9 @@ fn goto_if_not_truthy_records_guard_true_and_falls_through() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -3305,9 +3397,9 @@ fn goto_if_not_falsy_records_guard_false_and_jumps() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -3361,9 +3453,9 @@ fn goto_if_not_requires_concrete_int_value() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -3743,9 +3835,9 @@ fn inline_call_recursion_writes_subreturn_into_caller_dst_register() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -3784,6 +3876,7 @@ fn inline_call_recursion_writes_subreturn_into_caller_dst_register() {
         ConcreteValue::Null,
         "normal inline return must clear the caller's concrete exception shadow",
     );
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     // dst register r5 must equal the arg the caller passed (since
     // callee's `ref_return r0` returns its registers_r[0] which
@@ -3864,9 +3957,9 @@ fn inline_call_subwalk_uses_heap_frames_past_the_old_host_stack_cap() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4062,9 +4155,9 @@ fn inline_call_r_i_writes_int_subreturn_into_caller_int_bank() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4092,13 +4185,15 @@ fn inline_call_r_i_writes_int_subreturn_into_caller_int_bank() {
     let (outcome, next_pc) = step(&caller_code, 0, &mut wc).expect("inline_call_r_i must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, caller_code.len());
+    let returned_int = wc.registers_i.get(3);
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     // Callee's int_return[i0] surfaced SubReturn{Some(NONE)}; the
     // helper wrote that into caller's registers_i[3]. Sentinel is
     // gone, replaced by OpRef::NONE.
     assert_eq!(
-        regs_i[3],
-        OpRef::NONE,
+        returned_int,
+        Some(OpRef::NONE),
         "inline_call_r_i must write SubReturn value into caller registers_i[dst]",
     );
     // Wrong-bank check: registers_r[3] must remain its original
@@ -4178,9 +4273,9 @@ fn inline_call_ir_r_populates_callee_int_and_ref_banks() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4209,6 +4304,7 @@ fn inline_call_ir_r_populates_callee_int_and_ref_banks() {
         step(&caller_code, 0, &mut wc).expect("inline_call_ir_r must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, caller_code.len());
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     // dst register r5 must equal the caller's R-list arg (which the
     // callee returned via ref_return r0).
@@ -4289,9 +4385,9 @@ fn inline_call_irf_r_populates_all_three_kind_banks() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4320,6 +4416,7 @@ fn inline_call_irf_r_populates_all_three_kind_banks() {
         step(&caller_code, 0, &mut wc).expect("inline_call_irf_r must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, caller_code.len());
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     // Smoking gun: dst register r5 must equal the caller's R-list
     // arg (passed through callee's `ref_return r0`). A list-byte
@@ -4389,9 +4486,9 @@ fn inline_call_ir_int_arity_overflow_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4485,9 +4582,9 @@ fn inline_call_recursion_propagates_subraise_from_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4563,9 +4660,9 @@ fn inline_call_with_unresolvable_descr_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4620,9 +4717,9 @@ fn inline_call_with_missing_sub_jitcode_lookup_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -4673,9 +4770,9 @@ fn step_through_live_opcode_advances_by_offset_size() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -4735,9 +4832,9 @@ fn step_through_ref_return_records_finish_with_descr_and_correct_arg() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -4795,9 +4892,9 @@ fn ref_return_with_out_of_range_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -4856,9 +4953,9 @@ fn raise_with_unwritten_register_surfaces_register_read_unbound() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut registers_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(registers_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete_registers_r,
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -4918,9 +5015,9 @@ fn step_through_int_return_records_finish_with_int_descr() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -4997,9 +5094,9 @@ fn step_through_int_return_subwalk_surfaces_subreturn_some() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5064,9 +5161,9 @@ fn step_through_void_return_stashes_void_finish_payload() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5132,9 +5229,9 @@ fn step_through_void_return_subwalk_surfaces_subreturn_none() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5188,9 +5285,9 @@ fn raise_with_out_of_range_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5247,9 +5344,9 @@ fn step_through_goto_jumps_to_label_target() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5306,9 +5403,9 @@ fn step_through_goto_handles_high_byte_of_label() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5419,9 +5516,9 @@ fn step_through_catch_exception_with_active_exception_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5473,9 +5570,9 @@ fn step_through_catch_exception_advances_past_label_operand() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5541,9 +5638,9 @@ fn step_through_raise_records_outermost_finish_and_terminates() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5619,9 +5716,9 @@ fn top_level_raise_settles_the_vable_token() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5740,9 +5837,9 @@ fn raise_r_emits_guard_class_when_concrete_exc_pinned_in_shadow() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete,
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5846,9 +5943,9 @@ fn step_through_reraise_at_top_level_records_outermost_finish() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5923,9 +6020,9 @@ fn step_through_reraise_without_last_exc_value_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -5977,9 +6074,9 @@ fn raise_at_top_level_populates_last_exc_value_before_finish() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6095,9 +6192,9 @@ fn inline_call_subraise_jumps_to_caller_catch_exception_target() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -6215,9 +6312,9 @@ fn inline_call_subraise_without_caller_catch_bubbles_up_in_subwalk() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -6285,9 +6382,9 @@ fn step_through_int_copy_advances_past_operand_bytes() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6351,9 +6448,9 @@ fn int_copy_writes_src_value_into_dst_register() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6380,12 +6477,14 @@ fn int_copy_writes_src_value_into_dst_register() {
     };
     let _ = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
     assert_eq!(
-        wc.registers_i[5], src_val_pre,
+        wc.registers_i.get(5).expect("int register in range"),
+        src_val_pre,
         "int_copy must copy registers_i[src] into registers_i[dst] \
              (RPython _opimpl_any_copy + `>i` result coding)",
     );
     assert_eq!(
-        wc.registers_i[2], src_val_pre,
+        wc.registers_i.get(2).expect("int register in range"),
+        src_val_pre,
         "src register must remain unchanged",
     );
 }
@@ -6408,9 +6507,9 @@ fn int_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6464,9 +6563,9 @@ fn int_copy_with_out_of_range_src_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [], // empty — index 7 must surface OOR
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(), // empty — index 7 must surface OOR
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6540,9 +6639,9 @@ fn step_through_ref_copy_advances_past_operand_bytes() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6604,9 +6703,9 @@ fn ref_copy_writes_src_value_into_dst_register() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6633,12 +6732,14 @@ fn ref_copy_writes_src_value_into_dst_register() {
     };
     let _ = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
     assert_eq!(
-        wc.registers_r[5], src_val_pre,
+        wc.registers_r.get(5).expect("ref register in range"),
+        src_val_pre,
         "ref_copy must copy registers_r[src] into registers_r[dst] \
              (RPython _opimpl_any_copy + `>r` result coding)",
     );
     assert_eq!(
-        wc.registers_r[2], src_val_pre,
+        wc.registers_r.get(2).expect("ref register in range"),
+        src_val_pre,
         "src register must remain unchanged",
     );
 }
@@ -6659,9 +6760,9 @@ fn ref_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6713,9 +6814,9 @@ fn ref_copy_with_out_of_range_src_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [], // empty — index 7 must surface OOR
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(), // empty — index 7 must surface OOR
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6778,9 +6879,9 @@ fn drive_int_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -6809,7 +6910,7 @@ fn drive_int_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 4, "`{opname}` operand layout `ii>i` = 3 bytes");
-    let dst_post = wc.registers_i[6];
+    let dst_post = wc.registers_i.get(6).expect("int register in range");
     assert_ne!(
         dst_post, dst_pre,
         "`{opname}` must write a fresh OpRef into registers_i[dst]",
@@ -7003,9 +7104,9 @@ fn drive_int_between(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7034,7 +7135,7 @@ fn drive_int_between(
         int_between_record(&code, &op, &mut wc).expect("int_between_record must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 5, "operand layout `iii>i` consumes 4 bytes");
-    let dst_post = wc.registers_i[8];
+    let dst_post = wc.registers_i.get(8).expect("int register in range");
     drop(wc);
     let new_ops: Vec<majit_ir::OpCode> = tc
         .ops()
@@ -7140,9 +7241,9 @@ fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7171,7 +7272,7 @@ fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 4, "`{opname}` operand layout `ff>f` = 3 bytes");
-    let dst_post = wc.registers_f[6];
+    let dst_post = wc.registers_f.get(6).expect("float register in range");
     assert_ne!(
         dst_post, dst_pre,
         "`{opname}` must write a fresh OpRef into registers_f[dst]",
@@ -7230,9 +7331,9 @@ fn drive_float_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7261,7 +7362,7 @@ fn drive_float_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         step(&code, 0, &mut wc).unwrap_or_else(|_| panic!("`{opname}` must dispatch"));
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 3, "`{opname}` operand layout `f>f` = 2 bytes");
-    let dst_post = wc.registers_f[5];
+    let dst_post = wc.registers_f.get(5).expect("float register in range");
     assert_ne!(dst_post, dst_pre);
     drop(wc);
     assert_eq!(tc.num_ops(), ops_before + 1);
@@ -7308,9 +7409,9 @@ fn drive_int_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7339,7 +7440,7 @@ fn drive_int_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 3, "`{opname}` operand layout `i>i` = 2 bytes");
-    let dst_post = wc.registers_i[5];
+    let dst_post = wc.registers_i.get(5).expect("int register in range");
     assert_ne!(dst_post, dst_pre);
     drop(wc);
     assert_eq!(tc.num_ops(), ops_before + 1);
@@ -7421,9 +7522,9 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7452,7 +7553,7 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
         .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 4, "`{opname}` operand layout `rr>i` = 3 bytes");
-    let dst_post = wc.registers_i[6];
+    let dst_post = wc.registers_i.get(6).expect("int register in range");
     assert_ne!(dst_post, dst_pre);
     drop(wc);
     assert_eq!(tc.num_ops(), ops_before + 1);
@@ -7592,9 +7693,9 @@ fn run_float_step(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: regs_i,
-        registers_f: regs_f,
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7619,7 +7720,10 @@ fn run_float_step(
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
     };
-    step(code, 0, &mut wc)
+    let result = step(code, 0, &mut wc);
+    regs_f.copy_from_slice(&wc.registers_f.to_vec());
+    regs_i.copy_from_slice(&wc.registers_i.to_vec());
+    result
 }
 
 #[test]
@@ -7786,9 +7890,9 @@ fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7841,9 +7945,9 @@ fn int_add_with_out_of_range_src_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7898,9 +8002,9 @@ fn int_add_with_out_of_range_dst_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -7972,9 +8076,9 @@ fn unsupported_opname_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8113,9 +8217,9 @@ fn empty_str_concat_helper_aborts_before_the_unwired_op_is_dispatched() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut registers_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(registers_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete_registers_r,
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8187,9 +8291,9 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8247,7 +8351,10 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         wc.trace_ctx.const_type(last_args1.to_opref()),
         Some(Type::Ref)
     );
-    assert_ne!(wc.registers_i[0], OpRef::None);
+    assert_ne!(
+        wc.registers_i.get(0).expect("int register in range"),
+        OpRef::None
+    );
 }
 
 #[test]
@@ -8356,9 +8463,9 @@ fn abort_result_r_stops_the_walk() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8421,9 +8528,9 @@ fn ref_guard_value_records_guardvalue_with_concrete_constant() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete_r,
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8473,7 +8580,7 @@ fn ref_guard_value_records_guardvalue_with_concrete_constant() {
         Some(Type::Ref)
     );
     assert_eq!(
-        wc.registers_r[0],
+        wc.registers_r.get(0).expect("ref register in range"),
         last_args1.to_opref(),
         "register slot still holding the original OpRef must be rewritten \
              to the promoted constant (pyjitpl.py:1923 replace_box)",
@@ -8505,9 +8612,9 @@ fn int_guard_value_records_guardvalue_with_concrete_constant() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
@@ -8558,7 +8665,7 @@ fn int_guard_value_records_guardvalue_with_concrete_constant() {
         Some(Type::Int)
     );
     assert_eq!(
-        wc.registers_i[0],
+        wc.registers_i.get(0).expect("int register in range"),
         last_args1.to_opref(),
         "register slot still holding the original OpRef must be rewritten \
          to the promoted constant (pyjitpl.py:1923 replace_box)",
@@ -8590,9 +8697,9 @@ fn ref_guard_value_on_const_records_nothing() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut concrete_r,
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -8625,7 +8732,10 @@ fn ref_guard_value_on_const_records_nothing() {
         baseline_ops,
         "no op should be recorded when input is already Const"
     );
-    assert_eq!(wc.registers_r[0], value_opref);
+    assert_eq!(
+        wc.registers_r.get(0).expect("ref register in range"),
+        value_opref
+    );
 }
 
 #[test]
@@ -8685,9 +8795,9 @@ fn step_through_residual_call_r_r_records_callr_with_descr_and_args() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -8856,9 +8966,9 @@ fn run_symbolic_box_str_dispatch(
             ..test_fbw_mode()
         },
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -8884,6 +8994,7 @@ fn run_symbolic_box_str_dispatch(
         live_after_jit_pc: usize::MAX,
     };
     let outcome = step(&code, 0, &mut wc);
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     let dst = regs_r[1];
     let dst_value = tc.box_value(dst);
@@ -8996,9 +9107,9 @@ fn residual_call_r_r_with_elidable_cannot_raise_records_callpurer_no_guard() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -9079,9 +9190,9 @@ fn elidable_or_memoryerror_call_executes_and_stamps_its_result() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9151,9 +9262,9 @@ fn authoritative_walker_executes_may_force_call_and_stamps_result() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9209,9 +9320,9 @@ fn non_authoritative_walker_does_not_execute_may_force_call() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9281,9 +9392,9 @@ fn authoritative_walker_transcribes_may_force_raise_to_last_exc() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9383,9 +9494,9 @@ fn may_force_with_active_vable_executes_and_clears_token() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9484,9 +9595,9 @@ fn may_force_vable_escape_surfaces_typed_abort() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9581,9 +9692,9 @@ fn run_not_in_trace(
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -9710,9 +9821,9 @@ fn residual_call_r_r_with_jit_force_virtual_oopspec_returns_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -9767,9 +9878,9 @@ fn residual_call_r_r_with_elidable_can_raise_records_callpurer_plus_guard() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -9836,9 +9947,9 @@ fn residual_call_r_r_with_cannot_raise_records_callr_no_guard() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -9907,9 +10018,9 @@ fn residual_call_r_r_writes_recorder_result_into_dst_register() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -9942,7 +10053,7 @@ fn residual_call_r_r_writes_recorder_result_into_dst_register() {
     // the test compare without re-deriving the index (input args
     // also occupy OpRef indices, so `ops.iter().position()` would
     // be off by `num_inputargs`).
-    let dst_ref = wc.registers_r[3];
+    let dst_ref = wc.registers_r.get(3).expect("ref register in range");
     assert_ne!(
         dst_ref, dst_val_pre,
         "dst must change from its pre-call value",
@@ -9998,9 +10109,9 @@ fn residual_call_r_r_can_raise_writes_dst_before_guard_no_exception() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10028,6 +10139,7 @@ fn residual_call_r_r_can_raise_writes_dst_before_guard_no_exception() {
     wc.outer_jitcode_index = test_outer_resume_jitcode_index();
     wc.outer_resume_marker_jit_pc = Some(0);
     let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     let opcodes: Vec<_> = tc.ops().iter().skip(ops_before).map(|o| o.opcode).collect();
     assert_eq!(
@@ -10078,9 +10190,9 @@ fn residual_call_ir_r_can_raise_writes_dst_before_guard_no_exception() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10108,6 +10220,7 @@ fn residual_call_ir_r_can_raise_writes_dst_before_guard_no_exception() {
     wc.outer_jitcode_index = test_outer_resume_jitcode_index();
     wc.outer_resume_marker_jit_pc = Some(0);
     let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
+    let regs_r = wc.registers_r.to_vec();
     drop(wc);
     let opcodes: Vec<_> = tc.ops().iter().skip(ops_before).map(|o| o.opcode).collect();
     assert_eq!(
@@ -10157,9 +10270,9 @@ fn residual_call_r_r_with_out_of_range_dst_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10216,9 +10329,9 @@ fn residual_call_r_r_with_descr_index_out_of_range_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10313,9 +10426,9 @@ fn step_through_residual_call_r_i_records_calli_with_int_dst_writeback() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10373,7 +10486,7 @@ fn step_through_residual_call_r_i_records_calli_with_int_dst_writeback() {
         "CallI descr must be descr_refs[1] (not decoy at index 0)",
     );
     // dst writeback into the int bank (NOT the r bank).
-    let dst_post = wc.registers_i[3];
+    let dst_post = wc.registers_i.get(3).expect("int register in range");
     assert_ne!(
         dst_post, dst_pre,
         "registers_i[dst] must change from its pre-call value",
@@ -10409,9 +10522,9 @@ fn residual_call_r_i_with_elidable_cannot_raise_records_callpurei_no_guard() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10513,9 +10626,9 @@ fn step_through_residual_call_ir_r_records_callr_with_int_and_ref_args() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10584,7 +10697,7 @@ fn step_through_residual_call_ir_r_records_callr_with_int_and_ref_args() {
         "CallR descr must be descr_refs[1] (not decoy at index 0)",
     );
     // dst writeback into registers_r[0].
-    let dst_post = wc.registers_r[0];
+    let dst_post = wc.registers_r.get(0).expect("ref register in range");
     assert_eq!(
         dst_post,
         call_op.pos.get(),
@@ -10649,9 +10762,9 @@ fn residual_call_ir_r_permutes_argboxes_per_arg_types_abi() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10721,9 +10834,9 @@ fn residual_call_descr_not_call_descr_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10779,9 +10892,9 @@ fn residual_call_r_r_with_out_of_range_arg_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10861,9 +10974,9 @@ fn walk_return_value_helper_terminates_at_first_ref_return() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -10974,9 +11087,9 @@ fn walk_pop_top_helper_terminates_with_recorded_ops() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11102,9 +11215,9 @@ fn helper_descent_defers_the_limit_check_to_the_enclosing_frame() {
                 ..test_fbw_mode()
             },
             session: &session,
-            registers_r: &mut regs_r,
-            registers_i: &mut [],
-            registers_f: &mut [],
+            registers_r: &RegisterBank::new(regs_r.iter().copied()),
+            registers_i: &RegisterBank::default(),
+            registers_f: &RegisterBank::default(),
             concrete_registers_r: &mut [],
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
@@ -11191,9 +11304,9 @@ fn inline_call_with_more_args_than_callee_regs_surfaces_arity_mismatch() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11301,9 +11414,9 @@ fn inline_call_r_v_accepts_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11384,9 +11497,9 @@ fn inline_call_r_v_rejects_non_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11468,9 +11581,9 @@ fn inline_call_ir_v_accepts_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11550,9 +11663,9 @@ fn inline_call_ir_v_rejects_non_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11637,9 +11750,9 @@ fn inline_call_irf_v_accepts_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11722,9 +11835,9 @@ fn inline_call_irf_v_rejects_non_void_returning_callee() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut regs_f,
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::new(regs_f.iter().copied()),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11796,9 +11909,9 @@ fn getfield_gc_i_cache_miss_records_op_and_writes_dst() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11826,7 +11939,7 @@ fn getfield_gc_i_cache_miss_records_op_and_writes_dst() {
     let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 5, "getfield_gc_i/rd>i operand layout = 4 bytes");
-    let dst_post = wc.registers_i[5];
+    let dst_post = wc.registers_i.get(5).expect("int register in range");
     assert_ne!(
         dst_post, dst_pre,
         "cache miss must write a fresh recorder OpRef into registers_i[dst]",
@@ -11891,9 +12004,9 @@ fn getfield_gc_i_cache_hit_returns_cached_box_without_recording() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11919,7 +12032,7 @@ fn getfield_gc_i_cache_hit_returns_cached_box_without_recording() {
         live_after_jit_pc: usize::MAX,
     };
     let _ = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
-    let dst_post = wc.registers_i[5];
+    let dst_post = wc.registers_i.get(5).expect("int register in range");
     drop(wc);
     assert_eq!(
         tc.num_ops(),
@@ -11964,9 +12077,9 @@ fn getfield_gc_r_cache_miss_records_op_and_writes_ref_dst() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -11992,7 +12105,7 @@ fn getfield_gc_r_cache_miss_records_op_and_writes_ref_dst() {
         live_after_jit_pc: usize::MAX,
     };
     let _ = step(&code, 0, &mut wc).expect("getfield_gc_r must dispatch");
-    let dst_post = wc.registers_r[6];
+    let dst_post = wc.registers_r.get(6).expect("ref register in range");
     assert_ne!(dst_post, dst_pre);
     drop(wc);
     assert_eq!(tc.num_ops(), ops_before + 1);
@@ -12025,9 +12138,9 @@ fn getfield_gc_with_out_of_range_obj_register_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12098,9 +12211,9 @@ fn getfield_vable_i_routes_through_metainterp_and_writes_dst() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12128,7 +12241,7 @@ fn getfield_vable_i_routes_through_metainterp_and_writes_dst() {
     let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_vable_i must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 5, "getfield_vable_i/rd>i operand layout = 4 bytes");
-    let dst_post = wc.registers_i[5];
+    let dst_post = wc.registers_i.get(5).expect("int register in range");
     assert_ne!(
         dst_post, dst_pre,
         "fallback must write a fresh recorder OpRef into registers_i[dst]",
@@ -12191,9 +12304,9 @@ fn setfield_vable_i_routes_through_metainterp_records_setfield_gc_fallback() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12274,9 +12387,9 @@ fn setfield_gc_i_redundant_write_skips_recording() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12335,9 +12448,9 @@ fn setfield_gc_i_fresh_write_records_op_and_caches_value() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12422,9 +12535,9 @@ fn setfield_gc_r_records_setfieldgc_with_ref_valuebox() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12492,9 +12605,9 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12525,7 +12638,7 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
         next_pc, 6,
         "getarrayitem_gc_r/rid>r operand layout = 5 bytes"
     );
-    let dst_post = wc.registers_r[5];
+    let dst_post = wc.registers_r.get(5).expect("ref register in range");
     assert_ne!(dst_post, dst_pre);
     drop(wc);
     assert_eq!(tc.num_ops(), ops_before + 1);
@@ -12640,9 +12753,9 @@ fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12670,7 +12783,7 @@ fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
     let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getarrayitem_gc_i_pure must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 6);
-    let dst_post = wc.registers_i[5];
+    let dst_post = wc.registers_i.get(5).expect("int register in range");
     drop(wc);
     assert!(dst_post.is_constant(), "the bypass substitutes a Const");
     assert_eq!(
@@ -12717,9 +12830,9 @@ fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12745,7 +12858,7 @@ fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
         live_after_jit_pc: usize::MAX,
     };
     let _ = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
-    let dst_post = wc.registers_r[5];
+    let dst_post = wc.registers_r.get(5).expect("ref register in range");
     drop(wc);
     assert_eq!(
         tc.num_ops(),
@@ -12786,9 +12899,9 @@ fn setarrayitem_gc_r_records_setarrayitemgc_with_three_args() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
@@ -12860,8 +12973,8 @@ fn dispatch_via_miframe_runs_ref_return_through_real_miframe_state() {
     let mut tc = TraceCtx::for_test_types(&[majit_ir::Type::Ref]);
     let expected_arg = tc.const_ref(0xCAFE_F00D);
     let mut sym = PyreSym::new_uninit(OpRef::NONE);
-    *sym.registers_r_mut() = vec![OpRef::NONE; 8];
-    sym.registers_r_mut()[2] = expected_arg;
+    sym.registers_r_mut().replace(vec![OpRef::NONE; 8]);
+    sym.registers_r_mut().set(2, expected_arg);
 
     let miframe = MIFrame {
         ctx: &mut tc,
@@ -12942,8 +13055,8 @@ fn dispatch_via_miframe_mirrors_last_exc_value_back_into_sym() {
     // The walk now reads the concrete exception's traceback head.
     let exc_oprep = tc.const_ref(exc as i64);
     let mut sym = PyreSym::new_uninit(OpRef::NONE);
-    *sym.registers_r_mut() = vec![OpRef::NONE; 8];
-    sym.registers_r_mut()[3] = exc_oprep;
+    sym.registers_r_mut().replace(vec![OpRef::NONE; 8]);
+    sym.registers_r_mut().set(3, exc_oprep);
     // Pre-condition: sym.last_exc_box is unset.
     assert!(sym.last_exc_box().is_none());
 
@@ -13028,8 +13141,8 @@ fn dispatch_via_miframe_leaves_class_of_last_exc_is_const_unchanged_when_no_rais
     let mut tc = TraceCtx::for_test_types(&[majit_ir::Type::Ref]);
     let value = tc.const_ref(0xC0FFEE);
     let mut sym = PyreSym::new_uninit(OpRef::NONE);
-    *sym.registers_r_mut() = vec![OpRef::NONE; 8];
-    sym.registers_r_mut()[2] = value;
+    sym.registers_r_mut().replace(vec![OpRef::NONE; 8]);
+    sym.registers_r_mut().set(2, value);
     // Pre-condition: simulate prior raise — class_of_last_exc_is_const
     // is true and last_exc_box is set.
     sym.set_class_of_last_exc_is_const(true);
@@ -13104,9 +13217,9 @@ fn walk_undecodable_byte_surfaces_typed_error() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -13182,9 +13295,9 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -13270,9 +13383,9 @@ fn loop_header_stamps_seen_flag() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -13338,9 +13451,9 @@ fn jit_merge_point_int_form_resolves_jdindex_from_the_int_bank() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -13401,9 +13514,9 @@ fn jit_merge_point_unresolved_green_key_fails_loud() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -13792,9 +13905,9 @@ fn int_scratch_move_carries_the_concrete_shadow_to_the_destination() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
@@ -13825,7 +13938,11 @@ fn int_scratch_move_carries_the_concrete_shadow_to_the_destination() {
     let (outcome, next_pc) = step(&code, next_pc, &mut wc).expect("`int_pop/>i` must dispatch");
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next_pc, 4);
-    assert_eq!(wc.registers_i[1], src, "the pop moves the source OpRef");
+    assert_eq!(
+        wc.registers_i.get(1).expect("int register in range"),
+        src,
+        "the pop moves the source OpRef"
+    );
     assert_eq!(
         wc.concrete_registers_i[1],
         ConcreteValue::Int(7),
@@ -13983,9 +14100,9 @@ fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -14102,9 +14219,9 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -14195,9 +14312,9 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut regs_r,
-        registers_i: &mut regs_i,
-        registers_f: &mut [],
+        registers_r: &RegisterBank::new(regs_r.iter().copied()),
+        registers_i: &RegisterBank::new(regs_i.iter().copied()),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &[],
@@ -14425,9 +14542,9 @@ fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
         session: &session,
-        registers_r: &mut [],
-        registers_i: &mut [],
-        registers_f: &mut [],
+        registers_r: &RegisterBank::default(),
+        registers_i: &RegisterBank::default(),
+        registers_f: &RegisterBank::default(),
         concrete_registers_r: &mut [],
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -737,7 +737,15 @@ fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
     let mut concrete_r = Vec::new();
     let mut concrete_i = Vec::new();
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: mode,
@@ -745,7 +753,7 @@ fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut concrete_r,
+
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -756,15 +764,15 @@ fn parentless_populated_callee_does_not_publish_a_lone_resume_frame() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -1290,7 +1298,15 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -1298,7 +1314,7 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete,
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -1309,15 +1325,15 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -1554,7 +1570,15 @@ fn getfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
     let mut regs_i = vec![OpRef::NONE];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -1562,7 +1586,7 @@ fn getfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -1573,15 +1597,15 @@ fn getfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -1610,7 +1634,15 @@ fn setfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
     let mut regs_i = vec![OpRef::NONE];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -1618,7 +1650,7 @@ fn setfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -1629,15 +1661,15 @@ fn setfield_vable_with_none_obj_surfaces_vable_box_not_seeded() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -1684,7 +1716,15 @@ fn array_vable_handlers_with_none_obj_surface_vable_box_not_seeded() {
         let mut regs_i = vec![OpRef::NONE];
         let session = std::cell::RefCell::new(WalkSession::default());
         let mut wc = WalkContext {
-            callee_shadow: None,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: None,
+                concrete_registers_r: ([]).to_vec(),
+                outer_active_boxes: Vec::new(),
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
+                ..Default::default()
+            }),
             inline_callee_consts: None,
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
@@ -1692,7 +1732,7 @@ fn array_vable_handlers_with_none_obj_surface_vable_box_not_seeded() {
             registers_r: &RegisterBank::new(regs_r.iter().copied()),
             registers_i: &RegisterBank::new(regs_i.iter().copied()),
             registers_f: &RegisterBank::default(),
-            concrete_registers_r: &mut [],
+
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
             trace_ctx: &mut tc,
@@ -1703,15 +1743,15 @@ fn array_vable_handlers_with_none_obj_surface_vable_box_not_seeded() {
             outer_jitcode_index: 0,
             raw_descrs: RawDescrPool::Global,
             is_authoritative_executor: false,
-            outer_active_boxes: Vec::new(),
+
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -1780,7 +1820,15 @@ fn array_vable_handlers_with_unpinned_index_surface_index_not_concrete() {
         let mut regs_i = vec![OpRef::NONE, OpRef::NONE];
         let session = std::cell::RefCell::new(WalkSession::default());
         let mut wc = WalkContext {
-            callee_shadow: None,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: None,
+                concrete_registers_r: ([]).to_vec(),
+                outer_active_boxes: Vec::new(),
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
+                ..Default::default()
+            }),
             inline_callee_consts: None,
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
@@ -1788,7 +1836,7 @@ fn array_vable_handlers_with_unpinned_index_surface_index_not_concrete() {
             registers_r: &RegisterBank::new(regs_r.iter().copied()),
             registers_i: &RegisterBank::new(regs_i.iter().copied()),
             registers_f: &RegisterBank::default(),
-            concrete_registers_r: &mut [],
+
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
             trace_ctx: &mut tc,
@@ -1799,15 +1847,15 @@ fn array_vable_handlers_with_unpinned_index_surface_index_not_concrete() {
             outer_jitcode_index: 0,
             raw_descrs: RawDescrPool::Global,
             is_authoritative_executor: false,
-            outer_active_boxes: Vec::new(),
+
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -1911,7 +1959,15 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
         let guards_before = tc.num_guards();
         let session = std::cell::RefCell::new(WalkSession::default());
         let mut wc = WalkContext {
-            callee_shadow: None,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: None,
+                concrete_registers_r: ([]).to_vec(),
+                outer_active_boxes: Vec::new(),
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
+                ..Default::default()
+            }),
             inline_callee_consts: None,
             inline_poison_pcs: None,
             fbw_mode: test_fbw_mode(),
@@ -1919,7 +1975,7 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
             registers_r: &RegisterBank::new(regs_r.iter().copied()),
             registers_i: &RegisterBank::new(regs_i.iter().copied()),
             registers_f: &RegisterBank::default(),
-            concrete_registers_r: &mut [],
+
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
             raw_descrs: RawDescrPool::PerFn(&raw_pool),
@@ -1930,15 +1986,15 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
             entry_py_pc: EntryPyPc::Py(0),
             outer_resume_marker_jit_pc: None,
             outer_jitcode_index: 0,
-            outer_active_boxes: Vec::new(),
+
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -2182,7 +2238,15 @@ fn drive_int_add_jump_if_ovf(
     ];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -2190,7 +2254,7 @@ fn drive_int_add_jump_if_ovf(
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -2201,15 +2265,15 @@ fn drive_int_add_jump_if_ovf(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: Some(0),
         outer_jitcode_index: test_outer_resume_jitcode_index(),
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -2339,7 +2403,15 @@ fn drive_alloc_with_descr(
     let mut concrete_r = vec![ConcreteValue::Null];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -2347,7 +2419,7 @@ fn drive_alloc_with_descr(
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete_r,
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -2358,15 +2430,15 @@ fn drive_alloc_with_descr(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: Some(0),
         outer_jitcode_index: test_outer_resume_jitcode_index(),
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -2565,7 +2637,15 @@ fn run_hint_step_full(
     let outer_jitcode_index = test_outer_resume_jitcode_index();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: concrete_r.to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -2573,7 +2653,7 @@ fn run_hint_step_full(
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: concrete_r,
+
         concrete_registers_i: concrete_i,
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -2584,15 +2664,15 @@ fn run_hint_step_full(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: Some(0),
         outer_jitcode_index,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -2601,6 +2681,7 @@ fn run_hint_step_full(
     regs_f.copy_from_slice(&wc.registers_f.to_vec());
     regs_i.copy_from_slice(&wc.registers_i.to_vec());
     regs_r.copy_from_slice(&wc.registers_r.to_vec());
+    concrete_r.copy_from_slice(&wc.frame_state.borrow().concrete_registers_r);
     result
 }
 
@@ -3157,7 +3238,15 @@ fn switch_id_hit_jumps_to_matching_target() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3165,7 +3254,7 @@ fn switch_id_hit_jumps_to_matching_target() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -3176,15 +3265,15 @@ fn switch_id_hit_jumps_to_matching_target() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3214,7 +3303,15 @@ fn switch_id_miss_falls_through() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3222,7 +3319,7 @@ fn switch_id_miss_falls_through() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -3233,15 +3330,15 @@ fn switch_id_miss_falls_through() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3270,7 +3367,15 @@ fn switch_id_requires_concrete_int_value() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3278,7 +3383,7 @@ fn switch_id_requires_concrete_int_value() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -3289,15 +3394,15 @@ fn switch_id_requires_concrete_int_value() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3335,7 +3440,15 @@ fn goto_if_not_truthy_records_guard_true_and_falls_through() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3343,7 +3456,7 @@ fn goto_if_not_truthy_records_guard_true_and_falls_through() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -3354,15 +3467,15 @@ fn goto_if_not_truthy_records_guard_true_and_falls_through() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3392,7 +3505,15 @@ fn goto_if_not_falsy_records_guard_false_and_jumps() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3400,7 +3521,7 @@ fn goto_if_not_falsy_records_guard_false_and_jumps() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -3411,15 +3532,15 @@ fn goto_if_not_falsy_records_guard_false_and_jumps() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3448,7 +3569,15 @@ fn goto_if_not_requires_concrete_int_value() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3456,7 +3585,7 @@ fn goto_if_not_requires_concrete_int_value() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -3467,15 +3596,15 @@ fn goto_if_not_requires_concrete_int_value() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3830,7 +3959,15 @@ fn inline_call_recursion_writes_subreturn_into_caller_dst_register() {
         sess.last_exc_value_concrete = ConcreteValue::Int(123);
     }
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3838,7 +3975,7 @@ fn inline_call_recursion_writes_subreturn_into_caller_dst_register() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -3849,15 +3986,15 @@ fn inline_call_recursion_writes_subreturn_into_caller_dst_register() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -3952,7 +4089,15 @@ fn inline_call_subwalk_uses_heap_frames_past_the_old_host_stack_cap() {
         .class_now_known(expected, 0x1234_5678);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut walk_ctx = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -3960,7 +4105,7 @@ fn inline_call_subwalk_uses_heap_frames_past_the_old_host_stack_cap() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -3971,15 +4116,15 @@ fn inline_call_subwalk_uses_heap_frames_past_the_old_host_stack_cap() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4150,7 +4295,15 @@ fn inline_call_r_i_writes_int_subreturn_into_caller_int_bank() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4158,7 +4311,7 @@ fn inline_call_r_i_writes_int_subreturn_into_caller_int_bank() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4169,15 +4322,15 @@ fn inline_call_r_i_writes_int_subreturn_into_caller_int_bank() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4268,7 +4421,15 @@ fn inline_call_ir_r_populates_callee_int_and_ref_banks() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4276,7 +4437,7 @@ fn inline_call_ir_r_populates_callee_int_and_ref_banks() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4287,15 +4448,15 @@ fn inline_call_ir_r_populates_callee_int_and_ref_banks() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4380,7 +4541,15 @@ fn inline_call_irf_r_populates_all_three_kind_banks() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4388,7 +4557,7 @@ fn inline_call_irf_r_populates_all_three_kind_banks() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4399,15 +4568,15 @@ fn inline_call_irf_r_populates_all_three_kind_banks() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4481,7 +4650,15 @@ fn inline_call_ir_int_arity_overflow_surfaces_typed_error() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4489,7 +4666,7 @@ fn inline_call_ir_int_arity_overflow_surfaces_typed_error() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4500,15 +4677,15 @@ fn inline_call_ir_int_arity_overflow_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4577,7 +4754,15 @@ fn inline_call_recursion_propagates_subraise_from_callee() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4585,7 +4770,7 @@ fn inline_call_recursion_propagates_subraise_from_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4596,15 +4781,15 @@ fn inline_call_recursion_propagates_subraise_from_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4655,7 +4840,15 @@ fn inline_call_with_unresolvable_descr_surfaces_typed_error() {
     let descr_pool: Vec<DescrRef> = (0..16).map(|i| make_fail_descr(1 + i)).collect();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4663,7 +4856,7 @@ fn inline_call_with_unresolvable_descr_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4674,15 +4867,15 @@ fn inline_call_with_unresolvable_descr_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4712,7 +4905,15 @@ fn inline_call_with_missing_sub_jitcode_lookup_surfaces_typed_error() {
     descr_pool[3] = make_jitcode_descr(999_999);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4720,7 +4921,7 @@ fn inline_call_with_missing_sub_jitcode_lookup_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -4731,15 +4932,15 @@ fn inline_call_with_missing_sub_jitcode_lookup_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4765,7 +4966,15 @@ fn step_through_live_opcode_advances_by_offset_size() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4773,7 +4982,7 @@ fn step_through_live_opcode_advances_by_offset_size() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -4784,15 +4993,15 @@ fn step_through_live_opcode_advances_by_offset_size() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4827,7 +5036,15 @@ fn step_through_ref_return_records_finish_with_descr_and_correct_arg() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4835,7 +5052,7 @@ fn step_through_ref_return_records_finish_with_descr_and_correct_arg() {
         registers_r: &RegisterBank::new(regs.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -4846,15 +5063,15 @@ fn step_through_ref_return_records_finish_with_descr_and_correct_arg() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4887,7 +5104,15 @@ fn ref_return_with_out_of_range_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4895,7 +5120,7 @@ fn ref_return_with_out_of_range_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -4906,15 +5131,15 @@ fn ref_return_with_out_of_range_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -4948,7 +5173,15 @@ fn raise_with_unwritten_register_surfaces_register_read_unbound() {
     let mut registers_r = [OpRef::NONE, OpRef::NONE];
     let mut concrete_registers_r = [ConcreteValue::Null, ConcreteValue::Null];
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_registers_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -4956,7 +5189,7 @@ fn raise_with_unwritten_register_surfaces_register_read_unbound() {
         registers_r: &RegisterBank::new(registers_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete_registers_r,
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -4967,15 +5200,15 @@ fn raise_with_unwritten_register_surfaces_register_read_unbound() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5010,7 +5243,15 @@ fn step_through_int_return_records_finish_with_int_descr() {
     let descr_int = make_fail_descr(42);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5018,7 +5259,7 @@ fn step_through_int_return_records_finish_with_int_descr() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5029,15 +5270,15 @@ fn step_through_int_return_records_finish_with_int_descr() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5089,7 +5330,15 @@ fn step_through_int_return_subwalk_surfaces_subreturn_some() {
     let expected = regs_i[1];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5097,7 +5346,7 @@ fn step_through_int_return_subwalk_surfaces_subreturn_some() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5108,15 +5357,15 @@ fn step_through_int_return_subwalk_surfaces_subreturn_some() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5156,7 +5405,15 @@ fn step_through_void_return_stashes_void_finish_payload() {
     let mut tc = fresh_trace_ctx();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5164,7 +5421,7 @@ fn step_through_void_return_stashes_void_finish_payload() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5175,15 +5432,15 @@ fn step_through_void_return_stashes_void_finish_payload() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5224,7 +5481,15 @@ fn step_through_void_return_subwalk_surfaces_subreturn_none() {
     let mut tc = fresh_trace_ctx();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5232,7 +5497,7 @@ fn step_through_void_return_subwalk_surfaces_subreturn_none() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5243,15 +5508,15 @@ fn step_through_void_return_subwalk_surfaces_subreturn_none() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5280,7 +5545,15 @@ fn raise_with_out_of_range_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5288,7 +5561,7 @@ fn raise_with_out_of_range_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5299,15 +5572,15 @@ fn raise_with_out_of_range_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5339,7 +5612,15 @@ fn step_through_goto_jumps_to_label_target() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5347,7 +5628,7 @@ fn step_through_goto_jumps_to_label_target() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5358,15 +5639,15 @@ fn step_through_goto_jumps_to_label_target() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5398,7 +5679,15 @@ fn step_through_goto_handles_high_byte_of_label() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5406,7 +5695,7 @@ fn step_through_goto_handles_high_byte_of_label() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5417,15 +5706,15 @@ fn step_through_goto_handles_high_byte_of_label() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5511,7 +5800,15 @@ fn step_through_catch_exception_with_active_exception_surfaces_typed_error() {
         sess.last_exc_value = Some(active_exc);
     }
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5519,7 +5816,7 @@ fn step_through_catch_exception_with_active_exception_surfaces_typed_error() {
         registers_r: &RegisterBank::new(regs.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5530,15 +5827,15 @@ fn step_through_catch_exception_with_active_exception_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5565,7 +5862,15 @@ fn step_through_catch_exception_advances_past_label_operand() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5573,7 +5878,7 @@ fn step_through_catch_exception_advances_past_label_operand() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5584,15 +5889,15 @@ fn step_through_catch_exception_advances_past_label_operand() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5633,7 +5938,15 @@ fn step_through_raise_records_outermost_finish_and_terminates() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5641,7 +5954,7 @@ fn step_through_raise_records_outermost_finish_and_terminates() {
         registers_r: &RegisterBank::new(regs.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5652,15 +5965,15 @@ fn step_through_raise_records_outermost_finish_and_terminates() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5711,7 +6024,15 @@ fn top_level_raise_settles_the_vable_token() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5719,7 +6040,7 @@ fn top_level_raise_settles_the_vable_token() {
         registers_r: &RegisterBank::new(regs.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5730,15 +6051,15 @@ fn top_level_raise_settles_the_vable_token() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5832,7 +6153,15 @@ fn raise_r_emits_guard_class_when_concrete_exc_pinned_in_shadow() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5840,7 +6169,7 @@ fn raise_r_emits_guard_class_when_concrete_exc_pinned_in_shadow() {
         registers_r: &RegisterBank::new(regs.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete,
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5851,15 +6180,15 @@ fn raise_r_emits_guard_class_when_concrete_exc_pinned_in_shadow() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -5938,7 +6267,15 @@ fn step_through_reraise_at_top_level_records_outermost_finish() {
         sess.last_exc_value = Some(active_exc);
     }
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -5946,7 +6283,7 @@ fn step_through_reraise_at_top_level_records_outermost_finish() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -5957,15 +6294,15 @@ fn step_through_reraise_at_top_level_records_outermost_finish() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6015,7 +6352,15 @@ fn step_through_reraise_without_last_exc_value_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6023,7 +6368,7 @@ fn step_through_reraise_without_last_exc_value_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6034,15 +6379,15 @@ fn step_through_reraise_without_last_exc_value_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6069,7 +6414,15 @@ fn raise_at_top_level_populates_last_exc_value_before_finish() {
     let descr_done = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6077,7 +6430,7 @@ fn raise_at_top_level_populates_last_exc_value_before_finish() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6088,15 +6441,15 @@ fn raise_at_top_level_populates_last_exc_value_before_finish() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6187,7 +6540,15 @@ fn inline_call_subraise_jumps_to_caller_catch_exception_target() {
     descr_pool[11] = make_jitcode_descr(11);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6195,7 +6556,7 @@ fn inline_call_subraise_jumps_to_caller_catch_exception_target() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -6206,15 +6567,15 @@ fn inline_call_subraise_jumps_to_caller_catch_exception_target() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6307,7 +6668,15 @@ fn inline_call_subraise_without_caller_catch_bubbles_up_in_subwalk() {
     descr_pool[13] = make_jitcode_descr(13);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6315,7 +6684,7 @@ fn inline_call_subraise_without_caller_catch_bubbles_up_in_subwalk() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -6327,15 +6696,15 @@ fn inline_call_subraise_without_caller_catch_bubbles_up_in_subwalk() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6377,7 +6746,15 @@ fn step_through_int_copy_advances_past_operand_bytes() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6385,7 +6762,7 @@ fn step_through_int_copy_advances_past_operand_bytes() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6396,15 +6773,15 @@ fn step_through_int_copy_advances_past_operand_bytes() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6443,7 +6820,15 @@ fn int_copy_writes_src_value_into_dst_register() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6451,7 +6836,7 @@ fn int_copy_writes_src_value_into_dst_register() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6462,15 +6847,15 @@ fn int_copy_writes_src_value_into_dst_register() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6502,7 +6887,15 @@ fn int_copy_with_out_of_range_dst_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6510,7 +6903,7 @@ fn int_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6521,15 +6914,15 @@ fn int_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6558,7 +6951,15 @@ fn int_copy_with_out_of_range_src_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6566,7 +6967,7 @@ fn int_copy_with_out_of_range_src_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(), // empty — index 7 must surface OOR
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6577,15 +6978,15 @@ fn int_copy_with_out_of_range_src_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6634,7 +7035,15 @@ fn step_through_ref_copy_advances_past_operand_bytes() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6642,7 +7051,7 @@ fn step_through_ref_copy_advances_past_operand_bytes() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6653,15 +7062,15 @@ fn step_through_ref_copy_advances_past_operand_bytes() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6698,7 +7107,15 @@ fn ref_copy_writes_src_value_into_dst_register() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6706,7 +7123,7 @@ fn ref_copy_writes_src_value_into_dst_register() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6717,15 +7134,15 @@ fn ref_copy_writes_src_value_into_dst_register() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6755,7 +7172,15 @@ fn ref_copy_with_out_of_range_dst_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6763,7 +7188,7 @@ fn ref_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6774,15 +7199,15 @@ fn ref_copy_with_out_of_range_dst_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6809,7 +7234,15 @@ fn ref_copy_with_out_of_range_src_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6817,7 +7250,7 @@ fn ref_copy_with_out_of_range_src_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(), // empty — index 7 must surface OOR
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6828,15 +7261,15 @@ fn ref_copy_with_out_of_range_src_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -6874,7 +7307,15 @@ fn drive_int_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -6882,7 +7323,7 @@ fn drive_int_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -6893,15 +7334,15 @@ fn drive_int_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7099,7 +7540,15 @@ fn drive_int_between(
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7107,7 +7556,7 @@ fn drive_int_between(
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7118,15 +7567,15 @@ fn drive_int_between(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7236,7 +7685,15 @@ fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7244,7 +7701,7 @@ fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7255,15 +7712,15 @@ fn drive_float_binop(opname: &str, expected_opcode: majit_ir::OpCode) {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7326,7 +7783,15 @@ fn drive_float_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7334,7 +7799,7 @@ fn drive_float_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7345,15 +7810,15 @@ fn drive_float_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7404,7 +7869,15 @@ fn drive_int_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7412,7 +7885,7 @@ fn drive_int_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7423,15 +7896,15 @@ fn drive_int_unop(opname: &str, expected_opcode: majit_ir::OpCode) {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7517,7 +7990,15 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7525,7 +8006,7 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7536,15 +8017,15 @@ fn drive_ptr_compare(opname: &str, expected_opcode: majit_ir::OpCode) {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7688,7 +8169,15 @@ fn run_float_step(
     let outer_jitcode_index = test_outer_resume_jitcode_index();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7696,7 +8185,7 @@ fn run_float_step(
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7707,15 +8196,15 @@ fn run_float_step(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: Some(0),
         outer_jitcode_index,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7885,7 +8374,15 @@ fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7893,7 +8390,7 @@ fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7904,15 +8401,15 @@ fn float_add_with_out_of_range_src_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7940,7 +8437,15 @@ fn int_add_with_out_of_range_src_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -7948,7 +8453,7 @@ fn int_add_with_out_of_range_src_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -7959,15 +8464,15 @@ fn int_add_with_out_of_range_src_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -7997,7 +8502,15 @@ fn int_add_with_out_of_range_dst_register_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8005,7 +8518,7 @@ fn int_add_with_out_of_range_dst_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8016,15 +8529,15 @@ fn int_add_with_out_of_range_dst_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8071,7 +8584,15 @@ fn unsupported_opname_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8079,7 +8600,7 @@ fn unsupported_opname_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8090,15 +8611,15 @@ fn unsupported_opname_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8212,7 +8733,15 @@ fn empty_str_concat_helper_aborts_before_the_unwired_op_is_dispatched() {
     let mut registers_r = vec![OpRef::NONE; body.c_num_regs_r as usize];
     let mut concrete_registers_r = vec![ConcreteValue::Null; body.c_num_regs_r as usize];
     let mut walk_ctx = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_registers_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8220,7 +8749,7 @@ fn empty_str_concat_helper_aborts_before_the_unwired_op_is_dispatched() {
         registers_r: &RegisterBank::new(registers_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete_registers_r,
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8231,15 +8760,15 @@ fn empty_str_concat_helper_aborts_before_the_unwired_op_is_dispatched() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8286,7 +8815,15 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
     let mut regs_i = [OpRef::None];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8294,7 +8831,7 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8305,15 +8842,15 @@ fn ptr_nonzero_records_ptrne_with_box_and_null() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8458,7 +8995,15 @@ fn abort_result_r_stops_the_walk() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8466,7 +9011,7 @@ fn abort_result_r_stops_the_walk() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8477,15 +9022,15 @@ fn abort_result_r_stops_the_walk() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8513,17 +9058,27 @@ fn ref_guard_value_records_guardvalue_with_concrete_constant() {
     let code = [byte, 0];
     let mut tc = fresh_trace_ctx();
     let descr = done_descr_ref_for_tests();
-    // Symbolic side: a recorded op OpRef (not a Const).
-    let value_opref = tc.record_op(majit_ir::OpCode::PtrEq, &[]);
+    // MIFrame.replace_active_box_in_frame selects the bank by the Box type.
+    // Use a real Ref result; PtrEq would manufacture an IntOp in registers_r.
+    let concrete_ptr: usize = 0xdead_beef;
+    let source = tc.const_ref(concrete_ptr as i64);
+    let value_opref = tc.record_op(majit_ir::OpCode::SameAsR, &[source]);
     let mut regs_r = [value_opref];
     let mut regs_i = [OpRef::None];
-    let concrete_ptr: usize = 0xdead_beef;
     let mut concrete_r = [ConcreteValue::Ref(
         concrete_ptr as *mut pyre_object::pyobject::PyObject,
     )];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8531,7 +9086,7 @@ fn ref_guard_value_records_guardvalue_with_concrete_constant() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete_r,
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8542,15 +9097,15 @@ fn ref_guard_value_records_guardvalue_with_concrete_constant() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8607,7 +9162,15 @@ fn int_guard_value_records_guardvalue_with_concrete_constant() {
     let mut concrete_i = [ConcreteValue::Int(42)];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8615,7 +9178,7 @@ fn int_guard_value_records_guardvalue_with_concrete_constant() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8626,15 +9189,15 @@ fn int_guard_value_records_guardvalue_with_concrete_constant() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8692,7 +9255,15 @@ fn ref_guard_value_on_const_records_nothing() {
     )];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: (concrete_r).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8700,7 +9271,7 @@ fn ref_guard_value_on_const_records_nothing() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut concrete_r,
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -8711,15 +9282,15 @@ fn ref_guard_value_on_const_records_nothing() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8790,7 +9361,15 @@ fn step_through_residual_call_r_r_records_callr_with_descr_and_args() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -8798,7 +9377,7 @@ fn step_through_residual_call_r_r_records_callr_with_descr_and_args() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -8809,15 +9388,15 @@ fn step_through_residual_call_r_r_records_callr_with_descr_and_args() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -8958,7 +9537,15 @@ fn run_symbolic_box_str_dispatch(
     )];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: FbwWalkMode {
@@ -8969,7 +9556,7 @@ fn run_symbolic_box_str_dispatch(
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -8980,15 +9567,15 @@ fn run_symbolic_box_str_dispatch(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9102,7 +9689,15 @@ fn residual_call_r_r_with_elidable_cannot_raise_records_callpurer_no_guard() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9110,7 +9705,7 @@ fn residual_call_r_r_with_elidable_cannot_raise_records_callpurer_no_guard() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -9121,15 +9716,15 @@ fn residual_call_r_r_with_elidable_cannot_raise_records_callpurer_no_guard() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9185,7 +9780,15 @@ fn elidable_or_memoryerror_call_executes_and_stamps_its_result() {
     let mut regs_r: Vec<OpRef> = Vec::new();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9193,7 +9796,7 @@ fn elidable_or_memoryerror_call_executes_and_stamps_its_result() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9204,15 +9807,15 @@ fn elidable_or_memoryerror_call_executes_and_stamps_its_result() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9257,7 +9860,15 @@ fn authoritative_walker_executes_may_force_call_and_stamps_result() {
     let call_descr = descr.as_call_descr().expect("CallI descr");
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9265,7 +9876,7 @@ fn authoritative_walker_executes_may_force_call_and_stamps_result() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9276,15 +9887,15 @@ fn authoritative_walker_executes_may_force_call_and_stamps_result() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9315,7 +9926,15 @@ fn non_authoritative_walker_does_not_execute_may_force_call() {
     let call_descr = descr.as_call_descr().expect("CallI descr");
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9323,7 +9942,7 @@ fn non_authoritative_walker_does_not_execute_may_force_call() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9334,15 +9953,15 @@ fn non_authoritative_walker_does_not_execute_may_force_call() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9387,7 +10006,15 @@ fn authoritative_walker_transcribes_may_force_raise_to_last_exc() {
     let call_descr = descr.as_call_descr().expect("CallI descr");
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9395,7 +10022,7 @@ fn authoritative_walker_transcribes_may_force_raise_to_last_exc() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9406,15 +10033,15 @@ fn authoritative_walker_transcribes_may_force_raise_to_last_exc() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9489,7 +10116,15 @@ fn may_force_with_active_vable_executes_and_clears_token() {
     let call_descr = descr.as_call_descr().expect("CallI descr");
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9497,7 +10132,7 @@ fn may_force_with_active_vable_executes_and_clears_token() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9508,15 +10143,15 @@ fn may_force_with_active_vable_executes_and_clears_token() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9590,7 +10225,15 @@ fn may_force_vable_escape_surfaces_typed_abort() {
     let call_descr = descr.as_call_descr().expect("CallI descr");
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9598,7 +10241,7 @@ fn may_force_vable_escape_surfaces_typed_abort() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9609,15 +10252,15 @@ fn may_force_vable_escape_surfaces_typed_abort() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9687,7 +10330,15 @@ fn run_not_in_trace(
     NOT_IN_TRACE_CALLS.with(|c| c.set(0));
     let ops_before = tc.ops().len();
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9695,7 +10346,7 @@ fn run_not_in_trace(
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -9706,15 +10357,15 @@ fn run_not_in_trace(
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9816,7 +10467,15 @@ fn residual_call_r_r_with_jit_force_virtual_oopspec_returns_typed_error() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9824,7 +10483,7 @@ fn residual_call_r_r_with_jit_force_virtual_oopspec_returns_typed_error() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -9835,15 +10494,15 @@ fn residual_call_r_r_with_jit_force_virtual_oopspec_returns_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9873,7 +10532,15 @@ fn residual_call_r_r_with_elidable_can_raise_records_callpurer_plus_guard() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9881,7 +10548,7 @@ fn residual_call_r_r_with_elidable_can_raise_records_callpurer_plus_guard() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -9892,15 +10559,15 @@ fn residual_call_r_r_with_elidable_can_raise_records_callpurer_plus_guard() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -9942,7 +10609,15 @@ fn residual_call_r_r_with_cannot_raise_records_callr_no_guard() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -9950,7 +10625,7 @@ fn residual_call_r_r_with_cannot_raise_records_callr_no_guard() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -9961,15 +10636,15 @@ fn residual_call_r_r_with_cannot_raise_records_callr_no_guard() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10013,7 +10688,15 @@ fn residual_call_r_r_writes_recorder_result_into_dst_register() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10021,7 +10704,7 @@ fn residual_call_r_r_writes_recorder_result_into_dst_register() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10032,15 +10715,15 @@ fn residual_call_r_r_writes_recorder_result_into_dst_register() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10104,7 +10787,15 @@ fn residual_call_r_r_can_raise_writes_dst_before_guard_no_exception() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10112,7 +10803,7 @@ fn residual_call_r_r_can_raise_writes_dst_before_guard_no_exception() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10123,15 +10814,15 @@ fn residual_call_r_r_can_raise_writes_dst_before_guard_no_exception() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10185,7 +10876,15 @@ fn residual_call_ir_r_can_raise_writes_dst_before_guard_no_exception() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10193,7 +10892,7 @@ fn residual_call_ir_r_can_raise_writes_dst_before_guard_no_exception() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10204,15 +10903,15 @@ fn residual_call_ir_r_can_raise_writes_dst_before_guard_no_exception() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10265,7 +10964,15 @@ fn residual_call_r_r_with_out_of_range_dst_register_surfaces_typed_error() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10273,7 +10980,7 @@ fn residual_call_r_r_with_out_of_range_dst_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10284,15 +10991,15 @@ fn residual_call_r_r_with_out_of_range_dst_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10324,7 +11031,15 @@ fn residual_call_r_r_with_descr_index_out_of_range_surfaces_typed_error() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10332,7 +11047,7 @@ fn residual_call_r_r_with_descr_index_out_of_range_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10343,15 +11058,15 @@ fn residual_call_r_r_with_descr_index_out_of_range_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10421,7 +11136,15 @@ fn step_through_residual_call_r_i_records_calli_with_int_dst_writeback() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10429,7 +11152,7 @@ fn step_through_residual_call_r_i_records_calli_with_int_dst_writeback() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10440,15 +11163,15 @@ fn step_through_residual_call_r_i_records_calli_with_int_dst_writeback() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10517,7 +11240,15 @@ fn residual_call_r_i_with_elidable_cannot_raise_records_callpurei_no_guard() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10525,7 +11256,7 @@ fn residual_call_r_i_with_elidable_cannot_raise_records_callpurei_no_guard() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10536,15 +11267,15 @@ fn residual_call_r_i_with_elidable_cannot_raise_records_callpurei_no_guard() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10621,7 +11352,15 @@ fn step_through_residual_call_ir_r_records_callr_with_int_and_ref_args() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10629,7 +11368,7 @@ fn step_through_residual_call_ir_r_records_callr_with_int_and_ref_args() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10640,15 +11379,15 @@ fn step_through_residual_call_ir_r_records_callr_with_int_and_ref_args() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10757,7 +11496,15 @@ fn residual_call_ir_r_permutes_argboxes_per_arg_types_abi() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10765,7 +11512,7 @@ fn residual_call_ir_r_permutes_argboxes_per_arg_types_abi() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10776,15 +11523,15 @@ fn residual_call_ir_r_permutes_argboxes_per_arg_types_abi() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10829,7 +11576,15 @@ fn residual_call_descr_not_call_descr_surfaces_typed_error() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10837,7 +11592,7 @@ fn residual_call_descr_not_call_descr_surfaces_typed_error() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10848,15 +11603,15 @@ fn residual_call_descr_not_call_descr_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10887,7 +11642,15 @@ fn residual_call_r_r_with_out_of_range_arg_register_surfaces_typed_error() {
     let frame_done_descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10895,7 +11658,7 @@ fn residual_call_r_r_with_out_of_range_arg_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10906,15 +11669,15 @@ fn residual_call_r_r_with_out_of_range_arg_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -10969,7 +11732,15 @@ fn walk_return_value_helper_terminates_at_first_ref_return() {
     fbw_finish_payload_reset();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -10977,7 +11748,7 @@ fn walk_return_value_helper_terminates_at_first_ref_return() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -10988,15 +11759,15 @@ fn walk_return_value_helper_terminates_at_first_ref_return() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11082,7 +11853,15 @@ fn walk_pop_top_helper_terminates_with_recorded_ops() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11090,7 +11869,7 @@ fn walk_pop_top_helper_terminates_with_recorded_ops() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11101,15 +11880,15 @@ fn walk_pop_top_helper_terminates_with_recorded_ops() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11207,7 +11986,15 @@ fn helper_descent_defers_the_limit_check_to_the_enclosing_frame() {
         descr_pool[7] = make_jitcode_descr(7);
         let session = std::cell::RefCell::new(WalkSession::default());
         let mut wc = WalkContext {
-            callee_shadow: None,
+            frame_state: WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: None,
+                concrete_registers_r: ([]).to_vec(),
+                outer_active_boxes: Vec::new(),
+                vstack_boxes: Vec::new(),
+                vstack_last_ref: OpRef::NONE,
+                vstack_reorder_saved: None,
+                ..Default::default()
+            }),
             inline_callee_consts: None,
             inline_poison_pcs: None,
             fbw_mode: FbwWalkMode {
@@ -11218,7 +12005,7 @@ fn helper_descent_defers_the_limit_check_to_the_enclosing_frame() {
             registers_r: &RegisterBank::new(regs_r.iter().copied()),
             registers_i: &RegisterBank::default(),
             registers_f: &RegisterBank::default(),
-            concrete_registers_r: &mut [],
+
             concrete_registers_i: &mut [],
             descr_refs: &descr_pool,
             raw_descrs: RawDescrPool::Global,
@@ -11229,15 +12016,15 @@ fn helper_descent_defers_the_limit_check_to_the_enclosing_frame() {
             entry_py_pc: EntryPyPc::Py(0),
             outer_resume_marker_jit_pc: None,
             outer_jitcode_index: 0,
-            outer_active_boxes: Vec::new(),
+
             pending_guard_snapshot_error: None,
-            vstack_boxes: Vec::new(),
+
             vstack_depth: 0,
             vstack_cur_pypc: 0,
             vstack_valid: false,
-            vstack_last_ref: OpRef::NONE,
+
             vstack_reorder_ceiling: u32::MAX,
-            vstack_reorder_saved: None,
+
             vstack_handler_landing_py: None,
             live_before_jit_pc: usize::MAX,
             live_after_jit_pc: usize::MAX,
@@ -11299,7 +12086,15 @@ fn inline_call_with_more_args_than_callee_regs_surfaces_arity_mismatch() {
     descr_pool[5] = make_jitcode_descr(5);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11307,7 +12102,7 @@ fn inline_call_with_more_args_than_callee_regs_surfaces_arity_mismatch() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11318,15 +12113,15 @@ fn inline_call_with_more_args_than_callee_regs_surfaces_arity_mismatch() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11409,7 +12204,15 @@ fn inline_call_r_v_accepts_void_returning_callee() {
         sess.last_exc_value_concrete = ConcreteValue::Int(123);
     }
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11417,7 +12220,7 @@ fn inline_call_r_v_accepts_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11428,15 +12231,15 @@ fn inline_call_r_v_accepts_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11492,7 +12295,15 @@ fn inline_call_r_v_rejects_non_void_returning_callee() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11500,7 +12311,7 @@ fn inline_call_r_v_rejects_non_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11511,15 +12322,15 @@ fn inline_call_r_v_rejects_non_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11576,7 +12387,15 @@ fn inline_call_ir_v_accepts_void_returning_callee() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11584,7 +12403,7 @@ fn inline_call_ir_v_accepts_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11595,15 +12414,15 @@ fn inline_call_ir_v_accepts_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11658,7 +12477,15 @@ fn inline_call_ir_v_rejects_non_void_returning_callee() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11666,7 +12493,7 @@ fn inline_call_ir_v_rejects_non_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11677,15 +12504,15 @@ fn inline_call_ir_v_rejects_non_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11745,7 +12572,15 @@ fn inline_call_irf_v_accepts_void_returning_callee() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11753,7 +12588,7 @@ fn inline_call_irf_v_accepts_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11764,15 +12599,15 @@ fn inline_call_irf_v_accepts_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11830,7 +12665,15 @@ fn inline_call_irf_v_rejects_non_void_returning_callee() {
     descr_pool[7] = make_jitcode_descr(7);
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11838,7 +12681,7 @@ fn inline_call_irf_v_rejects_non_void_returning_callee() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::new(regs_f.iter().copied()),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11849,15 +12692,15 @@ fn inline_call_irf_v_rejects_non_void_returning_callee() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11904,7 +12747,15 @@ fn getfield_gc_i_cache_miss_records_op_and_writes_dst() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -11912,7 +12763,7 @@ fn getfield_gc_i_cache_miss_records_op_and_writes_dst() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -11923,15 +12774,15 @@ fn getfield_gc_i_cache_miss_records_op_and_writes_dst() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -11999,7 +12850,15 @@ fn getfield_gc_i_cache_hit_returns_cached_box_without_recording() {
 
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12007,7 +12866,7 @@ fn getfield_gc_i_cache_hit_returns_cached_box_without_recording() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12018,15 +12877,15 @@ fn getfield_gc_i_cache_hit_returns_cached_box_without_recording() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12072,7 +12931,15 @@ fn getfield_gc_r_cache_miss_records_op_and_writes_ref_dst() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12080,7 +12947,7 @@ fn getfield_gc_r_cache_miss_records_op_and_writes_ref_dst() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12091,15 +12958,15 @@ fn getfield_gc_r_cache_miss_records_op_and_writes_ref_dst() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12133,7 +13000,15 @@ fn getfield_gc_with_out_of_range_obj_register_surfaces_typed_error() {
     let frame_done = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12141,7 +13016,7 @@ fn getfield_gc_with_out_of_range_obj_register_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12152,15 +13027,15 @@ fn getfield_gc_with_out_of_range_obj_register_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12206,7 +13081,15 @@ fn getfield_vable_i_routes_through_metainterp_and_writes_dst() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12214,7 +13097,7 @@ fn getfield_vable_i_routes_through_metainterp_and_writes_dst() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12225,15 +13108,15 @@ fn getfield_vable_i_routes_through_metainterp_and_writes_dst() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12299,7 +13182,15 @@ fn setfield_vable_i_routes_through_metainterp_records_setfield_gc_fallback() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12307,7 +13198,7 @@ fn setfield_vable_i_routes_through_metainterp_records_setfield_gc_fallback() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12318,15 +13209,15 @@ fn setfield_vable_i_routes_through_metainterp_records_setfield_gc_fallback() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12382,7 +13273,15 @@ fn setfield_gc_i_redundant_write_skips_recording() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12390,7 +13289,7 @@ fn setfield_gc_i_redundant_write_skips_recording() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12401,15 +13300,15 @@ fn setfield_gc_i_redundant_write_skips_recording() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12443,7 +13342,15 @@ fn setfield_gc_i_fresh_write_records_op_and_caches_value() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12451,7 +13358,7 @@ fn setfield_gc_i_fresh_write_records_op_and_caches_value() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12462,15 +13369,15 @@ fn setfield_gc_i_fresh_write_records_op_and_caches_value() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12530,7 +13437,15 @@ fn setfield_gc_r_records_setfieldgc_with_ref_valuebox() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12538,7 +13453,7 @@ fn setfield_gc_r_records_setfieldgc_with_ref_valuebox() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12549,15 +13464,15 @@ fn setfield_gc_r_records_setfieldgc_with_ref_valuebox() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12600,7 +13515,15 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12608,7 +13531,7 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12619,15 +13542,15 @@ fn getarrayitem_gc_r_cache_miss_records_op_and_writes_dst() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12748,7 +13671,15 @@ fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
     let prof_before = tc.profiler().snapshot();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12756,7 +13687,7 @@ fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12767,15 +13698,15 @@ fn getarrayitem_gc_pure_const_operands_fold_without_recording_or_counting() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12825,7 +13756,15 @@ fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12833,7 +13772,7 @@ fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12844,15 +13783,15 @@ fn getarrayitem_gc_r_cache_hit_returns_cached_box() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -12894,7 +13833,15 @@ fn setarrayitem_gc_r_records_setarrayitemgc_with_three_args() {
     let ops_before = tc.num_ops();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -12902,7 +13849,7 @@ fn setarrayitem_gc_r_records_setarrayitemgc_with_three_args() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -12913,15 +13860,15 @@ fn setarrayitem_gc_r_records_setarrayitemgc_with_three_args() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13212,7 +14159,15 @@ fn walk_undecodable_byte_surfaces_typed_error() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13220,7 +14175,7 @@ fn walk_undecodable_byte_surfaces_typed_error() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13231,15 +14186,15 @@ fn walk_undecodable_byte_surfaces_typed_error() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13290,7 +14245,15 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13298,7 +14261,7 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13309,15 +14272,15 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13378,7 +14341,15 @@ fn loop_header_stamps_seen_flag() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13386,7 +14357,7 @@ fn loop_header_stamps_seen_flag() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13397,15 +14368,15 @@ fn loop_header_stamps_seen_flag() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13446,7 +14417,15 @@ fn jit_merge_point_int_form_resolves_jdindex_from_the_int_bank() {
     let mut regs_r = [pycode];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13454,7 +14433,7 @@ fn jit_merge_point_int_form_resolves_jdindex_from_the_int_bank() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13465,15 +14444,15 @@ fn jit_merge_point_int_form_resolves_jdindex_from_the_int_bank() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13509,7 +14488,15 @@ fn jit_merge_point_unresolved_green_key_fails_loud() {
     let descr = done_descr_ref_for_tests();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13517,7 +14504,7 @@ fn jit_merge_point_unresolved_green_key_fails_loud() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13528,15 +14515,15 @@ fn jit_merge_point_unresolved_green_key_fails_loud() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -13900,7 +14887,15 @@ fn int_scratch_move_carries_the_concrete_shadow_to_the_destination() {
     let mut concrete_i = vec![ConcreteValue::Int(7), ConcreteValue::Int(99)];
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -13908,7 +14903,7 @@ fn int_scratch_move_carries_the_concrete_shadow_to_the_destination() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut concrete_i,
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -13919,15 +14914,15 @@ fn int_scratch_move_carries_the_concrete_shadow_to_the_destination() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -14095,7 +15090,15 @@ fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
     let mut regs_r: Vec<OpRef> = Vec::new();
     let session = std::cell::RefCell::new(WalkSession::default());
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -14103,7 +15106,7 @@ fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -14114,15 +15117,15 @@ fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -14214,7 +15217,15 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
     let mut regs_r: Vec<OpRef> = Vec::new();
     let session = std::cell::RefCell::new(WalkSession::default());
     let wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -14222,7 +15233,7 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -14233,15 +15244,15 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -14307,7 +15318,15 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
     let mut regs_r: Vec<OpRef> = Vec::new();
     let session = std::cell::RefCell::new(WalkSession::default());
     let wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -14315,7 +15334,7 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
         registers_r: &RegisterBank::new(regs_r.iter().copied()),
         registers_i: &RegisterBank::new(regs_i.iter().copied()),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &[],
         raw_descrs: RawDescrPool::Global,
@@ -14326,15 +15345,15 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,
@@ -14537,7 +15556,15 @@ fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
     let session = std::cell::RefCell::new(WalkSession::default());
     let callee_index = 4242;
     let mut wc = WalkContext {
-        callee_shadow: None,
+        frame_state: WalkFrameState::new(WalkFrameStateData {
+            callee_shadow: None,
+            concrete_registers_r: ([]).to_vec(),
+            outer_active_boxes: Vec::new(),
+            vstack_boxes: Vec::new(),
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_saved: None,
+            ..Default::default()
+        }),
         inline_callee_consts: None,
         inline_poison_pcs: None,
         fbw_mode: test_fbw_mode(),
@@ -14545,7 +15572,7 @@ fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
         registers_r: &RegisterBank::default(),
         registers_i: &RegisterBank::default(),
         registers_f: &RegisterBank::default(),
-        concrete_registers_r: &mut [],
+
         concrete_registers_i: &mut [],
         descr_refs: &descr_pool,
         raw_descrs: RawDescrPool::Global,
@@ -14556,15 +15583,15 @@ fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
         entry_py_pc: EntryPyPc::Py(0),
         outer_resume_marker_jit_pc: None,
         outer_jitcode_index: 0,
-        outer_active_boxes: Vec::new(),
+
         pending_guard_snapshot_error: None,
-        vstack_boxes: Vec::new(),
+
         vstack_depth: 0,
         vstack_cur_pypc: 0,
         vstack_valid: false,
-        vstack_last_ref: OpRef::NONE,
+
         vstack_reorder_ceiling: u32::MAX,
-        vstack_reorder_saved: None,
+
         vstack_handler_landing_py: None,
         live_before_jit_pc: usize::MAX,
         live_after_jit_pc: usize::MAX,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -17,23 +17,18 @@ use super::*;
 /// All register banks share the frame's owned slots, so replacement follows
 /// `MIFrame.replace_active_box_in_frame` without a retained mutable slice or
 /// delayed replay. Ref-bank GC registration retains the same shared storage.
-/// Walker-only extras (vstack, callee shadow) remain
-/// queued and `apply` before the owner executes again.
-///
-/// Delivery of the extras must precede the caller continuation, not the
-/// next opcode: trace rollback can reuse an OpRef id, and a later
-/// delivery could rewrite a new value that was never present in the
-/// paused caller.
+/// Walker-only extras (vstack, callee shadow) share the same frame-owned
+/// state and are rewritten at the same time, never replayed on resume.
 ///
 /// Weak registration neither extends a frame's lifetime nor leaks aliases
 /// into a nested trace session. Heap-owned SubWalkFrames keep this owner
 /// across suspension; recursive callers keep it for precisely the child call.
-/// Convergence for the remaining extras is one red frame per inlined call
+/// Convergence for the semantic/color mirrors is one red frame per inlined call
 /// (#1731).
 pub(super) struct FrameBoxReplacements(std::rc::Rc<FrameBoxReplacementInbox>);
 
 pub(crate) struct FrameBoxReplacementInbox {
-    pending: std::cell::RefCell<Vec<(OpRef, OpRef)>>,
+    frame_state: std::cell::RefCell<Option<WalkFrameState>>,
     listening: std::cell::Cell<bool>,
     banks_r: std::cell::RefCell<Option<RegisterBank>>,
     banks_i: std::cell::RefCell<Option<RegisterBank>>,
@@ -43,7 +38,7 @@ pub(crate) struct FrameBoxReplacementInbox {
 impl FrameBoxReplacements {
     pub(super) fn new(session: &std::cell::RefCell<WalkSession>) -> Self {
         let pending = std::rc::Rc::new(FrameBoxReplacementInbox {
-            pending: std::cell::RefCell::new(Vec::new()),
+            frame_state: std::cell::RefCell::new(None),
             listening: std::cell::Cell::new(true),
             banks_r: std::cell::RefCell::new(None),
             banks_i: std::cell::RefCell::new(None),
@@ -66,11 +61,8 @@ impl FrameBoxReplacements {
         *self.0.banks_f.borrow_mut() = Some(f.clone());
     }
 
-    pub(super) fn apply<Sym: WalkSym>(&self, ctx: &mut WalkContext<'_, '_, Sym>) {
-        for (oldbox, newbox) in self.0.pending.borrow_mut().drain(..) {
-            // Owned slots were updated at replace_box, not on resume.
-            replace_box_in_walk_frame(ctx, oldbox, newbox);
-        }
+    pub(super) fn bind_frame_state(&self, state: &WalkFrameState) {
+        *self.0.frame_state.borrow_mut() = Some(state.clone());
     }
 
     pub(super) fn set_listening(&self, listening: bool) {
@@ -91,35 +83,17 @@ fn replace_box_in_walk_frame<Sym: WalkSym>(
     oldbox: OpRef,
     newbox: OpRef,
 ) {
-    replace_slots(&mut ctx.outer_active_boxes, oldbox, newbox);
-    replace_slots(&mut ctx.vstack_boxes, oldbox, newbox);
-    replace_slots(
-        std::slice::from_mut(&mut ctx.vstack_last_ref),
-        oldbox,
-        newbox,
-    );
-    if let Some((_, _, boxes, _)) = ctx.vstack_reorder_saved.as_mut() {
-        replace_slots(boxes, oldbox, newbox);
-    }
-    if let Some(shadow) = ctx.callee_shadow.as_mut() {
-        replace_slots(std::slice::from_mut(&mut shadow.frame_box), oldbox, newbox);
-        for value in shadow.opref.values_mut() {
-            replace_slots(std::slice::from_mut(value), oldbox, newbox);
-        }
-    }
-    if ctx.fbw_mode.current_exception_seed == Some(oldbox) {
-        ctx.fbw_mode.current_exception_seed = Some(newbox);
-    }
+    ctx.frame_state.replace_active_box(oldbox, newbox);
 }
 
 fn replace_bound_banks(frame: &FrameBoxReplacementInbox, oldbox: OpRef, newbox: OpRef) {
-    if let Some(bank) = frame.banks_r.borrow().as_ref() {
-        bank.replace_active_box(oldbox, newbox);
-    }
-    if let Some(bank) = frame.banks_i.borrow().as_ref() {
-        bank.replace_active_box(oldbox, newbox);
-    }
-    if let Some(bank) = frame.banks_f.borrow().as_ref() {
+    let bank = match oldbox.ty() {
+        Some(Type::Int) => &frame.banks_i,
+        Some(Type::Ref) => &frame.banks_r,
+        Some(Type::Float) => &frame.banks_f,
+        _ => panic!("replace_active_box_in_frame requires a typed value: {oldbox:?}"),
+    };
+    if let Some(bank) = bank.borrow().as_ref() {
         bank.replace_active_box(oldbox, newbox);
     }
 }
@@ -129,9 +103,11 @@ fn replace_box_in_paused_frames(session: &mut WalkSession, oldbox: OpRef, newbox
         if let Some(frame) = frame.upgrade() {
             if frame.listening.get() {
                 // `MIFrame.replace_active_box_in_frame`: write the bound
-                // banks now. Walker extras stay on `pending` for `apply`.
+                // banks and every frame-owned mirror now.
                 replace_bound_banks(&frame, oldbox, newbox);
-                frame.pending.borrow_mut().push((oldbox, newbox));
+                if let Some(state) = frame.frame_state.borrow().as_ref() {
+                    state.replace_active_box(oldbox, newbox);
+                }
             }
             true
         } else {
@@ -168,10 +144,33 @@ pub(super) fn apply_pending_vable_box_replace<Sym: WalkSym>(ctx: &mut WalkContex
     let Some((oldbox, newbox)) = ctx.trace_ctx.take_pending_box_replace() else {
         return;
     };
+    replace_box_in_all_walk_frames(ctx, oldbox, newbox);
+}
+
+/// `pyjitpl.py MetaInterp.replace_box`: promotion updates the recording
+/// state and every live MIFrame, including callers suspended in descendants.
+pub(super) fn walker_replace_box<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    oldbox: OpRef,
+    newbox: OpRef,
+) {
+    ctx.trace_ctx.replace_box(oldbox, newbox);
+    replace_box_in_all_walk_frames(ctx, oldbox, newbox);
+}
+
+fn replace_box_in_all_walk_frames<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    oldbox: OpRef,
+    newbox: OpRef,
+) {
     replace_box_in_paused_frames(&mut ctx.session.borrow_mut(), oldbox, newbox);
-    ctx.registers_r.replace_active_box(oldbox, newbox);
-    ctx.registers_i.replace_active_box(oldbox, newbox);
-    ctx.registers_f.replace_active_box(oldbox, newbox);
+    let bank = match oldbox.ty() {
+        Some(Type::Int) => ctx.registers_i,
+        Some(Type::Ref) => ctx.registers_r,
+        Some(Type::Float) => ctx.registers_f,
+        _ => panic!("replace_active_box_in_frame requires a typed value: {oldbox:?}"),
+    };
+    bank.replace_active_box(oldbox, newbox);
     replace_box_in_walk_frame(ctx, oldbox, newbox);
 }
 
@@ -201,6 +200,24 @@ mod frame_replacement_tests {
         );
         let active = FrameBoxReplacements::new(&session);
         active.set_listening(false);
+        let make_state = || {
+            WalkFrameState::new(WalkFrameStateData {
+                callee_shadow: Some(CalleeLocalsShadow {
+                    frame_box: old,
+                    ..Default::default()
+                }),
+                outer_active_boxes: vec![old],
+                vstack_boxes: vec![old],
+                vstack_last_ref: old,
+                ..Default::default()
+            })
+        };
+        let parent_state = make_state();
+        let suspended_state = make_state();
+        let active_state = make_state();
+        parent.bind_frame_state(&parent_state);
+        suspended.bind_frame_state(&suspended_state);
+        active.bind_frame_state(&active_state);
         session.borrow_mut().framestack.push(InlineFrame {
             w_code: 1,
             recursion_greenkey: true,
@@ -223,25 +240,26 @@ mod frame_replacement_tests {
         assert_eq!(suspended_regs.get(0), Some(standard));
         // The active frame is rewritten directly, never on a later replay
         // where the trace could have reused one of these operation ids.
-        assert!(active.0.pending.borrow().is_empty());
+        assert_eq!(active_state.borrow().vstack_boxes, [old]);
         drop(active);
         // Guard capture in the child already sees the rewritten caller.
         assert_eq!(
             session.borrow().framestack[0].parents[0].boxes,
             vec![standard]
         );
-        // Consuming one frame's mailbox must not consume another's.
-        for (owner, regs) in [(parent, parent_regs), (suspended, suspended_regs)] {
+        // Both frames have already changed before either continuation runs.
+        assert_eq!(parent_state.borrow().vstack_boxes, [standard]);
+        assert_eq!(suspended_state.borrow().vstack_boxes, [standard]);
+        for (owner, regs, state) in [
+            (parent, parent_regs, parent_state),
+            (suspended, suspended_regs, suspended_state),
+        ] {
             let mut trace = TraceCtx::for_test_types(&[Type::Ref; 3]);
             let mut ints = Vec::new();
             let mut floats = Vec::new();
-            let mut concrete_r = Vec::new();
             let mut concrete_i = Vec::new();
             let mut ctx = WalkContext {
-                callee_shadow: Some(CalleeLocalsShadow {
-                    frame_box: old,
-                    ..Default::default()
-                }),
+                frame_state: state,
                 inline_callee_consts: None,
                 inline_poison_pcs: None,
                 fbw_mode: FbwWalkMode::<crate::state::PyreSym>::default(),
@@ -249,7 +267,7 @@ mod frame_replacement_tests {
                 registers_r: &regs,
                 registers_i: &RegisterBank::new(ints.iter().copied()),
                 registers_f: &RegisterBank::new(floats.iter().copied()),
-                concrete_registers_r: &mut concrete_r,
+
                 concrete_registers_i: &mut concrete_i,
                 descr_refs: &[],
                 raw_descrs: RawDescrPool::Global,
@@ -260,32 +278,44 @@ mod frame_replacement_tests {
                 entry_py_pc: EntryPyPc::Py(0),
                 outer_resume_marker_jit_pc: None,
                 outer_jitcode_index: 0,
-                outer_active_boxes: vec![old],
+
                 pending_guard_snapshot_error: None,
-                vstack_boxes: vec![old],
+
                 vstack_depth: 1,
                 vstack_cur_pypc: 0,
                 vstack_valid: true,
-                vstack_last_ref: old,
+
                 vstack_reorder_ceiling: u32::MAX,
-                vstack_reorder_saved: None,
+
                 vstack_handler_landing_py: None,
                 live_before_jit_pc: usize::MAX,
                 live_after_jit_pc: usize::MAX,
             };
-            owner.apply(&mut ctx);
             assert_eq!(ctx.registers_r.to_vec(), vec![standard]);
-            assert_eq!(ctx.outer_active_boxes, vec![standard]);
-            assert_eq!(ctx.vstack_boxes, vec![standard]);
-            assert_eq!(ctx.callee_shadow.as_ref().unwrap().frame_box, standard);
-            assert!(owner.0.pending.borrow().is_empty());
+            assert_eq!(ctx.frame_state.borrow().outer_active_boxes, vec![standard]);
+            assert_eq!(ctx.frame_state.borrow().vstack_boxes, vec![standard]);
+            assert_eq!(
+                ctx.frame_state
+                    .borrow()
+                    .callee_shadow
+                    .as_ref()
+                    .unwrap()
+                    .frame_box,
+                standard
+            );
 
             // The traceback emitter is another vable writer, outside the
             // bytecode arms. An alias promoted there must rewrite registers
             // before the next writer can replace the single pending slot.
             owner.set_listening(false);
+            // Explicit guard promotions use the same full-frame operation as
+            // nonstandard virtualizable promotion, not just this Ref bank.
+            walker_replace_box(&mut ctx, standard, middle);
+            assert_eq!(ctx.frame_state.borrow().vstack_boxes, [middle]);
+            assert_eq!(session.borrow().framestack[0].parents[0].boxes, [middle]);
+            walker_replace_box(&mut ctx, middle, standard);
             ctx.registers_r.set(0, old);
-            ctx.vstack_boxes[0] = old;
+            ctx.frame_state.borrow_mut().vstack_boxes[0] = old;
             let mut info =
                 majit_metainterp::virtualizable::VirtualizableInfo::without_vable_token();
             info.add_field("last_instr", Type::Int, 0);
@@ -318,7 +348,7 @@ mod frame_replacement_tests {
             .unwrap();
             assert!(ctx.trace_ctx.num_guards() > guards_before);
             assert_eq!(ctx.registers_r.to_vec(), vec![standard]);
-            assert_eq!(ctx.vstack_boxes, vec![standard]);
+            assert_eq!(ctx.frame_state.borrow().vstack_boxes, vec![standard]);
             assert!(ctx.trace_ctx.take_pending_box_replace().is_none());
         }
         // Re-entering after the frames die does not retain their aliases.
@@ -369,8 +399,9 @@ mod frame_replacement_tests {
 /// `virtualizable_boxes` preserves its concrete value. Pyre splits that Box
 /// between an OpRef bank and a parallel concrete bank. Ref values prefer the
 /// recorder Box payload because the active-trace root walker forwards it in
-/// place across a collection; the raw concrete shadow is not a GC root and can
-/// retain the pre-forwarding address. Residual results do not necessarily have
+/// place across a collection. The frame-owned concrete shadow is now rooted
+/// too; retaining this preference preserves the canonical Box payload when
+/// both channels are present. Residual results do not necessarily have
 /// such a payload, so they fall back to the authoritative walker's shadow.
 /// Int/Float values are not GC addresses and keep the shadow-first order.
 pub(super) fn vable_value_concrete<Sym: WalkSym>(
@@ -677,7 +708,7 @@ pub(crate) fn setfield_vable_via_metainterp<Sym: WalkSym>(
             ctx.trace_ctx
                 .virtualizable_info()
                 .and_then(|info| info.static_field_by_descr(&descr)),
-            ctx.callee_shadow.as_ref(),
+            ctx.frame_state.borrow().callee_shadow.as_ref(),
         ) {
             if let Some(frame) = durable_resume_frame(ctx, shadow.concrete_frame) {
                 fbw_arm_durable_frame_undo(frame);
@@ -844,8 +875,7 @@ fn walker_promote_vable_array_index<Sym: WalkSym>(
     ctx.trace_ctx
         .record_guard(OpCode::GuardValue, &[index, expected], 0);
     walker_capture_snapshot_for_last_guard(ctx, pc)?;
-    ctx.trace_ctx.replace_box(index, expected);
-    ctx.registers_i.replace_active_box(index, expected);
+    walker_replace_box(ctx, index, expected);
     Ok(expected)
 }
 
@@ -878,11 +908,13 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
     if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
         let index = read_int_reg(code, op, 1, ctx)?;
         if let Some(majit_ir::Value::Int(slot)) = ctx.trace_ctx.concrete_of_opref(index) {
-            if let Some(result) = ctx
+            let result = ctx
+                .frame_state
+                .borrow()
                 .callee_shadow
                 .as_ref()
-                .and_then(|shadow| shadow.opref.get(&slot).copied())
-            {
+                .and_then(|shadow| shadow.opref.get(&slot).copied());
+            if let Some(result) = result {
                 let dst = code[op.pc + 7] as usize;
                 let concrete = concrete_from_recorded_opref(ctx, result);
                 match dst_bank {
@@ -980,11 +1012,15 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
     // heapcache entry this pass, yet its recording-time concrete is known.
     let shadow_value = if matches!(shadow_value, Value::Void) {
         let entry = ctx
+            .frame_state
+            .borrow()
             .callee_shadow
             .as_ref()
             .and_then(|shadow| shadow.concrete.get(&index_value).copied())
             .filter(|entry| entry.frame_reg == code[op.pc + 1] as u16);
         let slot_opref = ctx
+            .frame_state
+            .borrow()
             .callee_shadow
             .as_ref()
             .and_then(|shadow| shadow.opref.get(&index_value).copied());
@@ -1062,7 +1098,8 @@ fn folded_store_is_observable_local<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     slot: i64,
 ) -> bool {
-    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+    let state = ctx.frame_state.borrow();
+    let Some(shadow) = state.callee_shadow.as_ref() else {
         return false;
     };
     if !shadow.frame_materialized {
@@ -1089,7 +1126,7 @@ fn active_frame_code<'a, Sym: WalkSym>(
     // A resolved shadow is authoritative: falling back to the outer sym when
     // its `code_ptr` is unset would answer with the CALLER's frame, the exact
     // misattribution `active_frame_nlocals` exists to prevent.
-    let code_ptr = if let Some(shadow) = ctx.callee_shadow.as_ref() {
+    let code_ptr = if let Some(shadow) = ctx.frame_state.borrow().callee_shadow.as_ref() {
         shadow.code_ptr
     } else {
         let sym = ctx.fbw_mode.snapshot_sym;
@@ -1123,7 +1160,7 @@ fn active_frame_code<'a, Sym: WalkSym>(
 /// callee then read them back as NULL from the reconstructed frame — the next
 /// call in the callee arrived one positional argument short.
 fn active_frame_nlocals<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> Option<i64> {
-    if ctx.callee_shadow.is_some() {
+    if ctx.frame_state.borrow().callee_shadow.is_some() {
         return active_frame_code(ctx)
             .map(|code| crate::state::callee_layout_for_call_assembler(code).0 as i64);
     }
@@ -1170,7 +1207,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             };
             let concrete = vable_value_concrete(code, op, 2, ctx, value_bank, value)
                 .unwrap_or(majit_ir::Value::Void);
-            if let Some(shadow) = ctx.callee_shadow.as_mut() {
+            if let Some(shadow) = ctx.frame_state.borrow_mut().callee_shadow.as_mut() {
                 shadow.set_opref(slot, value);
                 shadow.set_concrete(fold_frame_reg, slot, concrete);
             }
@@ -1183,7 +1220,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
                 "folded locals_cells_stack_w store must carry a Ref-compatible value"
             );
             if matches!(concrete, majit_ir::Value::Ref(_))
-                && let Some(shadow) = ctx.callee_shadow.as_ref()
+                && let Some(shadow) = ctx.frame_state.borrow().callee_shadow.as_ref()
             {
                 if let Some(frame) = durable_resume_frame(ctx, shadow.concrete_frame) {
                     fbw_arm_durable_frame_undo(frame);
@@ -1258,7 +1295,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
         && let Some(nlocals) = active_frame_nlocals(ctx)
         && index_value >= 0
         && index_value < nlocals
-        && let Some(&tos) = ctx.vstack_boxes.last()
+        && let Some(&tos) = ctx.frame_state.borrow().vstack_boxes.last()
         && !tos.is_none()
     {
         value = tos;
@@ -1305,7 +1342,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     // through the (GC-forwarded) op-table over the raw `concrete` copy, so the
     // OpRef must track the stored value on every write — otherwise a re-stored
     // slot would re-resolve a stale OpRef while `concrete` held the fresh value.
-    if let Some(shadow) = ctx.callee_shadow.as_mut() {
+    if let Some(shadow) = ctx.frame_state.borrow_mut().callee_shadow.as_mut() {
         shadow.set_opref(index_value, value);
         shadow.set_concrete(code[op.pc + 1] as u16, index_value, concrete);
     }
@@ -1338,10 +1375,13 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             });
             let stack_slot = (index_value - nlocals) as usize;
             if method_load {
-                if ctx.vstack_boxes.len() <= stack_slot {
-                    ctx.vstack_boxes.resize(stack_slot + 1, OpRef::NONE);
+                if ctx.frame_state.borrow().vstack_boxes.len() <= stack_slot {
+                    ctx.frame_state
+                        .borrow_mut()
+                        .vstack_boxes
+                        .resize(stack_slot + 1, OpRef::NONE);
                 }
-                ctx.vstack_boxes[stack_slot] = value;
+                ctx.frame_state.borrow_mut().vstack_boxes[stack_slot] = value;
             }
             // Mark the slot as execution-derived while an out-of-order region
             // is armed, so the boundary restore does not put its pc-derived
@@ -1357,13 +1397,15 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             // whose only executed store came from, say, `LOAD_NAME` or
             // `BINARY_OP` reported an empty mask and the restore reinstated the
             // pre-window mirror wholesale over it.
-            if let Some((_, _, _, mask)) = ctx.vstack_reorder_saved.as_mut() {
+            if let Some((_, _, _, mask)) =
+                ctx.frame_state.borrow_mut().vstack_reorder_saved.as_mut()
+            {
                 if mask.len() <= stack_slot {
                     mask.resize(stack_slot + 1, false);
                 }
                 mask[stack_slot] = true;
             }
-            ctx.vstack_last_ref = value;
+            ctx.frame_state.borrow_mut().vstack_last_ref = value;
         }
     }
     Ok((DispatchOutcome::Continue, op.next_pc))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -12,24 +12,64 @@ use super::*;
 
 /// Register-bank half of `pyjitpl.MetaInterp.replace_box`, owned by a live
 /// walker frame. Resume snapshots (`InlineParentFrame.boxes`) are rewritten
-/// immediately, as `replace_box` walks `framestack`. Register banks stay
-/// queued: Rust cannot borrow a paused caller's banks while its child holds
-/// `TraceCtx`. Convergence is one red frame per inlined call (#1731) so
-/// replace can write those banks in place.
+/// immediately, as `replace_box` walks `framestack`.
 ///
-/// Apply the queue before that frame executes again. Delivery must precede
-/// the caller continuation, not the next opcode: trace rollback can reuse
-/// an OpRef id, and a later delivery could rewrite a new value that was
-/// never present in the paused caller.
+/// Bound register banks are rewritten in place the same way
+/// `MIFrame.replace_active_box_in_frame` writes `registers_{i,r,f}`. The
+/// owner captures those slice pointers while it still holds the banks;
+/// a paused caller is not borrowed through `TraceCtx`. Walker-only extras
+/// (vstack, callee shadow) stay queued and `apply` before the owner
+/// executes again.
+///
+/// Delivery of the extras must precede the caller continuation, not the
+/// next opcode: trace rollback can reuse an OpRef id, and a later
+/// delivery could rewrite a new value that was never present in the
+/// paused caller.
 ///
 /// Weak registration neither extends a frame's lifetime nor leaks aliases
 /// into a nested trace session. Heap-owned SubWalkFrames keep this owner
 /// across suspension; recursive callers keep it for precisely the child call.
+/// Convergence for the remaining extras is one red frame per inlined call
+/// (#1731).
 pub(super) struct FrameBoxReplacements(std::rc::Rc<FrameBoxReplacementInbox>);
+
+#[derive(Clone, Copy)]
+struct BoundBank {
+    ptr: *mut OpRef,
+    len: usize,
+}
 
 pub(crate) struct FrameBoxReplacementInbox {
     pending: std::cell::RefCell<Vec<(OpRef, OpRef)>>,
     listening: std::cell::Cell<bool>,
+    banks_r: std::cell::Cell<BoundBank>,
+    banks_i: std::cell::Cell<BoundBank>,
+    banks_f: std::cell::Cell<BoundBank>,
+}
+
+impl BoundBank {
+    const EMPTY: Self = Self {
+        ptr: std::ptr::null_mut(),
+        len: 0,
+    };
+
+    fn from_slice(slots: &mut [OpRef]) -> Self {
+        Self {
+            ptr: slots.as_mut_ptr(),
+            len: slots.len(),
+        }
+    }
+
+    unsafe fn as_mut_slice(&self) -> Option<&mut [OpRef]> {
+        if self.ptr.is_null() || self.len == 0 {
+            None
+        } else {
+            // The owning walk frame captured this slice and is still
+            // listening, so the allocation is live and not reborrowed
+            // through a WalkContext.
+            Some(unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) })
+        }
+    }
 }
 
 impl FrameBoxReplacements {
@@ -37,6 +77,9 @@ impl FrameBoxReplacements {
         let pending = std::rc::Rc::new(FrameBoxReplacementInbox {
             pending: std::cell::RefCell::new(Vec::new()),
             listening: std::cell::Cell::new(true),
+            banks_r: std::cell::Cell::new(BoundBank::EMPTY),
+            banks_i: std::cell::Cell::new(BoundBank::EMPTY),
+            banks_f: std::cell::Cell::new(BoundBank::EMPTY),
         });
         let mut session = session.borrow_mut();
         session
@@ -46,6 +89,15 @@ impl FrameBoxReplacements {
             .box_replacement_frames
             .push(std::rc::Rc::downgrade(&pending));
         Self(pending)
+    }
+
+    /// Capture the owner's register banks so `replace_box` can write them
+    /// without waiting for `apply`. The slices must stay allocated for as
+    /// long as this owner is listening.
+    pub(super) fn bind_banks(&self, r: &mut [OpRef], i: &mut [OpRef], f: &mut [OpRef]) {
+        self.0.banks_r.set(BoundBank::from_slice(r));
+        self.0.banks_i.set(BoundBank::from_slice(i));
+        self.0.banks_f.set(BoundBank::from_slice(f));
     }
 
     pub(super) fn apply<Sym: WalkSym>(&self, ctx: &mut WalkContext<'_, '_, Sym>) {
@@ -96,10 +148,25 @@ fn replace_box_in_walk_frame<Sym: WalkSym>(
     }
 }
 
+fn replace_bound_banks(frame: &FrameBoxReplacementInbox, oldbox: OpRef, newbox: OpRef) {
+    for bank in [
+        frame.banks_r.get(),
+        frame.banks_i.get(),
+        frame.banks_f.get(),
+    ] {
+        if let Some(slots) = unsafe { bank.as_mut_slice() } {
+            replace_slots(slots, oldbox, newbox);
+        }
+    }
+}
+
 fn replace_box_in_paused_frames(session: &mut WalkSession, oldbox: OpRef, newbox: OpRef) {
     session.box_replacement_frames.retain(|frame| {
         if let Some(frame) = frame.upgrade() {
             if frame.listening.get() {
+                // `MIFrame.replace_active_box_in_frame`: write the bound
+                // banks now. Walker extras stay on `pending` for `apply`.
+                replace_bound_banks(&frame, oldbox, newbox);
                 frame.pending.borrow_mut().push((oldbox, newbox));
             }
             true
@@ -277,6 +344,20 @@ mod frame_replacement_tests {
         // Re-entering after the frames die does not retain their aliases.
         let _next = FrameBoxReplacements::new(&session);
         assert_eq!(session.borrow().box_replacement_frames.len(), 1);
+    }
+
+    #[test]
+    fn replace_box_rewrites_bound_paused_banks_immediately() {
+        let old = OpRef::input_arg_ref(0);
+        let standard = OpRef::input_arg_ref(1);
+        let session = std::cell::RefCell::new(WalkSession::default());
+        let parent = FrameBoxReplacements::new(&session);
+        let mut regs = vec![old];
+        let mut ints = Vec::new();
+        let mut floats = Vec::new();
+        parent.bind_banks(&mut regs, &mut ints, &mut floats);
+        replace_box_in_paused_frames(&mut session.borrow_mut(), old, standard);
+        assert_eq!(regs, vec![standard]);
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -14,12 +14,11 @@ use super::*;
 /// walker frame. Resume snapshots (`InlineParentFrame.boxes`) are rewritten
 /// immediately, as `replace_box` walks `framestack`.
 ///
-/// Bound register banks are rewritten in place the same way
-/// `MIFrame.replace_active_box_in_frame` writes `registers_{i,r,f}`. The
-/// owner captures those slice pointers while it still holds the banks;
-/// a paused caller is not borrowed through `TraceCtx`. Walker-only extras
-/// (vstack, callee shadow) stay queued and `apply` before the owner
-/// executes again.
+/// All register banks share the frame's owned slots, so replacement follows
+/// `MIFrame.replace_active_box_in_frame` without a retained mutable slice or
+/// delayed replay. Ref-bank GC registration retains the same shared storage.
+/// Walker-only extras (vstack, callee shadow) remain
+/// queued and `apply` before the owner executes again.
 ///
 /// Delivery of the extras must precede the caller continuation, not the
 /// next opcode: trace rollback can reuse an OpRef id, and a later
@@ -33,43 +32,12 @@ use super::*;
 /// (#1731).
 pub(super) struct FrameBoxReplacements(std::rc::Rc<FrameBoxReplacementInbox>);
 
-#[derive(Clone, Copy)]
-struct BoundBank {
-    ptr: *mut OpRef,
-    len: usize,
-}
-
 pub(crate) struct FrameBoxReplacementInbox {
     pending: std::cell::RefCell<Vec<(OpRef, OpRef)>>,
     listening: std::cell::Cell<bool>,
-    banks_r: std::cell::Cell<BoundBank>,
-    banks_i: std::cell::Cell<BoundBank>,
-    banks_f: std::cell::Cell<BoundBank>,
-}
-
-impl BoundBank {
-    const EMPTY: Self = Self {
-        ptr: std::ptr::null_mut(),
-        len: 0,
-    };
-
-    fn from_slice(slots: &mut [OpRef]) -> Self {
-        Self {
-            ptr: slots.as_mut_ptr(),
-            len: slots.len(),
-        }
-    }
-
-    unsafe fn as_mut_slice(&self) -> Option<&mut [OpRef]> {
-        if self.ptr.is_null() || self.len == 0 {
-            None
-        } else {
-            // The owning walk frame captured this slice and is still
-            // listening, so the allocation is live and not reborrowed
-            // through a WalkContext.
-            Some(unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) })
-        }
-    }
+    banks_r: std::cell::RefCell<Option<RegisterBank>>,
+    banks_i: std::cell::RefCell<Option<RegisterBank>>,
+    banks_f: std::cell::RefCell<Option<RegisterBank>>,
 }
 
 impl FrameBoxReplacements {
@@ -77,9 +45,9 @@ impl FrameBoxReplacements {
         let pending = std::rc::Rc::new(FrameBoxReplacementInbox {
             pending: std::cell::RefCell::new(Vec::new()),
             listening: std::cell::Cell::new(true),
-            banks_r: std::cell::Cell::new(BoundBank::EMPTY),
-            banks_i: std::cell::Cell::new(BoundBank::EMPTY),
-            banks_f: std::cell::Cell::new(BoundBank::EMPTY),
+            banks_r: std::cell::RefCell::new(None),
+            banks_i: std::cell::RefCell::new(None),
+            banks_f: std::cell::RefCell::new(None),
         });
         let mut session = session.borrow_mut();
         session
@@ -91,17 +59,16 @@ impl FrameBoxReplacements {
         Self(pending)
     }
 
-    /// Capture the owner's register banks so `replace_box` can write them
-    /// without waiting for `apply`. The slices must stay allocated for as
-    /// long as this owner is listening.
-    pub(super) fn bind_banks(&self, r: &mut [OpRef], i: &mut [OpRef], f: &mut [OpRef]) {
-        self.0.banks_r.set(BoundBank::from_slice(r));
-        self.0.banks_i.set(BoundBank::from_slice(i));
-        self.0.banks_f.set(BoundBank::from_slice(f));
+    /// Share each frame-owned list; no captured mutable slice outlives a borrow.
+    pub(super) fn bind_banks(&self, r: &RegisterBank, i: &RegisterBank, f: &RegisterBank) {
+        *self.0.banks_r.borrow_mut() = Some(r.clone());
+        *self.0.banks_i.borrow_mut() = Some(i.clone());
+        *self.0.banks_f.borrow_mut() = Some(f.clone());
     }
 
     pub(super) fn apply<Sym: WalkSym>(&self, ctx: &mut WalkContext<'_, '_, Sym>) {
         for (oldbox, newbox) in self.0.pending.borrow_mut().drain(..) {
+            // Owned slots were updated at replace_box, not on resume.
             replace_box_in_walk_frame(ctx, oldbox, newbox);
         }
     }
@@ -124,9 +91,6 @@ fn replace_box_in_walk_frame<Sym: WalkSym>(
     oldbox: OpRef,
     newbox: OpRef,
 ) {
-    replace_slots(ctx.registers_r, oldbox, newbox);
-    replace_slots(ctx.registers_i, oldbox, newbox);
-    replace_slots(ctx.registers_f, oldbox, newbox);
     replace_slots(&mut ctx.outer_active_boxes, oldbox, newbox);
     replace_slots(&mut ctx.vstack_boxes, oldbox, newbox);
     replace_slots(
@@ -149,14 +113,14 @@ fn replace_box_in_walk_frame<Sym: WalkSym>(
 }
 
 fn replace_bound_banks(frame: &FrameBoxReplacementInbox, oldbox: OpRef, newbox: OpRef) {
-    for bank in [
-        frame.banks_r.get(),
-        frame.banks_i.get(),
-        frame.banks_f.get(),
-    ] {
-        if let Some(slots) = unsafe { bank.as_mut_slice() } {
-            replace_slots(slots, oldbox, newbox);
-        }
+    if let Some(bank) = frame.banks_r.borrow().as_ref() {
+        bank.replace_active_box(oldbox, newbox);
+    }
+    if let Some(bank) = frame.banks_i.borrow().as_ref() {
+        bank.replace_active_box(oldbox, newbox);
+    }
+    if let Some(bank) = frame.banks_f.borrow().as_ref() {
+        bank.replace_active_box(oldbox, newbox);
     }
 }
 
@@ -205,6 +169,9 @@ pub(super) fn apply_pending_vable_box_replace<Sym: WalkSym>(ctx: &mut WalkContex
         return;
     };
     replace_box_in_paused_frames(&mut ctx.session.borrow_mut(), oldbox, newbox);
+    ctx.registers_r.replace_active_box(oldbox, newbox);
+    ctx.registers_i.replace_active_box(oldbox, newbox);
+    ctx.registers_f.replace_active_box(oldbox, newbox);
     replace_box_in_walk_frame(ctx, oldbox, newbox);
 }
 
@@ -220,6 +187,18 @@ mod frame_replacement_tests {
         let session = std::cell::RefCell::new(WalkSession::default());
         let parent = FrameBoxReplacements::new(&session);
         let suspended = FrameBoxReplacements::new(&session);
+        let parent_regs = RegisterBank::new([old]);
+        let suspended_regs = RegisterBank::new([old]);
+        parent.bind_banks(
+            &parent_regs,
+            &RegisterBank::default(),
+            &RegisterBank::default(),
+        );
+        suspended.bind_banks(
+            &suspended_regs,
+            &RegisterBank::default(),
+            &RegisterBank::default(),
+        );
         let active = FrameBoxReplacements::new(&session);
         active.set_listening(false);
         session.borrow_mut().framestack.push(InlineFrame {
@@ -240,6 +219,8 @@ mod frame_replacement_tests {
         });
         replace_box_in_paused_frames(&mut session.borrow_mut(), old, middle);
         replace_box_in_paused_frames(&mut session.borrow_mut(), middle, standard);
+        assert_eq!(parent_regs.get(0), Some(standard));
+        assert_eq!(suspended_regs.get(0), Some(standard));
         // The active frame is rewritten directly, never on a later replay
         // where the trace could have reused one of these operation ids.
         assert!(active.0.pending.borrow().is_empty());
@@ -250,9 +231,8 @@ mod frame_replacement_tests {
             vec![standard]
         );
         // Consuming one frame's mailbox must not consume another's.
-        for owner in [parent, suspended] {
+        for (owner, regs) in [(parent, parent_regs), (suspended, suspended_regs)] {
             let mut trace = TraceCtx::for_test_types(&[Type::Ref; 3]);
-            let mut regs = vec![old];
             let mut ints = Vec::new();
             let mut floats = Vec::new();
             let mut concrete_r = Vec::new();
@@ -266,9 +246,9 @@ mod frame_replacement_tests {
                 inline_poison_pcs: None,
                 fbw_mode: FbwWalkMode::<crate::state::PyreSym>::default(),
                 session: &session,
-                registers_r: &mut regs,
-                registers_i: &mut ints,
-                registers_f: &mut floats,
+                registers_r: &regs,
+                registers_i: &RegisterBank::new(ints.iter().copied()),
+                registers_f: &RegisterBank::new(floats.iter().copied()),
                 concrete_registers_r: &mut concrete_r,
                 concrete_registers_i: &mut concrete_i,
                 descr_refs: &[],
@@ -294,7 +274,7 @@ mod frame_replacement_tests {
                 live_after_jit_pc: usize::MAX,
             };
             owner.apply(&mut ctx);
-            assert_eq!(ctx.registers_r, &[standard]);
+            assert_eq!(ctx.registers_r.to_vec(), vec![standard]);
             assert_eq!(ctx.outer_active_boxes, vec![standard]);
             assert_eq!(ctx.vstack_boxes, vec![standard]);
             assert_eq!(ctx.callee_shadow.as_ref().unwrap().frame_box, standard);
@@ -304,7 +284,7 @@ mod frame_replacement_tests {
             // bytecode arms. An alias promoted there must rewrite registers
             // before the next writer can replace the single pending slot.
             owner.set_listening(false);
-            ctx.registers_r[0] = old;
+            ctx.registers_r.set(0, old);
             ctx.vstack_boxes[0] = old;
             let mut info =
                 majit_metainterp::virtualizable::VirtualizableInfo::without_vable_token();
@@ -337,7 +317,7 @@ mod frame_replacement_tests {
             )
             .unwrap();
             assert!(ctx.trace_ctx.num_guards() > guards_before);
-            assert_eq!(ctx.registers_r, &[standard]);
+            assert_eq!(ctx.registers_r.to_vec(), vec![standard]);
             assert_eq!(ctx.vstack_boxes, vec![standard]);
             assert!(ctx.trace_ctx.take_pending_box_replace().is_none());
         }
@@ -352,12 +332,34 @@ mod frame_replacement_tests {
         let standard = OpRef::input_arg_ref(1);
         let session = std::cell::RefCell::new(WalkSession::default());
         let parent = FrameBoxReplacements::new(&session);
-        let mut regs = vec![old];
-        let mut ints = Vec::new();
-        let mut floats = Vec::new();
-        parent.bind_banks(&mut regs, &mut ints, &mut floats);
+        let regs = RegisterBank::new([old]);
+        let ints = RegisterBank::default();
+        let floats = RegisterBank::default();
+        parent.bind_banks(&regs, &ints, &floats);
         replace_box_in_paused_frames(&mut session.borrow_mut(), old, standard);
-        assert_eq!(regs, vec![standard]);
+        assert_eq!(regs.to_vec(), vec![standard]);
+    }
+
+    #[test]
+    fn paused_float_bank_keeps_ownership_across_active_writes() {
+        let old = OpRef::input_arg_float(0);
+        let new = OpRef::input_arg_float(1);
+        let session = std::cell::RefCell::new(WalkSession::default());
+        let parent = FrameBoxReplacements::new(&session);
+        let bank = RegisterBank::new([old]);
+        parent.bind_banks(&RegisterBank::default(), &RegisterBank::default(), &bank);
+        parent.set_listening(false);
+        bank.set(0, new);
+        parent.set_listening(true);
+        replace_box_in_paused_frames(&mut session.borrow_mut(), new, old);
+        assert_eq!(bank.get(0), Some(old));
+        drop(bank);
+        // Registration owns the storage, not a pointer into the dropped owner.
+        replace_box_in_paused_frames(&mut session.borrow_mut(), old, new);
+        assert_eq!(
+            parent.0.banks_f.borrow().as_ref().unwrap().get(0),
+            Some(new)
+        );
     }
 }
 
@@ -591,16 +593,16 @@ pub(crate) fn getfield_vable_via_metainterp<Sym: WalkSym>(
         }
         'f' => {
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     }
@@ -843,11 +845,7 @@ fn walker_promote_vable_array_index<Sym: WalkSym>(
         .record_guard(OpCode::GuardValue, &[index, expected], 0);
     walker_capture_snapshot_for_last_guard(ctx, pc)?;
     ctx.trace_ctx.replace_box(index, expected);
-    for slot in ctx.registers_i.iter_mut() {
-        if *slot == index {
-            *slot = expected;
-        }
-    }
+    ctx.registers_i.replace_active_box(index, expected);
     Ok(expected)
 }
 
@@ -892,15 +890,16 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
                     'r' => write_ref_reg(ctx, op.pc, dst, result, concrete)?,
                     'f' => {
                         let len = ctx.registers_f.len();
-                        let slot_ref = ctx.registers_f.get_mut(dst).ok_or(
-                            DispatchError::RegisterOutOfRange {
-                                pc: op.pc,
-                                reg: dst,
-                                len,
-                                bank: "f",
-                            },
-                        )?;
-                        *slot_ref = result;
+                        let _ =
+                            ctx.registers_f
+                                .get(dst)
+                                .ok_or(DispatchError::RegisterOutOfRange {
+                                    pc: op.pc,
+                                    reg: dst,
+                                    len,
+                                    bank: "f",
+                                })?;
+                        ctx.registers_f.set(dst, result);
                     }
                     _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
                 }
@@ -1033,16 +1032,16 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
         'r' => write_ref_reg(ctx, op.pc, dst, result, concrete_for_shadow)?,
         'f' => {
             let len = ctx.registers_f.len();
-            let slot = ctx
+            let _ = ctx
                 .registers_f
-                .get_mut(dst)
+                .get(dst)
                 .ok_or(DispatchError::RegisterOutOfRange {
                     pc: op.pc,
                     reg: dst,
                     len,
                     bank: "f",
                 })?;
-            *slot = result;
+            ctx.registers_f.set(dst, result);
         }
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -612,25 +612,13 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             ctx.frame_state
                 .borrow_mut()
                 .vstack_boxes
-                .truncate(new_depth);
-            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
-                ctx.frame_state
-                    .borrow_mut()
-                    .vstack_boxes
-                    .resize(new_depth, OpRef::NONE);
-            }
+                .resize(new_depth, OpRef::NONE);
         }
         VstackOpClass::ResultToTos => {
             ctx.frame_state
                 .borrow_mut()
                 .vstack_boxes
-                .truncate(new_depth);
-            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
-                ctx.frame_state
-                    .borrow_mut()
-                    .vstack_boxes
-                    .resize(new_depth, OpRef::NONE);
-            }
+                .resize(new_depth, OpRef::NONE);
             if new_depth > 0 {
                 // `NONE` means the result was produced in an unboxed bank;
                 // leave an intentional hole so the capture overlay around
@@ -696,13 +684,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             ctx.frame_state
                 .borrow_mut()
                 .vstack_boxes
-                .truncate(new_depth);
-            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
-                ctx.frame_state
-                    .borrow_mut()
-                    .vstack_boxes
-                    .resize(new_depth, OpRef::NONE);
-            }
+                .resize(new_depth, OpRef::NONE);
             if repeat_boundary {
                 // The retiring boundary performs the exchange.
             } else if new_depth >= 1 && i >= 1 && i <= new_depth {
@@ -729,13 +711,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
                     ctx.frame_state
                         .borrow_mut()
                         .vstack_boxes
-                        .truncate(new_depth);
-                    if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
-                        ctx.frame_state
-                            .borrow_mut()
-                            .vstack_boxes
-                            .resize(new_depth, OpRef::NONE);
-                    }
+                        .resize(new_depth, OpRef::NONE);
                     ctx.frame_state.borrow_mut().vstack_boxes[new_depth - 1] = src;
                 }
                 _ => ctx.vstack_valid = false,
@@ -781,13 +757,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             ctx.frame_state
                 .borrow_mut()
                 .vstack_boxes
-                .truncate(new_depth);
-            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
-                ctx.frame_state
-                    .borrow_mut()
-                    .vstack_boxes
-                    .resize(new_depth, OpRef::NONE);
-            }
+                .resize(new_depth, OpRef::NONE);
             for s in pop_point..new_depth {
                 ctx.frame_state.borrow_mut().vstack_boxes[s] = OpRef::NONE;
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -355,7 +355,7 @@ pub(crate) fn reconcile_load_global_method_shape(
 }
 
 /// #73: reconcile the PREVIOUS Python opcode's stack effect into
-/// [`WalkContext::vstack_boxes`] at an opcode boundary, BEFORE the new
+/// [`WalkFrameStateData::vstack_boxes`] at an opcode boundary, BEFORE the new
 /// opcode (`new_pypc`) is walked.  Running this before the new op means
 /// that when the new op is a branch guard, `vstack_boxes` already holds
 /// the correct boxes for the guard's resume depth.
@@ -447,14 +447,15 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     // instead of running unprotected.
     if ctx.vstack_reorder_ceiling != u32::MAX && new_pypc > ctx.vstack_reorder_ceiling {
         ctx.vstack_reorder_ceiling = u32::MAX;
-        ctx.vstack_reorder_saved = None;
+        ctx.frame_state.borrow_mut().vstack_reorder_saved = None;
     }
     if !cfg_successor && ctx.vstack_reorder_ceiling == u32::MAX {
         ctx.vstack_reorder_ceiling = (new_pypc as usize).max(prev_pypc) as u32;
-        ctx.vstack_reorder_saved = Some((
+        let mut state = ctx.frame_state.borrow_mut();
+        state.vstack_reorder_saved = Some((
             prev_pypc as u32,
             ctx.vstack_depth,
-            ctx.vstack_boxes.clone(),
+            state.vstack_boxes.clone(),
             Vec::new(),
         ));
     }
@@ -476,7 +477,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             },
             crate::liveness::target_pc(code, &instr, prev_pypc, op_arg),
             crate::liveness::exception_target_pc(code, prev_pypc),
-            ctx.vstack_last_ref
+            ctx.frame_state.borrow().vstack_last_ref
         );
     }
     // A JitCode's block layout can visit source-PC floor segments out of
@@ -511,12 +512,14 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     // place, so the interpreter has no walk position to leave and return to,
     // and nothing here to mirror.
     let returned_to_arm_point = matches!(
-        &ctx.vstack_reorder_saved,
+        &ctx.frame_state.borrow().vstack_reorder_saved,
         Some((pc, depth, _, _)) if *pc == new_pypc && *depth == new_depth
     );
     let restored = in_reorder_region && returned_to_arm_point;
     if restored {
         let (_, _, saved, mask) = ctx
+            .frame_state
+            .borrow_mut()
             .vstack_reorder_saved
             .take()
             .expect("checked by returned_to_arm_point");
@@ -552,22 +555,28 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
         // blackhole resuming into WITH_EXCEPT_START calls with the receiver
         // twice.
         if mask.iter().all(|&w| !w) {
-            ctx.vstack_boxes = saved;
+            ctx.frame_state.borrow_mut().vstack_boxes = saved;
         } else {
             // Merge per slot rather than keeping either side whole: one window
             // can hold both an executed store and a slot the reseed dropped.
-            let cur = std::mem::replace(&mut ctx.vstack_boxes, saved);
-            if ctx.vstack_boxes.len() < new_depth {
-                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            let cur = std::mem::replace(&mut ctx.frame_state.borrow_mut().vstack_boxes, saved);
+            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                ctx.frame_state
+                    .borrow_mut()
+                    .vstack_boxes
+                    .resize(new_depth, OpRef::NONE);
             }
             for s in 0..new_depth {
                 if mask.get(s).copied().unwrap_or(false)
                     && let Some(&v) = cur.get(s)
                 {
-                    ctx.vstack_boxes[s] = v;
+                    ctx.frame_state.borrow_mut().vstack_boxes[s] = v;
                 }
             }
-            ctx.vstack_boxes.truncate(new_depth);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
         }
         ctx.vstack_reorder_ceiling = u32::MAX;
     }
@@ -600,21 +609,33 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
         // replaying a stale effect.  The reorder region is already served by
         // the `ShadowReseed` arm, so exclude it here.
         _ if layout_only_boundary && !in_reorder_region => {
-            ctx.vstack_boxes.truncate(new_depth);
-            if ctx.vstack_boxes.len() < new_depth {
-                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
+            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                ctx.frame_state
+                    .borrow_mut()
+                    .vstack_boxes
+                    .resize(new_depth, OpRef::NONE);
             }
         }
         VstackOpClass::ResultToTos => {
-            ctx.vstack_boxes.truncate(new_depth);
-            if ctx.vstack_boxes.len() < new_depth {
-                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
+            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                ctx.frame_state
+                    .borrow_mut()
+                    .vstack_boxes
+                    .resize(new_depth, OpRef::NONE);
             }
             if new_depth > 0 {
                 // `NONE` means the result was produced in an unboxed bank;
                 // leave an intentional hole so the capture overlay around
                 // stack_sync omits the slot and resume rematerializes it.
-                let mut top = ctx.vstack_last_ref;
+                let mut top = ctx.frame_state.borrow().vstack_last_ref;
                 if top == OpRef::NONE {
                     // A value `LOAD_CONST` (large int / float) routes its result
                     // through the unboxed int/float bank, so `write_ref_reg`
@@ -632,7 +653,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
                     // reaches this fallback.
                     top = loadconst_operand_ref(ctx, code, &instr, op_arg);
                 }
-                ctx.vstack_boxes[new_depth - 1] = top;
+                ctx.frame_state.borrow_mut().vstack_boxes[new_depth - 1] = top;
             }
         }
         VstackOpClass::LoadGlobalMethod => {
@@ -641,14 +662,17 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             // semantically live even though it carries no GC pointer.
             let null = ctx.trace_ctx.const_null();
             reconcile_load_global_method_shape(
-                &mut ctx.vstack_boxes,
+                &mut ctx.frame_state.borrow_mut().vstack_boxes,
                 ctx.vstack_depth,
                 new_depth,
                 null,
             );
         }
         VstackOpClass::PopOnlyOrSideStore => {
-            ctx.vstack_boxes.truncate(new_depth);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
         }
         VstackOpClass::Swap(i) => {
             // SWAP is net-depth-0 (prev_depth == new_depth).  Exchange the
@@ -669,16 +693,22 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             // depth matches the fallthrough successor.  The depth normalization
             // still runs: it is what keeps mirror slot `s` naming operand-stack
             // slot `s` at the observed depth.
-            ctx.vstack_boxes.truncate(new_depth);
-            if ctx.vstack_boxes.len() < new_depth {
-                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
+            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                ctx.frame_state
+                    .borrow_mut()
+                    .vstack_boxes
+                    .resize(new_depth, OpRef::NONE);
             }
             if repeat_boundary {
                 // The retiring boundary performs the exchange.
             } else if new_depth >= 1 && i >= 1 && i <= new_depth {
                 let top = new_depth - 1;
                 let other = new_depth - i;
-                ctx.vstack_boxes.swap(top, other);
+                ctx.frame_state.borrow_mut().vstack_boxes.swap(top, other);
             } else {
                 ctx.vstack_valid = false;
             }
@@ -692,13 +722,21 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             // is faithful; `COPY 1` reduces to dup-of-TOS.  A missing source
             // slot or out-of-range arg declines (latch invalid).
             match new_depth.checked_sub(1 + i) {
-                Some(src_idx) if i >= 1 && src_idx < ctx.vstack_boxes.len() => {
-                    let src = ctx.vstack_boxes[src_idx];
-                    ctx.vstack_boxes.truncate(new_depth);
-                    if ctx.vstack_boxes.len() < new_depth {
-                        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+                Some(src_idx)
+                    if i >= 1 && src_idx < ctx.frame_state.borrow().vstack_boxes.len() =>
+                {
+                    let src = ctx.frame_state.borrow().vstack_boxes[src_idx];
+                    ctx.frame_state
+                        .borrow_mut()
+                        .vstack_boxes
+                        .truncate(new_depth);
+                    if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                        ctx.frame_state
+                            .borrow_mut()
+                            .vstack_boxes
+                            .resize(new_depth, OpRef::NONE);
                     }
-                    ctx.vstack_boxes[new_depth - 1] = src;
+                    ctx.frame_state.borrow_mut().vstack_boxes[new_depth - 1] = src;
                 }
                 _ => ctx.vstack_valid = false,
             }
@@ -710,8 +748,11 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             // unsourceable slot (genuine NULL exc-info / Int temp) stays NONE
             // and `mirror_covers_kept` declines for it — the conservative
             // fallback, never a corrupt box.
-            ctx.vstack_boxes.clear();
-            ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            ctx.frame_state.borrow_mut().vstack_boxes.clear();
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .resize(new_depth, OpRef::NONE);
         }
         VstackOpClass::MultiResultFromShadow | VstackOpClass::LoadSpecialMethod => {
             // UNPACK_* pops ONE sequence (at `prev_depth - 1`) and pushes its
@@ -737,16 +778,22 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
                 _ => None,
             };
             let pop_point = ctx.vstack_depth.saturating_sub(1);
-            ctx.vstack_boxes.truncate(new_depth);
-            if ctx.vstack_boxes.len() < new_depth {
-                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            ctx.frame_state
+                .borrow_mut()
+                .vstack_boxes
+                .truncate(new_depth);
+            if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+                ctx.frame_state
+                    .borrow_mut()
+                    .vstack_boxes
+                    .resize(new_depth, OpRef::NONE);
             }
             for s in pop_point..new_depth {
-                ctx.vstack_boxes[s] = OpRef::NONE;
+                ctx.frame_state.borrow_mut().vstack_boxes[s] = OpRef::NONE;
             }
             if new_depth > 0 {
                 if let Some(null) = trailing_null {
-                    ctx.vstack_boxes[new_depth - 1] = null;
+                    ctx.frame_state.borrow_mut().vstack_boxes[new_depth - 1] = null;
                 }
             }
         }
@@ -781,6 +828,8 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
         // admitted it, so `inline_subwalk` alone is that predicate here.
         let callee_local_shadow = ctx.fbw_mode.inline_subwalk;
         let hole = ctx
+            .frame_state
+            .borrow()
             .vstack_boxes
             .get(..new_depth)
             .map(|s| s.iter().any(|&b| b == OpRef::NONE))
@@ -800,7 +849,7 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     if ctx.vstack_valid {
         ctx.vstack_cur_pypc = new_pypc;
         ctx.vstack_depth = new_depth;
-        ctx.vstack_last_ref = OpRef::NONE;
+        ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
     }
 }
 
@@ -814,15 +863,24 @@ fn reseed_vstack_from_callee_shadow<Sym: WalkSym>(
     code: &pyre_interpreter::CodeObject,
     new_depth: usize,
 ) -> bool {
-    if ctx.vstack_boxes.len() < new_depth {
-        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+    if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+        ctx.frame_state
+            .borrow_mut()
+            .vstack_boxes
+            .resize(new_depth, OpRef::NONE);
     }
     let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
-    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+    let mut state = ctx.frame_state.borrow_mut();
+    let WalkFrameStateData {
+        callee_shadow,
+        vstack_boxes,
+        ..
+    } = &mut *state;
+    let Some(shadow) = callee_shadow.as_ref() else {
         return false;
     };
     let mut all_present = true;
-    for (s, slot) in ctx.vstack_boxes[..new_depth].iter_mut().enumerate() {
+    for (s, slot) in vstack_boxes[..new_depth].iter_mut().enumerate() {
         if *slot != OpRef::NONE {
             continue;
         }
@@ -888,12 +946,15 @@ pub(crate) fn reseed_vstack_from_shadow<Sym: WalkSym>(
     // refuses an image with any unresolved slot, and an escape inside the call
     // then had no blackhole image at all and fell back to the legacy entry
     // replay — which re-runs the residuals the walk already executed.
-    if ctx.vstack_boxes.len() < new_depth {
-        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+    if ctx.frame_state.borrow().vstack_boxes.len() < new_depth {
+        ctx.frame_state
+            .borrow_mut()
+            .vstack_boxes
+            .resize(new_depth, OpRef::NONE);
     }
     let mut all_present = true;
     for s in 0..new_depth {
-        if ctx.vstack_boxes[s] != OpRef::NONE {
+        if ctx.frame_state.borrow().vstack_boxes[s] != OpRef::NONE {
             continue;
         }
         let flat = nvs + nlocals + s;
@@ -903,7 +964,7 @@ pub(crate) fn reseed_vstack_from_shadow<Sym: WalkSym>(
                     && (!opref_is_null_const_ptr(b)
                         || ctx.trace_ctx.virtualizable_slot_stored_live_null(flat)) =>
             {
-                ctx.vstack_boxes[s] = b;
+                ctx.frame_state.borrow_mut().vstack_boxes[s] = b;
             }
             // Fill what we can; an unsourceable hole (NONE / NULL const-ptr —
             // an Int/Float-bank temp or a function-local the portal never
@@ -1146,16 +1207,16 @@ pub(crate) fn seed_callee_vstack_mirror<Sym: WalkSym>(
     let Some((first_pypc, _code_ptr, _depth)) = frame.vstack_coordinate_for_jitcode_pc(0) else {
         return;
     };
-    ctx.vstack_boxes.clear();
+    ctx.frame_state.borrow_mut().vstack_boxes.clear();
     ctx.vstack_depth = 0;
     ctx.vstack_cur_pypc = first_pypc;
-    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
     ctx.vstack_handler_landing_py = None;
     ctx.vstack_valid = true;
 }
 
 /// #73: seed the walk-level operand-stack box mirror
-/// ([`WalkContext::vstack_boxes`]) at full-body-walk entry.  Enables the
+/// ([`WalkFrameStateData::vstack_boxes`]) at full-body-walk entry.  Enables the
 /// mirror (`vstack_valid = true`) only when the outer `sym` owns the
 /// virtualizable shadow AND the entry operand stack can be fully sourced
 /// from that shadow.  Sets `vstack_cur_pypc = entry_py_pc` and
@@ -1257,10 +1318,10 @@ pub(crate) fn seed_vstack_mirror<Sym: WalkSym>(
             _ => return,
         }
     }
-    ctx.vstack_boxes = boxes;
+    ctx.frame_state.borrow_mut().vstack_boxes = boxes;
     ctx.vstack_depth = depth;
     ctx.vstack_cur_pypc = first_pypc;
-    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
     ctx.vstack_handler_landing_py = None;
     ctx.vstack_valid = true;
 }
@@ -1316,7 +1377,7 @@ pub(crate) fn disarm_vstack_reorder_region<Sym: WalkSym>(ctx: &mut WalkContext<'
         return;
     }
     ctx.vstack_reorder_ceiling = u32::MAX;
-    ctx.vstack_reorder_saved = None;
+    ctx.frame_state.borrow_mut().vstack_reorder_saved = None;
 }
 
 /// `PYRE_VSTACK_KEEP_REORDER`: leave an armed region in place across a mirror
@@ -1425,12 +1486,15 @@ pub(crate) fn vstack_enter_exception_handler<Sym: WalkSym>(
     } else {
         py_stack_depth(code_ptr, handler_py)
     };
-    ctx.vstack_boxes.clear();
-    ctx.vstack_boxes.resize(handler_depth, OpRef::NONE);
+    ctx.frame_state.borrow_mut().vstack_boxes.clear();
+    ctx.frame_state
+        .borrow_mut()
+        .vstack_boxes
+        .resize(handler_depth, OpRef::NONE);
     disarm_vstack_reorder_region(ctx);
     // The unwinder pushes the caught exception onto the new TOS.
     if handler_depth >= 1 && exc != OpRef::NONE {
-        ctx.vstack_boxes[handler_depth - 1] = exc;
+        ctx.frame_state.borrow_mut().vstack_boxes[handler_depth - 1] = exc;
     }
     vstack_handler_diag(
         "outer",
@@ -1442,7 +1506,7 @@ pub(crate) fn vstack_enter_exception_handler<Sym: WalkSym>(
     );
     ctx.vstack_cur_pypc = handler_py;
     ctx.vstack_depth = handler_depth;
-    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
     ctx.vstack_handler_landing_py = (floor_py != handler_py).then_some(floor_py);
     // Revive: the handler-entry state is shadow-sourced, independent of the
     // pre-raise mirror.
@@ -1500,11 +1564,14 @@ fn vstack_enter_exception_handler_callee<Sym: WalkSym>(
     // Truncate to the handler's setup depth, keeping the tracked survivors; a
     // mirror shallower than the handler depth pads with NONE holes, which
     // `mirror_covers_kept` declines per slot rather than latching invalid.
-    ctx.vstack_boxes.resize(handler_depth, OpRef::NONE);
+    ctx.frame_state
+        .borrow_mut()
+        .vstack_boxes
+        .resize(handler_depth, OpRef::NONE);
     disarm_vstack_reorder_region(ctx);
     // The unwinder pushes the caught exception onto the new TOS.
     if handler_depth >= 1 && exc != OpRef::NONE {
-        ctx.vstack_boxes[handler_depth - 1] = exc;
+        ctx.frame_state.borrow_mut().vstack_boxes[handler_depth - 1] = exc;
     }
     vstack_handler_diag(
         "callee",
@@ -1516,6 +1583,6 @@ fn vstack_enter_exception_handler_callee<Sym: WalkSym>(
     );
     ctx.vstack_cur_pypc = handler_py;
     ctx.vstack_depth = handler_depth;
-    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.frame_state.borrow_mut().vstack_last_ref = OpRef::NONE;
     ctx.vstack_handler_landing_py = (floor_py != handler_py).then_some(floor_py);
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2235,7 +2235,7 @@ pub fn seed_compiled_trace_jitcode_test_state(
         if reg_idx >= sym.registers_r.len() {
             sym.registers_r.resize(reg_idx + 1, OpRef::NONE);
         }
-        sym.registers_r[reg_idx] = opref;
+        sym.registers_r.set(reg_idx, opref);
     }
 
     let banks = frame_liveness_reg_indices_by_bank_from_pc(jitcode_index, live_jit_pc);
@@ -3120,7 +3120,7 @@ pub struct PyreSym {
     /// (mapped from RebuiltValue::Box(n) in rebuild_from_resumedata) instead
     /// of the vable_array_base-based layout. This ensures bridge traces see
     /// frame locals as symbolic InputArgs, not concrete values.
-    pub(crate) bridge_local_oprefs: Option<Vec<OpRef>>,
+    pub(crate) bridge_local_oprefs: crate::jitcode_dispatch::RegisterList,
     /// Bridge-specific override for the kept operand-stack slice of
     /// registers_r ([nlocals..nlocals+stack_only], semantic-slot == color
     /// in that prefix). resume.py:1042 parity: setup_bridge_sym resolves
@@ -3129,18 +3129,7 @@ pub struct PyreSym {
     /// in pyre's bridge launcher) does not clobber the rebuilt stack tail
     /// back to NONE, and so the full-body-walk argbox seed can recover the
     /// kept conditional-expression / short-circuit value (#124).
-    pub(crate) bridge_stack_oprefs: Option<Vec<OpRef>>,
-    /// Reference register banks of the inline sub-walks open under this trace,
-    /// as addresses.  `inline_call.rs` builds the callee `WalkContext` over a
-    /// local `Vec<OpRef>` and calls `walk` directly, without entering
-    /// `trace_bytecode`, so a `ConstPtr` a callee fold parks there sits in a
-    /// bank that is not `registers_r` and that
-    /// `walk_active_sym_register_area` would otherwise not reach.  Pushed and
-    /// popped by `trace::InlineRegisterBankGuard` around each sub-walk, so the
-    /// list holds only banks whose owning frame is live.  Each entry is the
-    /// bank's `(address, length)`: `WalkContext` holds the bank as a slice, so
-    /// one word does not describe it.
-    pub(crate) inline_register_banks: Vec<(usize, usize)>,
+    pub(crate) bridge_stack_oprefs: crate::jitcode_dispatch::RegisterList,
     /// Kept-stack branch-guard resume coordinate for the full-body walk: the
     /// guard's OWN jitcode byte offset (`frame0.jitcode_pc`, the mid-opcode
     /// `goto_if_not`), resolved the same way the blackhole resolves its
@@ -3179,7 +3168,7 @@ pub struct PyreSym {
     /// recover an operand live across a resumed call (e.g. `t1` in
     /// `return fib(n-1)+fib(n-2)`) that the semantic mirror does not carry
     /// by color.
-    pub(crate) bridge_registers_r: Option<Vec<OpRef>>,
+    pub(crate) bridge_registers_r: crate::jitcode_dispatch::RegisterList,
     /// Bridge-specific override for symbolic_local_types.
     /// virtualizable.py:44 + interp_jit.py:25-30: locals_cells_stack_w[*]
     /// is a W_Root array → all items are Type::Ref. setup_bridge_sym
@@ -3264,7 +3253,7 @@ pub struct PyreSym {
     /// RPython MetaInterp.last_exc_value (pyjitpl.py): concrete
     /// exception object pending during tracing. Set by execute_ll_raised
     /// (raise_varargs), consumed by handle_possible_exception.
-    pub(crate) last_exc_value: pyre_object::PyObjectRef,
+    pub(crate) last_exc_value: std::rc::Rc<std::cell::Cell<pyre_object::PyObjectRef>>,
     /// RPython MetaInterp.class_of_last_exc_is_const (pyjitpl.py):
     /// True after GUARD_EXCEPTION or GUARD_CLASS on the exception.
     pub(crate) class_of_last_exc_is_const: bool,
@@ -3273,24 +3262,9 @@ pub struct PyreSym {
     /// by handle_possible_exception after GUARD_EXCEPTION, then consumed
     /// by finishframe_exception for stack push.
     pub(crate) last_exc_box: OpRef,
-    /// Maps the OpRef of a trace-built (fresh `NewWithVtable`)
-    /// exception to its trace-time concrete instance.  `RAISE_VARARGS`
-    /// reuses the instance to take the instance fast path — skip the
-    /// residual `normalize_raise_varargs_jit` publish + `GUARD_EXCEPTION`
-    /// round-trip so the exception stays virtualizable — and to apply the
-    /// unconditional `__context__ = ec.sys_exc_value` chaining that is
-    /// valid only for a freshly constructed exception (w_context still
-    /// null, self-cycle impossible).
-    ///
-    /// The entry is dropped as soon as freshness can no longer be proven:
-    /// `RAISE_VARARGS` consumes it (a re-raise of the same object must
-    /// take the residual path — its `w_context` is set by then), and
-    /// the retired Python-helper boxing path removed any value escaping into a
-    /// python-helper residual call (which may mutate the exception).
-    pub(crate) trace_built_exc: indexmap::IndexMap<OpRef, pyre_object::PyObjectRef>,
     /// Symbolic mirror of executioncontext.current_exception/sys_exc_info.
     /// Used by PUSH_EXC_INFO / POP_EXCEPT to preserve nested handler state.
-    pub(crate) current_exc_value: pyre_object::PyObjectRef,
+    pub(crate) current_exc_value: std::rc::Rc<std::cell::Cell<pyre_object::PyObjectRef>>,
     pub(crate) current_exc_box: OpRef,
     // ── RPython MIFrame.registers_{i,r,f} port (pyjitpl.py) ──
     //
@@ -3316,7 +3290,7 @@ pub struct PyreSym {
     //     color-indexed Ref-bank snapshot before reading liveness.
     pub(crate) registers_i: Vec<OpRef>,
     #[vable(locals)]
-    pub(crate) registers_r: Vec<OpRef>,
+    pub(crate) registers_r: crate::jitcode_dispatch::RegisterList,
     pub(crate) registers_f: Vec<OpRef>,
 }
 
@@ -3326,8 +3300,8 @@ pub trait WalkSym {
     fn set_execution_context(&mut self, value: OpRef);
     fn registers_i(&self) -> &[OpRef];
     fn registers_i_mut(&mut self) -> &mut Vec<OpRef>;
-    fn registers_r(&self) -> &[OpRef];
-    fn registers_r_mut(&mut self) -> &mut Vec<OpRef>;
+    fn registers_r(&self) -> &crate::jitcode_dispatch::RegisterList;
+    fn registers_r_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList;
     fn registers_f(&self) -> &[OpRef];
     fn registers_f_mut(&mut self) -> &mut Vec<OpRef>;
     fn nlocals(&self) -> usize;
@@ -3341,11 +3315,11 @@ pub trait WalkSym {
     fn set_live_vable_frame_addr(&mut self, value: usize);
     fn bridge_walk_entry_pc(&self) -> Option<usize>;
     fn bridge_walk_entry_jitcode_index(&self) -> i32;
-    fn bridge_registers_r(&self) -> Option<&Vec<OpRef>>;
-    fn bridge_registers_r_mut(&mut self) -> &mut Option<Vec<OpRef>>;
-    fn bridge_stack_oprefs(&self) -> Option<&Vec<OpRef>>;
-    fn bridge_stack_oprefs_mut(&mut self) -> &mut Option<Vec<OpRef>>;
-    fn bridge_local_oprefs_mut(&mut self) -> &mut Option<Vec<OpRef>>;
+    fn bridge_registers_r(&self) -> Option<&crate::jitcode_dispatch::RegisterList>;
+    fn bridge_registers_r_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList;
+    fn bridge_stack_oprefs(&self) -> Option<&crate::jitcode_dispatch::RegisterList>;
+    fn bridge_stack_oprefs_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList;
+    fn bridge_local_oprefs_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList;
     fn vable_array_base(&self) -> Option<u32>;
     fn vable_last_instr(&self) -> OpRef;
     fn vable_valuestackdepth(&self) -> OpRef;
@@ -3358,15 +3332,10 @@ pub trait WalkSym {
     fn set_class_of_last_exc_is_const(&mut self, value: bool);
     fn set_current_exc_value(&mut self, value: pyre_object::PyObjectRef);
     fn set_current_exc_box(&mut self, value: OpRef);
-    fn trace_built_exc(&self) -> &indexmap::IndexMap<OpRef, pyre_object::PyObjectRef>;
-    fn trace_built_exc_mut(&mut self) -> &mut indexmap::IndexMap<OpRef, pyre_object::PyObjectRef>;
     fn owns_virtualizable_shadow(&self) -> bool;
-    /// The trace-time exception-carrier anchor to publish for GC rooting, or
-    /// `None` for syms holding no such carriers (novable drivers). Only
-    /// `PyreSym` carries `last_exc_value` / `current_exc_value` /
-    /// `trace_built_exc`, which a mid-trace collection reaches through
-    /// [`crate::trace::walk_active_sym_exc_roots`].
-    fn active_exc_anchor(&mut self) -> Option<*mut PyreSym> {
+    /// Publish independently owned tracing roots for the duration of this
+    /// attempt, as translated roots keep the MIFrame and its lists alive.
+    fn enter_trace_roots(&self) -> Option<crate::trace::TraceRoots> {
         None
     }
     fn init_symbolic(&mut self, ctx: &mut TraceCtx, concrete_frame: usize);
@@ -3409,13 +3378,13 @@ impl WalkSym for PyreSym {
     }
 
     #[inline]
-    fn registers_r(&self) -> &[OpRef] {
+    fn registers_r(&self) -> &crate::jitcode_dispatch::RegisterList {
         &self.registers_r
     }
 
     #[inline]
-    fn registers_r_mut(&mut self) -> &mut Vec<OpRef> {
-        &mut self.registers_r
+    fn registers_r_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList {
+        &self.registers_r
     }
 
     #[inline]
@@ -3479,27 +3448,27 @@ impl WalkSym for PyreSym {
     }
 
     #[inline]
-    fn bridge_registers_r(&self) -> Option<&Vec<OpRef>> {
+    fn bridge_registers_r(&self) -> Option<&crate::jitcode_dispatch::RegisterList> {
         self.bridge_registers_r.as_ref()
     }
 
     #[inline]
-    fn bridge_registers_r_mut(&mut self) -> &mut Option<Vec<OpRef>> {
+    fn bridge_registers_r_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList {
         &mut self.bridge_registers_r
     }
 
     #[inline]
-    fn bridge_stack_oprefs(&self) -> Option<&Vec<OpRef>> {
+    fn bridge_stack_oprefs(&self) -> Option<&crate::jitcode_dispatch::RegisterList> {
         self.bridge_stack_oprefs.as_ref()
     }
 
     #[inline]
-    fn bridge_stack_oprefs_mut(&mut self) -> &mut Option<Vec<OpRef>> {
+    fn bridge_stack_oprefs_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList {
         &mut self.bridge_stack_oprefs
     }
 
     #[inline]
-    fn bridge_local_oprefs_mut(&mut self) -> &mut Option<Vec<OpRef>> {
+    fn bridge_local_oprefs_mut(&mut self) -> &crate::jitcode_dispatch::RegisterList {
         &mut self.bridge_local_oprefs
     }
 
@@ -3525,12 +3494,12 @@ impl WalkSym for PyreSym {
 
     #[inline]
     fn last_exc_value(&self) -> pyre_object::PyObjectRef {
-        self.last_exc_value
+        self.last_exc_value.get()
     }
 
     #[inline]
     fn set_last_exc_value(&mut self, value: pyre_object::PyObjectRef) {
-        self.last_exc_value = value;
+        self.last_exc_value.set(value);
     }
 
     #[inline]
@@ -3555,7 +3524,7 @@ impl WalkSym for PyreSym {
 
     #[inline]
     fn set_current_exc_value(&mut self, value: pyre_object::PyObjectRef) {
-        self.current_exc_value = value;
+        self.current_exc_value.set(value);
     }
 
     #[inline]
@@ -3564,23 +3533,13 @@ impl WalkSym for PyreSym {
     }
 
     #[inline]
-    fn trace_built_exc(&self) -> &indexmap::IndexMap<OpRef, pyre_object::PyObjectRef> {
-        &self.trace_built_exc
-    }
-
-    #[inline]
-    fn trace_built_exc_mut(&mut self) -> &mut indexmap::IndexMap<OpRef, pyre_object::PyObjectRef> {
-        &mut self.trace_built_exc
-    }
-
-    #[inline]
     fn owns_virtualizable_shadow(&self) -> bool {
         PyreSym::owns_virtualizable_shadow(self)
     }
 
     #[inline]
-    fn active_exc_anchor(&mut self) -> Option<*mut PyreSym> {
-        Some(self as *mut PyreSym)
+    fn enter_trace_roots(&self) -> Option<crate::trace::TraceRoots> {
+        Some(crate::trace::TraceRoots::enter(self))
     }
 
     #[inline]
@@ -6800,8 +6759,42 @@ pub(crate) fn fail_arg_types_for_virtualizable_state(len: usize) -> Vec<Type> {
 ///        `resume.rs::ResumeDataLoopMemo`'s `large_ints` / `refs`
 ///        memo separately dedups constants when assigning
 ///        resume numbering tags.
-fn copy_constants<F>(registers: &mut Vec<OpRef>, constants: &[i64], targetindex: usize, mut mint: F)
-where
+trait ConstantRegisters {
+    fn len(&self) -> usize;
+    fn resize(&mut self, len: usize, value: OpRef);
+    fn set(&mut self, index: usize, value: OpRef);
+}
+
+impl ConstantRegisters for Vec<OpRef> {
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+    fn resize(&mut self, len: usize, value: OpRef) {
+        Vec::resize(self, len, value);
+    }
+    fn set(&mut self, index: usize, value: OpRef) {
+        self[index] = value;
+    }
+}
+
+impl ConstantRegisters for crate::jitcode_dispatch::RegisterList {
+    fn len(&self) -> usize {
+        Self::len(self)
+    }
+    fn resize(&mut self, len: usize, value: OpRef) {
+        Self::resize(self, len, value);
+    }
+    fn set(&mut self, index: usize, value: OpRef) {
+        Self::set(self, index, value);
+    }
+}
+
+fn copy_constants<F>(
+    registers: &mut impl ConstantRegisters,
+    constants: &[i64],
+    targetindex: usize,
+    mut mint: F,
+) where
     F: FnMut(i64) -> OpRef,
 {
     let num_regs_and_consts = targetindex + constants.len();
@@ -6809,7 +6802,7 @@ where
         registers.resize(num_regs_and_consts, OpRef::NONE);
     }
     for (i, &val) in constants.iter().enumerate() {
-        registers[targetindex + i] = mint(val);
+        registers.set(targetindex + i, mint(val));
     }
 }
 
@@ -6824,12 +6817,11 @@ impl PyreSym {
             locals_cells_stack_array_ref: OpRef::NONE,
             valuestackdepth: 0,
             nlocals: 0,
-            bridge_local_oprefs: None,
-            bridge_stack_oprefs: None,
-            inline_register_banks: Vec::new(),
+            bridge_local_oprefs: Default::default(),
+            bridge_stack_oprefs: Default::default(),
             bridge_walk_entry_pc: None,
             bridge_walk_entry_jitcode_index: -1,
-            bridge_registers_r: None,
+            bridge_registers_r: Default::default(),
             bridge_local_types: None,
             vable_last_instr: OpRef::NONE,
             vable_pycode: OpRef::NONE,
@@ -6847,11 +6839,12 @@ impl PyreSym {
             concrete_execution_context: std::ptr::null(),
             concrete_vable_ptr: std::ptr::null_mut(),
             live_vable_frame_addr: 0,
-            last_exc_value: std::ptr::null_mut(),
+            last_exc_value: Default::default(),
             class_of_last_exc_is_const: false,
             last_exc_box: OpRef::NONE,
-            trace_built_exc: indexmap::IndexMap::new(),
-            current_exc_value: pyre_interpreter::eval::get_current_exception(),
+            current_exc_value: std::rc::Rc::new(std::cell::Cell::new(
+                pyre_interpreter::eval::get_current_exception(),
+            )),
             current_exc_box: OpRef::NONE,
             // RPython pyjitpl.py:74-78 init: registers_X[i] = CONST_NULL for
             // i in num_regs. Sized lazily here — `setup_kind_register_banks`
@@ -6860,7 +6853,7 @@ impl PyreSym {
             // semantic-slot logic; the encoder is not yet rewired to
             // per-bank reads for `registers_r`.
             registers_i: Vec::new(),
-            registers_r: Vec::new(),
+            registers_r: Default::default(),
             registers_f: Vec::new(),
         }
     }
@@ -7020,7 +7013,7 @@ impl PyreSym {
         sym.locals_cells_stack_array_ref = state.locals_cells_stack_array_ref;
         sym.symbolic_local_types = state.symbolic_local_types;
         sym.symbolic_stack_types = state.symbolic_stack_types;
-        sym.registers_r = state.registers_r;
+        sym.registers_r.replace(state.registers_r);
         sym.concrete_stack = state.concrete_stack;
         sym.concrete_namespace = state.concrete_namespace;
         sym.vable_last_instr = state.vable_last_instr;
@@ -7077,19 +7070,21 @@ impl PyreSym {
         // of registers_r. The bridge override / vable inputarg / NONE
         // shape is the per-trace seed; subsequent load_local_value /
         // store_local_value updates the per-color slot directly.
-        self.registers_r = if let Some(ref overrides) = self.bridge_local_oprefs {
-            // resume.py:1042 parity: bridge trace uses OpRefs derived from
-            // rebuild_from_resumedata (Box(n) → bridge InputArg OpRef::from_raw(n)).
-            let mut locals = overrides.clone();
-            locals.resize(nlocals, OpRef::NONE);
-            locals
-        } else if let Some(base) = self.vable_array_base {
-            (0..nlocals)
-                .map(|i| OpRef::input_arg_ref(base + i as u32))
-                .collect()
-        } else {
-            vec![OpRef::NONE; nlocals]
-        };
+        self.registers_r.replace(
+            if let Some(ref overrides) = self.bridge_local_oprefs.as_ref() {
+                // resume.py:1042 parity: bridge trace uses OpRefs derived from
+                // rebuild_from_resumedata (Box(n) → bridge InputArg OpRef::from_raw(n)).
+                let mut locals = overrides.to_vec();
+                locals.resize(nlocals, OpRef::NONE);
+                locals
+            } else if let Some(base) = self.vable_array_base {
+                (0..nlocals)
+                    .map(|i| OpRef::input_arg_ref(base + i as u32))
+                    .collect()
+            } else {
+                vec![OpRef::NONE; nlocals]
+            },
+        );
         // RPython resume.py:1042 parity: bridge traces enter with the
         // failing guard's saved boxes, NOT with the loop's full
         // virtualizable inputarg layout. Each `bridge_local_oprefs[i]`
@@ -7101,7 +7096,7 @@ impl PyreSym {
         //
         // Loop / function-entry traces still use vable_array_base because
         // their inputarg list is the full vable layout.
-        let inputarg_slot_types = if let Some(ref overrides) = self.bridge_local_oprefs {
+        let inputarg_slot_types = if let Some(ref overrides) = self.bridge_local_oprefs.as_ref() {
             let inputarg_types = ctx.inputarg_types();
             let locals: Vec<Type> = (0..nlocals)
                 .map(|i| {
@@ -7177,14 +7172,14 @@ impl PyreSym {
             (0..stack_only_depth)
                 .map(|i| OpRef::input_arg_ref(stack_base + i as u32))
                 .collect()
-        } else if let Some(ref bridge_stack) = self.bridge_stack_oprefs {
+        } else if let Some(ref bridge_stack) = self.bridge_stack_oprefs.as_ref() {
             // #124: a bridge resumes from a guard whose live operand stack
             // setup_bridge_sym already resolved into these OpRefs. The local
             // override (above) plus the comment at the bridge_local_oprefs
             // branch assume setup_bridge_sym overwrites the rebuilt tail,
             // but pyre's launcher runs setup_bridge_sym BEFORE this; so
             // preserve the kept temps here rather than reset them to NONE.
-            let mut seed = bridge_stack.clone();
+            let mut seed = bridge_stack.to_vec();
             seed.resize(stack_only_depth, OpRef::NONE);
             seed
         } else {
@@ -9140,7 +9135,8 @@ fn prepare_bridge_pending_fields(
                 continue;
             };
             sym.last_exc_box = value_box;
-            sym.last_exc_value = value_ref.as_usize() as pyre_object::PyObjectRef;
+            sym.last_exc_value
+                .set(value_ref.as_usize() as pyre_object::PyObjectRef);
             sym.class_of_last_exc_is_const = false;
         } else {
             // resume.py `_prepare_pendingfields`: replay ordinary
@@ -10225,16 +10221,16 @@ fn seed_bridge_standing_exception_from_current(
         return;
     }
 
-    let mut exc = sym.current_exc_value;
+    let mut exc = sym.current_exc_value.get();
     let exc_box = sym.current_exc_box;
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         let current = pyre_interpreter::eval::get_current_exception();
         if !current.is_null() && unsafe { pyre_object::is_exception(current) } {
             exc = current;
         } else {
-            sym.current_exc_value = std::ptr::null_mut();
+            sym.current_exc_value.set(std::ptr::null_mut());
             sym.current_exc_box = OpRef::NONE;
-            sym.last_exc_value = std::ptr::null_mut();
+            sym.last_exc_value.set(std::ptr::null_mut());
             sym.last_exc_box = OpRef::NONE;
             sym.class_of_last_exc_is_const = false;
             return;
@@ -10246,9 +10242,9 @@ fn seed_bridge_standing_exception_from_current(
     } else {
         exc_box
     };
-    sym.current_exc_value = exc;
+    sym.current_exc_value.set(exc);
     sym.current_exc_box = exc_box;
-    sym.last_exc_value = exc;
+    sym.last_exc_value.set(exc);
     sym.last_exc_box = exc_box;
     sym.class_of_last_exc_is_const = true;
 }
@@ -11263,7 +11259,7 @@ impl JitState for PyreJitState {
             }
         }
         seed_bridge_standing_exception_from_current(sym, ctx);
-        sym.registers_r = semantic_mirror;
+        sym.registers_r.replace(semantic_mirror);
         sym.symbolic_local_types = {
             let mut types = bridge_local_types.clone();
             types.resize(sym.nlocals, Type::Ref);
@@ -11393,7 +11389,7 @@ impl JitState for PyreJitState {
                 let null_ref = ctx.const_ref(pyre_object::PY_NULL as i64);
                 bridge_array_items.resize(semantic_array_len, null_ref);
             }
-            for (slot, &opref) in sym
+            for (slot, opref) in sym
                 .registers_r
                 .iter()
                 .take(semantic_array_len)
@@ -11453,7 +11449,7 @@ impl JitState for PyreJitState {
         // subsequent LOAD_FAST / close_loop_args_at calls.
         sym.symbolic_stack_types = vec![Type::Ref; stack_only];
         sym.valuestackdepth = bridge_valuestackdepth;
-        sym.bridge_local_oprefs = Some(bridge_locals);
+        sym.bridge_local_oprefs.replace(bridge_locals);
         // #124: preserve the resolved kept operand-stack temps. `bridge_stack`
         // is the stack tail of the slot-indexed `semantic_mirror` (computed
         // above by inverting each live color to its slot), so it is correct
@@ -11462,7 +11458,7 @@ impl JitState for PyreJitState {
         // and would otherwise reset this tail to NONE; keeping it lets both the
         // rebuilt registers_r and the full-body-walk argbox seed recover the
         // kept conditional-expression / short-circuit value.
-        sym.bridge_stack_oprefs = Some(bridge_stack);
+        sym.bridge_stack_oprefs.replace(bridge_stack);
         // Kept-stack branch guards resume the full-body walk at the guard's OWN
         // mid-opcode jitcode offset — the same resolved coordinate stored in
         // the frame pc — instead of the opcode-entry marker for `py_pc`.
@@ -11478,7 +11474,7 @@ impl JitState for PyreJitState {
         // (`_get_list_of_active_boxes`, pyjitpl.py:216-233). `sym.registers_r`
         // is about to be overwritten with the slot-indexed semantic mirror and
         // then rebuilt by init_symbolic, losing this color decode.
-        sym.bridge_registers_r = Some(bridge_registers_r.clone());
+        sym.bridge_registers_r.replace(bridge_registers_r.clone());
 
         // pyjitpl.py `rebuild_state_after_failure` tail —
         // `consume_virtualref_boxes` (resume.py):
@@ -13649,6 +13645,28 @@ mod tests {
     }
 
     #[test]
+    fn collect_jump_args_rejects_locals_beyond_register_storage() {
+        let mut ctx = crate::trace_ctx_for_test(0);
+        let mut sym = PyreSym::new_uninit(ctx.const_ref(0));
+        sym.nlocals = 1;
+        sym.valuestackdepth = 1;
+        // Value-only iteration must retain the old slice's bounds check,
+        // including when the stack window itself is empty.
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                sym.vable_collect_jump_args()
+            }))
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                sym.vable_collect_typed_jump_args()
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
     fn test_pypyjit_collect_jump_args_inserts_ec_after_frame() {
         let mut ctx = crate::trace_ctx_for_test(0);
         let frame_ref = ctx.const_ref(0x1000);
@@ -13668,7 +13686,7 @@ mod tests {
         sym.vable_debugdata = ctx.const_ref(0);
         sym.frame_w_globals = namespace_ref;
         sym.execution_context = ec_ref;
-        sym.registers_r = vec![local0, stack0, stack1];
+        sym.registers_r.replace(vec![local0, stack0, stack1]);
         sym.symbolic_local_types = vec![Type::Ref];
         sym.symbolic_stack_types = vec![Type::Ref, Type::Ref];
 
@@ -13699,7 +13717,7 @@ mod tests {
 
         let mut sym = PyreSym::new_uninit(frame_ref);
         sym.execution_context = ec_ref;
-        sym.registers_r = vec![stale_local];
+        sym.registers_r.replace(vec![stale_local]);
 
         // TraceCtx::collect_virtualizable_typed_boxes order:
         // static fields, array items, trailing standard-vable identity.
@@ -13832,7 +13850,7 @@ mod tests {
         // registers_r[i] tracks locals_cells_stack_w[*] — W_Root array, Type::Ref.
         let obj = OpRef::input_arg_ref(0);
         let mut sym = PyreSym::new_uninit(OpRef::NONE);
-        sym.registers_r = vec![obj];
+        sym.registers_r.replace(vec![obj]);
         sym.symbolic_local_types = vec![Type::Ref];
         sym.nlocals = 1;
 
@@ -13873,7 +13891,7 @@ mod tests {
         // value_type is Ref per the comment above; registers_r[0] = inputarg slot 0.
         let int_obj = OpRef::input_arg_ref(0);
         let mut sym = PyreSym::new_uninit(OpRef::NONE);
-        sym.registers_r = vec![int_obj];
+        sym.registers_r.replace(vec![int_obj]);
         sym.symbolic_local_types = vec![Type::Ref];
         sym.nlocals = 1;
 
@@ -14298,7 +14316,11 @@ mod tests {
             assert_eq!(sym.registers_i[i], OpRef::NONE, "registers_i[{i}] reg-slot");
         }
         for i in 0..4 {
-            assert_eq!(sym.registers_r[i], OpRef::NONE, "registers_r[{i}] reg-slot");
+            assert_eq!(
+                sym.registers_r.get(i).expect("bound Ref register"),
+                OpRef::NONE,
+                "registers_r[{i}] reg-slot"
+            );
         }
         for i in 0..2 {
             assert_eq!(sym.registers_f[i], OpRef::NONE, "registers_f[{i}] reg-slot");
@@ -14314,7 +14336,7 @@ mod tests {
                 .expect("constants pool resolves trailing int slot");
             assert_eq!(val, majit_ir::Value::Int(100 + 100 * i as i64));
         }
-        let op_r = sym.registers_r[4];
+        let op_r = sym.registers_r.get(4).expect("bound Ref register");
         assert_ne!(op_r, OpRef::NONE);
         assert!(matches!(
             ctx.constants_get_value(op_r),
@@ -14337,7 +14359,7 @@ mod tests {
             .constants_get_value(sym.registers_i[3])
             .expect("first-call trailing int slot resolves to a constant");
         let trailing_r_value_before = ctx
-            .constants_get_value(sym.registers_r[4])
+            .constants_get_value(sym.registers_r.get(4).expect("bound Ref register"))
             .expect("first-call trailing ref slot resolves to a constant");
         let trailing_f_value_before = ctx
             .constants_get_value(sym.registers_f[2])
@@ -14351,7 +14373,7 @@ mod tests {
             Some(trailing_i_value_before),
         );
         assert_eq!(
-            ctx.constants_get_value(sym.registers_r[4]),
+            ctx.constants_get_value(sym.registers_r.get(4).expect("bound Ref register")),
             Some(trailing_r_value_before),
         );
         assert_eq!(
@@ -14575,7 +14597,7 @@ mod tests {
         // must match so variant-aware Eq lines up with the resolved
         // bridge inputarg list.
         assert_eq!(
-            sym.registers_r,
+            sym.registers_r.to_vec(),
             vec![
                 OpRef::input_arg_ref(6),
                 OpRef::input_arg_ref(7),
@@ -14586,7 +14608,7 @@ mod tests {
         assert_eq!(sym.symbolic_stack_types, vec![Type::Ref]);
         assert_eq!(sym.execution_context, OpRef::input_arg_ref(1));
         assert_eq!(
-            sym.bridge_local_oprefs,
+            sym.bridge_local_oprefs.as_ref().map(|regs| regs.to_vec()),
             Some(vec![OpRef::input_arg_ref(6), OpRef::input_arg_ref(7)])
         );
         assert_eq!(
@@ -14690,11 +14712,11 @@ mod tests {
         // local0 / stack0 / stack1 are Ref-typed per `symbolic_local_types`
         // / `symbolic_stack_types` below — the macro mints the matching
         // `InputArgRef` variant.
-        sym.registers_r = vec![
+        sym.registers_r.replace(vec![
             OpRef::input_arg_ref(6),
             OpRef::input_arg_ref(7),
             OpRef::input_arg_ref(8),
-        ];
+        ]);
         sym.symbolic_local_types = vec![Type::Ref];
         sym.symbolic_stack_types = vec![Type::Ref, Type::Ref];
         sym.concrete_stack = vec![ConcreteValue::Null, ConcreteValue::Null];
@@ -14790,7 +14812,7 @@ mod tests {
         sym.vable_valuestackdepth = OpRef::input_arg_int(4);
         sym.vable_debugdata = OpRef::input_arg_ref(5);
         sym.frame_w_globals = ctx.const_ref(frame.get_w_globals() as usize as i64);
-        sym.registers_r = vec![OpRef::input_arg_ref(6)];
+        sym.registers_r.replace(vec![OpRef::input_arg_ref(6)]);
         sym.symbolic_local_types = vec![Type::Ref];
         sym.symbolic_stack_types = Vec::new();
         sym.concrete_vable_ptr = frame_ptr as *mut u8;
@@ -15078,7 +15100,7 @@ pub(crate) fn assemble_bridge_inline_pending(
     // The Ref bank IS the unified locals+stack register file decoded by
     // `reconstruct_inline_recipe`; int/float banks are empty (gated out).
     sym.registers_i = recipe.registers_i.clone();
-    sym.registers_r = recipe.registers_r.clone();
+    sym.registers_r.replace(recipe.registers_r.clone());
     sym.registers_f = recipe.registers_f.clone();
     // locals_cells_stack_w is a W_Root array — every live slot is Ref.
     sym.symbolic_local_types = vec![Type::Ref; nlocals];

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7072,7 +7072,7 @@ impl PyreSym {
         // store_local_value updates the per-color slot directly.
         self.registers_r.replace(
             if let Some(ref overrides) = self.bridge_local_oprefs.as_ref() {
-                // resume.py:1042 parity: bridge trace uses OpRefs derived from
+                // resume.py `rebuild_from_resumedata`: bridge trace uses OpRefs derived from
                 // rebuild_from_resumedata (Box(n) → bridge InputArg OpRef::from_raw(n)).
                 let mut locals = overrides.to_vec();
                 locals.resize(nlocals, OpRef::NONE);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -333,220 +333,101 @@ pub unsafe fn walk_walk_end_roots_area(
 }
 
 thread_local! {
-    /// Raw pointer to the `PyreSym` being traced on this thread, or null when no
-    /// trace is in flight. Lets [`walk_active_sym_exc_roots`] reach the
-    /// trace-time exception carriers (`trace_built_exc` / `last_exc_value` /
-    /// `current_exc_value`) during a collection triggered mid-trace. Set at
-    /// [`trace_bytecode`] entry, restored on return.
-    static ACTIVE_SYM_EXC: std::cell::Cell<*mut PyreSym> =
-        const { std::cell::Cell::new(std::ptr::null_mut()) };
+    // Current execution-context state only, not a root owner or a borrowed
+    // frame pointer. Each TraceRoots independently owns all its publications.
+    static ACTIVE_TRACE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// RAII guard restoring the previous [`ACTIVE_SYM_EXC`] on drop, so nested /
-/// re-entrant `trace_bytecode` (recursive portal) unwinds to the outer trace's
-/// sym rather than leaving a stale or null anchor.
-pub(crate) struct ActiveSymExcGuard {
-    prev: *mut PyreSym,
+/// Translated stack roots for a tracing attempt. Nested attempts retain their
+/// outer roots without reaching back through a borrowed PyreSym.
+pub struct TraceRoots {
+    prev_active: bool,
+    _register_roots: [crate::jitcode_dispatch::RegisterListRoot; 4],
+    _exception_roots: [ExceptionRoot; 2],
 }
 
-impl Drop for ActiveSymExcGuard {
+impl TraceRoots {
+    pub(crate) fn enter(owner: &PyreSym) -> Self {
+        let register_roots = [
+            owner.registers_r.root(),
+            owner.bridge_registers_r.root(),
+            owner.bridge_local_oprefs.root(),
+            owner.bridge_stack_oprefs.root(),
+        ];
+        let exception_roots = [
+            ExceptionRoot::new(&owner.last_exc_value),
+            ExceptionRoot::new(&owner.current_exc_value),
+        ];
+        let prev_active = ACTIVE_TRACE.with(|c| c.replace(true));
+        Self {
+            prev_active,
+            _register_roots: register_roots,
+            _exception_roots: exception_roots,
+        }
+    }
+}
+
+impl Drop for TraceRoots {
     fn drop(&mut self) {
-        ACTIVE_SYM_EXC.with(|c| c.set(self.prev));
+        ACTIVE_TRACE.with(|c| c.set(self.prev_active));
     }
 }
 
-/// Publish `sym` as the active trace's exception-carrier anchor for the lifetime
-/// of the returned guard. Called once at [`trace_bytecode`] entry.
-pub(crate) fn set_active_sym_exc(sym: *mut PyreSym) -> ActiveSymExcGuard {
-    let prev = ACTIVE_SYM_EXC.with(|c| c.replace(sym));
-    ActiveSymExcGuard { prev }
+/// pyjitpl.py MetaInterp.execute_ll_raised/clear_exception stores the carrier
+/// on its owner, where the translated GC reaches it. The native cell keeps
+/// that ownership independent of the tracer's exclusive PyreSym borrow.
+struct ExceptionRoot {
+    _area: majit_gc::shadow_stack::MutatorExtraAreaGuard,
+    _owner: std::rc::Rc<std::cell::Cell<pyre_object::PyObjectRef>>,
 }
 
-/// The LIVE interpreter frame of the walk currently recording, or `0` outside
-/// one.
-///
-/// The walk owns this frame's resume coordinate: it steps the frame's opcodes
-/// itself and, when it declines its end state, hands the frame back for the
-/// interpreter to re-enter.  A hook that writes `PyFrame` fields the resume
-/// path reads must leave this one alone.  Every OTHER frame a walk materializes
-/// — the seeded inline-callee levels — takes no per-opcode store and is never
-/// resumed, which is what makes those safe to write.
-///
-/// SAFETY: same contract as [`walk_active_sym_exc_roots`] — the reader runs on
-/// the tracing thread, so the tracer's `&mut PyreSym` up the stack is a
-/// suspended frame and only a shared read of one `usize` field is taken.
-pub fn active_walk_live_frame() -> usize {
-    let sym_ptr = ACTIVE_SYM_EXC.with(|c| c.get());
-    if sym_ptr.is_null() {
-        return 0;
+impl ExceptionRoot {
+    fn new(owner: &std::rc::Rc<std::cell::Cell<pyre_object::PyObjectRef>>) -> Self {
+        let area = unsafe {
+            // Stable Rc allocation retained until after area retirement.
+            majit_gc::shadow_stack::MutatorExtraAreaGuard::new(
+                walk_exception_slot,
+                std::rc::Rc::as_ptr(owner).cast(),
+                "trace_exception",
+            )
+        };
+        Self {
+            _area: area,
+            _owner: owner.clone(),
+        }
     }
-    use crate::state::WalkSym as _;
-    unsafe { (*sym_ptr).live_vable_frame_addr() }
 }
 
-/// Root the trace-time exception carriers held in the active `PyreSym`.
-///
-/// Between construction (`sym.trace_built_exc` insert, `state.rs`) and
-/// lift-out (`swap_remove` at the raise), a trace-built exception is reachable
-/// only through `sym.trace_built_exc`, invisible to the precise collector; an
-/// allocating safepoint in that window would otherwise sweep it. `last_exc_value`
-/// / `current_exc_value` cover the seeded-raise and reraise paths.
-///
-/// Mirrors `walk_jit_exc_value`: the carriers are oldgen-stable exceptions
-/// (`try_gc_alloc_stable_raw`), so a bare mark-by-value suffices — no forwarded
-/// write-back — which means only a shared read of the sym is taken, never a
-/// second `&mut` aliasing the tracer's live borrow.
-pub fn walk_active_sym_exc_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    let sym_ptr = ACTIVE_SYM_EXC.with(|c| c.get());
-    if sym_ptr.is_null() {
+unsafe fn walk_exception_slot(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let slot = unsafe { &*(data as *const std::cell::Cell<pyre_object::PyObjectRef>) };
+    let p = slot.get();
+    if p.is_null() {
         return;
     }
-    // SAFETY: a collection triggered mid-trace runs on the SAME thread (the
-    // allocating thread becomes the collector), so the tracer's `&mut PyreSym`
-    // up the stack is a suspended frame. Only a shared `&PyreSym` is formed and
-    // oldgen-stable (non-moving) exceptions are marked by value, never writing a
-    // forwarded pointer back — matching the accepted `jit_driver_pair_from_root_area`
-    // convention in `pyre-jit`.
-    let sym = unsafe { &*sym_ptr };
-    let carriers = [sym.last_exc_value, sym.current_exc_value];
-    for p in carriers
-        .into_iter()
-        .chain(sym.trace_built_exc.values().copied())
-    {
-        if p.is_null() {
-            continue;
-        }
-        let mut gcref = majit_ir::GcRef(p as usize);
-        visitor(&mut gcref);
-        // The carrier is non-moving, so a minor's root visitor no-ops on it
-        // and never reaches its fields: young children (tracebacks/args built
-        // while tracing) would be left dangling across the minor. Forward the
-        // raw child slots explicitly; the writes land in the exception
-        // object, not the sym, so the shared-read contract above holds.
-        unsafe { pyre_interpreter::eval::walk_raw_exception_roots(p, visitor) };
-    }
+    let mut gcref = majit_ir::GcRef(p as usize);
+    visitor(&mut gcref);
+    let forwarded = gcref.0 as pyre_object::PyObjectRef;
+    slot.set(forwarded);
+    // Native exception carriers are oldgen-stable. A minor's bare root visit
+    // does not trace their young args/traceback children, so preserve the
+    // explicit child traversal of the former active-sym walker.
+    unsafe { pyre_interpreter::eval::walk_raw_exception_roots(forwarded, visitor) };
 }
 
-/// Capture this mutator's [`ACTIVE_SYM_EXC`] cell for STW root walking.
-pub fn capture_active_sym_root_area() -> *const () {
-    ACTIVE_SYM_EXC.with(|c| c as *const _ as *const ())
-}
-
-/// Root the inline `ConstPtr` GcRefs a fold has parked in the active walk's
-/// reference register banks.
+/// Root the frame's register list for the lifetime of a sub-walk, including
+/// suspension and unwind. Like the translated root of MIFrame.registers_r,
+/// publication names the owned list, not the currently selected PyreSym.
 ///
-/// `MIFrame.registers_r` is an ordinary RPython list of `GCREF` upstream, so
-/// the collector traces and forwards it with every other field and a fold never
-/// has to ask where its result is going to sit.  Pyre mirrors that bank as a
-/// `Vec<OpRef>` on `PyreSym`, which nothing else reaches: `TraceCtx::const_ref`
-/// mints an `OpRef::ConstPtr` carrying an inline `GcRef`, and
-/// `write_residual_call_result_to_dst` parks it in the bank until an operation
-/// consumes it into the recorder — from there `walk_active_trace_refs` and the
-/// emit-time `LoadFromGcTable` rewrite take over.  A collection landing in that
-/// window used to move the object and leave the bank naming the old address,
-/// which is the hazard the `can_move` tests on the walker folds stood in for.
-///
-/// Only the innermost `PyreSym` is anchored, and that covers the window: a mint
-/// and the operation recording it sit inside one opcode's dispatch, while a
-/// re-entrant `trace_bytecode` can only open between opcodes.
-///
-/// An inline sub-walk is the one bank that is not `sym.registers_r`:
-/// `inline_call.rs` gives the callee `WalkContext` a local `Vec<OpRef>` and
-/// calls `walk` on it directly, leaving `ACTIVE_SYM_EXC` on the caller's sym.
-/// [`InlineRegisterBankGuard`] publishes each such bank on
-/// `PyreSym::inline_register_banks` for the length of that sub-walk, so a
-/// callee fold's mint is rooted on the same terms as the outer one.
-///
-/// `MIFrame.pre_opcode_registers_r`, the opcode-start rollback clone, hangs off
-/// the per-instruction wrapper rather than the anchor, and so would be out of
-/// this area's reach.  Nothing writes it: every constructor leaves it `None`,
-/// the sole assignment clears it, and each read is an `is_some()` fallback, so
-/// no clone exists to be read forward stale.  A writer restored there carries
-/// the same defect this area closes, one level down, and would need an anchor
-/// of its own.
-///
-/// # Safety
-/// `data` must come from [`capture_active_sym_root_area`], and the owning
-/// mutator must be quiesced when a foreign collector thread calls this.  Unlike
-/// [`walk_active_sym_exc_roots`] this walk writes forwarded pointers back, so it
-/// reaches the banks through `addr_of_mut!` on the raw anchor rather than
-/// re-forming a whole `&mut PyreSym` alongside the tracer's.
-pub unsafe fn walk_active_sym_register_area(
-    data: *const (),
-    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
-) {
-    let cell = unsafe { &*(data as *const std::cell::Cell<*mut PyreSym>) };
-    let sym_ptr = cell.get();
-    if sym_ptr.is_null() {
-        return;
-    }
-    unsafe {
-        let bank = &mut *std::ptr::addr_of_mut!((*sym_ptr).registers_r);
-        for slot in bank.iter_mut() {
-            slot.walk_const_ptr_refs_mut(visitor);
-        }
-        // The bridge-setup overrides of the same bank, each of which a resume
-        // fills from `rd_consts` and can therefore carry an inline `ConstPtr`.
-        for bank in [
-            &mut *std::ptr::addr_of_mut!((*sym_ptr).bridge_registers_r),
-            &mut *std::ptr::addr_of_mut!((*sym_ptr).bridge_local_oprefs),
-            &mut *std::ptr::addr_of_mut!((*sym_ptr).bridge_stack_oprefs),
-        ] {
-            let Some(bank) = bank.as_mut() else { continue };
-            for slot in bank.iter_mut() {
-                slot.walk_const_ptr_refs_mut(visitor);
-            }
-        }
-        // The open sub-walks' own banks: each entry is the `(address, length)`
-        // of the Ref bank of a frame below this one, published for that
-        // frame's whole residency on `SubWalkDriver::frames` -- a parent
-        // suspended at a CALL keeps minted `ConstPtr`s in its bank while the
-        // child walks, so the publication outlives its own `walk` call.
-        // A shared borrow of the list is enough
-        // -- every bank it names is a separate allocation, so the `&mut`
-        // slices below do not alias it.
-        let inline = &*std::ptr::addr_of!((*sym_ptr).inline_register_banks);
-        for index in 0..inline.len() {
-            let (addr, len) = inline[index];
-            let bank = std::slice::from_raw_parts_mut(addr as *mut majit_ir::OpRef, len);
-            for slot in bank.iter_mut() {
-                slot.walk_const_ptr_refs_mut(visitor);
-            }
-        }
-    }
-}
-
-/// Publish an inline sub-walk's reference register bank on the active
-/// [`PyreSym`] for the length of the sub-walk, and take it back down on the way
-/// out — including an unwind, so an aborted callee body leaves no address the
-/// next collection would walk into a dead frame.
-///
-/// A null anchor (no trace in flight) makes this inert: nothing walks the bank
-/// then either.
+/// Without a trace in flight this is inert; there are no traced bank roots
+/// to publish.
 pub(crate) struct InlineRegisterBankGuard {
-    sym: *mut PyreSym,
+    _root: Option<crate::jitcode_dispatch::RegisterBankRoot>,
 }
 
 impl InlineRegisterBankGuard {
-    pub(crate) fn enter(bank: *mut [majit_ir::OpRef]) -> Self {
-        let sym = ACTIVE_SYM_EXC.with(|c| c.get());
-        if !sym.is_null() {
-            let entry = (bank as *mut majit_ir::OpRef as usize, bank.len());
-            unsafe {
-                (*std::ptr::addr_of_mut!((*sym).inline_register_banks)).push(entry);
-            }
-        }
-        Self { sym }
-    }
-}
-
-impl Drop for InlineRegisterBankGuard {
-    fn drop(&mut self) {
-        if self.sym.is_null() {
-            return;
-        }
-        unsafe {
-            (*std::ptr::addr_of_mut!((*self.sym).inline_register_banks)).pop();
+    pub(crate) fn enter(bank: &crate::jitcode_dispatch::RegisterBank) -> Self {
+        Self {
+            _root: ACTIVE_TRACE.with(|c| c.get().then(|| bank.root())),
         }
     }
 }
@@ -1407,12 +1288,9 @@ pub fn trace_bytecode<Sym: WalkSym>(
     // trace left unconsumed.
     let _ = crate::state::take_trace_abort_requested();
 
-    // Publish this trace's `sym` as the exception-carrier root anchor: a
-    // collection triggered by an allocating traced opcode marks the trace-built
-    // exception held only in `sym.trace_built_exc` (and the seeded/caught
-    // `last_exc_value` / `current_exc_value`). The guard restores the prior
-    // anchor on every return path, including panics and nested tracing.
-    let _active_sym_guard = sym.active_exc_anchor().map(set_active_sym_exc);
+    // Root this attempt's owned lists and exception slots through every exit,
+    // including nested attempts and unwind, without publishing a PyreSym borrow.
+    let _trace_roots = sym.enter_trace_roots();
 
     let ctx = meta
         .trace_ctx()
@@ -1864,7 +1742,7 @@ fn inject_root_call_result<Sym: WalkSym>(
         if bridge_regs.len() <= result_reg {
             bridge_regs.resize(result_reg + 1, majit_ir::OpRef::NONE);
         }
-        bridge_regs[result_reg] = result;
+        bridge_regs.set(result_reg, result);
     }
     let post_call_depth = residual_call
         .and_then(|(call_pc, _)| payload.depth_after_residual_for_jitcode_pc(call_pc))
@@ -1881,7 +1759,7 @@ fn inject_root_call_result<Sym: WalkSym>(
             if locals.len() <= semantic_result_slot {
                 locals.resize(semantic_result_slot + 1, majit_ir::OpRef::NONE);
             }
-            locals[semantic_result_slot] = result;
+            locals.set(semantic_result_slot, result);
         }
     } else {
         let slot = semantic_result_slot - nlocals;
@@ -1889,7 +1767,7 @@ fn inject_root_call_result<Sym: WalkSym>(
         if bridge.len() <= slot {
             bridge.resize(slot + 1, majit_ir::OpRef::NONE);
         }
-        bridge[slot] = result;
+        bridge.set(slot, result);
     }
     // `MIFrame.make_result_of_lastop` both stores the value and advances the
     // caller's stack pointer.  Without the matching depth update,
@@ -2073,6 +1951,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         is_being_profiled,
         ..Default::default()
     });
+    let _session_roots = crate::jitcode_dispatch::WalkSessionRoots::new(&session);
     crate::jitcode_dispatch::fbw_finish_payload_reset();
     crate::jitcode_dispatch::fbw_store_journal_reset();
     // A prior walk's blackhole image must not be adopted as this drain's
@@ -4085,6 +3964,7 @@ fn run_perfn_walk<Sym: WalkSym>(
         is_being_profiled,
         ..Default::default()
     });
+    let _session_roots = crate::jitcode_dispatch::WalkSessionRoots::new(&session);
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
         eprintln!("[walk-perfn] no per-CodeObject PyJitCode for code={w_code:?}");
         return None;
@@ -4460,7 +4340,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                 // shortcut below is wrong here because a kept temp's abstract
                 // color is not `nlocals + depth` under free register coloring.
                 if let Some(bridge_regs_r) = sym.bridge_registers_r() {
-                    for (color, &opref) in bridge_regs_r.iter().enumerate() {
+                    for (color, opref) in bridge_regs_r.iter().enumerate() {
                         if opref.is_none() {
                             continue;
                         }
@@ -4534,7 +4414,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                 // A NONE `bridge_stack[i]` (dead/empty slot) leaves the color's
                 // red seed intact — the red genuinely still owns the color there.
                 let nl = sym.nlocals();
-                for (i, &opref) in bridge_stack.iter().enumerate() {
+                for (i, opref) in bridge_stack.iter().enumerate() {
                     if !opref.is_none() {
                         let color = (nl + i) as u8;
                         seed(color, opref);
@@ -4557,7 +4437,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                         });
                 if let Some((color, opref)) = pending_result_color.and_then(|color| {
                     sym.bridge_registers_r()
-                        .and_then(|regs| regs.get(color).copied())
+                        .and_then(|regs| regs.get(color))
                         .filter(|opref| !opref.is_none())
                         .map(|opref| (color, opref))
                 }) {
@@ -6976,6 +6856,117 @@ mod tests {
     use pyre_interpreter::bytecode::Instruction;
     use pyre_interpreter::compile_exec;
     use pyre_interpreter::decode_instruction_at;
+
+    #[test]
+    fn nested_inline_banks_remain_visible_to_collector() {
+        // Diagnostic only: manually nesting anchors does not demonstrate a
+        // reachable nested trace. Upstream warmstate.py bound_reached owns a
+        // fresh MetaInterp per attempt; a translated collector sees all live
+        // attempts. Verify that an inner anchor cannot hide outer frame banks.
+        use crate::jitcode_dispatch::RegisterBank;
+        use crate::state::PyreSym;
+        use majit_ir::{GcRef, OpRef};
+
+        let _runtime = crate::trace_ctx_for_test(0);
+        let ptr = |word| OpRef::const_ptr(GcRef(word));
+        let outer = Box::new(PyreSym::new_uninit(OpRef::NONE));
+        let inner = Box::new(PyreSym::new_uninit(OpRef::NONE));
+        outer.registers_r.replace(vec![ptr(0x1000)]);
+        inner.registers_r.replace(vec![ptr(0x2000)]);
+        let outer_bank = RegisterBank::new([ptr(0x3000)]);
+        let inner_bank = RegisterBank::new([ptr(0x4000)]);
+        // Do not expose sentinel addresses to another test's real collector.
+        let _stw = majit_gc::gc_sync::quiesce_mutators();
+        let outer_anchor = super::TraceRoots::enter(&outer);
+        let outer_registration = super::InlineRegisterBankGuard::enter(&outer_bank);
+        let inner_anchor = super::TraceRoots::enter(&inner);
+        let inner_registration = super::InlineRegisterBankGuard::enter(&inner_bank);
+        let mut seen = Vec::new();
+        // Sentinel words are never dereferenced. This is a forwarding visitor,
+        // not a real collection. Use the actual registry, including the
+        // independently registered frame banks, not just the current anchor.
+        {
+            majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+                if (0x1000..0x5000).contains(&root.0) {
+                    seen.push(root.0);
+                    root.0 += 0x80;
+                }
+            });
+        }
+        drop(inner_registration);
+        drop(inner_anchor);
+        assert_eq!(seen, [0x1000, 0x3000, 0x2000, 0x4000]);
+        assert_eq!(outer.registers_r.to_vec(), [ptr(0x1080)]);
+        assert_eq!(outer_bank.get(0), Some(ptr(0x3080)));
+        assert_eq!(inner.registers_r.to_vec(), [ptr(0x2080)]);
+        assert_eq!(inner_bank.get(0), Some(ptr(0x4080)));
+
+        seen.clear();
+        {
+            majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+                if (0x1000..0x5000).contains(&root.0) {
+                    seen.push(root.0);
+                    root.0 += 0x80;
+                }
+            });
+        }
+        drop(outer_registration);
+        drop(outer_anchor);
+        assert_eq!(seen, [0x1080, 0x3080]);
+        assert_eq!(outer.registers_r.to_vec(), [ptr(0x1100)]);
+        assert_eq!(outer_bank.get(0), Some(ptr(0x3100)));
+    }
+
+    #[test]
+    fn nested_exception_roots_keep_outer_carriers_and_children() {
+        use majit_ir::OpRef;
+        use pyre_object::interp_exceptions::{ExcKind, W_BaseException, w_exception_new_empty};
+        pyre_interpreter::typedef::init_typeobjects();
+        let _pins = pyre_object::gc_roots::push_roots();
+        let outer_exc =
+            pyre_object::gc_roots::pin_root(w_exception_new_empty(ExcKind::UnicodeTranslateError));
+        let inner_exc = pyre_object::gc_roots::pin_root(w_exception_new_empty(ExcKind::TypeError));
+        let child =
+            pyre_object::gc_roots::pin_root(pyre_object::unicodeobject::w_str_new("outer child"));
+        let replacement = pyre_object::gc_roots::pin_root(pyre_object::unicodeobject::w_str_new(
+            "forwarded child",
+        ));
+        let _stw = majit_gc::gc_sync::quiesce_mutators();
+        // init_typeobjects entered the runtime thread and registered its
+        // mutator already; its TLS owner unregisters after these roots drop.
+        let outer = crate::state::PyreSym::new_uninit(OpRef::NONE);
+        let inner = crate::state::PyreSym::new_uninit(OpRef::NONE);
+        outer.last_exc_value.set(outer_exc);
+        inner.last_exc_value.set(inner_exc);
+        unsafe {
+            (*(outer_exc as *mut W_BaseException)).w_object = child;
+        }
+        let outer_roots = super::TraceRoots::enter(&outer);
+        let inner_roots = super::TraceRoots::enter(&inner);
+        let mut seen = Vec::new();
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            seen.push(root.0);
+            if root.0 == child as usize {
+                root.0 = replacement as usize;
+            }
+        });
+        assert!(seen.contains(&(outer_exc as usize)));
+        assert!(seen.contains(&(inner_exc as usize)));
+        assert!(seen.contains(&(child as usize)));
+        assert_eq!(
+            unsafe { (*(outer_exc as *const W_BaseException)).w_object },
+            replacement
+        );
+        drop(inner_roots);
+        seen.clear();
+        majit_gc::shadow_stack::walk_my_extra_areas(|root| {
+            seen.push(root.0);
+        });
+        assert!(seen.contains(&(outer_exc as usize)));
+        assert!(seen.contains(&(replacement as usize)));
+        assert!(!seen.contains(&(inner_exc as usize)));
+        drop(outer_roots);
+    }
 
     #[test]
     fn complete_image_walk_abort_keeps_blackhole_terminal_result() {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -424,6 +424,20 @@ pub(crate) struct InlineRegisterBankGuard {
     _root: Option<crate::jitcode_dispatch::RegisterBankRoot>,
 }
 
+/// Keep the frame's semantic mirrors rooted through both execution and
+/// suspension, just like the register bank owned by the same MIFrame.
+pub(crate) struct InlineFrameStateGuard {
+    _root: Option<crate::jitcode_dispatch::WalkFrameStateRoot>,
+}
+
+impl InlineFrameStateGuard {
+    pub(crate) fn enter(state: &crate::jitcode_dispatch::WalkFrameState) -> Self {
+        Self {
+            _root: ACTIVE_TRACE.with(|c| c.get().then(|| state.root())),
+        }
+    }
+}
+
 impl InlineRegisterBankGuard {
     pub(crate) fn enter(bank: &crate::jitcode_dispatch::RegisterBank) -> Self {
         Self {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -668,7 +668,7 @@ pub(crate) fn write_stack_slot(
         if reg_idx >= sym.registers_r.len() {
             sym.registers_r.resize(reg_idx + 1, OpRef::NONE);
         }
-        sym.registers_r[reg_idx] = boxed;
+        sym.registers_r.set(reg_idx, boxed);
     }
     if stack_idx >= sym.symbolic_stack_types.len() {
         sym.symbolic_stack_types.resize(stack_idx + 1, Type::Ref);
@@ -775,15 +775,17 @@ pub(crate) fn read_stack_slot(sym: &mut PyreSym, ctx: &mut TraceCtx, stack_idx: 
     if reg_idx >= sym.registers_r.len() {
         sym.registers_r.resize(reg_idx + 1, OpRef::NONE);
     }
-    if sym.registers_r[reg_idx] == OpRef::NONE {
+    if sym.registers_r.get(reg_idx).expect("bound Ref register") == OpRef::NONE {
         if sym.locals_cells_stack_array_ref == OpRef::NONE {
             sym.locals_cells_stack_array_ref = frame_locals_cells_stack_array(ctx, sym.frame);
         }
         let idx_const = ctx.const_int(semantic_idx as i64);
-        sym.registers_r[reg_idx] =
-            trace_array_getitem_value(ctx, sym.locals_cells_stack_array_ref, idx_const);
+        sym.registers_r.set(
+            reg_idx,
+            trace_array_getitem_value(ctx, sym.locals_cells_stack_array_ref, idx_const),
+        );
     }
-    sym.registers_r[reg_idx]
+    sym.registers_r.get(reg_idx).expect("bound Ref register")
 }
 
 /// Swap two operand-stack slots — third member of the
@@ -979,7 +981,7 @@ impl MIFrame {
     }
 
     #[doc(hidden)]
-    pub fn symbolic_registers_r(&self) -> &[OpRef] {
+    pub fn symbolic_registers_r(&self) -> &crate::jitcode_dispatch::RegisterList {
         &self.sym().registers_r
     }
 
@@ -1308,11 +1310,7 @@ impl MIFrame {
                         .virtualizable_box_at(nvs + semantic_idx)
                         .expect("get_list_of_active_boxes: missing vable frame box");
                 }
-                let val = s
-                    .registers_r
-                    .get(semantic_idx)
-                    .copied()
-                    .unwrap_or(OpRef::NONE);
+                let val = s.registers_r.get(semantic_idx).unwrap_or(OpRef::NONE);
                 if val != OpRef::NONE {
                     return val;
                 }
@@ -1323,7 +1321,7 @@ impl MIFrame {
                 if semantic_idx < nlocals {
                     let value = MIFrame::load_local_value(self, ctx, semantic_idx)
                         .expect("get_list_of_active_boxes: failed to lazy-load live local");
-                    self.sym_mut().registers_r[color_idx] = value;
+                    self.sym_mut().registers_r.set(color_idx, value);
                 } else {
                     // Stack lazy-fill: heap read at semantic index,
                     // store in both the semantic mirror (read_live) and
@@ -1340,8 +1338,8 @@ impl MIFrame {
                     if semantic_idx >= s.registers_r.len() {
                         s.registers_r.resize(semantic_idx + 1, OpRef::NONE);
                     }
-                    s.registers_r[semantic_idx] = value;
-                    s.registers_r[color_idx] = value;
+                    s.registers_r.set(semantic_idx, value);
+                    s.registers_r.set(color_idx, value);
                 }
             }
             let live_value = if live_value_pre == OpRef::NONE {
@@ -1390,7 +1388,7 @@ impl MIFrame {
             };
             let valid_len = (s.nlocals + valid_stack_only).min(source_len);
             let mut registers_i = s.registers_i.clone();
-            let mut registers_r_bank = s.registers_r.clone();
+            let mut registers_r_bank = s.registers_r.to_vec();
             let mut registers_f = s.registers_f.clone();
             for &(bank, reg_idx, value) in &bank_materializations {
                 match bank {
@@ -1430,7 +1428,7 @@ impl MIFrame {
                         .map(|idx| ctx.virtualizable_box_at(nvs + idx).unwrap_or(OpRef::NONE))
                         .collect()
                 } else {
-                    s.registers_r[..valid_len.min(s.registers_r.len())].to_vec()
+                    s.registers_r.iter().take(valid_len).collect()
                 };
             if in_a_call {
                 if let Some(result_idx) = self.pending_result_stack_idx {
@@ -1717,7 +1715,7 @@ impl MIFrame {
         if idx >= s.registers_r.len() {
             return Err(PyError::type_error("local index out of range in trace"));
         }
-        if s.registers_r[idx] == OpRef::NONE {
+        if s.registers_r.get(idx).expect("bound Ref register") == OpRef::NONE {
             if s.bridge_local_oprefs.is_some() {
                 // Bridge trace: OpRef::NONE means this local is a constant
                 // or virtual from resume data, not a missing vable slot.
@@ -1752,7 +1750,8 @@ impl MIFrame {
                 let frame_ref = s.frame;
                 let array_ref = crate::state::frame_locals_cells_stack_array(ctx, frame_ref);
                 let idx_const = ctx.const_int(idx as i64);
-                s.registers_r[idx] = trace_array_getitem_value(ctx, array_ref, idx_const);
+                s.registers_r
+                    .set(idx, trace_array_getitem_value(ctx, array_ref, idx_const));
             } else {
                 // Active vable owner whose registers_r[idx] is NONE cannot
                 // exist: init_symbolic (state.rs) seeds
@@ -1767,11 +1766,13 @@ impl MIFrame {
                 // locals_cells_stack_w array (seeded by Stage 1 at
                 // the retired inline-call path).
                 let idx_const = ctx.const_int(idx as i64);
-                s.registers_r[idx] =
-                    trace_array_getitem_value(ctx, s.locals_cells_stack_array_ref, idx_const);
+                s.registers_r.set(
+                    idx,
+                    trace_array_getitem_value(ctx, s.locals_cells_stack_array_ref, idx_const),
+                );
             }
         }
-        Ok(s.registers_r[idx])
+        Ok(s.registers_r.get(idx).expect("bound Ref register"))
     }
 
     #[allow(dead_code)]
@@ -2327,8 +2328,7 @@ impl MIFrame {
                     .collect();
                 (locals_vec, stack_vec)
             } else {
-                let read_color =
-                    |color: usize| s.registers_r.get(color).copied().unwrap_or(OpRef::NONE);
+                let read_color = |color: usize| s.registers_r.get(color).unwrap_or(OpRef::NONE);
                 let locals_vec: Vec<OpRef> = (0..nlocals).map(|i| read_color(i)).collect();
                 let live_stack_len = stack_only.min(target_stack_capacity);
                 let stack_vec: Vec<OpRef> = (0..live_stack_len)
@@ -2550,7 +2550,7 @@ impl MIFrame {
                     // slot regardless of whether the dedup refers to a
                     // local or a stack entry.
                     if local_idx < s.registers_r.len() {
-                        s.registers_r[local_idx] = new_opref;
+                        s.registers_r.set(local_idx, new_opref);
                     }
                 }
             }
@@ -2994,7 +2994,7 @@ impl MIFrame {
                 pre_r[..pre_r.len().min(nlocals)].to_vec()
             } else {
                 let s = self.sym();
-                s.registers_r[..s.registers_r.len().min(nlocals)].to_vec()
+                s.registers_r.iter().take(nlocals).collect()
             };
             let mut diverge = 0usize;
             for i in 0..registers_r_src.len() {
@@ -3605,9 +3605,9 @@ mod tests {
         );
 
         let mut sym = PyreSym::new_uninit(OpRef::NONE);
-        sym.bridge_local_oprefs = Some(Vec::new()); // owns via the bridge half
+        sym.bridge_local_oprefs.replace(Vec::new()); // owns via the bridge half
         sym.nlocals = 0;
-        sym.registers_r = vec![OpRef::NONE; 2]; // swap's semantic mirror needs both slots
+        sym.registers_r.replace(vec![OpRef::NONE; 2]); // swap's semantic mirror needs both slots
         assert!(sym.owns_virtualizable_shadow());
 
         let ptr = 0xdead_beef_usize as *mut pyre_object::pyobject::PyObject;
@@ -3705,7 +3705,7 @@ mod tests {
         sym.valuestackdepth = 2;
         sym.execution_context = OpRef::input_arg_ref(0);
         sym.registers_i = vec![OpRef::NONE, OpRef::NONE, int_box];
-        sym.registers_r = vec![OpRef::NONE, ref_box];
+        sym.registers_r.replace(vec![OpRef::NONE, ref_box]);
         sym.registers_f = vec![OpRef::NONE, OpRef::NONE, OpRef::NONE, float_box];
 
         let mut ctx = crate::trace_ctx_for_test(1);
@@ -3800,7 +3800,7 @@ mod tests {
         // Semantic mirror: local0 is at slot 0, while stack depth 0 is at
         // semantic slot 2. Liveness color 0 belongs to the live stack slot,
         // reusing dead local0's color.
-        sym.registers_r = vec![local0, local1, stack0];
+        sym.registers_r.replace(vec![local0, local1, stack0]);
 
         let mut ctx = crate::trace_ctx_for_test(1);
         let mut frame = MIFrame {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -296,6 +296,38 @@ mod tests {
     }
 
     #[test]
+    fn blackhole_leave_marks_a_parent_beyond_1024_frames() {
+        std::thread::spawn(|| {
+            let mut ec = pyre_interpreter::PyExecutionContext::default();
+            // Allocate the complete chain before publishing any pointers.
+            let mut frames: Vec<PyFrame> = (0..1026).map(|_| stack_pyframe()).collect();
+            let base = frames.as_mut_ptr();
+            for index in 1..frames.len() {
+                // Keep accesses derived from the published allocation pointer;
+                // do not reborrow the Vec's entire mutable slice between links.
+                unsafe { (*base.add(index)).f_backref = base.add(index - 1) };
+            }
+            let top = unsafe { base.add(frames.len() - 1) };
+            ec.topframeref = top;
+            pyre_interpreter::call::set_last_exec_ctx(&mut ec);
+            let mut bh = majit_metainterp::blackhole::BlackholeInterpreter::default();
+            bh.virtualizable_ptr = base as i64;
+            super::leave_resumed_blackhole_frame(&bh, false);
+            // Clear the TLS anchor before an assertion can unwind the frame owner.
+            pyre_interpreter::call::set_last_exec_ctx(std::ptr::null_mut());
+            assert!(frames[0].frame_finished_execution());
+            assert!(
+                frames[1..]
+                    .iter()
+                    .all(|frame| !frame.frame_finished_execution())
+            );
+            assert!(std::ptr::eq(ec.topframeref, top));
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
     fn blackhole_leave_closes_the_open_scope() {
         std::thread::spawn(|| {
             let mut ec = pyre_interpreter::PyExecutionContext::default();
@@ -2507,10 +2539,10 @@ fn frame_is_on_unforced_ec_chain(
     frame_ptr: *mut PyFrame,
 ) -> bool {
     let mut cur = unsafe { pyre_interpreter::executioncontext::vref_referent((*ec).topframeref) };
-    for _ in 0..1024 {
-        if cur.is_null() {
-            return false;
-        }
+    // ExecutionContext.enter/leave (executioncontext.py) maintain a chain
+    // ending at null, not a fixed-depth window. A recovered ancestor may be
+    // arbitrarily far below the open scope when the recursion limit is raised.
+    while !cur.is_null() {
         if std::ptr::eq(cur, frame_ptr) {
             return true;
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5087,11 +5087,6 @@ fn walk_parked_exception_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // Stored `PyError` carrier whose GC refs the precise collector cannot
     // reach through its raw TLS cell. Mirrors `walk_pending_call_error`.
     crate::call_jit::walk_last_ca_exception(visitor);
-    // Trace-time exception carriers held only in the active `PyreSym`
-    // (`trace_built_exc` / `last_exc_value` / `current_exc_value`): a
-    // trace-built exception is unreachable to the precise collector between its
-    // construction and the RAISE_VARARGS lift-out.
-    pyre_jit_trace::trace::walk_active_sym_exc_roots(visitor);
 }
 
 /// The immortal, process-global stores whose GC-heap slots nothing else
@@ -5196,11 +5191,6 @@ fn register_thread_root_areas() {
             walk_end_root_walker_area,
             pyre_jit_trace::trace::capture_walk_end_root_area(),
             "walk_end",
-        );
-        register(
-            active_sym_registers_root_walker_area,
-            pyre_jit_trace::trace::capture_active_sym_root_area(),
-            "active_sym_registers",
         );
         register(
             mapdict_root_walker_area,
@@ -6098,19 +6088,6 @@ unsafe fn fbw_finish_payload_root_walker_area(
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
     unsafe { pyre_jit_trace::jitcode_dispatch::fbw_finish_payload_root_walker_area(data, visitor) };
-}
-
-/// The recording walk's own reference register banks, whose inline `ConstPtr`
-/// GcRefs nothing else forwards.  See
-/// `pyre_jit_trace::trace::walk_active_sym_register_area`.
-///
-/// # Safety
-/// `data` must be this mutator's `capture_active_sym_root_area()`.
-unsafe fn active_sym_registers_root_walker_area(
-    data: *const (),
-    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
-) {
-    unsafe { pyre_jit_trace::trace::walk_active_sym_register_area(data, visitor) };
 }
 
 unsafe fn walk_end_root_walker_area(
@@ -16403,7 +16380,10 @@ mod tests {
             let stack_value = [stack0, stack1][depth];
             let semantic_idx = 2 + depth;
             assert_eq!(
-                state.symbolic_registers_r()[semantic_idx],
+                state
+                    .symbolic_registers_r()
+                    .get(semantic_idx)
+                    .expect("bound semantic register"),
                 stack_value,
                 "stack depth {} must be in semantic registers_r[{}]",
                 depth,
@@ -16948,8 +16928,11 @@ mod tests {
             "register file must cover the virtualizable window"
         );
         assert!(
-            state.symbolic_registers_r()[nlocals..nlocals + stack_only]
+            state
+                .symbolic_registers_r()
                 .iter()
+                .skip(nlocals)
+                .take(stack_only)
                 .all(|opref| !opref.is_none()),
             "live stack slots carried by the JUMP must be preserved"
         );

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -635,15 +635,12 @@ assert result == 21, result
 }
 
 /// A trace-built exception raised with a bare-class `from` cause survives a
-/// collection that fires while the fresh exception lives only in the tracer's
-/// `sym.trace_built_exc` (window A). `raise ValueError(n) from KeyError` builds
-/// the `ValueError(n)` instance at trace time and parks it in `trace_built_exc`;
-/// the `KeyError` cause normalization then allocates (a GC safepoint) before the
-/// instance is lifted back out at the raise. The `walk_active_sym_exc_roots`
-/// root walker keeps the parked instance alive across that collection — without
-/// it the caught exception's `args` are read from a swept block (wrong value or
-/// fault). Under `MAJIT_GC_STRESS` every allocation forces a full collection, so
-/// the cause normalization deterministically hits the window.
+/// collection during construction and cause normalization. The generated walk
+/// carries concrete exceptions on recorder boxes and the active exception
+/// slots; it no longer has the retired PyreSym.trace_built_exc map. Preserve
+/// this end-to-end assertion independently of that former implementation.
+/// Under `MAJIT_GC_STRESS`, cause normalization also exercises allocating
+/// safepoints before the raised instance reaches the handler.
 #[test]
 fn trace_built_exc_from_class_cause_survives_collection() {
     const PROGRAM: &str = r#"


### PR DESCRIPTION
## Summary

- Replace retained mutable register-bank pointers with frame-owned Cell storage, preserving the mutable-register prefix and constant suffix.
- Publish scoped roots for dynamic Ref mirrors, exception carriers and per-attempt WalkSession state. Nested owners retain independent root coverage; exception child traversal is preserved.
- Root paused parent boxes and session scratch, remove the non-upstream 1024-frame EC-chain cutoff, and cover forwarding, independent retirement, unwind and bounds invariants.
- Put concrete Ref registers, callee shadows, operand/saved stacks and exception seeds in shared frame-owned storage; root the callee bank before frame allocation.
- Replace paused frame values synchronously, remove queued replay, and route all five direct promotion/replacement bypasses through full-frame replacement. Preserve typed register prefixes and constant suffixes.
- Release frame-state borrows before allocating locals writeback; reload later Ref slots from the rooted shared owner, root the destinations, and publish that same owner during residual force. This addresses the new boxing/GC review regression without creating unrooted shadow copies.
- Share CALL_PURE's `args_dict` across trace/compile/optimizer phases, root each cached Ref key/result independently, and hash reference keys by move-stable GC identity. Remove the native take/snapshot handoff; collection no longer loses cache hits or leaves stale cached references.
- Rebase onto origin/main `0b5c40fd08b`. Preserve main's consolidated qmut abort path and connect it to the moved frame-owned stack.

The ownership reference is PyPy's MIFrame register lists, MetaInterp.framestack/replace_box, and translated shadow-stack push_roots/pop_roots. Native scoped registration is explicit; this does not claim every generated-walker adaptation has converged.

## Verification

- Full workspace tests on the rebased cache change: dynasm and cranelift, each with --no-default-features. Metainterp: 1831/1829 passed respectively (1 ignored); trace: 470 passed, 8 ignored on both.
- `python3 pyre/check.py`: dynasm 549/549, cranelift 549/549, wasm 542/542. No baseline edits.
- Release strict CPython filters on both native backends: pickle 3 modules and threading 2 modules pass. Dynasm includes cpyext.
- New real MiniMarkGC test passes on both native feature sets: Ref keys/results survive forwarding and compiler handoff, equal forwarded keys replace the original entry, and the last owner retires all roots. A separate unit test covers typed constant equality, signed zero, NaN bits and shared dictionary identity.
- Earlier root-patch checks: base register bank/list actual-source Miri tests pass both borrow models (not a Miri claim for the new frame-state module). The frame-root release probe reaches all five root callbacks during a traced residual `gc.collect()`; observed trace depth is 1, not proof of production nested attempts. Synthetic forwarding tests cover nested owner publication, independent retirement, and collection between scalar writeback and later Ref slots. The writeback debugger probe reaches an inlined callee's traceback path; it is not claimed to reproduce the original failure naturally. These Miri/debugger probes were not rerun for the cache step.
- Independent parity review: no findings in sections 1–3; one documented native ownership adaptation in section 4, verified and retained. Formatting and diff checks pass.
- After a citation-only edit caused the initial dynasm build-window warning, a stable-input rebuild produced the identical executable SHA-256 as the full gate and stamped it normally. `--build=no` then accepted the build and `pickle_terminal_raise_resume` passed again. No manual stamp or baseline changes.

## Continuing work

Paused walker extras/concrete shadows now share frame-owned storage and immediate replacement; the call-pure cache now owns traced constants through compilation. The separate whole-driver mutable GC alias remains open and requires persistent/per-attempt ownership and execution-access boundaries. Temporary call-setup buffers and unrelated heapcache keys still require their own root/allocation-window census. These are not marked resolved by the cache fix. No automatic merge is requested.
