### PR TITLE
ir, backend: slimmer Ops and compile from OpRc

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -9249,10 +9249,14 @@ impl CraneliftBackend {
         inject_builtin_string_descrs(&mut normalized);
         {
             let rewriter = self.gc_rewriter();
+            // The rewriter takes/returns `OpRc`; cranelift still owns a
+            // `Vec<Op>` past this boundary, so wrap and unwrap here.
+            let boxed: Vec<OpRc> = normalized.into_iter().map(OpRc::new).collect();
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
             let (result, new_constants, gcrefs) =
-                rewriter.rewrite_for_gc_with_constants(&normalized, constants);
+                rewriter.rewrite_for_gc_with_constants(&boxed, constants);
+            let result: Vec<Op> = result.iter().map(|rc| (**rc).clone()).collect();
             // rewrite.py creates fresh ConstInt boxes for sizes, offsets
             // and helper addresses; `new_constants` is the full typed pool.
             // Pre-existing keys `or_insert`-no-op, keeping their original

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -21,7 +21,7 @@ pub(crate) type Assembler = dynasmrt::VecAssembler<dynasmrt::aarch64::Aarch64Rel
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
 use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
-use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRef, OpTypeIndex, TargetArgLoc, Type};
+use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRc, OpRef, OpTypeIndex, TargetArgLoc, Type};
 
 use crate::arch::*;
 use crate::codebuf;
@@ -497,7 +497,7 @@ pub struct AssemblerARM64<'a> {
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
     /// `op.type_` directly, RPython `box.type` parity).
-    operations: &'a [Op],
+    operations: &'a [OpRc],
     /// `arg.index` raw -> idx in inputargs, sentinel
     /// [`OpTypeIndex::NO_POS`] for unset slots. Mirrors
     /// `OpTypeIndex::inputarg_pos`.
@@ -749,7 +749,7 @@ impl<'a> AssemblerARM64<'a> {
         cpu_handle: crate::guard::CpuDescrHandle,
         malloc_slowpath_fixed: usize,
         inputargs: &'a [InputArg],
-        operations: &'a [Op],
+        operations: &'a [OpRc],
     ) -> Self {
         let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
@@ -2074,7 +2074,7 @@ impl<'a> AssemblerARM64<'a> {
     /// old frame-slot model where every value went through [rbp+offset].
     fn _assemble(&mut self, emit_prologue: bool) -> Result<(), BackendError> {
         let inputargs: &'a [InputArg] = self.inputargs;
-        let ops: &'a [Op] = self.operations;
+        let ops: &'a [OpRc] = self.operations;
         self.short_guard_branch_offsets.clear();
         self.guard_reach_violations.clear();
         self.unrelocated_jump_target = None;
@@ -2338,7 +2338,7 @@ impl<'a> AssemblerARM64<'a> {
         arglocs: &[Loc],
         result_loc: Option<&Loc>,
         fail_index: u32,
-        ops: &[Op],
+        ops: &[OpRc],
     ) {
         // Only an ADJACENT comparison/guard pair may share NZCV; anything
         // emitted in between invalidates the record (the comparison arms
@@ -5387,7 +5387,7 @@ impl<'a> AssemblerARM64<'a> {
     /// assembler.py _store_force_index: before a call that may force,
     /// store the next GUARD_NOT_FORCED's fail descr ptr to jf_force_descr,
     /// and zero jf_descr so GUARD_NOT_FORCED's CMP [jf_descr], 0 starts clean.
-    fn _store_force_index_if_next_guard(&mut self, ops: &[Op], op_idx: usize, fail_index: u32) {
+    fn _store_force_index_if_next_guard(&mut self, ops: &[OpRc], op_idx: usize, fail_index: u32) {
         // assembler.py _find_nearby_operation(+1)
         let next_idx = op_idx + 1;
         if next_idx >= ops.len() {

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -285,7 +285,7 @@ impl<'a> RegAlloc<'a> {
         );
         let arg_loc = self.make_sure_var_in_reg(arg, Type::Int, &[], None, false);
         self.possibly_free_var(arg, Type::Int);
-        let ops_ref: &[majit_ir::Op] = self.operations;
+        let ops_ref: &[majit_ir::OpRc] = self.operations;
         let res = self.force_allocate_reg_or_cc(dst, ops_ref, i);
         self.perform(i, vec![arg_loc], Some(res), output);
     }

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -173,11 +173,11 @@ pub(crate) struct TracePlan {
 impl TracePlan {
     /// Production lowering entry point. Register allocation uses only lowered
     /// operations, while reverse liveness is for diagnostics.
-    pub(crate) fn lower_ops(ops: &[Op]) -> Vec<LirOp> {
-        ops.iter().map(lower_op).collect()
+    pub(crate) fn lower_ops<T: AsRef<Op>>(ops: &[T]) -> Vec<LirOp> {
+        ops.iter().map(|op| lower_op(op.as_ref())).collect()
     }
 
-    pub(crate) fn build(inputargs: &[InputArg], ops: &[Op]) -> Self {
+    pub(crate) fn build<T: AsRef<Op>>(inputargs: &[InputArg], ops: &[T]) -> Self {
         let lowered = Self::lower_ops(ops);
         let live_points = compute_live_points(&lowered);
         let max_live = live_points

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -20,7 +20,7 @@ use crate::arch::*;
 use crate::gcmap::{allocate_gcmap, gcmap_set_bit};
 use crate::j2plan::{GuardKind, IntBinKind, IntUnaryKind, LirOp, LoadKind, StoreKind};
 use crate::regloc::*;
-use majit_ir::{InputArg, Op, OpCode, OpRef, OpTypeIndex, Type, descr_identity};
+use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, OpTypeIndex, Type, descr_identity};
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -418,12 +418,15 @@ impl LifetimeManager {
 // ── compute_vars_longevity ─────────────────────────────────────────
 
 /// regalloc.py compute_vars_longevity — backward liveness analysis.
-pub fn compute_vars_longevity(inputargs: &[InputArg], operations: &[Op]) -> LifetimeManager {
+pub fn compute_vars_longevity<T: AsRef<Op>>(
+    inputargs: &[InputArg],
+    operations: &[T],
+) -> LifetimeManager {
     let mut longevity = LifetimeManager::new();
 
     // regalloc.py:1179 iterate operations in REVERSE
     for i in (0..operations.len()).rev() {
-        let op = &operations[i];
+        let op = operations[i].as_ref();
         let opnum = op.opcode;
         let opref = op.pos.get();
         let i = i as i32;
@@ -1479,14 +1482,14 @@ impl RegisterManager {
     /// regalloc.py — RPython reads `v.type` directly during the
     /// reg-binding walk; pyre routes the lookup through `OpTypeIndex`
     /// since `OpRef(u32)` has no intrinsic type.
-    pub fn before_call(
+    pub fn before_call<T: AsRef<Op>>(
         &mut self,
         force_store: &[OpRef],
         save_all_regs: u8,
         longevity: &mut LifetimeManager,
         fm: &mut FrameManager,
         pending_moves: &mut Vec<(Loc, Loc)>,
-        type_index: &OpTypeIndex<'_>,
+        type_index: &OpTypeIndex<'_, T>,
     ) {
         self.spill_or_move_registers_before_call(
             &self.save_around_call_regs.clone(),
@@ -1500,7 +1503,7 @@ impl RegisterManager {
     }
 
     /// regalloc.py:714
-    pub fn spill_or_move_registers_before_call(
+    pub fn spill_or_move_registers_before_call<T: AsRef<Op>>(
         &mut self,
         save_sublist: &[RegLoc],
         force_store: &[OpRef],
@@ -1508,7 +1511,7 @@ impl RegisterManager {
         longevity: &mut LifetimeManager,
         fm: &mut FrameManager,
         pending_moves: &mut Vec<(Loc, Loc)>,
-        type_index: &OpTypeIndex<'_>,
+        type_index: &OpTypeIndex<'_, T>,
     ) {
         let mut new_free_regs: Vec<RegLoc> = Vec::new();
         let mut move_or_spill: Vec<OpRef> = Vec::new();
@@ -1696,7 +1699,7 @@ pub struct RegAlloc<'a> {
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
     /// `op.type_` directly, RPython `box.type` parity).
-    pub(crate) operations: &'a [Op],
+    pub(crate) operations: &'a [OpRc],
     /// `arg.index` raw -> idx in inputargs. Mirrors
     /// `OpTypeIndex::inputarg_pos`.
     inputarg_pos: majit_ir::PosIndex,
@@ -1732,7 +1735,7 @@ impl<'a> RegAlloc<'a> {
     pub fn new(
         constants: indexmap::IndexMap<u32, i64>,
         inputargs: &'a [InputArg],
-        operations: &'a [Op],
+        operations: &'a [OpRc],
     ) -> Self {
         // We create with empty longevity/managers; they get initialized in _prepare.
         let longevity = LifetimeManager::new();
@@ -2399,7 +2402,7 @@ impl<'a> RegAlloc<'a> {
 
     /// x86/regalloc.py walk_operations — main dispatch loop.
     pub fn walk_operations(&mut self) -> Vec<RegAllocOp> {
-        let operations: &'a [Op] = self.operations;
+        let operations: &'a [OpRc] = self.operations;
         let inputargs: &'a [InputArg] = self.inputargs;
         // Take the lowering plan so dispatch can borrow each LirOp without cloning it.
         let j2_ops = std::mem::take(&mut self.j2_ops);
@@ -3455,7 +3458,7 @@ impl<'a> RegAlloc<'a> {
         if !lhs_in_reg && !rhs_in_reg && !lhs.is_constant() && !rhs.is_constant() {
             arglocs[0] = self.make_sure_var_in_reg(lhs, Type::Int, &[], None, false);
         }
-        let ops_ref: &[Op] = self.operations;
+        let ops_ref: &[OpRc] = self.operations;
         let result_loc = self.force_allocate_reg_or_cc(dst, ops_ref, i);
         self.perform(i, arglocs, Some(result_loc), output);
     }
@@ -3683,11 +3686,11 @@ impl<'a> RegAlloc<'a> {
     /// - `CondCallN` via `guard_success_cc` (see
     ///   `genop_discard_cond_call`, mirrors `x86/assembler.py:2526
     ///   cond_call`).
-    fn next_op_can_accept_cc(&self, ops: &[Op], i: usize, result: OpRef) -> bool {
+    fn next_op_can_accept_cc<T: AsRef<Op>>(&self, ops: &[T], i: usize, result: OpRef) -> bool {
         if i + 1 >= ops.len() {
             return false;
         }
-        let next_op = &ops[i + 1];
+        let next_op = ops[i + 1].as_ref();
         let opnum = next_op.opcode;
         if !matches!(
             opnum,
@@ -3749,7 +3752,12 @@ impl<'a> RegAlloc<'a> {
     /// and `aarch64/assembler.rs flush_cc` publish `guard_success_cc` and
     /// emit nothing when `result_loc` is the frame register, so neither
     /// clobbers rbp / x29.
-    pub(crate) fn force_allocate_reg_or_cc(&mut self, result: OpRef, ops: &[Op], i: usize) -> Loc {
+    pub(crate) fn force_allocate_reg_or_cc<T: AsRef<Op>>(
+        &mut self,
+        result: OpRef,
+        ops: &[T],
+        i: usize,
+    ) -> Loc {
         if self.next_op_can_accept_cc(ops, i, result) {
             self.rm.force_allocate_frame_reg(result);
             return Loc::Reg(arch_regalloc::frame_reg());
@@ -3769,7 +3777,7 @@ impl<'a> RegAlloc<'a> {
             arglocs[0] = self.make_sure_var_in_reg(vx, Type::Int, &[], None, false);
         }
         // x86/regalloc.py force_allocate_reg_or_cc.
-        let ops_ref: &[Op] = self.operations;
+        let ops_ref: &[OpRc] = self.operations;
         let result_loc = self.force_allocate_reg_or_cc(op.pos.get(), ops_ref, i);
         self.perform(i, arglocs, Some(result_loc), output);
     }
@@ -4281,7 +4289,7 @@ impl<'a> RegAlloc<'a> {
         }
         // x86/regalloc.py:682 — a float comparison whose only consumer is the
         // next guard leaves its answer in the flags, like the integer one.
-        let ops_ref: &[Op] = self.operations;
+        let ops_ref: &[OpRc] = self.operations;
         let result_loc = self.force_allocate_reg_or_cc(op.pos.get(), ops_ref, i);
         self.perform(i, arglocs, Some(result_loc), output);
     }
@@ -4300,7 +4308,7 @@ impl<'a> RegAlloc<'a> {
         if !lhs_in_reg && !rhs_in_reg && !lhs.is_constant() {
             arglocs[0] = self.make_sure_var_in_reg(lhs, Type::Float, &[], None, false);
         }
-        let ops_ref: &[Op] = self.operations;
+        let ops_ref: &[OpRc] = self.operations;
         let result_loc = self.force_allocate_reg_or_cc(dst, ops_ref, i);
         self.perform(i, arglocs, Some(result_loc), output);
     }
@@ -6265,9 +6273,13 @@ mod tests {
     use super::*;
 
     use majit_ir::operand::Operand;
-    use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
+    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
     use majit_ir::forwarding::bound_operand_from_opref as rb;
+
+    fn rcs(ops: Vec<Op>) -> Vec<OpRc> {
+        ops.into_iter().map(OpRc::new).collect()
+    }
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
         let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
@@ -6443,6 +6455,7 @@ mod tests {
         finish.set_fail_arg_types(vec![Type::Ref, Type::Ref]);
         let ops = vec![malloc, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let unrelated = all_core_regs()
@@ -6508,6 +6521,7 @@ mod tests {
         let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
 
         let ops = vec![add, is_true, guard, finish];
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(constants, &inputargs, &ops);
         ra.prepare_loop();
         let ra_ops = ra.walk_operations();
@@ -6566,6 +6580,7 @@ mod tests {
         ops.push(guard);
         ops.push(finish);
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         ra.walk_operations();
@@ -6597,6 +6612,7 @@ mod tests {
         let store = Op::new(OpCode::GcStore, &[rb(i0), rb(c0), rb(i0)]);
         let ops = vec![store];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         ra.j2_ops[0] = crate::j2plan::LirOp::Finish { args: vec![i0] };
@@ -6644,6 +6660,7 @@ mod tests {
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let expected_argloc = ra.loc(i1, Type::Int);
@@ -6702,6 +6719,7 @@ mod tests {
         finish.pos.set(OpRef::void_op(2));
         let ops = vec![malloc, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let ra_ops = ra.walk_operations();
@@ -6741,6 +6759,7 @@ mod tests {
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let expected_argloc = ra.loc(i1, Type::Int);
@@ -6777,6 +6796,7 @@ mod tests {
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let expected_argloc = ra.loc(i1, Type::Ref);
@@ -6820,6 +6840,7 @@ mod tests {
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let expected_argloc = ra.loc(i1, Type::Ref);
@@ -6858,6 +6879,7 @@ mod tests {
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let expected_argloc = ra.loc(i1, Type::Int);
@@ -6898,6 +6920,7 @@ mod tests {
         let inputargs = vec![];
         let ops = vec![force, make_guard(OpCode::GuardNotForced2, 1, &[], &[token])];
 
+        let ops = rcs(ops);
         let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
         ra.prepare_loop();
         let output = ra.walk_operations();

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -17,7 +17,7 @@ use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, JitCellToken};
 // `gc_sync` hands out the concrete collector; the trait must be in scope for
 // its methods to resolve on that type.
 use majit_gc::GcAllocator;
-use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, OpRef, Type, Value};
+use majit_ir::{FailDescr, GcRef, InputArg, OpRc, OpRef, Type, Value};
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::assembler::{AssemblerARM64 as Asm, CompiledCode};
@@ -2039,35 +2039,32 @@ impl DynasmBackend {
     fn prepare_ops_for_compile(
         &mut self,
         inputargs: &[InputArg],
-        ops: &[Op],
-    ) -> (Vec<Op>, Vec<GcRef>) {
+        ops: &[OpRc],
+    ) -> (Vec<OpRc>, Vec<GcRef>) {
         let num_inputs = inputargs.len() as u32;
-        let mut normalized: Vec<Op> = ops
-            .iter()
-            .enumerate()
-            .map(|(op_idx, op)| {
-                let n = op.clone();
-                if n.result_type() != Type::Void && n.pos.get().is_none() {
-                    let pos = num_inputs + op_idx as u32;
-                    n.pos.set(match n.result_type() {
-                        Type::Int => OpRef::int_op(pos),
-                        Type::Float => OpRef::float_op(pos),
-                        Type::Ref => OpRef::ref_op(pos),
-                        Type::Void => unreachable!("filtered above"),
-                    });
-                }
-                n
-            })
-            .collect();
+        // rewrite.py assemble_loop mutates the same ResOperation objects.
+        // `pos` and `descr` are interior-mutable, so the incoming `OpRc`
+        // identities stay shared with the optimizer — no `Op` clone.
+        for (op_idx, op) in ops.iter().enumerate() {
+            if op.result_type() != Type::Void && op.pos.get().is_none() {
+                let pos = num_inputs + op_idx as u32;
+                op.pos.set(match op.result_type() {
+                    Type::Int => OpRef::int_op(pos),
+                    Type::Float => OpRef::float_op(pos),
+                    Type::Ref => OpRef::ref_op(pos),
+                    Type::Void => unreachable!("filtered above"),
+                });
+            }
+        }
         // rewrite.py:489 parity: inject str_descr/unicode_descr for NEWSTR/NEWUNICODE
-        inject_builtin_string_descrs(&mut normalized);
+        inject_builtin_string_descrs(ops);
         {
             let rewriter = self.gc_rewriter();
             use majit_gc::GcRewriter;
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
             let (result, new_constants, gcrefs) =
-                rewriter.rewrite_for_gc_with_constants(&normalized, &self.constants);
+                rewriter.rewrite_for_gc_with_constants(ops, &self.constants);
             // `new_constants` is the full typed pool: the rewriter clones the
             // current pool and only appends fresh ConstInts (size/offset/
             // helper-address keys minted above the existing max index — see
@@ -2148,7 +2145,7 @@ impl DynasmBackend {
     /// the resolver as a IndexMap up front.
     fn collect_classptr_typeid_table(
         &self,
-        ops: &[Op],
+        ops: &[OpRc],
         const_pool: &majit_ir::ConstMap<majit_ir::Const>,
     ) -> indexmap::IndexMap<i64, u32> {
         let mut table = indexmap::IndexMap::new();
@@ -2192,7 +2189,7 @@ impl DynasmBackend {
     /// per-box side table.
     fn collect_classptr_subclass_range_table(
         &self,
-        ops: &[Op],
+        ops: &[OpRc],
     ) -> indexmap::IndexMap<i64, (i64, i64)> {
         let mut table = indexmap::IndexMap::new();
         if with_dynasm_active_gc(|_| ()).is_none() {
@@ -2465,18 +2462,12 @@ impl Backend for DynasmBackend {
         if let Some(clt) = token.compiled_loop_token() {
             majit_backend::record_compiled_loop_token(&self.cpu_tracker, &clt);
         }
-        // Deep-clone Op out of OpRc for the internal pipeline. Backend
-        // stages do not depend on shared `_forwarded` identity with the
-        // trace; the optimizer has already resolved forwarding by the
-        // time ops reach `compile_loop` (history.py:528 vs. the
-        // backend-emit `Vec<Op>` boundary).
-        let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         token.set_inputarg_types(inputargs.iter().map(|ia| ia.tp).collect());
         let trace_id = self.next_trace_id;
         self.next_trace_id += 1;
         let header_pc = self.next_header_pc;
         // gc.py rewrite_assembler parity: run GC rewriter before regalloc.
-        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, &ops_owned);
+        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, ops);
         // The assembler stores the typed `Const` pool directly; each box
         // variant carries its own type (`Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
@@ -2721,13 +2712,10 @@ impl Backend for DynasmBackend {
         if let Some(clt) = original_token.compiled_loop_token() {
             clt.compiling_a_bridge(&self.cpu_tracker);
         }
-        // Deep-clone Op out of OpRc for the internal pipeline (see
-        // compile_loop above for rationale).
-        let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let trace_id = self.next_trace_id;
         self.next_trace_id += 1;
 
-        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, &ops_owned);
+        let (prepared_ops, gcrefs) = self.prepare_ops_for_compile(inputargs, ops);
         // format_trace reads raw `i64` values; the assembler stores the
         // typed `Const` pool directly (type rides on `Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
@@ -4144,7 +4132,8 @@ mod tests {
     use majit_ir::descr::SimpleArrayDescr;
     use majit_ir::operand::Operand;
     use majit_ir::{
-        CallDescr, DescrRef, EffectInfo, ExtraEffect, InputArg, OopSpecIndex, OpCode, Type, Value,
+        CallDescr, DescrRef, EffectInfo, ExtraEffect, InputArg, OopSpecIndex, Op, OpCode, Type,
+        Value,
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -5331,7 +5320,7 @@ fn builtin_string_hash_field_descr(opcode: majit_ir::OpCode) -> Option<majit_ir:
     }))
 }
 
-fn inject_builtin_string_descrs(ops: &mut [Op]) {
+fn inject_builtin_string_descrs(ops: &[OpRc]) {
     for op in ops {
         if op.has_descr() {
             continue;

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -21,7 +21,7 @@ pub(crate) type Assembler = dynasmrt::VecAssembler<dynasmrt::x64::X64Relocation>
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
 use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
-use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRef, OpTypeIndex, TargetArgLoc, Type};
+use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRc, OpRef, OpTypeIndex, TargetArgLoc, Type};
 
 use crate::arch::*;
 use crate::codebuf;
@@ -837,7 +837,7 @@ pub struct Assembler386<'a> {
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
     /// `op.type_` directly, RPython `box.type` parity).
-    operations: &'a [Op],
+    operations: &'a [OpRc],
     /// `arg.index` raw -> idx in inputargs, sentinel
     /// [`OpTypeIndex::NO_POS`] for unset slots. Mirrors
     /// `OpTypeIndex::inputarg_pos`.
@@ -1089,7 +1089,7 @@ impl<'a> Assembler386<'a> {
         malloc_slowpath_fixed: usize,
         malloc_slowpath_headerless: usize,
         inputargs: &'a [InputArg],
-        operations: &'a [Op],
+        operations: &'a [OpRc],
     ) -> Self {
         let inputarg_pos = OpTypeIndex::<Op>::build_inputarg_pos(inputargs);
         let op_pos = OpTypeIndex::build_op_pos(operations);
@@ -2651,7 +2651,7 @@ impl<'a> Assembler386<'a> {
     /// old frame-slot model where every value went through [rbp+offset].
     fn _assemble(&mut self, emit_prologue: bool) -> Result<(), BackendError> {
         let inputargs: &'a [InputArg] = self.inputargs;
-        let ops: &'a [Op] = self.operations;
+        let ops: &'a [OpRc] = self.operations;
         self.unrelocated_jump_target = None;
         if emit_prologue {
             self._call_header(inputargs);
@@ -2897,7 +2897,7 @@ impl<'a> Assembler386<'a> {
         arglocs: &[Loc],
         result_loc: Option<&Loc>,
         fail_index: u32,
-        ops: &[Op],
+        ops: &[OpRc],
     ) {
         match op.opcode {
             OpCode::IntAddOvf => {
@@ -6370,7 +6370,7 @@ impl<'a> Assembler386<'a> {
     /// assembler.py _store_force_index: before a call that may force,
     /// store the next GUARD_NOT_FORCED's fail descr ptr to jf_force_descr,
     /// and zero jf_descr so GUARD_NOT_FORCED's CMP [jf_descr], 0 starts clean.
-    fn _store_force_index_if_next_guard(&mut self, ops: &[Op], op_idx: usize, fail_index: u32) {
+    fn _store_force_index_if_next_guard(&mut self, ops: &[OpRc], op_idx: usize, fail_index: u32) {
         // assembler.py _find_nearby_operation(+1)
         let next_idx = op_idx + 1;
         if next_idx >= ops.len() {

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -347,7 +347,7 @@ impl<'a> RegAlloc<'a> {
         output: &mut Vec<RegAllocOp>,
     ) {
         let argloc = self.loc(arg, Type::Int);
-        let ops_ref: &[Op] = self.operations;
+        let ops_ref: &[OpRc] = self.operations;
         let resloc = self.force_allocate_reg_or_cc(dst, ops_ref, i);
         self.perform(i, vec![argloc], Some(resloc), output);
     }

--- a/majit/majit-backend-dynasm/src/x86/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/x86/regalloc.rs
@@ -15,7 +15,7 @@ use crate::regloc::{
     EAX, EBP, EBX, ECX, EDI, EDX, ESI, R8, R9, R10, R12, R13, R14, R15, RegLoc, XMM0, XMM1, XMM2,
     XMM3, XMM4, XMM5, XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14,
 };
-use majit_ir::{Op, OpRef, Type};
+use majit_ir::{OpRc, OpRef, Type};
 
 /// x86/regalloc.py X86_64_RegisterManager.all_regs — the GPR allocation
 /// pool.  Order chosen to prefer caller-save first (popped from end).

--- a/majit/majit-backend-dynasm/src/x86/reghint.rs
+++ b/majit/majit-backend-dynasm/src/x86/reghint.rs
@@ -60,9 +60,10 @@ impl RegisterHints {
         &self,
         longevity: &mut LifetimeManager,
         _inputargs: &[majit_ir::InputArg],
-        operations: &[Op],
+        operations: &[impl AsRef<Op>],
     ) {
         for (i, op) in operations.iter().enumerate() {
+            let op = op.as_ref();
             let position = i as i32;
             // reghint.py:34-35 skip dead no-side-effect ops.
             if op.opcode.has_no_side_effect() && !longevity.contains(op.pos.get()) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -9,7 +9,7 @@ pub use gcreftracer::{GcTable, install_gc_table_walker};
 /// 4. Stack maps for compiled code
 ///
 /// Reference: rpython/memory/gc/incminimark.py, rpython/jit/backend/llsupport/gc.py
-use majit_ir::{Const, ConstMap, GcRef, Op};
+use majit_ir::{Const, ConstMap, GcRef, OpRc};
 pub use trace::{
     ClassTypeLayout, CustomDataLayout, TypeEntry, TypeEntryTail, TypeInfo, TypeInfoLayout,
     VarSizeTypeInfoLayout,
@@ -1821,7 +1821,11 @@ impl GcAllocator for GcHandle {
 /// Reference: rpython/jit/backend/llsupport/rewrite.py GcRewriterAssembler.
 pub trait GcRewriter: Send {
     /// Rewrite a list of operations, inserting GC-aware code.
-    fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op>;
+    ///
+    /// Input and output stay `OpRc` so the rewriter can hand the same
+    /// objects `rewrite.py GcRewriterAssembler.rewrite` appends to
+    /// `self.newops` — no `Op` clone at the backend boundary.
+    fn rewrite_for_gc(&self, ops: &[OpRc]) -> Vec<OpRc>;
     /// Rewrite with access to the constant pool.
     /// Returns (rewritten ops, merged constants, gc_table gcrefs). Each
     /// `Const` box carries its own type via `Const::get_type`, so a separate
@@ -1837,9 +1841,9 @@ pub trait GcRewriter: Send {
     /// downstream readers that resolve `ConstInt.raw()` against this table.
     fn rewrite_for_gc_with_constants(
         &self,
-        ops: &[Op],
+        ops: &[OpRc],
         constants: &ConstMap<Const>,
-    ) -> (Vec<Op>, ConstMap<Const>, Vec<GcRef>) {
+    ) -> (Vec<OpRc>, ConstMap<Const>, Vec<GcRef>) {
         (self.rewrite_for_gc(ops), constants.clone(), Vec::new())
     }
 }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -15,7 +15,7 @@ use indexmap::{IndexMap, IndexSet};
 use majit_ir::Type;
 use majit_ir::descr::{DescrRef, FieldDescr, SizeDescr};
 use majit_ir::operand::Operand;
-use majit_ir::resoperation::{Op, OpCode, OpRef};
+use majit_ir::resoperation::{Op, OpCode, OpRc, OpRef};
 use majit_ir::{Const, ConstMap, GcRef, Value};
 
 use crate::{GcRewriter, WriteBarrierDescr};
@@ -1049,7 +1049,7 @@ impl GcRewriterImpl {
         &self,
         op: &Op,
         i: usize,
-        ops: &[Op],
+        ops: &[OpRc],
         st: &mut RewriteState,
     ) -> bool {
         if !op.opcode.is_comparison() {
@@ -3118,7 +3118,7 @@ impl GcRewriterImpl {
     /// leave a dangling reference.  Do the deferred use-check — the
     /// RESTORE_EXCEPTION carries the canonical class/value operands, so only
     /// strip when no op after the prefix reuses either.
-    fn remove_bridge_exception(ops: &[Op]) -> Vec<Op> {
+    fn remove_bridge_exception(ops: &[OpRc]) -> Vec<OpRc> {
         let mut start = 0;
         if ops
             .first()
@@ -3155,7 +3155,7 @@ impl GcRewriterImpl {
 }
 
 impl GcRewriter for GcRewriterImpl {
-    fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op> {
+    fn rewrite_for_gc(&self, ops: &[OpRc]) -> Vec<OpRc> {
         let (rewritten, _constants, gcrefs) =
             self.rewrite_for_gc_with_constants(ops, &ConstMap::default());
         // This wrapper drops the gc_table output list. A non-null ConstPtr
@@ -3172,9 +3172,9 @@ impl GcRewriter for GcRewriterImpl {
 
     fn rewrite_for_gc_with_constants(
         &self,
-        ops: &[Op],
+        ops: &[OpRc],
         constants: &ConstMap<Const>,
-    ) -> (Vec<Op>, ConstMap<Const>, Vec<GcRef>) {
+    ) -> (Vec<OpRc>, ConstMap<Const>, Vec<GcRef>) {
         // rewrite.py remove_bridge_exception: strip a
         // SaveExcClass+SaveException+RestoreException prefix that is
         // a no-op (common in bridges).
@@ -3237,7 +3237,7 @@ impl GcRewriter for GcRewriterImpl {
             // rewrite.py — if `remove_tested_failarg` rewrote this
             // op on a previous iteration, use the stashed replacement.
             let owned = st.changed_ops.swap_remove(&i);
-            let op: &Op = owned.as_ref().unwrap_or(orig_op);
+            let op: &Op = owned.as_ref().unwrap_or(orig_op.as_ref());
             st.current_i = i;
 
             // rewrite.py — is_guard OR could_merge_with_next_guard
@@ -3454,12 +3454,10 @@ impl GcRewriter for GcRewriterImpl {
         // Flush any remaining pending zeros at end of trace.
         st.emit_pending_zeros();
 
-        // Boundary unwrap: the trait still hands the backend a
-        // `Vec<Op>`; the clone preserves bound operands (the operand
-        // `Rc`s keep their producers alive), so no position-only
-        // re-minting happens here. A follow-up slice flips the trait
-        // to `Vec<OpRc>` and removes this clone.
-        let out: Vec<Op> = st.out.iter().map(|rc| (**rc).clone()).collect();
+        // rewrite.py `self.newops` is the list emit just appended;
+        // hand those `OpRc` identities to the backend instead of
+        // cloning each `Op` out of the Rc.
+        let out = st.out;
 
         // rewrite.py post-condition: `remove_constptr` replaced
         // every non-null reference-constant *operand* with a
@@ -3496,6 +3494,22 @@ mod tests {
 
     use majit_ir::descr::{ArrayDescr, Descr, DescrRef, SizeDescr};
     use majit_ir::value::Type;
+
+    impl GcRewriterImpl {
+        fn rewrite_ops(&self, ops: &[Op]) -> Vec<OpRc> {
+            let boxed: Vec<OpRc> = ops.iter().cloned().map(OpRc::new).collect();
+            GcRewriter::rewrite_for_gc(self, &boxed)
+        }
+
+        fn rewrite_ops_with_constants(
+            &self,
+            ops: &[Op],
+            constants: &ConstMap<Const>,
+        ) -> (Vec<OpRc>, ConstMap<Const>, Vec<GcRef>) {
+            let boxed: Vec<OpRc> = ops.iter().cloned().map(OpRc::new).collect();
+            self.rewrite_for_gc_with_constants(&boxed, constants)
+        }
+    }
 
     const TEST_STANDARD_ARRAY_BASESIZE: usize = std::mem::size_of::<usize>();
     const TEST_STANDARD_ARRAY_LENGTH_OFS: usize = 0;
@@ -3882,7 +3896,7 @@ mod tests {
         let ops = vec![Op::with_descr(OpCode::New, &[], size_descr(32, 7))];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Expect: CallMallocNursery, GcStore (tid)
         assert_eq!(result.len(), 2);
@@ -3945,7 +3959,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result
@@ -3996,7 +4010,7 @@ mod tests {
         new_array.pos.set(OpRef::ref_op(0));
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
-        let (result, _constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _constants, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         assert!(
             result
@@ -4040,7 +4054,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         let malloc = result
             .iter()
@@ -4068,7 +4082,7 @@ mod tests {
         )];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::CallR);
@@ -4111,7 +4125,7 @@ mod tests {
             array_descr_int(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Expect: CallMallocNurseryVarsize
         assert!(
@@ -4152,7 +4166,7 @@ mod tests {
         new_array.pos.set(OpRef::ref_op(0));
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         assert!(
             !result
@@ -4212,7 +4226,7 @@ mod tests {
             ref_field_descr(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Expect: CondCallGcWb(obj), GcStore(obj, 0, val, itemsize)
         assert_eq!(result.len(), 2);
@@ -4243,7 +4257,7 @@ mod tests {
             ref_field_descr(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert!(
             !result
@@ -4270,7 +4284,7 @@ mod tests {
             array_descr_ref(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert!(
             !result
@@ -4304,7 +4318,7 @@ mod tests {
             array_descr_ref(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::GetarrayitemRawR);
@@ -4329,7 +4343,7 @@ mod tests {
             int_field_descr(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Only the lowered GC_STORE — no WB for non-ref fields.
         assert_eq!(result.len(), 1);
@@ -4372,8 +4386,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Allocation header stores only (CallMallocNursery + tid GcStore) + Jump.
         // No delayed-zero NULL-pointer stores must be emitted because
@@ -4405,8 +4418,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, consts, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Collect the NULL-pointer stores emitted by the pending-zero flush.
         let mut seen_offsets: Vec<i64> = result
@@ -4454,8 +4466,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         let null_offsets: Vec<i64> = result
             .iter()
@@ -4489,7 +4500,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
@@ -4508,7 +4519,7 @@ mod tests {
         ];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert!(result.iter().any(|o| o.opcode == OpCode::CallMallocNursery));
         assert!(
@@ -4599,7 +4610,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(24, 2)),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // There should be two separate CallMallocNursery ops
         // (the CallN in between flushes the batch).
@@ -4623,7 +4634,7 @@ mod tests {
             Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val2)], ref_field_descr()),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Only one CondCallGcWb, then two lowered GC_STORE.
         let wb_count = result
@@ -4651,7 +4662,7 @@ mod tests {
             // We build the SetfieldGc referencing pos=0 from the CallMallocNursery result.
         ];
 
-        rw.rewrite_for_gc(&ops);
+        rw.rewrite_ops(&ops);
 
         // Now rewrite a SetfieldGc that stores a ref into the new object.
         // The allocation carries the position the store names it by.
@@ -4666,7 +4677,7 @@ mod tests {
             ),
         ];
 
-        let result2 = rw.rewrite_for_gc(&ops2);
+        let result2 = rw.rewrite_ops(&ops2);
 
         // The CallMallocNursery result at pos=0 is in wb_applied,
         // so the SetfieldGc at arg(0)=OpRef::ref_op(0) should NOT get a WB.
@@ -4691,7 +4702,7 @@ mod tests {
         )];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // CallMallocNursery + GcStore(tid) + GcStore(vtable)
         assert_eq!(result.len(), 3);
@@ -4732,7 +4743,7 @@ mod tests {
         ];
 
         let (result, _constants, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert!(
@@ -4768,7 +4779,7 @@ mod tests {
         )];
 
         let (result, _constants, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         assert_eq!(
@@ -4801,7 +4812,7 @@ mod tests {
         ];
 
         let (result, _constants, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(gcrefs, vec![GcRef(w_class as usize)]);
         let w_class_stores: Vec<_> = result
@@ -4833,7 +4844,7 @@ mod tests {
         ];
 
         let (result, _constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result.iter().any(|o| {
@@ -4873,7 +4884,7 @@ mod tests {
             array_descr_ref(),
         )];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].opcode, OpCode::IntLshift);
@@ -4896,7 +4907,7 @@ mod tests {
             Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val)], ref_field_descr()),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Two CondCallGcWb — the second one is needed because the CallN cleared the set.
         let wb_count = result
@@ -4918,7 +4929,7 @@ mod tests {
         new_b.pos.set(OpRef::ref_op(3));
         let ops = vec![new_a, new_b, mk_op(OpCode::Finish, &[OpRef::ref_op(3)], 4)];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         let first_alloc = result
             .iter()
@@ -4979,7 +4990,7 @@ mod tests {
             mk_op(OpCode::Finish, &[], none),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::IntLshift),
@@ -5023,7 +5034,7 @@ mod tests {
             ),
         ];
 
-        let twice = rw.rewrite_for_gc(&once);
+        let twice = rw.rewrite_ops(&once);
 
         let wb_count = twice
             .iter()
@@ -5071,7 +5082,7 @@ mod tests {
         ]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         // Expect the rewriter to have emitted SAME_AS_I BEFORE the IntLt.
         let same_idx = result
@@ -5115,8 +5126,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         let same = result
             .iter()
@@ -5143,8 +5153,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(10)), ro(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert!(
             result.iter().all(|o| o.opcode != OpCode::GuardAlwaysFails),
@@ -5194,7 +5203,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
         assert!(
             result.iter().all(|o| o.opcode != OpCode::SameAsI),
             "no merge → no hoisted SAME_AS_I"
@@ -5263,7 +5272,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         // All indices were SET, so the in-place ZERO_ARRAY is rewritten
         // to byte_length 0 — backend treats it as a no-op.
@@ -5321,7 +5330,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         let zeros: Vec<_> = result
             .iter()
@@ -5387,7 +5396,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         // The ZERO_ARRAY should appear before the guard.
         let zero_idx = result.iter().position(|o| o.opcode == OpCode::ZeroArray);
@@ -5471,7 +5480,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let (result, _out_consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+        let (result, _out_consts, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
 
         let zeros: Vec<_> = result
             .iter()
@@ -5509,7 +5518,7 @@ mod tests {
 
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         let zero_count = result
             .iter()
@@ -5592,7 +5601,7 @@ mod tests {
             ),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(
             result
@@ -5630,7 +5639,7 @@ mod tests {
             ),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(
             result
@@ -5682,7 +5691,7 @@ mod tests {
                 ),
                 Op::new(OpCode::Finish, &[]),
             ];
-            let (result, _, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+            let (result, _, _gcrefs) = rw.rewrite_ops_with_constants(&ops, &constants);
             let wb = result
                 .iter()
                 .filter(|o| o.opcode == OpCode::CondCallGcWb)
@@ -5733,7 +5742,7 @@ mod tests {
             Op::new(OpCode::Finish, &[]),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         assert_eq!(
             result
@@ -5771,7 +5780,7 @@ mod tests {
             ),
             Op::new(OpCode::Finish, &[]),
         ];
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
         let wb_arr = result
             .iter()
             .filter(|o| o.opcode == OpCode::CondCallGcWbArray)
@@ -5798,7 +5807,7 @@ mod tests {
             ),
             Op::new(OpCode::Finish, &[]),
         ];
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
         let any_wb = result
             .iter()
             .filter(|o| o.opcode == OpCode::CondCallGcWb || o.opcode == OpCode::CondCallGcWbArray)
@@ -5870,7 +5879,7 @@ mod tests {
         )];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         assert_eq!(
             result.len(),
@@ -5942,7 +5951,7 @@ mod tests {
         )];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Expect: LEA, LEA, INT_LSHIFT(i_len, 2), CALL_N
         assert_eq!(result.len(), 4);
@@ -5999,7 +6008,7 @@ mod tests {
         )];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=0 so no INT_LSHIFT):
         //   i2b = int_add(p0, i0)
@@ -6061,7 +6070,7 @@ mod tests {
         )];
 
         let (result, constants, _gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+            rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Expect (itemscale=2):
         //   i0s = int_lshift(i0, 2)
@@ -6159,7 +6168,7 @@ mod tests {
             ),
         ];
 
-        let result = rw.rewrite_for_gc(&ops);
+        let result = rw.rewrite_ops(&ops);
 
         let guard = result
             .iter()
@@ -6194,8 +6203,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // The reference constant is collected at index 0.
         assert_eq!(gcrefs, vec![r]);
@@ -6223,8 +6231,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Same ref ⇒ one gcref entry (dedup) and one LoadFromGcTable (block CSE).
         assert_eq!(gcrefs, vec![r]);
@@ -6261,8 +6268,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Distinct refs occupy distinct, stable indices.
         assert_eq!(gcrefs, vec![r0, r1]);
@@ -6286,8 +6292,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(null))],
         )];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py `bool(arg.value)` — a null ConstPtr stays inline.
         assert!(
@@ -6315,8 +6320,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // Dedup persists across the block boundary (one gcref) ...
         assert_eq!(gcrefs, vec![r]);
@@ -6337,8 +6341,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) =
-            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::default());
+        let (result, _consts, gcrefs) = rw.rewrite_ops_with_constants(&ops, &ConstMap::default());
 
         // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
         assert!(gcrefs.is_empty(), "JIT_DEBUG keeps its constants inline");
@@ -6366,7 +6369,8 @@ mod tests {
             restore,
             Op::new(OpCode::Finish, &[]),
         ];
-        let out = GcRewriterImpl::remove_bridge_exception(&ops);
+        let boxed: Vec<OpRc> = ops.into_iter().map(OpRc::new).collect();
+        let out = GcRewriterImpl::remove_bridge_exception(&boxed);
         // No op reuses the saved class/value, so the prefix is stripped.
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].opcode, OpCode::Finish);
@@ -6393,7 +6397,8 @@ mod tests {
             restore,
             consumer,
         ];
-        let out = GcRewriterImpl::remove_bridge_exception(&ops);
+        let boxed: Vec<OpRc> = ops.into_iter().map(OpRc::new).collect();
+        let out = GcRewriterImpl::remove_bridge_exception(&boxed);
         // The reused value pins the whole prefix in place.
         assert_eq!(out.len(), 4);
         assert_eq!(out[0].opcode, OpCode::SaveExcClass);

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -165,12 +165,10 @@ impl Op {
             .rd_pendingfields_arc()
     }
 
-    /// `resoperation.py/489 AbstractResOp/GuardResOp.getfailargs`
-    /// parity. Returns an owned `SmallVec` clone of the fail_args slot —
-    /// None for non-guard ops.  Clone is cheap because `Operand` is an `Rc`
-    /// bump and fail_args almost always fits inline (≤3 entries).  Owned
-    /// return avoids the `Ref<[T]>` ergonomics tax for callers that chain
-    /// through `.into_iter().flatten()` or `.iter()` patterns.
+    /// Owned snapshot of `GuardResOp.getfailargs` (`self._fail_args[:]`).
+    /// The live list is [`Op::guard_fail_args`]; use that on hot reads.
+    /// A `SmallVec<[; 3]>` clone heap-grows when resume failargs exceed
+    /// three live boxes, which is the common deopt shape.
     pub fn getfailargs(&self) -> Option<smallvec::SmallVec<[crate::operand::Operand; 3]>> {
         self.guard_fail_args()
             .map(|fa| fa.iter().cloned().collect())

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -51,24 +51,24 @@ impl Op {
     /// returns an owned clone of the per-op vector metadata installed
     /// by the vectorizer.
     pub fn get_vecinfo(&self) -> Option<crate::resoperation::VectorizationInfo> {
-        self.vecinfo.borrow().as_deref().cloned()
+        self.vecinfo_slot()
     }
 
     /// Overwrite the per-op vector metadata slot.  Takes `&self` —
     /// interior mutability through `RefCell` matches RPython's
     /// `op._vector_info = …` write on a shared object.
     pub fn set_vecinfo(&self, vecinfo: crate::resoperation::VectorizationInfo) {
-        *self.vecinfo.borrow_mut() = Some(Box::new(vecinfo));
+        self.set_vecinfo_slot(vecinfo);
     }
 
     /// Clear the per-op vector metadata slot.
     pub fn clear_vecinfo(&self) {
-        *self.vecinfo.borrow_mut() = None;
+        self.clear_vecinfo_slot();
     }
 
     /// True iff the per-op vector metadata slot is populated.
     pub fn has_vecinfo(&self) -> bool {
-        self.vecinfo.borrow().is_some()
+        self.vecinfo_slot().is_some()
     }
 
     /// Project the descr (if any) through a closure operating on a
@@ -172,9 +172,7 @@ impl Op {
     /// return avoids the `Ref<[T]>` ergonomics tax for callers that chain
     /// through `.into_iter().flatten()` or `.iter()` patterns.
     pub fn getfailargs(&self) -> Option<smallvec::SmallVec<[crate::operand::Operand; 3]>> {
-        self.fail_args
-            .borrow()
-            .as_ref()
+        self.guard_fail_args()
             .map(|fa| fa.iter().cloned().collect())
     }
 
@@ -186,7 +184,7 @@ impl Op {
     /// fail-args bug surfaces at the call site rather than returning
     /// a silently-empty vector.
     pub fn getfailargs_copy(&self) -> Vec<crate::operand::Operand> {
-        let borrow = self.fail_args.borrow();
+        let borrow = self.guard_fail_args();
         let fa = borrow.as_ref().unwrap_or_else(|| {
             panic!(
                 "getfailargs_copy on op with fail_args=None — RPython \
@@ -208,7 +206,7 @@ impl Op {
         // `Operand::Const`. An unbound position-only fail-arg is a contract
         // violation (every writer binds its producer) — `Operand::from_opref`
         // panics for it at the call site.
-        *self.fail_args.borrow_mut() = Some(fail_args.into_iter().collect());
+        self.ensure_guard_extra().fail_args = Some(fail_args.into_iter().collect());
     }
 
     /// In-place mutable view of the fail_args slot.  Lets callers iterate
@@ -218,7 +216,13 @@ impl Op {
     /// shared-`Op` callers should clone via `getfailargs_copy`, mutate
     /// the copy, and call `setfailargs`.
     pub fn fail_args_mut(&mut self) -> Option<&mut Vec<crate::operand::Operand>> {
-        self.fail_args.get_mut().as_mut()
+        match self.extra.get_mut().as_mut()?.as_mut() {
+            crate::resoperation::OpKindExtra::Guard(g)
+            | crate::resoperation::OpKindExtra::VectorGuard { guard: g, .. } => {
+                g.fail_args.as_mut()
+            }
+            crate::resoperation::OpKindExtra::Vector(_) => None,
+        }
     }
 
     /// Clear the fail_args slot.  PyPy has no separate `clearfailargs`
@@ -226,12 +230,14 @@ impl Op {
     /// pyre's signature distinguishes the two paths (set vs clear) for
     /// clarity.
     pub fn clearfailargs(&self) {
-        *self.fail_args.borrow_mut() = None;
+        if let Some(mut g) = self.try_guard_extra_mut() {
+            g.fail_args = None;
+        }
     }
 
     /// True iff the fail_args slot is populated.
     pub fn has_failargs(&self) -> bool {
-        self.fail_args.borrow().is_some()
+        self.guard_fail_args().is_some()
     }
 
     /// Per-failarg type vector accessor.  Pyre's `fail_arg_types` slot
@@ -242,29 +248,32 @@ impl Op {
     /// wrapped; callers no longer hold a borrow across other `Op`
     /// accesses.
     pub fn get_fail_arg_types(&self) -> Option<Vec<crate::value::Type>> {
-        self.fail_arg_types.borrow().clone()
+        self.try_guard_extra_mut()
+            .and_then(|g| g.fail_arg_types.clone())
     }
 
     /// Owned-clone variant — RPython would write `fail_arg_types[:]`.
     pub fn get_fail_arg_types_copy(&self) -> Vec<crate::value::Type> {
-        self.fail_arg_types.borrow().clone().unwrap_or_default()
+        self.get_fail_arg_types().unwrap_or_default()
     }
 
     /// Overwrite the per-failarg type vector.  Takes `&self`
     /// (interior mutability through `RefCell`) so shared `Op` instances
     /// can be re-stamped without `&mut`.
     pub fn set_fail_arg_types(&self, types: Vec<crate::value::Type>) {
-        *self.fail_arg_types.borrow_mut() = Some(types);
+        self.ensure_guard_extra().fail_arg_types = Some(types);
     }
 
     /// Clear the per-failarg type vector.
     pub fn clear_fail_arg_types(&self) {
-        *self.fail_arg_types.borrow_mut() = None;
+        if let Some(mut g) = self.try_guard_extra_mut() {
+            g.fail_arg_types = None;
+        }
     }
 
     /// True iff the per-failarg type vector slot is populated.
     pub fn has_fail_arg_types(&self) -> bool {
-        self.fail_arg_types.borrow().is_some()
+        self.get_fail_arg_types().is_some()
     }
 
     /// `resoperation.py AbstractResOp.getarglist` parity — the stored

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1650,7 +1650,7 @@ impl Op {
         self.setfailargs(boxes.into());
     }
 
-    pub(crate) fn guard_fail_args(&self) -> Option<std::cell::Ref<'_, [Operand]>> {
+    pub fn guard_fail_args(&self) -> Option<std::cell::Ref<'_, [Operand]>> {
         std::cell::Ref::filter_map(self.extra.borrow(), |extra| match extra.as_deref() {
             Some(OpKindExtra::Guard(g) | OpKindExtra::VectorGuard { guard: g, .. }) => {
                 g.fail_args.as_deref()

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1257,6 +1257,40 @@ pub type OpRc = std::rc::Rc<Op>;
 /// the [`forwarded`](Op::forwarded) field, matching RPython's
 /// object-identity model: every consumer holding the same `Rc<Op>` reads
 /// and writes the same slot.
+/// resoperation.py `VectorizationInfo`: per-op vector metadata for the vectorizer.
+/// Tracks how a scalar op maps to SIMD lanes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VectorizationInfo {
+    /// 'i' for integer, 'f' for float, '\0' for unset
+    pub datatype: char,
+    /// Byte size per element (-1 = machine word)
+    pub bytesize: i8,
+    /// Whether the values are signed
+    pub signed: bool,
+    /// Number of SIMD lanes (-1 = unset)
+    pub count: i16,
+}
+
+/// `resoperation.py GuardResOp` extras — `_fail_args` and the pyre
+/// `fail_arg_types` cache. Allocated only when the op is a guard.
+#[derive(Clone, Debug)]
+pub(crate) struct GuardExtra {
+    pub(crate) fail_args: Option<Vec<Operand>>,
+    pub(crate) fail_arg_types: Option<Vec<Type>>,
+}
+
+/// `resoperation.py` subclass payload: `GuardResOp` / `VectorOp` /
+/// `VectorGuardOp`. Stored behind `Op.extra` so `PlainResOp` stays slim.
+#[derive(Clone, Debug)]
+pub(crate) enum OpKindExtra {
+    Guard(GuardExtra),
+    Vector(VectorizationInfo),
+    VectorGuard {
+        guard: GuardExtra,
+        vec: VectorizationInfo,
+    },
+}
+
 #[derive(Debug)]
 pub struct Op {
     pub opcode: OpCode,
@@ -1289,48 +1323,23 @@ pub struct Op {
     /// (`resoperation.py:1597`). Populated at construction from
     /// `opcode.result_type()`. Replaces side-table `value_types: HashMap<u32, Type>`.
     pub type_: Type,
-    /// For guard ops: values to store in the dead frame on guard failure.
-    /// Mirrors rpython/jit/metainterp/resoperation.py getfailargs/setfailargs.
-    /// If None, the backend falls back to storing input args.  `RefCell` so
-    /// the optimizer can rewrite fail_args on a shared `Op` reached
-    /// through `Rc<Op>`: RPython writes
-    /// `op._fail_args = [...]` on the same Python object the trace list,
-    /// optimizer state, and backend input list all see.
-    ///
-    /// Stored as [`Operand`] (the same union as `args` — `GuardResOp.
-    /// _fail_args` holds the Box objects themselves, resoperation.py:483).
-    /// Each write sheds to a bound producer (`Operand::Op` / `InputArg`) or
-    /// an inline `Const`; the position-remap passes skip bound operands and
-    /// rewrite no longer-existing position-only snapshot, mirroring `args`.
-    // `GuardResOp` owns `_fail_args` upstream; ordinary ResOperations do not
-    // embed room for a fail-argument list.  Keep the optional Vec header here
-    // instead of a three-Operand inline SmallVec, which otherwise bloats every
-    // recorded non-guard op by the size of three Rc-bearing Operands.
-    pub fail_args: std::cell::RefCell<Option<Vec<Operand>>>,
-    /// Types of fail_args, set by the optimizer (`set_fail_arg_types`)
-    /// from each fail-arg operand's type.
-    /// When present, the backend uses these instead of inferring types.
-    /// `RefCell` so the optimizer can stamp types onto a shared `Op`
-    /// reached through `Rc<Op>`: RPython
-    /// writes `op.fail_arg_types = [...]` on the same Python object the
-    /// trace/backend/short preamble all observe.
-    pub fail_arg_types: std::cell::RefCell<Option<Vec<Type>>>,
     /// resoperation.py: GuardResOp.rd_resume_position — index of the
     /// guard in the trace for resume data lookup. Set by unroll when
     /// creating extra guards from short preamble / virtual state.
     /// -1 means unset. `Cell` so that mutators reachable via `&Op` (the
     /// shared-trace identity model from `Vec<Rc<Op>>`) can update the
     /// slot without requiring `&mut Op`.
+    ///
+    /// Lives on every `Op` (4 bytes) rather than in [`OpKindExtra`]:
+    /// resume-position reads are on the hot optimizer path and RPython
+    /// stores the field on `GuardResOp` only, but a side box here would
+    /// allocate on every recorded guard just to hold an i32.
     pub rd_resume_position: std::cell::Cell<i32>,
-    /// resoperation.py `VecOperationNew.__init__` stores
-    /// `datatype` / `bytesize` / `signed` / `count` on the op instance
-    /// itself. `resoperation.py copy_and_change` propagates them
-    /// across rewrites. The slot lives on every `Op` (not only on
-    /// vector ops) because pyre collapses the upstream
-    /// `VectorOp`/`VectorGuardOp` subclasses into the same struct;
-    /// scalar ops keep this `None`. `RefCell` mirrors the in-place
-    /// `op.bytesize = ...` overwrite in `VecOperation.__init__`.
-    pub vecinfo: std::cell::RefCell<Option<std::boxed::Box<VectorizationInfo>>>,
+    /// `resoperation.py` subclass extras: `GuardResOp._fail_args`,
+    /// `fail_arg_types`, and `VectorOp`/`VectorGuardOp` vector shape.
+    /// `PlainResOp` / `ResOpWithDescr` leave this `None` so ordinary
+    /// ops do not embed those fields.
+    pub(crate) extra: std::cell::RefCell<Option<Box<OpKindExtra>>>,
 
     /// `resoperation.py AbstractResOpOrInputArg._forwarded` parity
     /// slot — the canonical forwarding host for a bound ResOp box.
@@ -1363,30 +1372,12 @@ impl Clone for Op {
             descr: std::cell::RefCell::new(self.descr.borrow().clone()),
             pos: std::cell::Cell::new(self.pos.get()),
             type_: self.type_,
-            fail_args: std::cell::RefCell::new(self.fail_args.borrow().clone()),
-            fail_arg_types: std::cell::RefCell::new(self.fail_arg_types.borrow().clone()),
             rd_resume_position: std::cell::Cell::new(self.rd_resume_position.get()),
-            // resoperation.py VectorOp/VectorGuardOp.copy_and_change
-            // copies datatype/bytesize/signed/count from the source.
-            vecinfo: std::cell::RefCell::new(self.vecinfo.borrow().clone()),
+            extra: std::cell::RefCell::new(self.extra.borrow().clone()),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
         }
     }
-}
-
-/// resoperation.py:156-200: Per-op vector metadata for the vectorizer.
-/// Tracks how a scalar op maps to SIMD lanes.
-#[derive(Clone, Debug, PartialEq)]
-pub struct VectorizationInfo {
-    /// 'i' for integer, 'f' for float, '\0' for unset
-    pub datatype: char,
-    /// Byte size per element (-1 = machine word)
-    pub bytesize: i8,
-    /// Whether the values are signed
-    pub signed: bool,
-    /// Number of SIMD lanes (-1 = unset)
-    pub count: i16,
 }
 
 impl VectorizationInfo {
@@ -1495,7 +1486,7 @@ impl Op {
         for arg in self.args.borrow().iter() {
             arg.walk_const_ptr_refs(visitor);
         }
-        if let Some(fail_args) = self.fail_args.borrow().as_ref() {
+        if let Some(fail_args) = self.guard_fail_args() {
             for arg in fail_args.iter() {
                 arg.walk_const_ptr_refs(visitor);
             }
@@ -1509,10 +1500,8 @@ impl Op {
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
-            fail_args: std::cell::RefCell::new(None),
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
         }
@@ -1525,10 +1514,8 @@ impl Op {
             descr: std::cell::RefCell::new(Some(descr)),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
-            fail_args: std::cell::RefCell::new(None),
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
         }
@@ -1600,29 +1587,18 @@ impl Op {
             descr: std::cell::RefCell::new(new_descr),
             pos: std::cell::Cell::new(self.pos.get()),
             type_: opcode.result_type(),
-            fail_args: std::cell::RefCell::new(None),
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            // resoperation.py VectorGuardOp.copy_and_change +
-            // :534-541 VectorOp.copy_and_change propagate
-            // datatype/bytesize/signed/count from self. Scalar ops keep
-            // `self.vecinfo` as `None`, so the clone is a no-op for them.
-            vecinfo: std::cell::RefCell::new(self.vecinfo.borrow().clone()),
+            extra: std::cell::RefCell::new(self.extra.borrow().clone()),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
         };
         // resoperation.py GuardResOp.copy_and_change:
         //   newop.setfailargs(self.getfailargs())
         //   newop.rd_resume_position = self.rd_resume_position
-        // The check is on opcode.is_guard() because in RPython this lives
-        // on the GuardResOp class hierarchy.  rd_* live on the descr
-        // (compile.py:855 `_attrs_`); the descr Arc was already copied
-        // above, so newop reads the same payload through descr.fail_descr().
         if opcode.is_guard() || self.opcode.is_guard() {
-            *newop.fail_args.borrow_mut() = self.fail_args.borrow().clone();
-            *newop.fail_arg_types.borrow_mut() = self.fail_arg_types.borrow().clone();
             newop.rd_resume_position.set(self.rd_resume_position.get());
-            return newop;
+        } else {
+            newop.strip_guard_extra();
         }
         newop
     }
@@ -1671,7 +1647,105 @@ impl Op {
                 }
             }
         }
-        *self.fail_args.borrow_mut() = Some(boxes.into_iter().collect());
+        self.setfailargs(boxes.into());
+    }
+
+    pub(crate) fn guard_fail_args(&self) -> Option<std::cell::Ref<'_, [Operand]>> {
+        std::cell::Ref::filter_map(self.extra.borrow(), |extra| match extra.as_deref() {
+            Some(OpKindExtra::Guard(g) | OpKindExtra::VectorGuard { guard: g, .. }) => {
+                g.fail_args.as_deref()
+            }
+            _ => None,
+        })
+        .ok()
+    }
+
+    pub(crate) fn strip_guard_extra(&self) {
+        let mut extra = self.extra.borrow_mut();
+        match extra.as_deref() {
+            Some(OpKindExtra::VectorGuard { vec, .. }) => {
+                *extra = Some(Box::new(OpKindExtra::Vector(vec.clone())));
+            }
+            Some(OpKindExtra::Guard(_)) => {
+                *extra = None;
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn try_guard_extra_mut(&self) -> Option<std::cell::RefMut<'_, GuardExtra>> {
+        std::cell::RefMut::filter_map(self.extra.borrow_mut(), |extra| match extra.as_mut() {
+            Some(b) => match b.as_mut() {
+                OpKindExtra::Guard(g) | OpKindExtra::VectorGuard { guard: g, .. } => Some(g),
+                OpKindExtra::Vector(_) => None,
+            },
+            None => None,
+        })
+        .ok()
+    }
+
+    pub(crate) fn ensure_guard_extra(&self) -> std::cell::RefMut<'_, GuardExtra> {
+        {
+            let mut extra = self.extra.borrow_mut();
+            match extra.as_deref() {
+                Some(OpKindExtra::Guard(_) | OpKindExtra::VectorGuard { .. }) => {}
+                Some(OpKindExtra::Vector(v)) => {
+                    let vec = v.clone();
+                    *extra = Some(Box::new(OpKindExtra::VectorGuard {
+                        guard: GuardExtra {
+                            fail_args: None,
+                            fail_arg_types: None,
+                        },
+                        vec,
+                    }));
+                }
+                None => {
+                    *extra = Some(Box::new(OpKindExtra::Guard(GuardExtra {
+                        fail_args: None,
+                        fail_arg_types: None,
+                    })));
+                }
+            }
+        }
+        std::cell::RefMut::map(self.extra.borrow_mut(), |extra| {
+            match extra.as_mut().expect("ensure_guard_extra").as_mut() {
+                OpKindExtra::Guard(g) | OpKindExtra::VectorGuard { guard: g, .. } => g,
+                OpKindExtra::Vector(_) => unreachable!("ensure_guard_extra upgraded Vector"),
+            }
+        })
+    }
+
+    pub(crate) fn vecinfo_slot(&self) -> Option<VectorizationInfo> {
+        match self.extra.borrow().as_deref() {
+            Some(OpKindExtra::Vector(v) | OpKindExtra::VectorGuard { vec: v, .. }) => {
+                Some(v.clone())
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn set_vecinfo_slot(&self, info: VectorizationInfo) {
+        let mut extra = self.extra.borrow_mut();
+        match extra.as_deref_mut() {
+            Some(OpKindExtra::Vector(v)) => *v = info,
+            Some(OpKindExtra::VectorGuard { vec, .. }) => *vec = info,
+            Some(OpKindExtra::Guard(g)) => {
+                let guard = g.clone();
+                *extra = Some(Box::new(OpKindExtra::VectorGuard { guard, vec: info }));
+            }
+            None => *extra = Some(Box::new(OpKindExtra::Vector(info))),
+        }
+    }
+
+    pub(crate) fn clear_vecinfo_slot(&self) {
+        let mut extra = self.extra.borrow_mut();
+        match extra.as_deref() {
+            Some(OpKindExtra::VectorGuard { guard, .. }) => {
+                *extra = Some(Box::new(OpKindExtra::Guard(guard.clone())));
+            }
+            Some(OpKindExtra::Vector(_)) => *extra = None,
+            _ => {}
+        }
     }
 }
 
@@ -3750,7 +3824,7 @@ mod tests {
         #[cfg(target_pointer_width = "64")]
         {
             assert!(
-                std::mem::size_of::<Op>() <= 240,
+                std::mem::size_of::<Op>() <= 192,
                 "Op grew to {} bytes",
                 std::mem::size_of::<Op>()
             );
@@ -4849,34 +4923,24 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntAdd,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 3), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::Jump,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 4), crate::forwarding::test_support::bound_resop_operand(Type::Int, 3)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
         ];
         let mut constants = std::collections::HashMap::new();
@@ -4894,11 +4958,8 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(6)),
-            fail_args: std::cell::RefCell::new(None),
-
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         };
         let s = format!("{op}");
         assert_eq!(s, "v6 = IntAdd(v1, v2)");
@@ -4911,11 +4972,8 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(None),
-
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         };
         let s = format!("{op}");
         assert_eq!(s, "SetfieldGc(v0, v1)");
@@ -4928,13 +4986,17 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)])),
-
-
-            fail_arg_types: std::cell::RefCell::new(None),
+            // FAIL_ARGS applied below
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         };
+        op.setfailargs(
+            vec![
+                crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                crate::forwarding::test_support::bound_resop_operand(Type::Int, 1),
+            ]
+            .into(),
+        );
         let s = format!("{op}");
         assert_eq!(s, "GuardTrue(v0) [v0, v1]");
     }
@@ -4946,11 +5008,8 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(None),
-
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         };
         let s = format!("{op}");
         assert_eq!(s, "GuardTrue(v0)");
@@ -4963,11 +5022,8 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(1)),
-            fail_args: std::cell::RefCell::new(None),
-
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         }];
         let mut constants = std::collections::HashMap::new();
         constants.insert(10_000, 42);
@@ -4984,34 +5040,34 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+                extra: std::cell::RefCell::new(None),
             },
-            op! {
-                opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
-                descr: std::cell::RefCell::new(None),
-                pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)])),
-
-                fail_arg_types: std::cell::RefCell::new(None),
-                rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            {
+                let op = op! {
+                    opcode: OpCode::GuardTrue,
+                    args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
+                    descr: std::cell::RefCell::new(None),
+                    pos: std::cell::Cell::new(OpRef::NONE),
+                    rd_resume_position: std::cell::Cell::new(-1),
+                    extra: std::cell::RefCell::new(None),
+                };
+                op.setfailargs(
+                    vec![
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 1),
+                    ]
+                    .into(),
+                );
+                op
             },
             op! {
                 opcode: OpCode::Finish,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+                extra: std::cell::RefCell::new(None),
             },
         ];
         let mut constants = std::collections::HashMap::new();
@@ -5022,17 +5078,23 @@ mod tests {
 
     #[test]
     fn test_format_trace_constants_in_fail_args() {
-        let ops = vec![op! {
-            opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
-            descr: std::cell::RefCell::new(None),
-            pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)])),
-
-
-            fail_arg_types: std::cell::RefCell::new(None),
-            rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+        let ops = vec![{
+            let op = op! {
+                opcode: OpCode::GuardTrue,
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
+                descr: std::cell::RefCell::new(None),
+                pos: std::cell::Cell::new(OpRef::NONE),
+                rd_resume_position: std::cell::Cell::new(-1),
+                extra: std::cell::RefCell::new(None),
+            };
+            op.setfailargs(
+                vec![
+                    crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                    crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000),
+                ]
+                .into(),
+            );
+            op
         }];
         let mut constants = std::collections::HashMap::new();
         constants.insert(10_000, 99);
@@ -5060,45 +5122,32 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntAdd,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntAdd,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 3), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::Jump,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 4), crate::forwarding::test_support::bound_resop_operand(Type::Int, 3)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
         ];
         let mut constants = std::collections::HashMap::new();
@@ -5127,45 +5176,42 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntGt,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_001)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
-            op! {
-                opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
-                descr: std::cell::RefCell::new(None),
-                pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)])),
-
-                fail_arg_types: std::cell::RefCell::new(None),
-                rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            {
+                let op = op! {
+                    opcode: OpCode::GuardTrue,
+                    args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
+                    descr: std::cell::RefCell::new(None),
+                    pos: std::cell::Cell::new(OpRef::NONE),
+                    rd_resume_position: std::cell::Cell::new(-1),
+                    extra: std::cell::RefCell::new(None),
+                };
+                op.setfailargs(
+                    vec![
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 1),
+                    ]
+                    .into(),
+                );
+                op
             },
             op! {
                 opcode: OpCode::Finish,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+                extra: std::cell::RefCell::new(None),
             },
         ];
         let mut constants = std::collections::HashMap::new();
@@ -5191,11 +5237,8 @@ mod tests {
             args: std::cell::RefCell::new(smallvec::smallvec![]),
             descr: std::cell::RefCell::new(Some(descr)),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(None),
-
-            fail_arg_types: std::cell::RefCell::new(None),
             rd_resume_position: std::cell::Cell::new(-1),
-            vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
         }];
         let constants: std::collections::HashMap<u32, i64> = std::collections::HashMap::new();
         let output = format_trace(&ops, &constants);
@@ -5223,67 +5266,58 @@ mod tests {
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntAdd,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::IntLt,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 2), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
-            op! {
-                opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 3)]),
-                descr: std::cell::RefCell::new(None),
-                pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)])),
-
-                fail_arg_types: std::cell::RefCell::new(None),
-                rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            {
+                let op = op! {
+                    opcode: OpCode::GuardTrue,
+                    args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 3)]),
+                    descr: std::cell::RefCell::new(None),
+                    pos: std::cell::Cell::new(OpRef::NONE),
+                    rd_resume_position: std::cell::Cell::new(-1),
+                    extra: std::cell::RefCell::new(None),
+                };
+                op.setfailargs(
+                    vec![
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 2),
+                    ]
+                    .into(),
+                );
+                op
             },
             op! {
                 opcode: OpCode::IntSub,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 10_001)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
-                fail_args: std::cell::RefCell::new(None),
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
             op! {
                 opcode: OpCode::Jump,
                 args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 4), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(None),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            extra: std::cell::RefCell::new(None),
             },
         ];
         let mut constants = std::collections::HashMap::new();
@@ -5307,28 +5341,42 @@ mod tests {
     fn test_format_trace_multiple_guards_with_different_fail_args() {
         // Multiple guards in a single trace, each with distinct fail_args.
         let ops = vec![
-            op! {
-                opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
-                descr: std::cell::RefCell::new(None),
-                pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)])),
-
-                fail_arg_types: std::cell::RefCell::new(None),
-                rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            {
+                let op = op! {
+                    opcode: OpCode::GuardTrue,
+                    args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0)]),
+                    descr: std::cell::RefCell::new(None),
+                    pos: std::cell::Cell::new(OpRef::NONE),
+                    rd_resume_position: std::cell::Cell::new(-1),
+                    extra: std::cell::RefCell::new(None),
+                };
+                op.setfailargs(
+                    vec![crate::forwarding::test_support::bound_resop_operand(
+                        Type::Int,
+                        0,
+                    )]
+                    .into(),
+                );
+                op
             },
-            op! {
-                opcode: OpCode::GuardFalse,
-                args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
-                descr: std::cell::RefCell::new(None),
-                pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(vec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 0), crate::forwarding::test_support::bound_resop_operand(Type::Int, 1), crate::forwarding::test_support::bound_resop_operand(Type::Int, 2)])),
-
-
-                fail_arg_types: std::cell::RefCell::new(None),
-                rd_resume_position: std::cell::Cell::new(-1),
-                vecinfo: std::cell::RefCell::new(None),
+            {
+                let op = op! {
+                    opcode: OpCode::GuardFalse,
+                    args: std::cell::RefCell::new(smallvec::smallvec![crate::forwarding::test_support::bound_resop_operand(Type::Int, 1)]),
+                    descr: std::cell::RefCell::new(None),
+                    pos: std::cell::Cell::new(OpRef::NONE),
+                    rd_resume_position: std::cell::Cell::new(-1),
+                    extra: std::cell::RefCell::new(None),
+                };
+                op.setfailargs(
+                    vec![
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 0),
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 1),
+                        crate::forwarding::test_support::bound_resop_operand(Type::Int, 2),
+                    ]
+                    .into(),
+                );
+                op
             },
         ];
         let constants: std::collections::HashMap<u32, i64> = std::collections::HashMap::new();

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5481,8 +5481,9 @@ impl Optimizer {
             // post-finish (mod.rs::store_final_boxes_in_guard).
             op = Self::store_final_boxes_in_guard(op, ctx, knowledge, pending_for_finish);
             // optimizer.py: force_box on each fail_arg for unrolling.
-            if let Some(fa) = op.getfailargs() {
+            if let Some(fa) = op.guard_fail_args() {
                 let fargs: Vec<OpRef> = fa.iter().map(|a| a.to_opref()).collect();
+                drop(fa);
                 for farg in fargs {
                     if !farg.is_none() {
                         self.force_box(farg, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3578,13 +3578,14 @@ impl Optimizer {
                                 .unwrap_or_else(|| arg.clone());
                             preamble_op.setarg(i, resolved);
                         }
-                        if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
+                        if let Some(mut fail_args) = preamble_op.getfailargs() {
                             for arg in fail_args.iter_mut() {
                                 if arg.is_none() {
                                     continue;
                                 }
                                 *arg = ctx.get_box_replacement_operand(arg.to_opref());
                             }
+                            preamble_op.setfailargs(fail_args);
                         }
                         // Resolve the carried slot by entry kind. An InputArg
                         // label arg whose canonical result forwards away is absent
@@ -3948,7 +3949,7 @@ impl Optimizer {
                         );
                     }
                 }
-                if let Some(fail_args) = op.fail_args.borrow_mut().as_mut() {
+                if let Some(mut fail_args) = op.getfailargs() {
                     for arg in fail_args.iter_mut() {
                         // Same rule as the args loop above: a bound failarg
                         // live-tracks its producer's already-remapped
@@ -4053,8 +4054,8 @@ impl Optimizer {
                             "position-only exported-short-box arg remapped: {pre:?}"
                         );
                     }
-                    if let Some(fa) = entry.op.fail_args.borrow_mut().as_mut() {
-                        for arg in fa.iter_mut() {
+                    if let Some(fa) = entry.op.getfailargs() {
+                        for arg in fa.iter() {
                             // Bound failargs live-track the producer's
                             // already-remapped pos (same rule as the args
                             // loop above); re-remapping would double-map.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -889,6 +889,87 @@ fn snapshot_map_from_trace_snapshots(
     (box_map, size_map, vable_map, vref_map, frame_pcs_map)
 }
 
+fn snapshot_maps_from_ctx(
+    ctx: &mut TraceCtx,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
+) -> (
+    SnapshotBoxes,
+    SnapshotFrameSizes,
+    SnapshotBoxes,
+    SnapshotBoxes,
+    SnapshotFramePcs,
+) {
+    if ctx.recorder.has_byte_buffer() {
+        return snapshot_map_from_byte_recorder(&ctx.recorder, constants);
+    }
+    snapshot_map_from_trace_snapshots(ctx.snapshots(), constants)
+}
+
+fn snapshot_map_from_byte_recorder(
+    recorder: &crate::recorder::Trace,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
+) -> (
+    SnapshotBoxes,
+    SnapshotFrameSizes,
+    SnapshotBoxes,
+    SnapshotBoxes,
+    SnapshotFramePcs,
+) {
+    let _ = constants;
+    let box_to_unique = recorder.box_to_unique_map();
+    let n = recorder.snapshot_offset_count();
+    let mut box_map = Vec::with_capacity(n);
+    let mut size_map = Vec::with_capacity(n);
+    let mut vable_map = Vec::with_capacity(n);
+    let mut vref_map = Vec::with_capacity(n);
+    let mut frame_pcs_map = Vec::with_capacity(n);
+    let tagged_to_box = |t: crate::recorder::SnapshotTagged| -> SnapshotBox {
+        match t {
+            crate::recorder::SnapshotTagged::Box(opref, fallback_tp) => {
+                let tp = opref.ty().unwrap_or(fallback_tp);
+                SnapshotBox::typed(opref, tp)
+            }
+            crate::recorder::SnapshotTagged::Const(val, tp) => {
+                let value = heap_value_for(tp, val);
+                let opref = majit_ir::OpRef::const_inline_from_value(&value);
+                SnapshotBox::typed(opref, tp)
+            }
+        }
+    };
+    recorder.for_each_captured_snapshot_arrays(|vable_t, vref_t, frames_t, py_pcs| {
+        let mut boxes = Vec::new();
+        let mut frame_sizes = Vec::with_capacity(frames_t.len());
+        let mut frame_pcs = Vec::with_capacity(frames_t.len());
+        for (fi, (jc, pc, tagged)) in frames_t.into_iter().enumerate() {
+            frame_sizes.push(tagged.len());
+            frame_pcs.push((
+                crate::recorder::Trace::decode_jitcode_index(jc) as i32,
+                pc as i32,
+                py_pcs.get(fi).copied().unwrap_or(pc as u32) as i32,
+            ));
+            boxes.extend(
+                tagged
+                    .into_iter()
+                    .map(|t| tagged_to_box(recorder.untag_snapshot(t, &box_to_unique))),
+            );
+        }
+        let vable_boxes: Vec<SnapshotBox> = vable_t
+            .into_iter()
+            .map(|t| tagged_to_box(recorder.untag_snapshot(t, &box_to_unique)))
+            .collect();
+        let vref_boxes: Vec<SnapshotBox> = vref_t
+            .into_iter()
+            .map(|t| tagged_to_box(recorder.untag_snapshot(t, &box_to_unique)))
+            .collect();
+        box_map.push(Some(boxes));
+        size_map.push(Some(frame_sizes));
+        vable_map.push(Some(vable_boxes));
+        vref_map.push(Some(vref_boxes));
+        frame_pcs_map.push(Some(frame_pcs));
+    });
+    (box_map, size_map, vable_map, vref_map, frame_pcs_map)
+}
+
 struct PreparedBridgeTrace {
     ops: Vec<OpRc>,
     inputargs: Vec<InputArg>,
@@ -2680,7 +2761,7 @@ fn walk_op_const_ptr_refs(op: &Op, visitor: &mut dyn FnMut(&mut GcRef)) {
     for arg in op.args.borrow().iter() {
         arg.walk_const_ptr_refs(visitor);
     }
-    if let Some(fail_args) = op.fail_args.borrow().as_ref() {
+    if let Some(fail_args) = op.getfailargs() {
         for arg in fail_args.iter() {
             arg.walk_const_ptr_refs(visitor);
         }
@@ -9017,7 +9098,7 @@ impl<M: Clone> MetaInterp<M> {
             mut snapshot_vable_boxes,
             mut snapshot_vref_boxes,
             snapshot_frame_pcs,
-        ) = snapshot_map_from_trace_snapshots(ctx.snapshots(), &mut constants);
+        ) = snapshot_maps_from_ctx(ctx, &mut constants);
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
             &mut snapshot_boxes,
             &mut snapshot_vable_boxes,

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -405,7 +405,7 @@ impl Trace {
         }
     }
 
-    fn decode_jitcode_index(idx: i64) -> u32 {
+    pub(crate) fn decode_jitcode_index(idx: i64) -> u32 {
         if idx == -2 {
             UNSTAMPED_JITCODE_INDEX
         } else {
@@ -441,7 +441,7 @@ impl Trace {
         OpRef::op_typed(unique, slot.opcode.result_type())
     }
 
-    fn untag_snapshot(&self, tagged: i64, box_to_unique: &[u32]) -> SnapshotTagged {
+    pub(crate) fn untag_snapshot(&self, tagged: i64, box_to_unique: &[u32]) -> SnapshotTagged {
         use crate::opencoder::{TAG_MASK, TAG_SHIFT, TAGBOX, TAGCONSTOTHER, TAGCONSTPTR, TAGINT};
         let tag = (tagged & TAG_MASK as i64) as u8;
         let v = tagged >> TAG_SHIFT;
@@ -602,9 +602,7 @@ impl Trace {
         id
     }
 
-    /// Rebuild `Vec<Snapshot>` from `_snapshot_data` in capture order.
-    pub fn decode_captured_snapshots(&self) -> Option<Vec<Snapshot>> {
-        let trb = self.trb.as_ref()?;
+    pub(crate) fn box_to_unique_map(&self) -> Vec<u32> {
         let mut box_to_unique = Vec::new();
         for (unique, &mapped) in self.unique_to_box.iter().enumerate() {
             if mapped == u32::MAX {
@@ -615,6 +613,52 @@ impl Trace {
             }
             box_to_unique[mapped as usize] = unique as u32;
         }
+        box_to_unique
+    }
+
+    /// Walk each captured snapshot's tagged arrays without building
+    /// `Vec<Snapshot>`. `opencoder.py` keeps `_snapshot_data` as the
+    /// source of truth.
+    pub(crate) fn for_each_captured_snapshot_arrays(
+        &self,
+        mut f: impl FnMut(
+            smallvec::SmallVec<[i64; 8]>,
+            smallvec::SmallVec<[i64; 8]>,
+            smallvec::SmallVec<[(i64, i64, smallvec::SmallVec<[i64; 8]>); 4]>,
+            &[u32],
+        ),
+    ) -> bool {
+        let Some(trb) = self.trb.as_ref() else {
+            return false;
+        };
+        for (i, &offset) in self.snapshot_offsets.iter().enumerate() {
+            let it = trb.get_snapshot_iter(offset);
+            let vable_t: smallvec::SmallVec<[i64; 8]> = it.iter_vable_array().collect();
+            let vref_t: smallvec::SmallVec<[i64; 8]> = it.iter_vref_array().collect();
+            let frames_t: smallvec::SmallVec<[(i64, i64, smallvec::SmallVec<[i64; 8]>); 4]> = it
+                .framestack
+                .iter()
+                .copied()
+                .map(|snap_idx| {
+                    let (jc, pc) = it.unpack_jitcode_pc(snap_idx);
+                    let boxes: smallvec::SmallVec<[i64; 8]> = it.iter_array(snap_idx).collect();
+                    (jc, pc, boxes)
+                })
+                .collect();
+            let py_pcs = self
+                .snapshot_py_pcs
+                .get(i)
+                .map(smallvec::SmallVec::as_slice)
+                .unwrap_or(&[]);
+            f(vable_t, vref_t, frames_t, py_pcs);
+        }
+        true
+    }
+
+    /// Rebuild `Vec<Snapshot>` from `_snapshot_data` in capture order.
+    pub fn decode_captured_snapshots(&self) -> Option<Vec<Snapshot>> {
+        let trb = self.trb.as_ref()?;
+        let box_to_unique = self.box_to_unique_map();
         let mut out = Vec::with_capacity(self.snapshot_offsets.len());
         for (i, &offset) in self.snapshot_offsets.iter().enumerate() {
             let (vable_t, vref_t, frames_t) = {
@@ -1509,8 +1553,8 @@ impl Trace {
                     arg.walk_const_ptr_refs(visitor);
                 }
             }
-            if let Some(fail_args) = op.fail_args.borrow().as_ref() {
-                for arg in fail_args {
+            if let Some(fail_args) = op.getfailargs() {
+                for arg in fail_args.iter() {
                     if !is_pooled_const_ptr(arg) {
                         arg.walk_const_ptr_refs(visitor);
                     }


### PR DESCRIPTION
Follow-up to #1749. Two compile-path cuts on the `and`/`or` row.

`GuardResOp` extras (`fail_args`, `fail_arg_types`, vector info) live in a boxed `OpKindExtra`, matching `resoperation.py` `GuardResOp` / `VectorOp` / `VectorGuardOp`. Ordinary Ops no longer carry those fields, so `size_of::<Op>() <= 192` and the 256 B class is gone. `compile_bridge` builds snapshot maps from `_snapshot_data` without rematerializing `Vec<Snapshot>`.

`GcRewriter` and the dynasm assemble path keep the `OpRc` identities `rewrite.py` appends to `newops`. `compile_loop` / `compile_bridge` no longer clone each `Op` into a `Vec<Op>`; `pos` and `descr` stay interior-mutable on the shared object.

Census on `and`/`or` (1 MiB, row 2): 4.1 → 3.8 allocs/char, 704.1 → 609.6 B/char. 192 B `Rc<Op>` at materialize remains 0.51 allocs/char.

`cargo test --all --no-default-features --features dynasm` passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced operation copying during compilation and garbage-collection processing, potentially improving compilation efficiency and memory usage.
  * Reduced memory usage for operation metadata.

* **Reliability**
  * Improved handling of trace snapshots and captured snapshot data during JIT compilation.

* **Refactor**
  * Standardized shared operation handling across compilation, register allocation, assembly, and garbage-collection processing while preserving generated code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->