### PR TITLE
majit: walk grain guard failures to a merge point

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -429,6 +429,14 @@ cover the condition they diagnose.
 - What it does: Whether `MAJIT_PROBE_LIVENESS` is set, cached at first access.
 - Retirement condition: **UNRECORDED** — owed by this gate's owner.
 
+### `MAJIT_REGALLOC_DEBUG`
+
+- Read sites: 2 — `majit/majit-translate/src/tool/algo/regalloc.rs`
+- Accessor: `std::env::var_os("MAJIT_REGALLOC_DEBUG")` in `perform_register_allocation` and `try_coalesce`
+- What it does: prints portal Ref colour occupancy, protected-sharing, and the names that share a merge-point red. Used to see whether a later Scope joined the reserved vm colour. The ordinary build still runs the reservation; this only opens the log.
+- Default polarity: **OFF**; unset disables the log.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
 ### `MAJIT_REG_WRITE_AUDIT`
 
 - Read sites: 1 — `majit/majit-ir/src/reg_write_audit.rs`

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -716,6 +716,11 @@ fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
     if let Some(r) = gc_box::with_mut(|g| g.alloc_oldgen_typed(type_id, size)) {
         return r;
     }
+    // Grain never installs MiniMark. A typed blackhole NEW with no collector
+    // is NULL (`bh_alloc_struct`), not a panic on the unset singleton.
+    if !majit_gc::gc_sync::is_initialized() {
+        return GcRef(0);
+    }
     majit_gc::gc_sync::gc_op(|g| g.alloc_oldgen_typed(type_id, size))
 }
 
@@ -1660,17 +1665,19 @@ impl DynasmBackend {
     }
 
     #[inline]
-    fn raw_mem_ptr(addr: i64, offset: i64) -> usize {
-        assert_ne!(
-            addr, 0,
-            "llmodel.py parity: raw memory helpers must not silently accept NULL addresses"
-        );
-        (addr as usize).wrapping_add(offset as usize)
+    fn raw_mem_ptr(addr: i64, offset: i64) -> Option<usize> {
+        if addr == 0 {
+            majit_backend::note_null_mem_access();
+            return None;
+        }
+        Some((addr as usize).wrapping_add(offset as usize))
     }
 
     /// llmodel.py read_int_at_mem(gcref, ofs, size, sign).
     fn read_int_at_mem(&self, addr: i64, offset: i64, size: usize, sign: bool) -> i64 {
-        let ptr = Self::raw_mem_ptr(addr, offset);
+        let Some(ptr) = Self::raw_mem_ptr(addr, offset) else {
+            return 0;
+        };
         unsafe {
             match (size, sign) {
                 (1, true) => (ptr as *const i8).read_unaligned() as i64,
@@ -1686,7 +1693,9 @@ impl DynasmBackend {
 
     /// llmodel.py write_int_at_mem(gcref, ofs, size, newvalue).
     fn write_int_at_mem(&self, addr: i64, offset: i64, size: usize, newvalue: i64) {
-        let ptr = Self::raw_mem_ptr(addr, offset);
+        let Some(ptr) = Self::raw_mem_ptr(addr, offset) else {
+            return;
+        };
         unsafe {
             match size {
                 1 => (ptr as *mut u8).write_unaligned(newvalue as u8),
@@ -1699,13 +1708,17 @@ impl DynasmBackend {
 
     /// llmodel.py read_float_at_mem(gcref, ofs).
     fn read_float_at_mem(&self, addr: i64, offset: i64) -> f64 {
-        let ptr = Self::raw_mem_ptr(addr, offset);
+        let Some(ptr) = Self::raw_mem_ptr(addr, offset) else {
+            return 0.0;
+        };
         unsafe { (ptr as *const f64).read_unaligned() }
     }
 
     /// llmodel.py write_float_at_mem(gcref, ofs, newvalue).
     fn write_float_at_mem(&self, addr: i64, offset: i64, newvalue: f64) {
-        let ptr = Self::raw_mem_ptr(addr, offset);
+        let Some(ptr) = Self::raw_mem_ptr(addr, offset) else {
+            return;
+        };
         unsafe { (ptr as *mut f64).write_unaligned(newvalue) }
     }
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -13,6 +13,19 @@ use std::sync::{Arc, OnceLock};
 
 use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 
+/// `llmodel.py protect_speculative_field` rejected a null gcptr.
+/// The walker aborts the trace instead of panicking the host.
+static NULL_MEM_ACCESS: AtomicBool = AtomicBool::new(false);
+
+pub fn note_null_mem_access() {
+    NULL_MEM_ACCESS.store(true, Ordering::Relaxed);
+}
+
+#[must_use]
+pub fn take_null_mem_access() -> bool {
+    NULL_MEM_ACCESS.swap(false, Ordering::Relaxed)
+}
+
 /// `rpython/jit/backend/model.py CPUTotalTracker` — per-CPU totals
 /// bumped by `CompiledLoopToken.__init__` / `compiling_a_bridge` (loops
 /// and bridges created) and by the memory manager (loops and bridges

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -13,17 +13,20 @@ use std::sync::{Arc, OnceLock};
 
 use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
 
+thread_local! {
+    static NULL_MEM_ACCESS: Cell<bool> = const { Cell::new(false) };
+}
+
 /// `llmodel.py protect_speculative_field` rejected a null gcptr.
 /// The walker aborts the trace instead of panicking the host.
-static NULL_MEM_ACCESS: AtomicBool = AtomicBool::new(false);
-
+/// Per-thread: two overlapping walks must not consume each other's latch.
 pub fn note_null_mem_access() {
-    NULL_MEM_ACCESS.store(true, Ordering::Relaxed);
+    NULL_MEM_ACCESS.with(|cell| cell.set(true));
 }
 
 #[must_use]
 pub fn take_null_mem_access() -> bool {
-    NULL_MEM_ACCESS.swap(false, Ordering::Relaxed)
+    NULL_MEM_ACCESS.with(|cell| cell.replace(false))
 }
 
 /// `rpython/jit/backend/model.py CPUTotalTracker` — per-CPU totals

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1896,6 +1896,15 @@ impl BlackholeInterpreter {
             // separates the two further: equal to `pos` means the frame was
             // `setposition`ed straight onto this byte and dispatched with no
             // prior step, so nothing walked it forward from a valid boundary.
+            //
+            // Grain never installs MiniMark. A walk that inlined a helper
+            // (`malformed`) and aborted leaves the blackhole on that helper
+            // body; those Charon-lowered opcodes are not in this table.
+            // Leave to the portal merge point rather than panic. Hosts that
+            // registered a MemoryError provider still fail loud.
+            if majit_backend::memory_error_singleton_ref() == 0 {
+                return Err(DispatchError::LeaveFrame);
+            }
             panic!(
                 "dispatch_step: unwired opcode={opcode:#x} pos={} entry={} \
                  table_len={} jitcode={:?} index={:?} startpoint={} — extend the \
@@ -8367,6 +8376,19 @@ enum CallDescrHandle {
 }
 
 impl CallDescrHandle {
+    /// The callee jitcode a canonical `inline_call_*` named, when the
+    /// descr pool still holds that object. Needed to byte-interpret a
+    /// helper whose `fnaddr` is a build-time symbolic hash.
+    fn as_callee_jitcode(&self) -> Option<std::sync::Arc<JitCode>> {
+        match self {
+            Self::InCalleeJitCode(jitcode) => Some(jitcode.clone()),
+            Self::InJitCode(jitcode, index) => jitcode
+                .descr_at(*index)
+                .and_then(|entry| entry.as_jitcode_owned()),
+            Self::InBuilderTable(_) => None,
+        }
+    }
+
     fn get(&self) -> &BhCallDescr {
         let descr = match self {
             Self::InJitCode(jitcode, index) => jitcode
@@ -9208,10 +9230,12 @@ fn check_blackhole_allocation_after(
 #[inline]
 fn blackhole_allocation_error(next_pos: usize) -> DispatchError {
     let exc = majit_backend::memory_error_singleton_ref();
-    assert!(
-        exc != 0,
-        "blackhole allocation failed before the MemoryError provider was installed"
-    );
+    // Grain never installs MiniMark or a MemoryError singleton. A typed
+    // `bh_new` then returns NULL; leave to the portal merge point rather
+    // than panic. Hosts that registered a provider still raise it.
+    if exc == 0 {
+        return DispatchError::LeaveFrame;
+    }
     DispatchError::RaiseException {
         exc,
         resume_position: next_pos,
@@ -11342,10 +11366,11 @@ fn handler_raise(
     let exc = bh.registers_r[code[p] as usize];
     // RPython blackhole.py `bhimpl_raise(self, excvalue)`
     // `e = cast_opaque_ptr(...); assert e; reraise(e)`.
-    assert!(
-        exc != 0,
-        "blackhole.py:1002 raise: excvalue must be non-null"
-    );
+    // Grain never installs MiniMark, so a helper `NEW` of the exception
+    // is NULL. Leave to the portal merge point rather than panic.
+    if exc == 0 {
+        return Err(DispatchError::LeaveFrame);
+    }
     Err(DispatchError::RaiseException {
         exc,
         resume_position: p + 1,
@@ -11358,10 +11383,10 @@ fn handler_reraise(
 ) -> Result<usize, DispatchError> {
     // `reraise/` decodes no operands, so `p` is already the end of the
     // instruction.
-    assert!(
-        bh.exception_last_value != 0,
-        "BlackholeInterpreter.bhimpl_reraise requires an active exception"
-    );
+    // Grain: no MiniMark means no exception object. Leave rather than panic.
+    if bh.exception_last_value == 0 {
+        return Err(DispatchError::LeaveFrame);
+    }
     Err(DispatchError::RaiseException {
         exc: bh.exception_last_value,
         resume_position: p,
@@ -12464,13 +12489,13 @@ pub(crate) fn is_callable_fnaddr(fnaddr: i64) -> bool {
     fnaddr != 0 && !is_symbolic_fnaddr(fnaddr)
 }
 
-/// Refuse to call an unresolved `inline_call_*` target.
+/// Refuse to call an unresolved `inline_call_*` target when its jitcode
+/// body is not available to interpret either.
 ///
-/// The walker declines the equivalent residual (`ResidualDecline::Symbolic`);
-/// the blackhole has no decline channel, so it aborts the frame — a
-/// guard-failure resume that cannot finish hands the continuation back to the
-/// interpreter, which is always correct, where an indirect branch to a hash is
-/// not.
+/// The walker declines the equivalent residual (`ResidualDecline::Symbolic`).
+/// The blackhole must finish the half-opcode (`convert_and_run_from_pyjitpl`);
+/// jumping to a symbolic hash is not a finish. Prefer
+/// [`interpret_unresolved_inline_call`] when the descr still names a body.
 #[inline]
 fn reject_unresolved_inline_call(
     bh: &mut BlackholeInterpreter,
@@ -12486,19 +12511,155 @@ fn reject_unresolved_inline_call(
     bh.aborted = true;
     DispatchError::LeaveFrame
 }
+
+/// Byte-interpret a canonical `inline_call_*` whose `fnaddr` is symbolic.
+///
+/// Upstream `bhimpl_inline_call_*` (`blackhole.py`) calls
+/// `cpu.bh_call_*(jitcode.fnaddr)` because the codewriter and the runtime
+/// share one process, so every helper jitcode carries a real entry.
+/// pyre's lowering runs in `build.rs`; an unpublished path stays a
+/// `symbolic_fnaddr_for_path` hash. `handler_inline_call_nested_ext`
+/// already interprets that shape when `fnaddr` is 0. The canonical
+/// handlers must do the same, or `convert_and_run_from_pyjitpl` aborts
+/// mid-opcode and the portal sees `usize::MAX` instead of a merge point.
+fn interpret_unresolved_inline_call(
+    bh: &mut BlackholeInterpreter,
+    handle: &CallDescrHandle,
+    jitcode_index: usize,
+    fnaddr: i64,
+    args_i: &[i64],
+    args_r: &[i64],
+    args_f: &[i64],
+    dest: Option<(JitArgKind, usize)>,
+    post_p: usize,
+) -> Result<usize, DispatchError> {
+    // Grain and other hosts that never install MiniMark cannot execute
+    // Charon-lowered helper bodies: those bodies emit GETFIELD_GC that
+    // expect the collector. Fall back to LeaveFrame; the portal resumes
+    // at its merge point rather than jumping to a symbolic hash.
+    if !majit_gc::gc_sync::is_initialized() {
+        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
+    }
+    let Some(sub_jitcode) = handle.as_callee_jitcode() else {
+        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
+    };
+    if crate::majit_log_enabled() {
+        eprintln!(
+            "[bh] inline_call interpreting jitcodes[{jitcode_index}] name={:?} \
+             (fnaddr={fnaddr:#x} is not callable)",
+            sub_jitcode.name,
+        );
+    }
+    let mut callee = bh
+        .inline_callee_scratch
+        .take()
+        .unwrap_or_else(|| Box::new(BlackholeInterpreter::default()));
+    callee.clone_context_from(bh);
+    callee.setposition(sub_jitcode, 0);
+    for (index, &value) in args_i.iter().enumerate() {
+        if index < callee.registers_i.len() {
+            callee.registers_i[index] = value;
+        }
+    }
+    for (index, &value) in args_r.iter().enumerate() {
+        if index < callee.registers_r.len() {
+            callee.registers_r[index] = value;
+        }
+    }
+    for (index, &value) in args_f.iter().enumerate() {
+        if index < callee.registers_f.len() {
+            callee.registers_f[index] = value;
+        }
+    }
+
+    let outcome = 'callee: {
+        match callee.run() {
+            BhRunOutcome::ContinueRunningNormally(args) => {
+                bh.position = post_p;
+                break 'callee Err(DispatchError::ContinueRunningNormally(args));
+            }
+            BhRunOutcome::EndOfCode => panic!(
+                "inline_call: callee jitcode {:?} index {:?} ended without a \
+                 return opcode, so there is no result for the caller",
+                callee.jitcode.name,
+                callee.jitcode.try_index(),
+            ),
+            BhRunOutcome::LeaveFrame | BhRunOutcome::Exception => {}
+        }
+        if callee.aborted {
+            bh.position = post_p;
+            bh.aborted = true;
+            bh.abort_permanent_bail = callee.abort_permanent_bail;
+            break 'callee Err(DispatchError::LeaveFrame);
+        }
+        if callee.got_exception {
+            let exc_val = callee.exception_last_value;
+            if exc_val != 0 {
+                break 'callee Err(DispatchError::RaiseException {
+                    exc: exc_val,
+                    resume_position: post_p,
+                });
+            }
+            bh.position = post_p;
+            bh.got_exception = true;
+            break 'callee Err(DispatchError::LeaveFrame);
+        }
+        if let Some((return_kind, callee_src)) = callee.jitcode.trailing_return_info() {
+            let caller_dst = dest.map(|(_, dst)| dst).expect(
+                "inline_call interpret: callee returns a value but the caller \
+                 declared no destination",
+            );
+            match return_kind {
+                JitArgKind::Int => {
+                    bh.registers_i[caller_dst] = callee.registers_i[callee_src as usize];
+                }
+                JitArgKind::Ref => {
+                    bh.registers_r[caller_dst] = callee.registers_r[callee_src as usize];
+                }
+                JitArgKind::Float => {
+                    bh.registers_f[caller_dst] = callee.registers_f[callee_src as usize];
+                }
+            }
+        } else {
+            assert!(
+                dest.is_none(),
+                "inline_call interpret: callee jitcode {:?} ends without a \
+                 typed return, but the caller declared dest {dest:?}",
+                callee.jitcode.name,
+            );
+        }
+        Ok(post_p)
+    };
+    if callee.called_residual.get() {
+        bh.called_residual.set(true);
+    }
+    callee.reset_for_inline_reuse();
+    bh.inline_callee_scratch = Some(callee);
+    outcome
+}
 fn handler_inline_call_irf_i(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let (af, p) = read_list_f(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &af,
+            Some((JitArgKind::Int, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_irf_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_irf_i(fnaddr, &ai, &ar, &af, calldescr.get());
@@ -12512,13 +12673,23 @@ fn handler_inline_call_irf_r(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let (af, p) = read_list_f(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &af,
+            Some((JitArgKind::Ref, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_irf_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_irf_r(fnaddr, &ai, &ar, &af, calldescr.get());
@@ -12532,13 +12703,23 @@ fn handler_inline_call_irf_f(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let (af, p) = read_list_f(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &af,
+            Some((JitArgKind::Float, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_irf_f.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_irf_f(fnaddr, &ai, &ar, &af, calldescr.get());
@@ -12552,12 +12733,22 @@ fn handler_inline_call_irf_v(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let (af, p) = read_list_f(bh, code, p);
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &af,
+            None,
+            p,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_irf_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_inline_call_irf_v(fnaddr, &ai, &ar, &af, calldescr.get());
@@ -12570,12 +12761,22 @@ fn handler_inline_call_ir_i(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &[],
+            Some((JitArgKind::Int, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_ir_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_ir_i(fnaddr, &ai, &ar, calldescr.get());
@@ -12589,12 +12790,22 @@ fn handler_inline_call_ir_r(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &[],
+            Some((JitArgKind::Ref, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_ir_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_ir_r(fnaddr, &ai, &ar, calldescr.get());
@@ -12608,11 +12819,21 @@ fn handler_inline_call_ir_v(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ai, p) = read_list_i(bh, code, p);
     let (ar, p) = read_list_r(bh, code, p);
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &ai,
+            &ar,
+            &[],
+            None,
+            p,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_ir_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_inline_call_ir_v(fnaddr, &ai, &ar, calldescr.get());
@@ -12625,11 +12846,21 @@ fn handler_inline_call_r_i(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ar, p) = read_list_r(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &[],
+            &ar,
+            &[],
+            Some((JitArgKind::Int, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_r_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_r_i(fnaddr, &ar, calldescr.get());
@@ -12643,11 +12874,21 @@ fn handler_inline_call_r_r(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ar, p) = read_list_r(bh, code, p);
     let dst = code[p] as usize;
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &[],
+            &ar,
+            &[],
+            Some((JitArgKind::Ref, dst)),
+            p + 1,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_r_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_inline_call_r_r(fnaddr, &ar, calldescr.get());
@@ -12661,10 +12902,20 @@ fn handler_inline_call_r_v(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let (jitcode_index, fnaddr, calldescr, p) = read_inline_call_jitcode(bh, code, p);
-    if !is_callable_fnaddr(fnaddr) {
-        return Err(reject_unresolved_inline_call(bh, jitcode_index, fnaddr));
-    }
     let (ar, p) = read_list_r(bh, code, p);
+    if !is_callable_fnaddr(fnaddr) {
+        return interpret_unresolved_inline_call(
+            bh,
+            &calldescr,
+            jitcode_index,
+            fnaddr,
+            &[],
+            &ar,
+            &[],
+            None,
+            p,
+        );
+    }
     // blackhole.py → bhimpl_inline_call_r_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_inline_call_r_v(fnaddr, &ar, calldescr.get());

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -4513,6 +4513,17 @@ mod tests {
         }
 
         #[test]
+        fn reraise_of_a_null_exception_aborts_the_frame() {
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.exception_last_value = 0;
+            let err = super::handler_reraise(&mut bh, &[], 0)
+                .expect_err("a null exception must leave the frame");
+            assert!(matches!(err, super::DispatchError::LeaveFrame));
+            assert!(bh.aborted);
+        }
+
+        #[test]
         fn obsolete_vtable_method_opcode_bails_instead_of_panicking() {
             let mut builder = super::build_inline_call_only_bh_builder();
             let mut bh = builder.acquire_interp();
@@ -9212,7 +9223,7 @@ fn check_residual_call_exception_after(
 /// NULL is never an ordinary `r` result that the following opcode may consume.
 #[inline]
 fn check_blackhole_allocation_after(
-    bh: &BlackholeInterpreter,
+    bh: &mut BlackholeInterpreter,
     result: i64,
     next_pos: usize,
 ) -> Result<(), DispatchError> {
@@ -9224,15 +9235,21 @@ fn check_blackhole_allocation_after(
     // the backend copy now; otherwise an unrelated later compiled call sees a
     // stale MemoryError.
     bh.cpu().clear_stored_exception();
-    Err(blackhole_allocation_error(next_pos))
+    let err = blackhole_allocation_error(next_pos);
+    // No MemoryError provider: `LeaveFrame` alone is a successful return
+    // in `resume_mainloop`. Mark the frame aborted so the caller bails.
+    if matches!(err, DispatchError::LeaveFrame) {
+        bh.aborted = true;
+    }
+    Err(err)
 }
 
 #[inline]
 fn blackhole_allocation_error(next_pos: usize) -> DispatchError {
     let exc = majit_backend::memory_error_singleton_ref();
     // Grain never installs MiniMark or a MemoryError singleton. A typed
-    // `bh_new` then returns NULL; leave to the portal merge point rather
-    // than panic. Hosts that registered a provider still raise it.
+    // `bh_new` then returns NULL; abort the frame rather than panic.
+    // Hosts that registered a provider still raise it.
     if exc == 0 {
         return DispatchError::LeaveFrame;
     }
@@ -11367,8 +11384,9 @@ fn handler_raise(
     // RPython blackhole.py `bhimpl_raise(self, excvalue)`
     // `e = cast_opaque_ptr(...); assert e; reraise(e)`.
     // Grain never installs MiniMark, so a helper `NEW` of the exception
-    // is NULL. Leave to the portal merge point rather than panic.
+    // is NULL. Abort the frame rather than panic or publish a void return.
     if exc == 0 {
+        bh.aborted = true;
         return Err(DispatchError::LeaveFrame);
     }
     Err(DispatchError::RaiseException {
@@ -11383,8 +11401,10 @@ fn handler_reraise(
 ) -> Result<usize, DispatchError> {
     // `reraise/` decodes no operands, so `p` is already the end of the
     // instruction.
-    // Grain: no MiniMark means no exception object. Leave rather than panic.
+    // Grain: no MiniMark means no exception object. Abort rather than
+    // panic or publish a void return.
     if bh.exception_last_value == 0 {
+        bh.aborted = true;
         return Err(DispatchError::LeaveFrame);
     }
     Err(DispatchError::RaiseException {
@@ -12265,21 +12285,25 @@ fn handler_newlist(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
+    let structdescr = structdescr.clone();
+    let lengthdescr = lengthdescr.clone();
+    let itemsdescr = itemsdescr.clone();
+    let arraydescr = arraydescr.clone();
     // blackhole.py:1163: result = cpu.bh_new(structdescr)
-    let result = bh.cpu().bh_new(structdescr);
+    let result = bh.cpu().bh_new(&structdescr);
     check_blackhole_allocation_after(bh, result, p + 1)?;
     // blackhole.py:1164: cpu.bh_setfield_gc_i(result, length, lengthdescr)
-    bh.cpu().bh_setfield_gc_i(result, length, lengthdescr);
+    bh.cpu().bh_setfield_gc_i(result, length, &lengthdescr);
     // blackhole.py:1165-1169: bh_new_array_clear when is_array_of_structs or is_array_of_pointers
     let items = if arraydescr.is_array_of_structs() || arraydescr.is_array_of_pointers() {
-        bh.cpu().bh_new_array_clear(length, arraydescr)
+        bh.cpu().bh_new_array_clear(length, &arraydescr)
     } else {
-        bh.cpu().bh_new_array(length, arraydescr)
+        bh.cpu().bh_new_array(length, &arraydescr)
     };
     check_blackhole_allocation_after(bh, items, p + 1)?;
     // blackhole.py:1170: cpu.bh_setfield_gc_r(result, items, itemsdescr)
     bh.cpu()
-        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), &itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }
@@ -12294,14 +12318,18 @@ fn handler_newlist_clear(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
-    let result = bh.cpu().bh_new(structdescr);
+    let structdescr = structdescr.clone();
+    let lengthdescr = lengthdescr.clone();
+    let itemsdescr = itemsdescr.clone();
+    let arraydescr = arraydescr.clone();
+    let result = bh.cpu().bh_new(&structdescr);
     check_blackhole_allocation_after(bh, result, p + 1)?;
-    bh.cpu().bh_setfield_gc_i(result, length, lengthdescr);
+    bh.cpu().bh_setfield_gc_i(result, length, &lengthdescr);
     // blackhole.py:1178: items = cpu.bh_new_array_clear(length, arraydescr)
-    let items = bh.cpu().bh_new_array_clear(length, arraydescr);
+    let items = bh.cpu().bh_new_array_clear(length, &arraydescr);
     check_blackhole_allocation_after(bh, items, p + 1)?;
     bh.cpu()
-        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), &itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }
@@ -12316,19 +12344,23 @@ fn handler_newlist_hint(
     let (lengthdescr, p) = read_descr(bh, code, p);
     let (itemsdescr, p) = read_descr(bh, code, p);
     let (arraydescr, p) = read_descr(bh, code, p);
-    let result = bh.cpu().bh_new(structdescr);
+    let structdescr = structdescr.clone();
+    let lengthdescr = lengthdescr.clone();
+    let itemsdescr = itemsdescr.clone();
+    let arraydescr = arraydescr.clone();
+    let result = bh.cpu().bh_new(&structdescr);
     check_blackhole_allocation_after(bh, result, p + 1)?;
     // blackhole.py:1186: cpu.bh_setfield_gc_i(result, 0, lengthdescr)
-    bh.cpu().bh_setfield_gc_i(result, 0, lengthdescr);
+    bh.cpu().bh_setfield_gc_i(result, 0, &lengthdescr);
     // blackhole.py:1187-1191: bh_new_array_clear when is_array_of_structs or is_array_of_pointers
     let items = if arraydescr.is_array_of_structs() || arraydescr.is_array_of_pointers() {
-        bh.cpu().bh_new_array_clear(lengthhint, arraydescr)
+        bh.cpu().bh_new_array_clear(lengthhint, &arraydescr)
     } else {
-        bh.cpu().bh_new_array(lengthhint, arraydescr)
+        bh.cpu().bh_new_array(lengthhint, &arraydescr)
     };
     check_blackhole_allocation_after(bh, items, p + 1)?;
     bh.cpu()
-        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), itemsdescr);
+        .bh_setfield_gc_r(result, majit_ir::GcRef(items as usize), &itemsdescr);
     bh.registers_r[code[p] as usize] = result;
     Ok(p + 1)
 }

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -510,6 +510,28 @@ pub trait JitState: Sized {
         None
     }
 
+    /// Rebind portal reds on a guard-resume framestack from the live
+    /// interpreter state.
+    ///
+    /// Generated `setup_bridge_sym` binds a state-field identity register
+    /// the resume frame does not carry as a `Const` from the live mirrors
+    /// `initialize_sym` left behind. A frontend whose reds *are* those
+    /// identities — Grain's live frame and live Vm, republished on every
+    /// merge-point consult — has the same gap on the opposite side: the
+    /// register is present, but `bridge_decode_red` keys it by failarg
+    /// index and the concrete bits can still be a walk-local address the
+    /// parent loop walk snapshotted. Residual calls then write through
+    /// that address instead of the interpreter object still on the stack.
+    ///
+    /// Only the concrete shadow is rewritten. The `OpRef` stays the
+    /// failarg or folded `Const` the resume stream named, so a compiled
+    /// bridge keeps taking a per-eval red rather than baking this eval's
+    /// stack pointer in. The default is a no-op: generated frontends
+    /// already rebound their identity registers in `setup_bridge_sym`,
+    /// and a state whose reds are not heap/stack identities has nothing
+    /// to replace.
+    fn rebind_bridge_reds(&self, _frames: &mut [GuardResumeFrame]) {}
+
     /// resume.py rebuild_from_resumedata: decode rd_numb to
     /// reconstruct the complete frame state for bridge tracing.
     ///

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -532,6 +532,14 @@ pub trait JitState: Sized {
     /// to replace.
     fn rebind_bridge_reds(&self, _frames: &mut [GuardResumeFrame]) {}
 
+    /// Same as [`Self::rebind_bridge_reds`], with the compiled guard's
+    /// failarg dump so a red that is a livebox but not a portal-register
+    /// occupant can still name an `InputArg`.
+    fn rebind_bridge_reds_from_fail(&self, frames: &mut [GuardResumeFrame], fail_values: &[i64]) {
+        let _ = fail_values;
+        self.rebind_bridge_reds(frames);
+    }
+
     /// resume.py rebuild_from_resumedata: decode rd_numb to
     /// reconstruct the complete frame state for bridge tracing.
     ///

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5939,7 +5939,7 @@ impl<S: JitState> JitDriver<S> {
         // from the live state. Grain's two reds are those identities and
         // the resume stream can still name a walk-local address; rewrite
         // the concrete shadows before the walk residual-calls through them.
-        state.rebind_bridge_reds(&mut frames);
+        state.rebind_bridge_reds_from_fail(&mut frames, raw_values);
 
         self.bridge_entered_at_guard_resume = true;
         let mut entered = false;

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4919,14 +4919,28 @@ impl<S: JitState> JitDriver<S> {
                     } else {
                         None
                     };
+                    let det_bridge_abort = self
+                        .meta
+                        .tracing
+                        .as_ref()
+                        .is_some_and(|ctx| ctx.deterministic_bridge_abort);
                     if let Some(source_descr) = setup_aborted_bridge_descr {
-                        // `pyjitpl.rs`'s `record_declined_bridge_guard`
-                        // structural-decline contract:
-                        // a bridge abort before bytecode-body ops is deterministic
-                        // setup failure from the fixed guard resume shape, so it
-                        // must not refire. The lone GetfieldRawI case is emitted
-                        // by bridge symbolic init before the body walker runs.
-                        self.meta.record_declined_bridge_guard(&source_descr);
+                        // Setup died before any body op: the reachable
+                        // set of the first callee still names an unbound
+                        // residual. Retrying rebuilds the same refuse.
+                        if !self.source_guard_already_bridged(&source_descr) {
+                            self.meta.record_declined_bridge_guard(&source_descr);
+                        }
+                    } else if det_bridge_abort {
+                        // `BC_ABORT` / walk-local refuse: the reconstructed
+                        // arm is not a compilable bridge. Decline so we do
+                        // not rebuild it every eagerness cycle. Do not
+                        // stamp a guard that already has a compiled bridge.
+                        if let Some(bridge) = self.meta.bridge_info_cloned() {
+                            if !self.source_guard_already_bridged(&bridge.source_descr) {
+                                self.meta.record_declined_bridge_guard(&bridge.source_descr);
+                            }
+                        }
                     }
                     // pyjitpl.py `run_blackhole_interp_to_cancel_tracing(stb)`
                     // consumes both the reason and raising_exception from the
@@ -4989,12 +5003,19 @@ impl<S: JitState> JitDriver<S> {
                     // frames are the sole record of where that left the
                     // interpreter, so this bridge needs the handoff for the
                     // same reason a fresh trace does.
+                    //
+                    // A deterministic bridge abort (`BC_ABORT` in a helper
+                    // such as `malformed`) must not take that handoff: the
+                    // cancel-tracing blackhole would run the error-path
+                    // helper for real and leave the compiled loop's later
+                    // entries failing the same guard every iteration.
                     if matches!(
                         action,
                         TraceAction::Abort | TraceAction::SwitchToBlackhole(_)
-                    ) && (self.meta.bridge_info().is_none()
-                        || self.bridge_attempt_declined
-                        || self.bridge_entered_at_guard_resume)
+                    ) && !det_bridge_abort
+                        && (self.meta.bridge_info().is_none()
+                            || self.bridge_attempt_declined
+                            || self.bridge_entered_at_guard_resume)
                     {
                         // This gate asks whether the session still has a bridge
                         // artifact to resume into, which is the PHASE, not the
@@ -5726,7 +5747,24 @@ impl<S: JitState> JitDriver<S> {
                 }
                 call_sites.push(Some(site));
             }
+            let allocator = self.blackhole_allocator.as_deref();
             let ctx = self.meta.tracing.as_mut().ok_or(Decline::NoResumeState)?;
+            let virtual_count = resume
+                .storage
+                .as_ref()
+                .map_or(0, |storage| storage.rd_virtuals().len());
+            let mut virt_cache = match allocator {
+                Some(allocator) => crate::BridgeVirtualCache::executing(
+                    virtual_count,
+                    crate::default_bridge_array_descr,
+                    allocator,
+                    raw_values,
+                    &fail_types,
+                ),
+                None => {
+                    crate::BridgeVirtualCache::new(virtual_count, crate::default_bridge_array_descr)
+                }
+            };
             let mut frames = Vec::with_capacity(sections.len());
             for (depth, (jitcode, pc)) in sections.into_iter().enumerate() {
                 let values = &resume.frames[depth].values;
@@ -5766,6 +5804,19 @@ impl<S: JitState> JitDriver<S> {
                         reg_indices.int.len() + reg_indices.ref_.len(),
                     ),
                 ];
+                if crate::bridge_debug_enabled() {
+                    eprintln!(
+                        "[bridgeB] liveness pc={pc} i={:?} r={:?} f={:?}",
+                        reg_indices.int, reg_indices.ref_, reg_indices.float
+                    );
+                    let code = &jitcode.code;
+                    let n = code.len().saturating_sub(pc).min(16);
+                    eprint!("[bridgeB] code[{pc}..]=");
+                    for b in &code[pc..pc + n] {
+                        eprint!(" {b:02x}");
+                    }
+                    eprintln!();
+                }
                 let mut regs = Vec::with_capacity(values.len());
                 for (bank, indices, base) in banks {
                     for (i, &index) in indices.iter().enumerate() {
@@ -5785,12 +5836,43 @@ impl<S: JitState> JitDriver<S> {
                                 };
                                 (opref, bits)
                             }
-                            // A virtual has an OpRef but no concrete value, and
-                            // an unassigned slot has neither. The walk executes,
-                            // so a register it cannot read a value out of is not
-                            // a register it can run past — decline the whole
-                            // frame rather than enter it half-seeded.
-                            RebuiltValue::Virtual(_) | RebuiltValue::Unassigned => {
+                            // resume.py consume_boxes → getvirtual: a virtual
+                            // is allocated and the register holds the object.
+                            // Unassigned still has nothing to execute.
+                            RebuiltValue::Virtual(vidx) => {
+                                let rd_virtuals =
+                                    resume.storage.as_ref().map(|storage| storage.rd_virtuals());
+                                let opref = crate::materialize_bridge_virtual(
+                                    ctx,
+                                    *vidx,
+                                    rd_virtuals,
+                                    resume,
+                                    &mut virt_cache,
+                                );
+                                let bits = if opref.is_none() {
+                                    None
+                                } else {
+                                    virt_cache.concrete_root_of(opref).or_else(|| {
+                                        ctx.box_value(opref).and_then(|value| match value {
+                                            majit_ir::Value::Ref(r) => Some(r.as_usize() as i64),
+                                            majit_ir::Value::Int(i) => Some(i),
+                                            majit_ir::Value::Float(f) => Some(f.to_bits() as i64),
+                                            majit_ir::Value::Void => None,
+                                        })
+                                    })
+                                };
+                                let Some(bits) = bits else {
+                                    if crate::bridge_debug_enabled() {
+                                        eprintln!(
+                                            "[bridgeB] DECLINE depth={depth} virtual {vidx} \
+                                             has no concrete"
+                                        );
+                                    }
+                                    return Err(Decline::UnreadableRegister);
+                                };
+                                (opref, bits)
+                            }
+                            RebuiltValue::Unassigned => {
                                 if crate::bridge_debug_enabled() {
                                     eprintln!(
                                         "[bridgeB] DECLINE depth={depth} unreadable slot {:?}",
@@ -5808,6 +5890,16 @@ impl<S: JitState> JitDriver<S> {
                         });
                     }
                 }
+                if crate::bridge_debug_enabled() {
+                    eprint!("[bridgeB] seeded");
+                    for reg in &regs {
+                        eprint!(
+                            " {:?}[{}]={:#x}/{:?}",
+                            reg.bank, reg.index, reg.value, reg.opref
+                        );
+                    }
+                    eprintln!();
+                }
                 frames.push(crate::jit_state::GuardResumeFrame {
                     jitcode,
                     pc,
@@ -5823,7 +5915,7 @@ impl<S: JitState> JitDriver<S> {
             }
             Ok(frames)
         })();
-        let frames = match seeded {
+        let mut frames = match seeded {
             Ok(frames) => frames,
             Err(why) => {
                 crate::mc_diag_bump(why.diag_slot());
@@ -5842,6 +5934,12 @@ impl<S: JitState> JitDriver<S> {
                 return None;
             }
         };
+
+        // Generated `setup_bridge_sym` rebinds a missing identity register
+        // from the live state. Grain's two reds are those identities and
+        // the resume stream can still name a walk-local address; rewrite
+        // the concrete shadows before the walk residual-calls through them.
+        state.rebind_bridge_reds(&mut frames);
 
         self.bridge_entered_at_guard_resume = true;
         let mut entered = false;
@@ -8920,6 +9018,23 @@ impl<S: JitState> JitDriver<S> {
             .opimpl_arraylen_vable(pc, vable_opref, vable_struct_ptr, fdescr, adescr)
     }
 
+    /// Whether `source_descr` already has a compiled bridge attached.
+    ///
+    /// Used to keep a working patch when a later FIRED re-enters setup
+    /// and aborts: `record_declined_bridge_guard` would otherwise make
+    /// every later fail skip that patch.
+    fn source_guard_already_bridged(
+        &self,
+        source_descr: &std::sync::Arc<dyn majit_ir::Descr>,
+    ) -> bool {
+        let Some(fd) = source_descr.as_fail_descr() else {
+            return false;
+        };
+        let green_key = self.meta.bridge_info().map(|b| b.green_key).unwrap_or(0);
+        self.meta
+            .bridge_was_compiled(green_key, fd.trace_id(), fd.fail_index_per_trace())
+    }
+
     /// Start bridge tracing from a guard failure point.
     ///
     /// Uses the compiled loop's stored meta so that the sym's
@@ -8967,6 +9082,16 @@ impl<S: JitState> JitDriver<S> {
         let green_key = jct.green_key();
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
+        // `pyjitpl.py` `raise_continue_running_normally` leaves this
+        // path once a bridge is attached. A later `must_compile` FIRED
+        // here is a pyre re-entry; walking again can abort setup and
+        // terminally decline the working source.
+        if self
+            .meta
+            .bridge_was_compiled(green_key, trace_id, fail_index)
+        {
+            return false;
+        }
         let Some(_loop_meta) = self.meta.get_compiled_meta(green_key).cloned() else {
             majit_metainterp::mc_diag_bump(15); // sbt early: no compiled_meta
             return false;

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -242,7 +242,9 @@ pub use parity::{TraceParityCase, assert_trace_parity, normalize_ops, normalize_
 /// (`blackhole.py:1432-1483` reads the descr straight out of the constant
 /// pool).  Exported so the descr-identity census can compare it against the
 /// pool-side resolution without re-deriving a second copy of the logic.
-pub use pyjitpl::dispatch::{field_descr_ref_from_bh, symbolic_residual_trace_aborts};
+pub use pyjitpl::dispatch::{
+    field_descr_ref_from_bh, publish_walk_abort_handoff, symbolic_residual_trace_aborts,
+};
 pub use pyjitpl::{
     BackEdgeAction, BridgeCompileResult, BridgeRetraceResult, ClosureRuntime,
     ClosureRuntimeWithResolver, CompileOutcome, CompiledExitLayout, CompiledTerminalExitLayout,
@@ -425,6 +427,58 @@ pub fn majit_log_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
         std::sync::LazyLock::new(|| std::env::var_os("MAJIT_LOG").is_some());
     *ENABLED
+}
+
+thread_local! {
+    static BRIDGE_WALKING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static WALK_ABORT_REQUESTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static RESIDUAL_COMMITTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Mark the current thread as walking a guard-resume (bridge) trace.
+///
+/// A walk-local `Dynamic` has a real stack address, so a pointer-range
+/// check cannot tell it from a live cell. The bridge walk is the path
+/// that residual-calls `operand_stack_store` with those locals; the
+/// initial loop walk uses the live interpreter frame.
+pub fn set_bridge_walking(active: bool) {
+    BRIDGE_WALKING.with(|cell| cell.set(active));
+}
+
+/// Whether [`set_bridge_walking`] is currently set on this thread.
+#[must_use]
+pub fn is_bridge_walking() -> bool {
+    BRIDGE_WALKING.with(std::cell::Cell::get)
+}
+
+/// A bound residual saw a walk-local `Vm` or index and did not run.
+/// The walker checks this after the call and aborts to the merge point.
+pub fn request_walk_abort() {
+    WALK_ABORT_REQUESTED.with(|cell| cell.set(true));
+}
+
+/// Consume a pending [`request_walk_abort`].
+#[must_use]
+pub fn take_walk_abort() -> bool {
+    WALK_ABORT_REQUESTED.with(|cell| cell.replace(false))
+}
+
+/// A bound residual already applied a heap effect on this walk.
+///
+/// `publish_walk_abort_handoff` declines both resume handoffs when the
+/// abort is an unbound symbolic target and no residual has run — replay
+/// of the source arm is then sound. After a mutating residual, replay
+/// applies that effect twice (`ITER_NEXT` after `iter_next_store` has
+/// already popped the iterator). The host sets this so the publisher
+/// keeps the live portal pc.
+pub fn note_residual_committed() {
+    RESIDUAL_COMMITTED.with(|cell| cell.set(true));
+}
+
+/// Consume [`note_residual_committed`]. Cleared at the start of each walk.
+#[must_use]
+pub fn take_residual_committed() -> bool {
+    RESIDUAL_COMMITTED.with(|cell| cell.replace(false))
 }
 
 /// Strict JIT mode: a non-`InvalidLoop` panic during compilation is a bug and

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1148,12 +1148,6 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
         if opref.is_constant() {
             return true;
         }
-        // An InputArg is never a Const, even when the optimizer knows
-        // its pointer. Walking that knowledge to TAGCONST drops a
-        // stack-resident red from resume liveboxes.
-        if opref.is_input_arg() {
-            return false;
-        }
         // One chain walk answers both tests below; `get_box_replacement`
         // materializes the terminal as an `Operand`, so walking twice built
         // it twice for every live box in every guard.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1148,6 +1148,12 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
         if opref.is_constant() {
             return true;
         }
+        // An InputArg is never a Const, even when the optimizer knows
+        // its pointer. Walking that knowledge to TAGCONST drops a
+        // stack-resident red from resume liveboxes.
+        if opref.is_input_arg() {
+            return false;
+        }
         // One chain walk answers both tests below; `get_box_replacement`
         // materializes the terminal as an `Operand`, so walking twice built
         // it twice for every live box in every guard.
@@ -4577,6 +4583,31 @@ impl OptContext {
             .push((opcode, arg0, arg1, result));
     }
 
+    /// Grain's reds (`Vm`, frame, `Scope`) live on the thread stack and
+    /// change address every `Vm::new`. Folding such an InputArg to
+    /// `ConstPtr` makes resume number it TAGCONST, so the next evaluation
+    /// has no live box to rebind. PyPy heap frames have stable GC identity
+    /// and stay foldable: only a Ref whose bits sit in this thread's stack
+    /// window is refused. Null / low sentinels (`addr <= 0x1000`) are not
+    /// stack objects.
+    fn operand_is_stack_resident_inputarg(op: &Operand) -> bool {
+        if !op.is_inputarg() {
+            return false;
+        }
+        match op.get_value() {
+            Some(Value::Ref(gcref)) => Self::ref_addr_is_stack_resident(gcref.0),
+            _ => false,
+        }
+    }
+
+    fn ref_addr_is_stack_resident(addr: usize) -> bool {
+        if addr <= 0x1000 {
+            return false;
+        }
+        let probe = 0usize;
+        (std::ptr::addr_of!(probe) as usize).abs_diff(addr) < 16 * 1024 * 1024
+    }
+
     /// `optimizer.py make_equal_to(op, newop)` (line-by-line port):
     ///
     /// ```python
@@ -4593,6 +4624,20 @@ impl OptContext {
         // chain head when `op` is itself a Const so callers can fold const
         // sources without an explicit guard.
         if op.is_constant() {
+            return;
+        }
+        // A stack-resident red (Grain's `Vm` / frame / `Scope`) folded
+        // to `ConstPtr` becomes TAGCONST in resume numbering
+        // (`isinstance(box, Const)` after `get_box_replacement`). The
+        // next evaluation has a different stack address, so the live
+        // InputArg must stay a TAGBOX.
+        if newop.is_constant()
+            && (Self::operand_is_stack_resident_inputarg(op)
+                || (op.is_inputarg()
+                    && newop.get_value().is_some_and(
+                        |v| matches!(v, Value::Ref(g) if Self::ref_addr_is_stack_resident(g.0)),
+                    )))
+        {
             return;
         }
         // optimizer.py op = get_box_replacement(op)
@@ -5809,6 +5854,12 @@ impl OptContext {
 
     /// optimizer.py make_constant(box, constbox)
     pub fn make_constant_box(&mut self, op: &Operand, value: Value) {
+        if Self::operand_is_stack_resident_inputarg(op)
+            || (op.is_inputarg()
+                && matches!(value, Value::Ref(g) if Self::ref_addr_is_stack_resident(g.0)))
+        {
+            return;
+        }
         // optimizer.py: box = get_box_replacement(box)
         let op = op.get_box_replacement(false);
         // optimizer.py:418-429: IntBound safety check
@@ -9366,6 +9417,34 @@ mod boxref_forwarding_tests {
         // Negative case: operand with no constant forwarding.
         let (nb, _ia_nb) = bound_inputarg_operand(Type::Int, 0);
         assert!(!nb.get_box_replacement(false).is_constant());
+    }
+
+    /// A stack-resident red InputArg must stay a TAGBOX. Folding it to
+    /// `ConstPtr` drops it from resume liveboxes; the next `Vm::new` then
+    /// has no InputArg to rebind.
+    #[test]
+    fn stack_resident_inputarg_is_not_folded_to_const() {
+        use majit_ir::GcRef;
+        let mut ctx = OptContext::with_num_inputs_and_start_pos(0, 1, 0, 1);
+        let (b0, ia0) = bound_inputarg_operand(Type::Ref, 0);
+        let probe = 0usize;
+        let stack_addr = std::ptr::addr_of!(probe) as usize;
+        ia0.set_value(Value::Ref(GcRef(stack_addr)));
+        ctx.seed_boxes_canonical(&[b0.clone()]);
+        ctx.make_constant_box(&b0, Value::Ref(GcRef(stack_addr)));
+        assert!(
+            !b0.get_box_replacement(false).is_constant(),
+            "stack-resident InputArg must not become ConstPtr"
+        );
+        let heap = GcRef(0x0000_0001_0000_0000);
+        let (b1, ia1) = bound_inputarg_operand(Type::Ref, 1);
+        ia1.set_value(Value::Ref(heap));
+        ctx.seed_boxes_canonical(&[b1.clone()]);
+        ctx.make_constant_box(&b1, Value::Ref(heap));
+        assert!(
+            b1.get_box_replacement(false).is_constant(),
+            "heap InputArg stays foldable (PyPy GC identity)"
+        );
     }
 
     /// `make_constant` mirrors PyPy optimizer.py

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -15225,6 +15225,13 @@ impl<M: Clone> MetaInterp<M> {
                     optimized_ops.len()
                 );
             }
+            // Grain's `Scope` and walk-local `Dynamic`s live on the
+            // interpreter stack. A bridge that folded one of those
+            // addresses into `ConstPtr` is correct only for the
+            // recording eval; the next `Vm::new` has a different
+            // stack and the baked pointer becomes a hot always-fail
+            // guard (switch bench `fail_index=4` on the iterator
+            // bridge). Refuse the artifact; later fails blackhole.
             // The source guard's recovery_layout is read from
             // the metainterp's `StoredExitLayout` cache (per-trace,
             // keyed by per-trace fail_index) and passed to the backend

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1233,7 +1233,10 @@ fn refuse_walk_local_ref_args(
     // The first `i` is a stack depth. A walk local in that slot is a
     // pointer-sized word. Do not match plain `ri`: that class also
     // carries `track_operation` position bits (`line << 16`).
-    let pointer_index = matches!(arg_classes, "rii" | "rif")
+    // Only during a bridge walk: `rii`/`rif` is also `shift(n, c, mark)`
+    // and other helpers whose first int is a payload, not a stack depth.
+    let pointer_index = crate::is_bridge_walking()
+        && matches!(arg_classes, "rii" | "rif")
         && raw_i.first().is_some_and(|&index| {
             let as_usize = index as u64 as usize;
             as_usize > 0x1_0000

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1208,6 +1208,77 @@ fn report_symbolic_residual_call_target(
     TraceAction::Abort
 }
 
+/// A walk-local `Dynamic` arrives as a small integer in a Ref register,
+/// not a live cell. Residual-calling a helper that drops `Union` through
+/// that address is `EXC_BAD_ACCESS`. Abort the walk the same way an
+/// unbound symbolic target does, so the portal resumes at the merge point.
+fn refuse_walk_local_ref_args(
+    ctx: &mut TraceCtx,
+    func: usize,
+    raw_i: &[i64],
+    raw_r: &[i64],
+    args: &[OpRef],
+    arg_classes: &str,
+) -> Option<TraceAction> {
+    let small_ref = raw_r.iter().any(|&ptr| {
+        let addr = ptr as u64 as usize;
+        addr != 0 && addr <= 0x1000
+    });
+    // `rir` is `operand_stack_store` / `operand_stack_take` of a
+    // walk-local `Dynamic`. That address is a real stack slot, so the
+    // small-integer check above cannot see it. `rr` is `dynamic_store` /
+    // `push_from_cell`; those helpers refuse a non-heap cell themselves.
+    let bridge_store = crate::is_bridge_walking() && matches!(arg_classes, "rir");
+    // `rii` is `operand_stack_store_int` / `_bool`; `rif` is `_float`.
+    // The first `i` is a stack depth. A walk local in that slot is a
+    // pointer-sized word. Do not match plain `ri`: that class also
+    // carries `track_operation` position bits (`line << 16`).
+    let pointer_index = matches!(arg_classes, "rii" | "rif")
+        && raw_i.first().is_some_and(|&index| {
+            let as_usize = index as u64 as usize;
+            as_usize > 0x1_0000
+        });
+    if !small_ref && !bridge_store && !pointer_index {
+        return None;
+    }
+    ctx.symbolic_residual_abort = true;
+    if crate::is_bridge_walking() || ctx.is_bridge_trace {
+        ctx.deterministic_bridge_abort = true;
+    }
+    SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if crate::majit_log_enabled() {
+        eprintln!(
+            "[jit] residual refused: walk-local Ref/index arg \
+             (fn={func:#x} classes={arg_classes} ints={raw_i:?} \
+             refs={raw_r:?} bridge={})",
+            crate::is_bridge_walking(),
+        );
+    }
+    Some(TraceAction::Abort)
+}
+
+fn host_requested_walk_abort(
+    ctx: &mut TraceCtx,
+    func: usize,
+    arg_classes: &str,
+) -> Option<TraceAction> {
+    if !crate::take_walk_abort() {
+        return None;
+    }
+    ctx.symbolic_residual_abort = true;
+    if crate::is_bridge_walking() || ctx.is_bridge_trace {
+        ctx.deterministic_bridge_abort = true;
+    }
+    SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if crate::majit_log_enabled() {
+        eprintln!(
+            "[jit] residual refused: host rejected walk-local Vm/index \
+             (fn={func:#x} classes={arg_classes})"
+        );
+    }
+    Some(TraceAction::Abort)
+}
+
 /// Refuse a trace whose statically reachable body contains an unbound
 /// symbolic residual target, before the walk can execute any body instruction.
 fn refuse_reachable_symbolic_residuals(jitcode: &JitCode) -> bool {
@@ -3070,6 +3141,14 @@ where
     }
 
     pub fn run_to_end(&mut self, ctx: &mut TraceCtx, sym: &mut S, runtime: &R) -> TraceAction {
+        // A previous walk may have left a committed-residual latch.
+        let _ = crate::take_residual_committed();
+        // Same latch class: a blackhole residual that refused a walk-local
+        // arms `request_walk_abort` with no walker to consume it. The next
+        // walk must not die on its first `run_one_step`.
+        if crate::take_walk_abort() && crate::majit_log_enabled() {
+            eprintln!("[jit] dropped leftover walk-abort at run_to_end");
+        }
         // Stable program-pc anchor for the state-field-JIT portal op —
         // the outer interpreter pc that `trace_jitcode` was invoked with.
         // Survives `BC_INLINE_CALL`'s `frame.pc = frame.code_cursor`
@@ -3764,6 +3843,13 @@ where
     }
 
     pub fn run_one_step(&mut self, ctx: &mut TraceCtx, sym: &mut S, _runtime: &R) -> TraceAction {
+        if crate::take_walk_abort() || majit_backend::take_null_mem_access() {
+            ctx.symbolic_residual_abort = true;
+            if crate::is_bridge_walking() || ctx.is_bridge_trace {
+                ctx.deterministic_bridge_abort = true;
+            }
+            return TraceAction::Abort;
+        }
         if self.frames.is_empty() {
             return TraceAction::Continue;
         }
@@ -4578,6 +4664,18 @@ where
                 };
                 let cached =
                     field_key.and_then(|key| ctx.heapcache_getfield_cached(struct_opref, key));
+                let cached_payload = cached.and_then(|cached| match ctx.box_value(cached) {
+                    Some(Value::Int(n)) => Some(n),
+                    Some(Value::Ref(r)) => Some(r.0 as i64),
+                    _ => None,
+                });
+                // Parentless placeholder descrs can share `field_key`, so a
+                // Position word and a frame `base` collide. A hit whose
+                // payload is not the live load is that collision: take the
+                // miss path and record a fresh op.
+                let cached = cached.filter(|_| {
+                    struct_ptr == 0 || cached_payload.is_none() || cached_payload == Some(loaded)
+                });
                 let (op, reg_concrete) = if let Some(cached) = cached {
                     // `profiler.count_ops(rop.GETFIELD_GC_I,
                     // Counters.HEAPCACHED_OPS)` — folded-away op
@@ -7661,6 +7759,16 @@ where
                 } else {
                     target.concrete_ptr
                 };
+                if let Some(action) = refuse_walk_local_ref_args(
+                    ctx,
+                    concrete_ptr as usize,
+                    &raw_i,
+                    &raw_r,
+                    &args,
+                    &calldescr.arg_classes,
+                ) {
+                    return action;
+                }
 
                 let effectinfo = &calldescr.extra_info;
 
@@ -7701,6 +7809,13 @@ where
                                 Some(&raw_f),
                             );
                         }
+                    }
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
                     }
                     // `pyjitpl.py do_not_in_trace_call`:
                     //     if self.last_exc_value:
@@ -7803,6 +7918,13 @@ where
                                 Some(&raw_f),
                             );
                         }
+                    }
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
                     }
                     // pyjitpl.py:2046-2049 — after the residual call,
                     // walk the vrefs.  If any were forced by the call
@@ -7990,6 +8112,16 @@ where
                 } else {
                     target.concrete_ptr
                 };
+                if let Some(action) = refuse_walk_local_ref_args(
+                    ctx,
+                    concrete_ptr as usize,
+                    &raw_i,
+                    &raw_r,
+                    &args,
+                    &calldescr.arg_classes,
+                ) {
+                    return action;
+                }
 
                 let effectinfo = &calldescr.extra_info;
 
@@ -8026,6 +8158,13 @@ where
                                 Some(&raw_f),
                             );
                         }
+                    }
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
                     }
                     // `pyjitpl.py do_not_in_trace_call`:
                     //     if self.last_exc_value: raise SwitchToBlackhole(
@@ -8114,6 +8253,13 @@ where
                             )
                         }
                     };
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
+                    }
                     // pyjitpl.py — vrefs_after_residual_call
                     // (see void arm for the explanation; gated on
                     // `is_forces` because the before-hook only stamps
@@ -8318,6 +8464,16 @@ where
                 } else {
                     target.concrete_ptr
                 };
+                if let Some(action) = refuse_walk_local_ref_args(
+                    ctx,
+                    concrete_ptr as usize,
+                    &raw_i,
+                    &raw_r,
+                    &args,
+                    &calldescr.arg_classes,
+                ) {
+                    return action;
+                }
 
                 let effectinfo = &calldescr.extra_info;
 
@@ -8345,6 +8501,13 @@ where
                                 Some(&raw_f),
                             );
                         }
+                    }
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
                     }
                     // `pyjitpl.py do_not_in_trace_call`:
                     //     if self.last_exc_value: raise SwitchToBlackhole(
@@ -8429,6 +8592,13 @@ where
                             )
                         }
                     };
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
+                    }
                     // pyjitpl.py — vrefs_after_residual_call
                     // (see void arm for the explanation; gated on
                     // `is_forces` because the before-hook only stamps
@@ -8598,6 +8768,16 @@ where
                 } else {
                     target.concrete_ptr
                 };
+                if let Some(action) = refuse_walk_local_ref_args(
+                    ctx,
+                    concrete_ptr as usize,
+                    &raw_i,
+                    &raw_r,
+                    &args,
+                    &calldescr.arg_classes,
+                ) {
+                    return action;
+                }
 
                 let effectinfo = &calldescr.extra_info;
 
@@ -8625,6 +8805,13 @@ where
                                 Some(&raw_f),
                             );
                         }
+                    }
+                    if let Some(action) = host_requested_walk_abort(
+                        ctx,
+                        concrete_ptr as usize,
+                        &calldescr.arg_classes,
+                    ) {
+                        return action;
                     }
                     // `pyjitpl.py do_not_in_trace_call`:
                     //     if self.last_exc_value: raise SwitchToBlackhole(
@@ -9486,6 +9673,12 @@ where
             }
             jitcode::insns::BC_ABORT => {
                 self.log_bytecode_abort("BC_ABORT");
+                // A helper's `BC_ABORT` is a compile-time "this path cannot
+                // be traced". The reconstructed registers that reached it
+                // will reach it again; retrying rebuilds the same abort.
+                if crate::is_bridge_walking() || ctx.is_bridge_trace {
+                    ctx.deterministic_bridge_abort = true;
+                }
                 return TraceAction::Abort;
             }
             jitcode::insns::BC_ABORT_PERMANENT => {
@@ -10560,7 +10753,7 @@ where
 ///
 /// Shared by every walk entry: where the walk started does not change what a
 /// consumer needs in order to resume from where it stopped.
-fn publish_walk_abort_handoff(
+pub fn publish_walk_abort_handoff(
     ctx: &mut TraceCtx,
     action: &TraceAction,
     standalone: &mut StandaloneFrameStack,
@@ -10573,12 +10766,23 @@ fn publish_walk_abort_handoff(
         // runtime Int register is invisible to that scan and reaches this
         // site-level backstop; it also takes the arm-replay position, because
         // the post-decode framestack would skip the refused call altogether.
-        // An earlier residual call in that arm may already have committed heap
-        // effects, so replay runs that prefix a second time. This narrowed
-        // duplicate-effect window is the residue the trace-start gate does not
-        // close, and replay is still preferred over publishing the post-decode
-        // framestack and skipping the refused call.
-        if std::mem::replace(&mut ctx.symbolic_residual_abort, false) {
+        //
+        // That replay is only sound when no residual has committed. A bound
+        // helper such as `iter_next_store` may already have popped the
+        // iterator; re-running the merge-point opcode then raises
+        // `no iterator to advance`. Compiled code can have made that
+        // call before the guard failed, so a bridge walk that then
+        // refuses an unbound residual (`__len`, `scope_rewind`) must
+        // not fall back to the loop header either — `pyjitpl.py
+        // run_blackhole_interp_to_cancel_tracing` converts the live
+        // framestack instead. Keep i0 and the framestack when the host
+        // marked a committed residual or this walk is already a
+        // guard-resume bridge.
+        if std::mem::replace(&mut ctx.symbolic_residual_abort, false)
+            && !crate::take_residual_committed()
+            && !crate::is_bridge_walking()
+            && !ctx.is_bridge_trace
+        {
             return;
         }
         if let Some(pc) = standalone.frames.frames[0]

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -4143,14 +4143,8 @@ impl ResumeDataLoopMemo {
                 numb_state.append_short(NULLREF);
                 continue;
             }
-            // An InputArg is never a Const (`isinstance(box, Const)`).
-            // Walking it into a forwarded ConstPtr makes TAGCONST and
-            // drops a stack-resident red from the liveboxes.
-            let opref = if raw_opref.is_input_arg() {
-                env.get_box_replacement_not_const(raw_opref)
-            } else {
-                env.get_box_replacement(raw_opref)
-            };
+            // resume.py: box = box.get_box_replacement()
+            let opref = env.get_box_replacement(raw_opref);
             if opref.is_none() {
                 numb_state.append_short(NULLREF);
                 continue;

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6490,6 +6490,166 @@ pub trait BlackholeAllocator {
 pub struct NullAllocator;
 impl BlackholeAllocator for NullAllocator {}
 
+/// `cpu.bh_setfield_gc_*` / `cpu.bh_setarrayitem_gc_*` (`llmodel.py`).
+///
+/// The applying reader records a deferred store *and* writes it. A
+/// frontend that has no object-model override still owes those writes
+/// — otherwise `start_bridge_tracing` marks the replay incomplete and
+/// every pending field declines to the blackhole.
+pub struct LlmodelBlackholeAllocator;
+
+/// `cpu.bh_new` / `bh_new_array` (`llmodel.py`): old-gen when a GC owns
+/// the heap, otherwise a zeroed raw block. A GC that is installed but
+/// cannot satisfy the request returns 0 rather than a raw pointer the
+/// collector will not trace.
+fn llmodel_alloc(type_id: u32, size: usize) -> i64 {
+    let size = size.max(1);
+    let gc = majit_gc::alloc_oldgen_typed(type_id, size);
+    if gc.0 != 0 {
+        return gc.0 as i64;
+    }
+    if majit_gc::gc_allocator_installed() {
+        return 0;
+    }
+    let mut block = vec![0u8; size].into_boxed_slice();
+    let ptr = block.as_mut_ptr();
+    std::mem::forget(block);
+    ptr as i64
+}
+
+impl BlackholeAllocator for LlmodelBlackholeAllocator {
+    fn allocate_with_vtable(&self, descr: &majit_ir::DescrRef, vtable: usize) -> i64 {
+        let Some(sd) = descr.as_size_descr() else {
+            return 0;
+        };
+        let ptr = llmodel_alloc(sd.type_id(), sd.size());
+        if ptr != 0 && vtable != 0 {
+            unsafe {
+                majit_backend::llmodel::write_ref_at_mem(ptr as usize, 0, vtable);
+            }
+        }
+        ptr
+    }
+
+    fn bh_new(&self, typedescr: &majit_ir::DescrRef) -> i64 {
+        let Some(sd) = typedescr.as_size_descr() else {
+            return 0;
+        };
+        llmodel_alloc(sd.type_id(), sd.size())
+    }
+
+    fn bh_new_array(&self, length: usize, arraydescr: &majit_ir::DescrRef) -> i64 {
+        let Some(ad) = arraydescr.as_array_descr() else {
+            return 0;
+        };
+        let size = ad
+            .base_size()
+            .saturating_add(length.saturating_mul(ad.item_size()));
+        llmodel_alloc(ad.type_id(), size)
+    }
+
+    fn bh_new_array_clear(&self, length: usize, arraydescr: &majit_ir::DescrRef) -> i64 {
+        self.bh_new_array(length, arraydescr)
+    }
+    fn bh_setfield_gc_i(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
+        if struct_ptr == 0 {
+            return;
+        }
+        unsafe {
+            majit_backend::llmodel::write_int_at_mem(
+                struct_ptr as usize,
+                descr_info.offset,
+                descr_info.field_size,
+                value,
+            );
+        }
+    }
+
+    fn bh_setfield_gc_r(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
+        if struct_ptr == 0 {
+            return;
+        }
+        unsafe {
+            majit_backend::llmodel::write_ref_at_mem(
+                struct_ptr as usize,
+                descr_info.offset,
+                value as usize,
+            );
+        }
+    }
+
+    fn bh_setfield_gc_f(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
+        if struct_ptr == 0 {
+            return;
+        }
+        unsafe {
+            majit_backend::llmodel::write_float_at_mem(
+                struct_ptr as usize,
+                descr_info.offset,
+                f64::from_bits(value as u64),
+            );
+        }
+    }
+
+    fn bh_setarrayitem_gc_i(
+        &self,
+        array: i64,
+        index: usize,
+        value: i64,
+        descr: &majit_ir::DescrRef,
+    ) {
+        let Some(ad) = descr.as_array_descr() else {
+            return;
+        };
+        let ofs = ad
+            .base_size()
+            .wrapping_add(index.wrapping_mul(ad.item_size()));
+        unsafe {
+            majit_backend::llmodel::write_int_at_mem(array as usize, ofs, ad.item_size(), value);
+        }
+    }
+
+    fn bh_setarrayitem_gc_r(
+        &self,
+        array: i64,
+        index: usize,
+        value: i64,
+        descr: &majit_ir::DescrRef,
+    ) {
+        let Some(ad) = descr.as_array_descr() else {
+            return;
+        };
+        let ofs = ad
+            .base_size()
+            .wrapping_add(index.wrapping_mul(ad.item_size()));
+        unsafe {
+            majit_backend::llmodel::write_ref_at_mem(array as usize, ofs, value as usize);
+        }
+    }
+
+    fn bh_setarrayitem_gc_f(
+        &self,
+        array: i64,
+        index: usize,
+        value: i64,
+        descr: &majit_ir::DescrRef,
+    ) {
+        let Some(ad) = descr.as_array_descr() else {
+            return;
+        };
+        let ofs = ad
+            .base_size()
+            .wrapping_add(index.wrapping_mul(ad.item_size()));
+        unsafe {
+            majit_backend::llmodel::write_float_at_mem(
+                array as usize,
+                ofs,
+                f64::from_bits(value as u64),
+            );
+        }
+    }
+}
+
 /// Metainterp-side extension methods on `VirtualInfo` (which lives in
 /// majit-backend since the Phase C-1 cascade).  These methods depend
 /// on `ResumeDataDirectReader` + `BlackholeAllocator` — both

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -527,6 +527,9 @@ impl BoxEnv for SimpleBoxEnv {
         if opref.is_constant() {
             return true;
         }
+        if opref.is_input_arg() {
+            return false;
+        }
         self.constants.contains_key(&opref.raw())
     }
     fn get_const(&self, opref: majit_ir::OpRef) -> (i64, majit_ir::Type) {
@@ -4140,7 +4143,14 @@ impl ResumeDataLoopMemo {
                 numb_state.append_short(NULLREF);
                 continue;
             }
-            let opref = env.get_box_replacement(raw_opref);
+            // An InputArg is never a Const (`isinstance(box, Const)`).
+            // Walking it into a forwarded ConstPtr makes TAGCONST and
+            // drops a stack-resident red from the liveboxes.
+            let opref = if raw_opref.is_input_arg() {
+                env.get_box_replacement_not_const(raw_opref)
+            } else {
+                env.get_box_replacement(raw_opref)
+            };
             if opref.is_none() {
                 numb_state.append_short(NULLREF);
                 continue;

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -196,7 +196,7 @@ impl<'a> BridgeVirtualCache<'a> {
 
     /// The address a materialized virtual currently lives at, by the `OpRef`
     /// the recording half minted for it.
-    fn concrete_root_of(&self, opref: OpRef) -> Option<i64> {
+    pub(crate) fn concrete_root_of(&self, opref: OpRef) -> Option<i64> {
         let vidx = self
             .virtuals_ptr_cache
             .iter()
@@ -483,6 +483,54 @@ fn apply_setfield(
     true
 }
 
+/// resume.py `ResumeDataBoxReader.setarrayitem` applying half.
+///
+/// `_prepare_pendingfields` dispatches `itemindex >= 0` to
+/// `execute_setarrayitem_gc` — the same three-way split
+/// `ResumeDataDirectReader.setarrayitem` makes over
+/// `cpu.bh_setarrayitem_gc_{r,f,i}`. Without this twin the applying
+/// reader declined every array pending field, so a guard that deferred
+/// a `SETARRAYITEM_GC` could only blackhole.
+fn apply_setarrayitem(
+    ctx: &crate::TraceCtx,
+    cache: &BridgeVirtualCache<'_>,
+    allocator: &dyn crate::resume::BlackholeAllocator,
+    array_op: OpRef,
+    index: i32,
+    value_op: OpRef,
+    descr: &majit_ir::DescrRef,
+) -> bool {
+    use majit_ir::Value;
+    let Some(ad) = descr.as_array_descr() else {
+        return false;
+    };
+    let Some(Value::Ref(array)) = operand_concrete(ctx, cache, array_op) else {
+        return false;
+    };
+    let Some(value) = operand_concrete(ctx, cache, value_op) else {
+        return false;
+    };
+    let array = array.as_usize() as i64;
+    let index = index as usize;
+    if ad.is_array_of_pointers() {
+        let Value::Ref(r) = value else {
+            return false;
+        };
+        allocator.bh_setarrayitem_gc_r(array, index, r.as_usize() as i64, descr);
+    } else if ad.is_array_of_floats() {
+        let Value::Float(f) = value else {
+            return false;
+        };
+        allocator.bh_setarrayitem_gc_f(array, index, f.to_bits() as i64, descr);
+    } else {
+        let Value::Int(i) = value else {
+            return false;
+        };
+        allocator.bh_setarrayitem_gc_i(array, index, i, descr);
+    }
+    true
+}
+
 pub fn materialize_bridge_virtual(
     ctx: &mut crate::TraceCtx,
     vidx: usize,
@@ -594,17 +642,6 @@ pub fn materialize_bridge_virtual(
         true
     }
 
-    // Only `VStructInfo` has its applying twin wired here (`bh_new` plus the
-    // `setfields` stores). Recording a NEW the heap does not hold would give
-    // the trace an identity the interpreter cannot resume against, so the
-    // applying reader declines every other kind instead. The recording reader
-    // is unaffected: a direct reader has already allocated for it.
-    if cache.allocator().is_some()
-        && !matches!(entry.as_ref(), majit_ir::RdVirtualInfo::VStructInfo { .. })
-    {
-        return OpRef::NONE;
-    }
-
     match entry.as_ref() {
         // resume.py VirtualInfo.allocate
         majit_ir::RdVirtualInfo::VirtualInfo {
@@ -625,6 +662,15 @@ pub fn materialize_bridge_virtual(
             ctx.heap_cache_mut().new_object(new_op);
             // resume.py decoder.virtuals_cache.set_ptr(index, struct)
             cache.set_ptr(vidx, new_op);
+            if let Some(allocator) = cache.allocator() {
+                let vtable = size_descr.as_size_descr().map_or(0, |sd| sd.vtable());
+                let ptr = allocator.allocate_with_vtable(&size_descr, vtable);
+                if ptr == 0 {
+                    return OpRef::NONE;
+                }
+                cache.set_concrete_root(vidx, ptr);
+                ctx.set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(ptr as usize)));
+            }
             // resume.py self.setfields(decoder, struct)
             if !setfields(
                 ctx,
@@ -751,6 +797,18 @@ pub fn materialize_bridge_virtual(
             ctx.heap_cache_mut().new_object(new_op);
             // resume.py decoder.virtuals_cache.set_ptr(index, array)
             cache.set_ptr(vidx, new_op);
+            if let Some(allocator) = cache.allocator() {
+                let ptr = if clear {
+                    allocator.bh_new_array_clear(length, &array_descr)
+                } else {
+                    allocator.bh_new_array(length, &array_descr)
+                };
+                if ptr == 0 {
+                    return OpRef::NONE;
+                }
+                cache.set_concrete_root(vidx, ptr);
+                ctx.set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(ptr as usize)));
+            }
             // resume.py:656-670 element loop: dispatch by arraydescr kind
             // NB. the check for the kind of array elements is moved out of the loop
             let set_opcode = match kind {
@@ -764,6 +822,9 @@ pub fn materialize_bridge_virtual(
                 }
                 let value = decode_fieldnum(ctx, fnum, rd_virtuals, resume_data, cache);
                 if value.is_none() {
+                    if cache.allocator().is_some() {
+                        return OpRef::NONE;
+                    }
                     continue;
                 }
                 let idx_ref = ctx.const_int(i as i64);
@@ -776,6 +837,19 @@ pub fn materialize_bridge_virtual(
                     &[new_op, idx_ref, value],
                     array_descr.clone(),
                 );
+                if let Some(allocator) = cache.allocator()
+                    && !apply_setarrayitem(
+                        ctx,
+                        cache,
+                        allocator,
+                        new_op,
+                        i as i32,
+                        value,
+                        &array_descr,
+                    )
+                {
+                    return OpRef::NONE;
+                }
             }
             if crate::majit_log_enabled() {
                 eprintln!(
@@ -1233,12 +1307,10 @@ pub fn emit_pending_field_op(
         }
         ctx.heapcache_setfield_cached(target_op, descr.index(), value_op);
     } else {
-        // No applying twin is wired for the array element form, so a reader
-        // that must apply declines rather than record a write the heap will
-        // not have.
-        if cache.allocator().is_some() {
-            return false;
-        }
+        // resume.py `_prepare_pendingfields` → `setarrayitem` →
+        // `execute_setarrayitem_gc`. Record the store and, when this
+        // is the applying reader, write it through the same
+        // `bh_setarrayitem_gc_*` split the direct reader uses.
         let index_op = ctx.const_int(item_index as i64);
         ctx.profiler()
             .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
@@ -1249,6 +1321,13 @@ pub fn emit_pending_field_op(
             &[target_op, index_op, value_op],
             descr.clone(),
         );
+        if let Some(allocator) = cache.allocator() {
+            if !apply_setarrayitem(
+                ctx, cache, allocator, target_op, item_index, value_op, descr,
+            ) {
+                return false;
+            }
+        }
         ctx.heapcache_setarrayitem(target_op, index_op, descr.index(), value_op);
     }
     true

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -568,10 +568,17 @@ pub struct TraceCtx {
     /// Set when the walk refused a residual call whose target was still a
     /// symbolic path hash.  A dispatch-arm sub-JitCode may contain an earlier
     /// residual call that already executed concretely, so neither replaying
-    /// the source opcode nor resuming after the refused call is sound.  The
-    /// abort publisher consumes this flag and declines both resume handoffs;
-    /// [`crate::symbolic_residual_trace_aborts`] is the embedder-facing signal.
+    /// the source opcode nor resuming after the refused call is sound —
+    /// unless the host marked that earlier call via
+    /// [`crate::note_residual_committed`], in which case replay applies the
+    /// heap effect twice and the publisher keeps the live portal pc.
+    /// The abort publisher consumes this flag; [`crate::symbolic_residual_trace_aborts`]
+    /// is the embedder-facing signal.
     pub symbolic_residual_abort: bool,
+    /// A bridge walk aborted on a walk-local residual that will fail the
+    /// same way every time. `handle_fail` must not `must_compile` this
+    /// guard again (`compile.py` blackhole `else` arm).
+    pub deterministic_bridge_abort: bool,
     /// `pyjitpl.py run_blackhole_interp_to_cancel_tracing` needs
     /// `metainterp.framestack` to still exist when it calls
     /// `blackhole.py convert_and_run_from_pyjitpl(self, ...)`.  RPython
@@ -1851,6 +1858,7 @@ impl TraceCtx {
             last_mp_green_pc: None,
             abort_after_panic: false,
             symbolic_residual_abort: false,
+            deterministic_bridge_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
             walk_finish_values: Vec::new(),
@@ -1952,6 +1960,7 @@ impl TraceCtx {
             last_mp_green_pc: None,
             abort_after_panic: false,
             symbolic_residual_abort: false,
+            deterministic_bridge_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
             walk_finish_values: Vec::new(),

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -359,6 +359,20 @@ impl RegAllocatorState {
         if (v_has_red && w_has_noncopy) || (w_has_red && v_has_noncopy) {
             return;
         }
+        if (v_has_red || w_has_red) && std::env::var_os("MAJIT_REGALLOC_DEBUG").is_some() {
+            let other = if v_has_red {
+                w.name_prefix()
+            } else {
+                v.name_prefix()
+            };
+            if other != "self" && other != "frame" && other != "v" {
+                eprintln!(
+                    "[regalloc] coalesce red with {other} (v={} w={})",
+                    v.name_prefix(),
+                    w.name_prefix(),
+                );
+            }
+        }
         if self
             .depgraph
             .neighbours
@@ -397,6 +411,13 @@ impl RegAllocatorState {
         kind: RegKind,
         consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
     ) {
+        // Identity reds are Ref (frame / vm). Int and float reds are
+        // loop-carried values with ordinary lifetimes; reserving those
+        // too can push a register-heavy portal past the assembler's
+        // 256-register cap.
+        if kind != RegKind::Ref {
+            return;
+        }
         let reds = portal_merge_point_reds(graph, kind);
         if reds.is_empty() {
             return;
@@ -937,11 +958,27 @@ fn log_portal_ref_colors(graph: &FunctionGraph, coloring: &VarMap<usize>) {
         }
     }
     kind_hits.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let mut name_hits: Vec<(String, usize)> = Vec::new();
+    for (var, color) in coloring {
+        if !red_colors.iter().any(|red| *red == Some(*color)) {
+            continue;
+        }
+        let prefix = var.name_prefix();
+        if let Some((_, n)) = name_hits.iter_mut().find(|(k, _)| *k == prefix) {
+            *n += 1;
+        } else {
+            name_hits.push((prefix, 1));
+        }
+    }
+    name_hits.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    if name_hits.len() > 16 {
+        name_hits.truncate(16);
+    }
     eprintln!(
         "[regalloc] portal {} ref reds={} colors={red_colors:?} \
          occupancy={red_occupancy:?} calls={call_hits} scope_calls={scope_calls} \
          scope_fields={scope_fields} protected_sharing_red={shared} colored={} \
-         red_kinds={kind_hits:?} samples={samples:?}",
+         red_kinds={kind_hits:?} samples={samples:?} red_names={name_hits:?}",
         graph.name,
         reds.len(),
         coloring.len(),

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -260,6 +260,20 @@ impl RegAllocatorState {
         graph: &FunctionGraph,
         consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
     ) {
+        // SSI copies of a merge-point red must still share its colour
+        // (`reserve_portal_red_identity` pins that colour). A call
+        // result (`scope_from_frame`) or the GETFIELD/vable load that
+        // remains when that helper is inlined must not join that
+        // class: the back edge would otherwise put the Scope in the
+        // reserved vm register, and a mid-opcode guard snapshots it
+        // there.
+        let portal_reds: VarSet = [RegKind::Int, RegKind::Ref, RegKind::Float]
+            .into_iter()
+            .flat_map(|kind| portal_merge_point_reds(graph, kind))
+            .collect();
+        let call_results = collect_protected_results(graph);
+        let non_copy_defs = collect_non_copy_results(graph);
+        let all_vars: Vec<crate::flowspace::model::Variable> = graph.iter_variables();
         let order = graph.iterblocks_order();
         for &bid in order.iter().rev() {
             let block = graph.block(bid);
@@ -291,7 +305,15 @@ impl RegAllocatorState {
                         if consider(arg_var) {
                             self.depgraph.add_node(arg_var.clone());
                         }
-                        self.try_coalesce(arg_var, target_var, consider);
+                        self.try_coalesce(
+                            arg_var,
+                            target_var,
+                            consider,
+                            &portal_reds,
+                            &call_results,
+                            &non_copy_defs,
+                            &all_vars,
+                        );
                     }
                 }
             }
@@ -307,6 +329,10 @@ impl RegAllocatorState {
         v: &crate::flowspace::model::Variable,
         w: &crate::flowspace::model::Variable,
         consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
+        portal_reds: &VarSet,
+        call_results: &VarSet,
+        non_copy_defs: &VarSet,
+        all_vars: &[crate::flowspace::model::Variable],
     ) {
         if !consider(v) || !consider(w) {
             return;
@@ -314,6 +340,23 @@ impl RegAllocatorState {
         let v0 = self.unionfind.find_rep(v.clone());
         let w0 = self.unionfind.find_rep(w.clone());
         if v0 == w0 {
+            return;
+        }
+        let v_has_red = class_hits_set(&mut self.unionfind, &v0, portal_reds, all_vars);
+        let w_has_red = class_hits_set(&mut self.unionfind, &w0, portal_reds, all_vars);
+        let v_has_call = class_hits_set(&mut self.unionfind, &v0, call_results, all_vars);
+        let w_has_call = class_hits_set(&mut self.unionfind, &w0, call_results, all_vars);
+        if (v_has_red && w_has_call) || (w_has_red && v_has_call) {
+            return;
+        }
+        // A later FieldRead / residual that is not in `call_results`
+        // (inlined `scope_from_frame`, a reborrow, a differently
+        // named load) must still stay off the reserved red: otherwise
+        // the class holds both `self` and `scope` and a mid-opcode
+        // guard snapshots Scope in the vm register.
+        let v_has_noncopy = class_hits_set(&mut self.unionfind, &v0, non_copy_defs, all_vars);
+        let w_has_noncopy = class_hits_set(&mut self.unionfind, &w0, non_copy_defs, all_vars);
+        if (v_has_red && w_has_noncopy) || (w_has_red && v_has_noncopy) {
             return;
         }
         if self
@@ -329,6 +372,54 @@ impl RegAllocatorState {
             self.depgraph.coalesce(w0, v0);
         } else {
             self.depgraph.coalesce(v0, w0);
+        }
+    }
+
+    /// Keep portal merge-point reds off every other same-kind colour.
+    ///
+    /// Generated `#[jit_interp]` states put identity in
+    /// `[ref_identity_base, ref_end)` and raise the body's `next_reg`
+    /// past that range so a temp cannot reuse the slot. The LLBC
+    /// portal has no such floor: `frame` / `vm` are ordinary SSA
+    /// values, and once their live range ends the colourer hands the
+    /// register to a later ref. A guard mid-opcode then snapshots
+    /// that later object under the merge-point's red-R index, and
+    /// `rebind_bridge_reds` that trusts the index writes a Vm over a
+    /// frame or scope.
+    ///
+    /// After coalescing, the red and every SSI-threaded copy share a
+    /// rep. Interfering that rep with every other considered rep is
+    /// the same reservation: one colour, never reused. Graphs with
+    /// no `JitMergePoint` are unchanged.
+    fn reserve_portal_red_identity(
+        &mut self,
+        graph: &FunctionGraph,
+        kind: RegKind,
+        consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
+    ) {
+        let reds = portal_merge_point_reds(graph, kind);
+        if reds.is_empty() {
+            return;
+        }
+        let red_reps: VarSet = reds
+            .into_iter()
+            .map(|var| self.unionfind.find_rep(var))
+            .collect();
+        let other_reps: VarSet = graph
+            .iter_variables()
+            .into_iter()
+            .filter(|var| consider(var))
+            .map(|var| self.unionfind.find_rep(var))
+            .filter(|rep| !red_reps.contains(rep))
+            .collect();
+        for red in &red_reps {
+            self.depgraph.add_node(red.clone());
+            for other in &other_reps {
+                self.depgraph.add_node(other.clone());
+                if red != other {
+                    self.depgraph.add_edge(red.clone(), other.clone());
+                }
+            }
         }
     }
 
@@ -665,6 +756,7 @@ pub fn perform_register_allocation(graph: &FunctionGraph, kind: RegKind) -> RegA
     let mut allocator = RegAllocatorState::new();
     allocator.make_dependencies(graph, &consider);
     allocator.coalesce_variables(graph, &consider);
+    allocator.reserve_portal_red_identity(graph, kind, &consider);
     allocator.find_node_coloring();
 
     let mut coloring: VarMap<usize> = VarMap::default();
@@ -682,6 +774,18 @@ pub fn perform_register_allocation(graph: &FunctionGraph, kind: RegKind) -> RegA
                 max_reg = color + 1;
             }
         }
+    }
+    if kind == RegKind::Ref && std::env::var_os("MAJIT_REGALLOC_DEBUG").is_some() {
+        let reds = portal_merge_point_reds(graph, kind);
+        if !reds.is_empty() || graph.name.contains("run_frame") {
+            eprintln!(
+                "[regalloc] graph {} merge_reds={} colored={}",
+                graph.name,
+                reds.len(),
+                coloring.len(),
+            );
+        }
+        log_portal_ref_colors(graph, &coloring);
     }
     RegAllocator {
         coloring,
@@ -704,6 +808,282 @@ fn variable_regkind(var: &crate::flowspace::model::Variable) -> Option<RegKind> 
 /// Signed → Int, GcRef → Ref, Float → Float.  Void / Unknown have
 /// no register class (the same way RPython's regalloc skips Void
 /// Variables, `flatten.py:325`).
+/// Merge-point reds of `kind` on this graph, if it is a portal.
+fn portal_merge_point_reds(
+    graph: &FunctionGraph,
+    kind: RegKind,
+) -> Vec<crate::flowspace::model::Variable> {
+    let mut reds = Vec::new();
+    for bid in graph.iterblocks_order() {
+        for op in &graph.block(bid).operations {
+            let OpKind::JitMergePoint {
+                reds_i,
+                reds_r,
+                reds_f,
+                ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            let list = match kind {
+                RegKind::Int => reds_i.as_slice(),
+                RegKind::Ref => reds_r.as_slice(),
+                RegKind::Float => reds_f.as_slice(),
+            };
+            for var in list {
+                if variable_regkind(var) == Some(kind) {
+                    reds.push(var.clone());
+                }
+            }
+        }
+    }
+    reds
+}
+
+fn is_defining_call(kind: &OpKind) -> bool {
+    matches!(
+        kind,
+        OpKind::Call { .. }
+            | OpKind::CallResidual { .. }
+            | OpKind::CallElidable { .. }
+            | OpKind::CallMayForce { .. }
+            | OpKind::IndirectCall { .. }
+            | OpKind::InlineCall { .. }
+    )
+}
+
+fn log_portal_ref_colors(graph: &FunctionGraph, coloring: &VarMap<usize>) {
+    let reds = portal_merge_point_reds(graph, RegKind::Ref);
+    if reds.is_empty() {
+        return;
+    }
+    let red_colors: Vec<Option<usize>> =
+        reds.iter().map(|var| coloring.get(var).copied()).collect();
+    let mut call_hits = 0usize;
+    let mut scope_calls = 0usize;
+    let mut scope_fields = 0usize;
+    for bid in graph.iterblocks_order() {
+        for op in &graph.block(bid).operations {
+            if is_defining_call(&op.kind) {
+                call_hits += 1;
+                if call_kind_mentions_scope(&op.kind) {
+                    scope_calls += 1;
+                }
+            }
+            if is_scope_load(&op.kind) {
+                scope_fields += 1;
+            }
+        }
+    }
+    let protected = collect_protected_results(graph);
+    let shared = protected
+        .iter()
+        .filter(|var| {
+            coloring
+                .get(*var)
+                .is_some_and(|color| red_colors.iter().any(|red| *red == Some(*color)))
+        })
+        .count();
+    let mut red_occupancy: Vec<(usize, usize)> = Vec::new();
+    for color in red_colors.iter().flatten() {
+        let n = coloring.values().filter(|c| *c == color).count();
+        red_occupancy.push((*color, n));
+    }
+    let mut kind_hits: Vec<(String, usize)> = Vec::new();
+    let mut samples: Vec<String> = Vec::new();
+    for bid in graph.iterblocks_order() {
+        for op in &graph.block(bid).operations {
+            let Some(result) = &op.result else {
+                continue;
+            };
+            let Some(color) = coloring.get(result) else {
+                continue;
+            };
+            if !red_colors.iter().any(|red| *red == Some(*color)) {
+                continue;
+            }
+            let label = match &op.kind {
+                OpKind::Call { target, .. }
+                | OpKind::CallResidual {
+                    funcptr: crate::model::CallFuncPtr::Target(target),
+                    ..
+                }
+                | OpKind::CallElidable {
+                    funcptr: crate::model::CallFuncPtr::Target(target),
+                    ..
+                }
+                | OpKind::CallMayForce {
+                    funcptr: crate::model::CallFuncPtr::Target(target),
+                    ..
+                } => format!("call:{target}"),
+                OpKind::FieldRead { field, .. } | OpKind::InteriorFieldRead { field, .. } => {
+                    format!("field:{}", field.name)
+                }
+                OpKind::VableFieldRead { .. } => "vable".into(),
+                OpKind::Input { name, .. } => format!("input:{name}"),
+                other => format!("{other:?}")
+                    .split_once(' ')
+                    .map(|(head, _)| head.to_string())
+                    .unwrap_or_else(|| format!("{other:?}")),
+            };
+            if let Some((_, n)) = kind_hits.iter_mut().find(|(k, _)| *k == label) {
+                *n += 1;
+            } else {
+                kind_hits.push((label.clone(), 1));
+            }
+            if samples.len() < 24 {
+                samples.push(format!("r{color}:{label}"));
+            }
+        }
+    }
+    kind_hits.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    eprintln!(
+        "[regalloc] portal {} ref reds={} colors={red_colors:?} \
+         occupancy={red_occupancy:?} calls={call_hits} scope_calls={scope_calls} \
+         scope_fields={scope_fields} protected_sharing_red={shared} colored={} \
+         red_kinds={kind_hits:?} samples={samples:?}",
+        graph.name,
+        reds.len(),
+        coloring.len(),
+    );
+}
+
+fn call_kind_mentions_scope(kind: &OpKind) -> bool {
+    let target = match kind {
+        OpKind::Call { target, .. }
+        | OpKind::CallElidable {
+            funcptr: crate::model::CallFuncPtr::Target(target),
+            ..
+        }
+        | OpKind::CallResidual {
+            funcptr: crate::model::CallFuncPtr::Target(target),
+            ..
+        }
+        | OpKind::CallMayForce {
+            funcptr: crate::model::CallFuncPtr::Target(target),
+            ..
+        } => target,
+        _ => return false,
+    };
+    target.to_string().contains("scope_from_frame")
+}
+
+fn is_scope_load(kind: &OpKind) -> bool {
+    match kind {
+        OpKind::FieldRead { field, .. } | OpKind::InteriorFieldRead { field, .. } => {
+            field.name == "scope"
+        }
+        OpKind::VableFieldRead { .. } => true,
+        _ => false,
+    }
+}
+
+fn is_protected_result_op(kind: &OpKind) -> bool {
+    // Any producer that is not an SSI/`same_as` copy can be a later
+    // object (Scope, engine, a residual). Seed the frontier with it
+    // so a reverse-order coalesce cannot union its inputarg copy
+    // with a portal red before the producer is attached.
+    !is_copy_kind(kind)
+}
+
+fn is_copy_kind(kind: &OpKind) -> bool {
+    match kind {
+        OpKind::Input { .. } => true,
+        OpKind::UnaryOp { op, .. } if op == "same_as" => true,
+        _ => false,
+    }
+}
+
+fn collect_non_copy_results(graph: &FunctionGraph) -> VarSet {
+    let mut results = VarSet::default();
+    for bid in graph.iterblocks_order() {
+        for op in &graph.block(bid).operations {
+            if let Some(result) = &op.result
+                && !is_copy_kind(&op.kind)
+            {
+                results.insert(result.clone());
+            }
+        }
+    }
+    results
+}
+
+fn collect_protected_results(graph: &FunctionGraph) -> VarSet {
+    let mut results = VarSet::default();
+    let mut frontier = VarSet::default();
+    for bid in graph.iterblocks_order() {
+        for op in &graph.block(bid).operations {
+            if let Some(result) = &op.result {
+                if is_defining_call(&op.kind) {
+                    results.insert(result.clone());
+                }
+                if is_protected_result_op(&op.kind) {
+                    results.insert(result.clone());
+                    frontier.insert(result.clone());
+                }
+            }
+        }
+    }
+    // Copies of a protected load are what the body actually uses:
+    // `same_as`, and the SSI inputarg a predecessor passes the load
+    // into. Leaving those unmarked lets a later back edge union the
+    // copy with the vm red while the GETFIELD result stays a
+    // different colour — occupancy then shows ~1300 vars in the red
+    // class and a mid-opcode guard snapshots Scope under the vm
+    // index.
+    let mut grew = true;
+    while grew {
+        grew = false;
+        for bid in graph.iterblocks_order() {
+            let block = graph.block(bid);
+            for op in &block.operations {
+                let OpKind::UnaryOp {
+                    op: name, operand, ..
+                } = &op.kind
+                else {
+                    continue;
+                };
+                if name != "same_as" || !frontier.contains(operand) {
+                    continue;
+                }
+                if let Some(result) = &op.result
+                    && frontier.insert(result.clone())
+                {
+                    results.insert(result.clone());
+                    grew = true;
+                }
+            }
+            for link in &block.exits {
+                let target_inputs: Vec<crate::flowspace::model::Variable> = graph
+                    .block(link.target)
+                    .input_variables()
+                    .cloned()
+                    .collect();
+                for (arg, target) in link.args.iter().zip(target_inputs.iter()) {
+                    let Some(arg_var) = arg.as_variable() else {
+                        continue;
+                    };
+                    if frontier.contains(arg_var) && frontier.insert(target.clone()) {
+                        results.insert(target.clone());
+                        grew = true;
+                    }
+                }
+            }
+        }
+    }
+    results
+}
+
+fn class_hits_set(
+    unionfind: &mut UnionFind<crate::flowspace::model::Variable>,
+    root: &crate::flowspace::model::Variable,
+    marked: &VarSet,
+    all: &[crate::flowspace::model::Variable],
+) -> bool {
+    all.iter()
+        .any(|var| marked.contains(var) && &unionfind.find_rep(var.clone()) == root)
+}
+
 fn concretetype_to_regkind(ty: &ConcreteType) -> Option<RegKind> {
     match ty {
         ConcreteType::Signed => Some(RegKind::Int),
@@ -716,7 +1096,7 @@ fn concretetype_to_regkind(ty: &ConcreteType) -> Option<RegKind> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ExitCase, ExitSwitch, FunctionGraph, Link, OpKind, ValueType};
+    use crate::model::{CallTarget, ExitCase, ExitSwitch, FunctionGraph, Link, OpKind, ValueType};
 
     fn push_int_input(
         graph: &mut FunctionGraph,
@@ -894,6 +1274,292 @@ mod tests {
             max_color <= 1,
             "chain needs at most 2 colors, got {}",
             max_color + 1
+        );
+    }
+
+    fn push_ref_input(
+        graph: &mut FunctionGraph,
+        block: crate::model::BlockId,
+        name: &str,
+    ) -> crate::flowspace::model::Variable {
+        let var = graph
+            .push_op_var(
+                block,
+                OpKind::Input {
+                    name: name.into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(block, var.clone());
+        var
+    }
+
+    #[test]
+    fn portal_merge_point_red_does_not_share_a_register_with_a_later_ref() {
+        // frame dies at the merge point; temp is born after. Without the
+        // reservation they share a colour (non_overlapping_lifetimes).
+        // The portal red must keep its colour so a mid-opcode guard still
+        // names the Vm/frame, not the later object.
+        let mut graph = FunctionGraph::new("portal");
+        let entry = graph.startblock;
+        let frame = push_ref_input(&mut graph, entry, "frame");
+        graph.push_op_var(
+            entry,
+            OpKind::JitMergePoint {
+                jitdriver_index: 0,
+                greens_i: vec![],
+                greens_r: vec![],
+                greens_f: vec![],
+                reds_i: vec![],
+                reds_r: vec![frame.clone()],
+                reds_f: vec![],
+            },
+            false,
+        );
+        let temp = graph
+            .push_op_var(entry, OpKind::ConstRefNull, true)
+            .unwrap();
+        graph.set_return(entry, Some(temp.clone()));
+
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&temp, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_ne!(
+            result.color_for_variable(&frame),
+            result.color_for_variable(&temp),
+            "a portal red must not share its colour with a later ref",
+        );
+        assert!(result.num_regs >= 2);
+    }
+
+    #[test]
+    fn a_graph_without_a_merge_point_still_shares_non_overlapping_refs() {
+        let mut graph = FunctionGraph::new("helper");
+        let entry = graph.startblock;
+        let early = push_ref_input(&mut graph, entry, "early");
+        let late = graph
+            .push_op_var(entry, OpKind::ConstRefNull, true)
+            .unwrap();
+        graph.set_return(entry, Some(late.clone()));
+
+        FunctionGraph::set_concretetype_of_inline(&early, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&late, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_eq!(
+            result.color_for_variable(&early),
+            result.color_for_variable(&late),
+            "reservation is inert off a portal",
+        );
+        assert_eq!(result.num_regs, 1);
+    }
+
+    #[test]
+    fn portal_red_does_not_coalesce_with_a_call_result() {
+        // Back edge would otherwise union the call result with the
+        // merge-point red and put the Scope in the reserved vm colour.
+        let mut graph = FunctionGraph::new("portal");
+        let entry = graph.startblock;
+        let frame = push_ref_input(&mut graph, entry, "frame");
+        graph.push_op_var(
+            entry,
+            OpKind::JitMergePoint {
+                jitdriver_index: 0,
+                greens_i: vec![],
+                greens_r: vec![],
+                greens_f: vec![],
+                reds_i: vec![],
+                reds_r: vec![frame.clone()],
+                reds_f: vec![],
+            },
+            false,
+        );
+        let temp = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::function_path(["scope_from_frame"]),
+                    args: vec![frame.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_goto(entry, entry, vec![temp.clone()]);
+
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&temp, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_ne!(
+            result.color_for_variable(&frame),
+            result.color_for_variable(&temp),
+            "a call result must not share the merge-point red's colour",
+        );
+    }
+
+    #[test]
+    fn portal_red_does_not_coalesce_with_a_scope_field_read() {
+        // The live portal still inlines `scope_from_frame` to a GETFIELD
+        // of `frame.scope`. That result must stay off the reserved vm
+        // colour the same way a residual call result does.
+        let mut graph = FunctionGraph::new("portal");
+        let entry = graph.startblock;
+        let frame = push_ref_input(&mut graph, entry, "frame");
+        graph.push_op_var(
+            entry,
+            OpKind::JitMergePoint {
+                jitdriver_index: 0,
+                greens_i: vec![],
+                greens_r: vec![],
+                greens_f: vec![],
+                reds_i: vec![],
+                reds_r: vec![frame.clone()],
+                reds_f: vec![],
+            },
+            false,
+        );
+        let temp = graph
+            .push_op_var(
+                entry,
+                OpKind::FieldRead {
+                    base: frame.clone(),
+                    field: crate::model::FieldDescriptor::new("scope", Some("GrainFrame".into())),
+                    ty: ValueType::Ref(None),
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_goto(entry, entry, vec![temp.clone()]);
+
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&temp, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_ne!(
+            result.color_for_variable(&frame),
+            result.color_for_variable(&temp),
+            "a scope field read must not share the merge-point red's colour",
+        );
+    }
+
+    #[test]
+    fn portal_red_does_not_coalesce_with_a_threaded_scope_copy() {
+        // The GETFIELD result is passed into a successor inputarg; that
+        // copy is what a later back edge would union with the red.
+        let mut graph = FunctionGraph::new("portal");
+        let entry = graph.startblock;
+        let mid = graph.create_block();
+        let frame = push_ref_input(&mut graph, entry, "frame");
+        graph.push_op_var(
+            entry,
+            OpKind::JitMergePoint {
+                jitdriver_index: 0,
+                greens_i: vec![],
+                greens_r: vec![],
+                greens_f: vec![],
+                reds_i: vec![],
+                reds_r: vec![frame.clone()],
+                reds_f: vec![],
+            },
+            false,
+        );
+        let loaded = graph
+            .push_op_var(
+                entry,
+                OpKind::FieldRead {
+                    base: frame.clone(),
+                    field: crate::model::FieldDescriptor::new("scope", Some("GrainFrame".into())),
+                    ty: ValueType::Ref(None),
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        let mid_in = graph
+            .push_op_var(
+                mid,
+                OpKind::Input {
+                    name: "scope_copy".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(mid, mid_in.clone());
+        graph.set_goto(entry, mid, vec![loaded.clone()]);
+        graph.set_goto(mid, entry, vec![mid_in.clone()]);
+
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&loaded, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&mid_in, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_ne!(
+            result.color_for_variable(&frame),
+            result.color_for_variable(&mid_in),
+            "a threaded scope copy must not share the merge-point red's colour",
+        );
+    }
+
+    #[test]
+    fn portal_red_does_not_coalesce_with_a_threaded_non_scope_load() {
+        // Inlined helpers leave FieldReads whose name is not `scope`
+        // (`engine`, a reborrow). Those were not in `call_results`, so a
+        // back edge could union them with the vm red.
+        let mut graph = FunctionGraph::new("portal");
+        let entry = graph.startblock;
+        let mid = graph.create_block();
+        let frame = push_ref_input(&mut graph, entry, "frame");
+        graph.push_op_var(
+            entry,
+            OpKind::JitMergePoint {
+                jitdriver_index: 0,
+                greens_i: vec![],
+                greens_r: vec![],
+                greens_f: vec![],
+                reds_i: vec![],
+                reds_r: vec![frame.clone()],
+                reds_f: vec![],
+            },
+            false,
+        );
+        let loaded = graph
+            .push_op_var(
+                entry,
+                OpKind::FieldRead {
+                    base: frame.clone(),
+                    field: crate::model::FieldDescriptor::new("engine", Some("Vm".into())),
+                    ty: ValueType::Ref(None),
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+        let mid_in = graph
+            .push_op_var(
+                mid,
+                OpKind::Input {
+                    name: "engine_copy".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(mid, mid_in.clone());
+        graph.set_goto(entry, mid, vec![loaded.clone()]);
+        graph.set_goto(mid, entry, vec![mid_in.clone()]);
+
+        FunctionGraph::set_concretetype_of_inline(&frame, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&loaded, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&mid_in, ConcreteType::GcRef);
+        let result = perform_register_allocation(&graph, RegKind::Ref);
+        assert_ne!(
+            result.color_for_variable(&frame),
+            result.color_for_variable(&mid_in),
+            "a threaded non-scope load must not share the merge-point red's colour",
         );
     }
 }


### PR DESCRIPTION
## Summary

Companion to [youknowone/rhai#1](https://github.com/youknowone/rhai/pull/1). Grain multi-arm loops compile a loop; a taken non-hot arm walks from the failed guard and resumes at a merge-point PC.

- Keep a compiled bridge when a later `must_compile` FIRED re-enters setup and aborts; do not terminally decline a guard that already has a patch.
- Interpret a symbolic `inline_call_*` from its jitcode body so the blackhole can finish the half-opcode instead of returning `usize::MAX`.
- Refuse residual calls whose Ref argument is a walk-local `Dynamic`.
- Do not fold a stack-resident InputArg to `ConstPtr` (`make_equal_to` / `make_constant_box`).
- Reserve portal merge-point reds and refuse coalescing a later FieldRead onto that colour.

## Validation

- Isolated switch 20000: walker and VM agree, `loops_compiled=1`, `entries=1601`, `FIRED=8`.
- `tight integer loop`: 1.67x, above its 1.30x floor, `entries=181`.
- `switch, 4 arms` still 0.18x: the default-arm bridge at portal pc=3943 still bakes `ConstPtr(first-eval Vm)` because that snapshot has Scope in the reserved vm register and no live-Vm failarg. That is the remaining owner, not a floor change.

## Non-goals

Does not residualize a whole `if`/`switch`, and does not lower grain-bench floors.