### PR TITLE
majit: root Cranelift execute_token refs across collecting malloc

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -295,7 +295,7 @@ use majit_backend::deadframe::FrameHeapOwner;
 use majit_backend::jitframe::{
     BASEITEMOFS, HostHeapGc, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
     JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, check_jitframe_descr, jitframe_is_gc_object,
-    jitframe_write_barrier, malloc_entry_jitframe_no_collect, malloc_jitframe_no_collect,
+    jitframe_write_barrier, malloc_entry_jitframe, malloc_jitframe_no_collect,
 };
 /// Byte offset of `jf_frame_length` from JitFrame start
 /// (`jitframe.py:84` — `jf_frame`'s length word sits at the array base).
@@ -8220,14 +8220,37 @@ fn run_compiled_code_inner(
     // llmodel.py:298 `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`:
     // the descr decides whether the frame is a nursery object under JITFRAME
     // — traced through `jf_gcmap`, held by the shadow stack through a root
-    // slot the collector updates when it copies — or a host block. Input
-    // slots are read once at entry (before any GC point) and their values
-    // live in SSA/ref_root_slots afterward.
-    let (use_gc_alloc, jf) = with_gc_ll_descr(|gc| {
-        (
-            jitframe_is_gc_object(gc),
-            malloc_entry_jitframe_no_collect(gc, payload_bytes),
-        )
+    // slot the collector updates when it copies — or a host block.
+    // `execute_token` receives typed `Value`s, so it can root refs across
+    // that collecting malloc the way dynasm `alloc_entry_jitframe` does.
+    // Flattened `i64` re-entry cannot name which words are refs, so it keeps
+    // the non-collecting allocator.
+    type EntryArgRoots = Vec<majit_gc::shadow_stack::OwnerRootGuard>;
+    let (use_gc_alloc, jf, arg_roots) = with_gc_ll_descr(|gc| {
+        let gc_object = jitframe_is_gc_object(gc);
+        match inputs {
+            FrameInputs::Values(values) => {
+                let roots: EntryArgRoots = if gc_object {
+                    values
+                        .iter()
+                        .filter_map(|arg| match arg {
+                            Value::Ref(value) => {
+                                Some(majit_gc::shadow_stack::OwnerRootGuard::new(*value))
+                            }
+                            _ => None,
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                (gc_object, malloc_entry_jitframe(gc, payload_bytes), roots)
+            }
+            FrameInputs::Ints(_) | FrameInputs::OwnedInts(_) => (
+                gc_object,
+                malloc_jitframe_no_collect(gc, payload_bytes),
+                Vec::new(),
+            ),
+        }
     });
     let jf_gcref = GcRef(jf as usize);
     unsafe {
@@ -8241,8 +8264,31 @@ fn run_compiled_code_inner(
 
     let jf_ptr = jf_gcref.0 as *mut i64;
 
-    // llmodel.py:306-315: set arguments in frame
-    unsafe { inputs.write_into(jf_ptr.add(header_words)) };
+    // llmodel.py:306-315: set arguments in frame. Collecting malloc may have
+    // moved the rooted refs; write the forwarded copies, then drop the
+    // owner-root slots so they are not extra GC roots during the run
+    // (dynasm `alloc_entry_jitframe` / `drop(arg_roots)`).
+    unsafe {
+        if let FrameInputs::Values(values) = inputs {
+            let mut ref_index = 0;
+            for (i, arg) in values.iter().enumerate() {
+                let raw = match arg {
+                    Value::Int(v) => *v,
+                    Value::Float(v) => v.to_bits() as i64,
+                    Value::Ref(r) => {
+                        let current = arg_roots.get(ref_index).map_or(*r, |root| root.get());
+                        ref_index += 1;
+                        current.0 as i64
+                    }
+                    Value::Void => 0,
+                };
+                *jf_ptr.add(header_words + i) = raw;
+            }
+        } else {
+            inputs.write_into(jf_ptr.add(header_words));
+        }
+    }
+    drop(arg_roots);
     // The one repeatable part of a compiled entry's call. Everything past this
     // point runs the trace and cannot be made to happen twice, but allocating
     // the frame and writing the arguments into it produces a frame NOTHING has

--- a/majit/majit-backend/EAGER.md
+++ b/majit/majit-backend/EAGER.md
@@ -70,6 +70,22 @@ discovery; this API does **not** claim to remove the measured per-call entry
 cost, binding cost, GC overhead, or actual host-function invocation cost. A
 dedicated low-overhead scalar ABI is separate work.
 
+The `majit` example `eager_vs_jit` probes that boundary using the same compiled
+token through `CompiledIr::execute` and `Backend::execute_token_raw`:
+
+```sh
+cargo run --release -p majit --no-default-features --features dynasm --example eager_vs_jit
+```
+
+Despite its historical name, it does not run a tracing frontend or compare AOT
+against JIT code generation. It reports one cold compilation, the first checked
+call, and seven-sample steady-state wall-clock minima for checked and raw entry.
+Inputs vary and integer overflow results are checked outside the timed loops.
+The panels run sequentially, so drift and timer noise prevent treating their
+difference as an exact cost decomposition. Both retain ordinary JITFRAME entry.
+Use `EAGER_BENCH_ITERS` to reduce iterations for a smoke run; use external power
+and the existing thread-CPU benchmark board for performance conclusions.
+
 For a CEL frontend, short-circuiting, errors, dynamic types and host side effects
 must survive lowering. Compiling an example input and treating the observed path
 as the whole program is not a valid implementation of this API's frontend.

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -346,31 +346,6 @@ pub fn malloc_entry_jitframe(
     }
 }
 
-/// [`malloc_entry_jitframe`] for a caller whose Rust-stack inputs are not
-/// rooted across a collecting allocation.
-///
-/// This is the compiled-entry counterpart of [`malloc_jitframe_no_collect`]:
-/// it preserves that function's non-collecting nursery allocation while
-/// keeping the entry allocator's narrower initialization contract.  The
-/// generated entry writes every live spill before publishing its GC map, so
-/// clearing trailing frame slots here has no upstream counterpart.
-pub fn malloc_entry_jitframe_no_collect(
-    gc: &mut dyn majit_gc::GcAllocator,
-    size_bytes: usize,
-) -> *mut JitFrame {
-    match gc.jitframe_type_id() {
-        Some(type_id) => {
-            let gcref = if jitframe_prefer_oldgen() {
-                gc.alloc_oldgen_typed(type_id, size_bytes)
-            } else {
-                gc.alloc_nursery_no_collect_typed(type_id, size_bytes)
-            };
-            entry_gc_frame(gcref)
-        }
-        None => malloc_host_jitframe(size_bytes),
-    }
-}
-
 /// `llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`,
 /// reached through `GcLLDescription.malloc_jitframe` (gc.py:132) and
 /// `jitframe_allocate` (`jitframe.py:48`).
@@ -933,42 +908,6 @@ mod tests {
         assert!(
             gc.is_in_nursery(frame as usize),
             "a false prefer-oldgen flag must not land the frame in mark-sweep old-gen"
-        );
-    }
-
-    #[test]
-    fn noncollecting_entry_jitframe_stays_in_the_nursery() {
-        let mut gc = majit_gc::collector::MiniMarkGC::with_config(majit_gc::collector::GcConfig {
-            nursery_size: 4096,
-            large_object_threshold: 4096,
-            ..majit_gc::collector::GcConfig::default()
-        });
-        let tid = gc.register_type(jitframe_type_info());
-        gc.set_jitframe_type_id(tid);
-        let frame = malloc_entry_jitframe_no_collect(&mut gc, JitFrame::alloc_size(8));
-        assert!(!frame.is_null());
-        assert!(
-            gc.is_in_nursery(frame as usize),
-            "the non-collecting entry allocator must keep the ordinary nursery placement"
-        );
-
-        // A collecting nursery alloc would run a minor collection once the
-        // nursery is full and then stay young. The no-collect path must not
-        // collect; it falls back to old-gen instead.
-        let pad = gc.register_type(majit_gc::TypeInfo::simple(16));
-        loop {
-            let obj = gc.alloc_nursery_no_collect_typed(pad, 16);
-            if obj.is_null() || !gc.is_in_nursery(obj.0) {
-                break;
-            }
-        }
-        let minors_before = gc.collection_counts().0;
-        let tight = malloc_entry_jitframe_no_collect(&mut gc, JitFrame::alloc_size(8));
-        assert!(!tight.is_null());
-        assert_eq!(
-            gc.collection_counts().0,
-            minors_before,
-            "malloc_entry_jitframe_no_collect must use alloc_nursery_no_collect_typed, not the collecting nursery allocator"
         );
     }
 }

--- a/majit/majit/Cargo.toml
+++ b/majit/majit/Cargo.toml
@@ -23,3 +23,7 @@ majit-backend-cranelift = { workspace = true, optional = true }
 majit-backend-dynasm = { workspace = true, optional = true }
 majit-gc = { workspace = true }
 majit-macros = { workspace = true }
+
+[[example]]
+name = "eager_vs_jit"
+required-features = ["dynasm"]

--- a/majit/majit/examples/eager_vs_jit.rs
+++ b/majit/majit/examples/eager_vs_jit.rs
@@ -1,0 +1,141 @@
+//! Eager compilation and checked-vs-raw backend entry cost (dynasm).
+//!
+//! cargo run --release -p majit --no-default-features --features dynasm --example eager_vs_jit
+//!
+//! Despite the historical filename, this does not run a tracing JIT.
+//! Both execution panels use the SAME compiled token and machine code.
+//! EAGER_BENCH_ITERS controls calls per sample (default 50,000).
+//! Wall-clock minima are diagnostic, not a replacement for the thread-CPU
+//! benchmark board. Run on external power before drawing performance conclusions.
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Instant;
+
+use majit::backend::{Backend, JitCellToken, RawExecResult};
+use majit::eager::CompiledIr;
+use majit::ir::descr::make_finish_descr;
+use majit::ir::operand::Operand;
+use majit::ir::{ConstMap, InputArg, Op, OpCode, OpRc, OpRef, Type, Value};
+use majit_backend_dynasm::runner::DynasmBackend;
+
+const SAMPLES: usize = 7;
+const WARMUP: u64 = 1_000;
+
+fn backend() -> DynasmBackend {
+    let mut cpu = DynasmBackend::new();
+    majit::backend::make_and_attach_done_descrs(&mut [&mut cpu as &mut dyn Backend]);
+    cpu.set_propagate_exception_descr(Arc::new(majit::backend::PropagateExceptionDescr::new()));
+    cpu.setup_once();
+    cpu
+}
+
+fn add_ir() -> (Vec<InputArg>, Vec<OpRc>) {
+    let x = InputArg::new_int_rc(0);
+    let y = InputArg::new_int_rc(1);
+    let add = OpRc::new(Op::new(
+        OpCode::IntAdd,
+        &[
+            Operand::from_bound_inputarg(&x),
+            Operand::from_bound_inputarg(&y),
+        ],
+    ));
+    add.pos.set(OpRef::int_op(1));
+    let finish = OpRc::new(Op::with_descr(
+        OpCode::Finish,
+        &[Operand::from_bound_op(&add)],
+        make_finish_descr(0, vec![Type::Int]),
+    ));
+    (
+        vec![x.fresh_value_copy(), y.fresh_value_copy()],
+        vec![add, finish],
+    )
+}
+
+fn arguments(i: u64) -> [Value; 2] {
+    [Value::Int(i as i64), Value::Int(2)]
+}
+
+fn check(exit: RawExecResult, i: u64) {
+    assert!(exit.is_finish);
+    assert_eq!(
+        exit.typed_outputs,
+        vec![Value::Int((i as i64).wrapping_add(2))]
+    );
+}
+
+fn minimum_ns_per_call(n: u64, mut run: impl FnMut(u64)) -> f64 {
+    for i in 0..WARMUP {
+        run(i);
+    }
+    (0..SAMPLES)
+        .map(|_| {
+            let start = Instant::now();
+            for i in 0..n {
+                run(i);
+            }
+            start.elapsed().as_secs_f64() * 1e9 / n as f64
+        })
+        .fold(f64::INFINITY, f64::min)
+}
+
+fn main() {
+    let iterations = std::env::var("EAGER_BENCH_ITERS")
+        .map(|s| {
+            s.parse::<u64>()
+                .expect("EAGER_BENCH_ITERS must be an integer")
+        })
+        .unwrap_or(50_000);
+    assert!(iterations > 0, "EAGER_BENCH_ITERS must be positive");
+    println!(
+        "# backend=dynasm calls/sample={iterations} samples={SAMPLES} timer=wall minimum=ns/call"
+    );
+    println!("# Same code/token; eager panel first, raw panel second; no tracing or batching.");
+    let mut cpu = backend();
+    // A single standalone CPU and compilation: token 1 is unique in this example.
+    let token = Arc::new(JitCellToken::new(1));
+    let (inputs, ops) = add_ir();
+    let start = Instant::now();
+    // SAFETY: integer-only, well-formed IR, initialized CPU, fresh token.
+    let mut compiled = unsafe {
+        CompiledIr::compile(
+            &mut cpu,
+            Arc::clone(&token),
+            &inputs,
+            &ops,
+            ConstMap::default(),
+        )
+    }
+    .expect("eager compile");
+    let compile_ns = start.elapsed().as_secs_f64() * 1e9;
+
+    let start = Instant::now();
+    // SAFETY: the IR uses integers only; no pointers, allocation or host calls.
+    let first = unsafe { compiled.execute(black_box(&arguments(40))) }.unwrap();
+    let first_ns = start.elapsed().as_secs_f64() * 1e9;
+    check(first, 40);
+    for i in [0, 1, 42, i64::MAX as u64, u64::MAX] {
+        check(unsafe { compiled.execute(&arguments(i)) }.unwrap(), i);
+    }
+
+    let eager_ns = minimum_ns_per_call(iterations, |i| {
+        // SAFETY: same integer-only program and two correctly typed arguments.
+        black_box(unsafe { compiled.execute(black_box(&arguments(i))) }.unwrap());
+    });
+    drop(compiled);
+
+    // Keep the dynamic Backend dispatch used inside CompiledIr::execute.
+    let cpu: &dyn Backend = &cpu;
+    for i in [0, 1, 42, i64::MAX as u64, u64::MAX] {
+        check(cpu.execute_token_raw(&token, &arguments(i)), i);
+    }
+    let raw_ns = minimum_ns_per_call(iterations, |i| {
+        black_box(cpu.execute_token_raw(&token, black_box(&arguments(i))));
+    });
+    println!("compile (one cold sample)    {compile_ns:>12.1} ns");
+    println!("first eager call            {first_ns:>12.1} ns");
+    println!("steady eager checked        {eager_ns:>12.1} ns/call");
+    println!("steady backend raw          {raw_ns:>12.1} ns/call");
+    println!("# Setup/lowering excluded; steady includes argument construction and result drop.");
+    println!("# Sequential panels can drift; neither path removes JITFRAME or GC entry costs.");
+}


### PR DESCRIPTION
Two commits on current `main`:

- Root Cranelift `execute_token` `Value`/`Ref` arguments across the collecting `malloc_entry_jitframe`. Drop `malloc_entry_jitframe_no_collect`. Flattened i64 re-entry still uses `malloc_jitframe_no_collect`.
- Add an example that times eager `CompiledIr` execute against the raw entry helper.

`#1711` (eager IR compile API) is already on `main`. The old remote `cel` tip still had the pre-merge stack; this branch does not replay those.

Rebase onto `upstream/main` (`0b5c40fd08b`) was a no-op — already linear. `cargo test -p majit-backend-cranelift --lib`: 150 passed. `python3 pyre/check.py --backend cranelift` did not run: LLBC under `build/llbc/` is stale for this tree (not caused by these two commits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `eager_vs_jit` example for comparing eager compilation with checked and raw execution performance.
  * Added configurable benchmark iterations, warmup runs, correctness checks, and overflow-case coverage.

* **Documentation**
  * Documented the benchmark’s scope, timing methodology, limitations, and recommended practices for interpreting results.

* **Bug Fixes**
  * Improved reliability when executing compiled code with garbage-collected object values, including cases where objects are moved during collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->