### PR TITLE
blackhole: resume vable arrays through the CPU chain

### DIFF
--- a/majit/examples/braininterp/src/jit_interp.rs
+++ b/majit/examples/braininterp/src/jit_interp.rs
@@ -4,6 +4,7 @@
 /// The program counter and bytecode are green inputs. The pointer and tape are
 /// red state, with tape cells represented as symbolic values while tracing.
 /// A backward `]` branch identifies the loop header.
+use majit_metainterp::virt_array::VirtArray;
 pub type Bytecode = [u8];
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -63,7 +64,7 @@ const DEFAULT_THRESHOLD: u32 = 3;
 
 struct BfState {
     pointer: i64,
-    tape: Vec<i64>,
+    tape: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -90,7 +91,7 @@ fn mainloop(program: &Bytecode, threshold: u32) -> String {
     let _stacksize: i32 = 0;
     let mut state = BfState {
         pointer: 0,
-        tape: vec![0i64; TAPE_SIZE],
+        tape: VirtArray::filled(0i64, TAPE_SIZE),
     };
     let mut output = String::new();
 

--- a/majit/examples/cel/src/colscalar.rs
+++ b/majit/examples/cel/src/colscalar.rs
@@ -5,6 +5,7 @@
 //! the virtualizable identity makes the read-only variant fail loop closing.
 
 use crate::common::*;
+use majit_metainterp::virt_array::VirtArray;
 use std::sync::atomic::Ordering;
 
 const OP_LOAD: i64 = 0; // [LOAD, imm, dst]
@@ -16,7 +17,7 @@ const OP_COL_LOAD_SF: i64 = 5; // [COL_LOAD_SF, ea_reg, dst]  dst=*(col_base+reg
 const OP_SET_BASE: i64 = 6; // [SET_BASE, src_reg]  state.col_base = regs[src]
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     col_base: i64,
     /// What `OP_RETURN` hands back.
     ///
@@ -50,7 +51,7 @@ fn mainloop(program: &Code, num_regs: usize, col_base: i64, threshold: u32) -> i
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = VmState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         col_base,
         ret: 0,
     };
@@ -141,7 +142,7 @@ fn mainloop(program: &Code, num_regs: usize, col_base: i64, threshold: u32) -> i
 }
 
 fn clean_interp(program: &Code, num_regs: usize, col_base: i64) -> i64 {
-    let mut regs = vec![0i64; num_regs];
+    let mut regs = VirtArray::filled(0i64, num_regs);
     let mut base = col_base;
     let mut pc = 0usize;
     loop {

--- a/majit/examples/cel/src/column.rs
+++ b/majit/examples/cel/src/column.rs
@@ -6,6 +6,7 @@
 //! two-column comparison policy.
 
 use crate::common::*;
+use majit_metainterp::virt_array::VirtArray;
 use std::hint::black_box;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -19,7 +20,7 @@ const OP_COL_LOAD: i64 = 5; // [COL_LOAD, base_reg, ea_reg, dst]  dst = *(regs[b
 const OP_GE: i64 = 6; // [GE, a, b, dst]  dst = (regs[a] >= regs[b]) as {0,1}
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     /// What `OP_RETURN` hands back.
     ///
     /// The `; state` merge point leaves the loop through `break` before it
@@ -51,7 +52,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = VmState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         ret: 0,
     };
 
@@ -148,7 +149,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
 /// implementation" baseline. Reads columns via the same raw load a real
 /// columnar interpreter would use (fair: same work, no JIT machinery).
 fn clean_interp(program: &Code, num_regs: usize) -> i64 {
-    let mut regs = vec![0i64; num_regs];
+    let mut regs = VirtArray::filled(0i64, num_regs);
     let mut pc = 0usize;
     loop {
         match program[pc] {

--- a/majit/examples/cel/src/float.rs
+++ b/majit/examples/cel/src/float.rs
@@ -18,6 +18,7 @@
 //!   COMPUTE: sum(a*b - a*a + b*b), two loads and five arithmetic operations.
 
 use crate::common::{ABORTS, COMPILES, Code, JIT_OFF, JIT_ON, majit_raw_load_f, median};
+use majit_metainterp::virt_array::VirtArray;
 use std::hint::black_box;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -55,7 +56,7 @@ struct VmState {
     n: i64,
     base_a: i64,
     base_b: i64,
-    regs: Vec<f64>,
+    regs: VirtArray<f64>,
 }
 
 #[majit_macros::jit_interp(
@@ -86,7 +87,7 @@ fn mainloop(program: &Code, base_a: i64, base_b: i64, n: i64, threshold: u32) ->
         n,
         base_a,
         base_b,
-        regs: vec![0.0; NUM_REGS + 1],
+        regs: VirtArray::filled(0.0, NUM_REGS + 1),
     };
 
     {
@@ -425,8 +426,8 @@ mod twobank {
     const BODY_PC: usize = 21; // 7 LOADs * 3
 
     struct TwoBankState {
-        regs: Vec<i64>,
-        fregs: Vec<f64>,
+        regs: VirtArray<i64>,
+        fregs: VirtArray<f64>,
         /// What `OP_RETURN` hands back.
         ///
         /// The `; state` merge point leaves the loop through `break` before it
@@ -461,8 +462,8 @@ mod twobank {
 
         let mut pc: usize = 0;
         let mut state = TwoBankState {
-            regs: vec![0; NUM_INT],
-            fregs: vec![0.0; NUM_FLOAT],
+            regs: VirtArray::filled(0, NUM_INT),
+            fregs: VirtArray::filled(0.0, NUM_FLOAT),
             ret: 0,
         };
 

--- a/majit/examples/cel/src/policy.rs
+++ b/majit/examples/cel/src/policy.rs
@@ -6,6 +6,7 @@
 //! interpreter, and JIT-disabled execution.
 
 use crate::common::*;
+use majit_metainterp::virt_array::VirtArray;
 use std::hint::black_box;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -24,7 +25,7 @@ const LO: i64 = i64::MIN + 1; // `bal >= LO` ~always true, not foldable
 const HI: i64 = i64::MAX; // `draw >= HI` ~always false, not foldable
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     /// What `OP_RETURN` hands back.
     ///
     /// The `; state` merge point leaves the loop through `break` before it
@@ -53,7 +54,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = VmState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         ret: 0,
     };
 
@@ -152,7 +153,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
 }
 
 fn clean_interp(program: &Code, num_regs: usize) -> i64 {
-    let mut regs = vec![0i64; num_regs];
+    let mut regs = VirtArray::filled(0i64, num_regs);
     let mut pc = 0usize;
     loop {
         match program[pc] {

--- a/majit/examples/cel/src/probe.rs
+++ b/majit/examples/cel/src/probe.rs
@@ -5,6 +5,7 @@
 //! interpreter, and JIT-disabled paths for result and timing comparisons.
 
 use crate::common::*;
+use majit_metainterp::virt_array::VirtArray;
 use std::hint::black_box;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -17,7 +18,7 @@ const OP_MUL: i64 = 4; // [MUL, a, b, dst]
 const OP_SUB: i64 = 5; // [SUB, a, b, dst]
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     /// What `OP_RETURN` hands back.
     ///
     /// The `; state` merge point leaves the loop through `break` before it
@@ -49,7 +50,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = VmState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         ret: 0,
     };
 
@@ -135,7 +136,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
 
 /// Interpreter for the same bytecode without JIT hooks.
 fn clean_interp(program: &Code, num_regs: usize) -> i64 {
-    let mut regs = vec![0i64; num_regs];
+    let mut regs = VirtArray::filled(0i64, num_regs);
     let mut pc = 0usize;
     loop {
         match program[pc] {

--- a/majit/examples/dualtape/src/jit_interp.rs
+++ b/majit/examples/dualtape/src/jit_interp.rs
@@ -3,6 +3,7 @@
 ///
 /// The program counter and bytecode are green inputs. Each tape contributes
 /// its pointer, length, and symbolic elements to the loop state.
+use majit_metainterp::virt_array::VirtArray;
 pub type Bytecode = [u8];
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -31,9 +32,9 @@ const DEFAULT_THRESHOLD: u32 = 3;
 
 struct DualState {
     pa: i64,
-    a: Vec<i64>,
+    a: VirtArray<i64>,
     pb: i64,
-    b: Vec<i64>,
+    b: VirtArray<i64>,
 }
 
 /// Uses split dispatch to exercise two virtualizable tapes and scalar tape
@@ -63,9 +64,9 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let mut state = DualState {
         pa: 0,
-        a: vec![0i64; TAPE_SIZE],
+        a: VirtArray::filled(0i64, TAPE_SIZE),
         pb: 0,
-        b: vec![0i64; TAPE_SIZE],
+        b: VirtArray::filled(0i64, TAPE_SIZE),
     };
 
     {

--- a/majit/examples/i64env/src/main.rs
+++ b/majit/examples/i64env/src/main.rs
@@ -11,6 +11,7 @@
 //! `[int]` array element is not restored on a CloseLoop guard deopt. (See the
 //! macro's loop-carried-plain-array diagnostic.)
 
+use majit_metainterp::virt_array::VirtArray;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// The env: an i64-word bytecode stream. The whole point of this example is
@@ -43,7 +44,7 @@ pub static LAST_HAS_JUMP: AtomicBool = AtomicBool::new(false);
 pub static LAST_ALWAYS_FAILS: AtomicBool = AtomicBool::new(false);
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     /// What `OP_RETURN` hands back. The `; state` merge point leaves the
     /// dispatch loop through `break` before the in-arm `return` can run, so the
     /// result has to arrive in `state` and be returned by the post-loop tail.
@@ -72,7 +73,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = VmState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         ret: 0,
     };
 

--- a/majit/examples/spcount/src/main.rs
+++ b/majit/examples/spcount/src/main.rs
@@ -6,6 +6,7 @@
 //! execution by both the trace walk and the native interpreter.
 
 /// Bytecode stream. Byte-wide opcodes/operands, same shape as the tl env.
+use majit_metainterp::virt_array::VirtArray;
 pub type Bytecode = [u8];
 
 // Opcodes
@@ -49,7 +50,7 @@ extern "C" fn touch(stackpos: i64) {
 /// Virtualizable stack: a scalar `stackpos` plus a loop-carried virt array.
 struct StackState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 // ── JIT mainloop ──
@@ -84,7 +85,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let stacksize: i32 = 0;
     let mut state = StackState {
         stackpos: 0,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
 
     // warmspot.py:281-289 canonical-liveness install hook.

--- a/majit/examples/tiny2/src/jit_interp.rs
+++ b/majit/examples/tiny2/src/jit_interp.rs
@@ -73,6 +73,12 @@ fn compile(words: &[&str]) -> Vec<u8> {
 /// RPython tiny2_hotpath.py Stack. `_virtualizable_ = ['stackpos', 'stack[*]']`.
 struct Tiny2State {
     stackpos: i64,
+    // Observer/replay `jit_merge_point!()` — not the `; state` close.
+    // `VirtArray` registers DirectPointer and lets `compile.py` emit the
+    // GETFIELD_GC_R + GETARRAYITEM_GC_* entry reload; that compiled loop
+    // disagrees with the interpreter on fib. `Vec` keeps RustVec storage
+    // so the entry seeds boxes via `initialize_virtualizable` instead.
+    // This portal does not resume `getarrayitem_vable_*` in the blackhole.
     stack: Vec<i64>,
 }
 

--- a/majit/examples/tiny3/src/jit_interp.rs
+++ b/majit/examples/tiny3/src/jit_interp.rs
@@ -14,6 +14,7 @@
 //! The JIT traces the integer-only path. Float arithmetic falls back to the
 //! plain interpreter. This matches RPython's promote(y.__class__) strategy.
 
+use majit_metainterp::virt_array::VirtArray;
 // ── Bytecode opcodes ──
 
 const OP_PUSH_INT: u8 = 0; // followed by 8 bytes (i64 LE)
@@ -78,7 +79,7 @@ fn compile(words: &[&str]) -> Vec<u8> {
 
 struct Tiny3State {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 pub type Bytecode = [u8];
@@ -123,7 +124,7 @@ fn mainloop(program: &Bytecode, num_args: usize, threshold: u32) -> i64 {
     let stacksize: i32 = 0;
     let mut state = Tiny3State {
         stackpos: num_args as i64,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
 
     // RPython warmspot.py:281-289 canonical-liveness install hook.

--- a/majit/examples/tinyframe/src/jit_interp.rs
+++ b/majit/examples/tinyframe/src/jit_interp.rs
@@ -4,6 +4,7 @@
 /// Reds:   [regs]  (tracked via state_fields)
 use crate::interp::{ADD, JUMP_IF_ABOVE, LOAD, RETURN};
 use majit_metainterp::embed::Census;
+use majit_metainterp::virt_array::VirtArray;
 
 pub type Bytecode = [u8];
 
@@ -21,7 +22,7 @@ impl BytecodeExt for [u8] {
 }
 
 struct TinyFrameState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     /// What `RETURN` hands back.
     ///
     /// The `; state` merge point leaves the loop through `break` before it
@@ -58,7 +59,7 @@ fn mainloop(
     let mut pc: usize = 0;
     let _stacksize: i32 = 0;
     let mut state = TinyFrameState {
-        regs: vec![0; num_regs],
+        regs: VirtArray::filled(0, num_regs),
         ret: 0,
     };
     for &(r, v) in init_regs {

--- a/majit/examples/tla/src/jit_interp.rs
+++ b/majit/examples/tla/src/jit_interp.rs
@@ -13,6 +13,7 @@
 /// the greens is also what gives the merge point a green pc to report, which the
 /// `; state` close needs to name a resume position.
 use majit_metainterp::embed::Census;
+use majit_metainterp::virt_array::VirtArray;
 
 pub type Bytecode = [u8];
 
@@ -35,7 +36,7 @@ const STACK_SIZE: usize = 8;
 
 struct TlaState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 // ── Opcodes ──
@@ -72,7 +73,7 @@ pub fn mainloop(program: &Bytecode, initial_value: i64, threshold: u32) -> i64 {
     let mut state = TlaState {
         stackpos: 1,
         stack: {
-            let mut s = vec![0i64; STACK_SIZE];
+            let mut s = VirtArray::filled(0i64, STACK_SIZE);
             s[0] = initial_value;
             s
         },

--- a/majit/examples/tlr/src/jit_interp.rs
+++ b/majit/examples/tlr/src/jit_interp.rs
@@ -5,6 +5,7 @@
 /// Greens: [pc, bytecode]
 /// Reds:   [a, regs]  (tracked via state_fields)
 use majit_metainterp::embed::Census;
+use majit_metainterp::virt_array::VirtArray;
 
 pub type Bytecode = [u8];
 
@@ -23,7 +24,7 @@ impl BytecodeExt for [u8] {
 
 struct TlrState {
     a: i64,
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 const MOV_A_R: u8 = 1;
@@ -53,7 +54,7 @@ const DEFAULT_THRESHOLD: u32 = 3;
 // (virtualizable), not plain `[int]`: a loop-carried plain `[int]` element is
 // kept in a trace register and is *not* restored to the array on a CloseLoop
 // guard deopt, so the post-loop value reads back as the pre-loop one. A virt
-// array writes through to the heap-backing Vec, which the deopt path reads
+// array writes through to the heap-backing block, which the deopt path reads
 // directly — the same mechanism braininterp relies on. (`a` is a plain scalar
 // red, which is restored correctly.)
 #[majit_macros::jit_interp(
@@ -75,7 +76,7 @@ fn mainloop(program: &Bytecode, initial_a: i64, threshold: u32) -> i64 {
     let _stacksize: i32 = 0;
     let mut state = TlrState {
         a: initial_a,
-        regs: Vec::new(),
+        regs: VirtArray::new(),
     };
 
     // RPython warmspot.py:281-289 canonical-liveness install hook.
@@ -134,7 +135,7 @@ fn mainloop(program: &Bytecode, initial_a: i64, threshold: u32) -> i64 {
             ALLOCATE => {
                 let n = program[pc] as usize;
                 pc += 1;
-                state.regs = vec![0; n];
+                state.regs = VirtArray::filled(0, n);
             }
             NEG_A => {
                 state.a = 0 - state.a;

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -8469,56 +8469,73 @@ fn read_descr_vable_field(bh: &BlackholeInterpreter, code: &[u8], pos: usize) ->
     )
 }
 
-/// Read a VableArray descriptor and resolve to a synthesized BhDescr::Field
-/// with the resolved field_offset via VirtualizableInfo.
-/// RPython: fielddescr carries byte offset for the array pointer field.
-/// pyre: VableArray.index → vinfo.array_fields[index].field_offset.
-#[inline]
-#[allow(dead_code)]
-fn read_descr_vable_array(bh: &BlackholeInterpreter, code: &[u8], pos: usize) -> (BhDescr, usize) {
-    let (descr, pos) = read_descr(bh, code, pos);
-    let array_index = descr.as_vable_array_index();
-    let vinfo = if bh.virtualizable_info.is_null() {
-        panic!(
-            "read_descr_vable_array: virtualizable_info must be set for VableArray index {} \
-             (RPython blackhole.py:1374 fielddescr.get_vinfo() parity)",
-            array_index
-        );
-    } else {
-        unsafe { &*bh.virtualizable_info }
-    };
+/// Synthesize the field descr `cpu.bh_getfield_gc_r` uses to load a
+/// virtualizable array pointer. RPython's `fielddescr` already carries that
+/// byte offset; pyre's `BhDescr::VableArray` is only an index into
+/// `vinfo.array_fields`.
+fn vable_array_field_descr(
+    vinfo: &crate::virtualizable::VirtualizableInfo,
+    array_index: usize,
+) -> BhDescr {
     let offset = vinfo
         .array_fields
         .get(array_index)
         .unwrap_or_else(|| {
             panic!(
-                "read_descr_vable_array: VableArray index {} out of bounds for {} array fields",
+                "vable_array_field_descr: VableArray index {} out of bounds for {} array fields",
                 array_index,
                 vinfo.array_fields.len()
             )
         })
         .field_offset;
+    BhDescr::Field {
+        offset,
+        // The array field is a pointer, so its width is the target word
+        // like the scalars above.  Latent rather than live: the `_gc_r`
+        // accessors this descr reaches take `as_offset()` and store at
+        // pointer width without consulting the size.
+        field_size: std::mem::size_of::<usize>(),
+        field_type: majit_ir::value::Type::Ref,
+        field_flag: majit_ir::descr::ArrayFlag::Pointer,
+        is_field_signed: false,
+        is_immutable: false,
+        is_quasi_immutable: false,
+        // No parent list, so there is no slot to claim — `None` rather than a
+        // `0` that reads as a claim on the first field of a list that does
+        // not exist here.
+        index_in_parent: None,
+        parent: None,
+        name: String::new(),
+        owner: String::new(),
+    }
+}
+
+/// Read a VableArray descriptor and resolve to a synthesized BhDescr::Field
+/// with the resolved field_offset via VirtualizableInfo.
+/// RPython: fielddescr carries byte offset for the array pointer field.
+/// pyre: VableArray.index → vinfo.array_fields[index].field_offset.
+///
+/// Returns `(field_descr, array_index, next_pos)`.
+#[inline]
+fn read_descr_vable_array(
+    bh: &BlackholeInterpreter,
+    code: &[u8],
+    pos: usize,
+) -> (BhDescr, usize, usize) {
+    let (descr, pos) = read_descr(bh, code, pos);
+    let array_index = descr.as_vable_array_index();
+    let vinfo = if bh.virtualizable_info.is_null() {
+        panic!(
+            "read_descr_vable_array: virtualizable_info must be set for VableArray index {} \
+             (RPython `bhimpl_getarrayitem_vable_*` `fielddescr.get_vinfo()` parity)",
+            array_index
+        );
+    } else {
+        unsafe { &*bh.virtualizable_info }
+    };
     (
-        BhDescr::Field {
-            offset,
-            // The array field is a pointer, so its width is the target word
-            // like the scalars above.  Latent rather than live: the `_gc_r`
-            // accessors this descr reaches take `as_offset()` and store at
-            // pointer width without consulting the size.
-            field_size: std::mem::size_of::<usize>(),
-            field_type: majit_ir::value::Type::Ref,
-            field_flag: majit_ir::descr::ArrayFlag::Pointer,
-            is_field_signed: false,
-            is_immutable: false,
-            is_quasi_immutable: false,
-            // No parent list, so there is no slot to claim — `None` rather than a
-            // `0` that reads as a claim on the first field of a list that does
-            // not exist here.
-            index_in_parent: None,
-            parent: None,
-            name: String::new(),
-            owner: String::new(),
-        },
+        vable_array_field_descr(vinfo, array_index),
+        array_index,
         pos,
     )
 }
@@ -10089,18 +10106,13 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     ] {
         insns.insert(key.to_string(), byte);
     }
-    // vable family (full 14-key coverage).  Path 3 (single-indirection
-    // `getfield_vable_*` / `setfield_vable_*` / `hint_force_virtualizable`)
-    // routes through the canonical `cpu.bh_getfield_gc_*` /
-    // `bh_setfield_gc_*` chain — both `runner.rs` (dynasm) and
-    // `compiler.rs::bh_getfield_gc_*` (cranelift) implement
-    // the chain via direct `*(struct_ptr + descr.as_offset())` reads,
-    // matching the old inline vinfo offset path.  Path 2
-    // (2-level indirection `getarrayitem_vable_*` /
-    // `setarrayitem_vable_*` / `arraylen_vable`) bypasses the cpu chain
-    // and calls `vable_*_array_item` / `bhimpl_arraylen_vable` directly
-    // to handle pyre's `EmbeddedArray` storage — see
-    // TODO header at `handler_getarrayitem_vable_i`.
+    // vable family (full 14-key coverage).  Scalar
+    // `getfield_vable_*` / `setfield_vable_*` / `hint_force_virtualizable`
+    // and `getarrayitem_vable_*` / `setarrayitem_vable_*` /
+    // `arraylen_vable` route through the canonical
+    // `cpu.bh_getfield_gc_*` / `bh_getarrayitem_gc_*` /
+    // `bh_setarrayitem_gc_*` / `bh_arraylen_gc` chain
+    // (`bhimpl_getarrayitem_vable_*`).
     // Together this makes the vable family strict-dispatch ready.
     insns.insert(
         "getfield_vable_i/rd>i".to_string(),
@@ -11578,25 +11590,10 @@ fn handler_setfield_vable_f(
 
 // @arguments("cpu", "r", "i", "d", "d", returns="X")
 // Two descriptors: fielddescr (VableArray) + arraydescr (Array).
-// RPython: fielddescr.get_vinfo().clear_vable_token(vable)
-//          array = cpu.bh_getfield_gc_r(vable, fielddescr)
-//          return cpu.bh_getarrayitem_gc_*(array, index, arraydescr)
-//
-// TODO: pyre's W_ListObject `EmbeddedArray` storage
-// (`virtualizable.rs`'s `VableArrayInfo`) reaches the array data via two pointer
-// dereferences from the vable (vable→container→data + `ptr_offset`),
-// while `cpu.bh_getfield_gc_r + cpu.bh_setarrayitem_gc_*`
-// (`runner.rs`) only does a single indirection.  The chain
-// therefore cannot reach EmbeddedArray items.  Resolve `array_idx`
-// from the `BhDescr::VableArray` index and delegate to
-// `vable_read_array_item` / `vable_write_array_item` /
-// `bhimpl_arraylen_vable` (`virtualizable.rs`) — these
-// dispatch on `VableArrayStorage` and handle both EmbeddedArray and
-// DirectPointer modes.  This keeps the same direct vable-array helper
-// path under strict dispatch.
-// Convergence path: redesign W_ListObject to
-// single-indirection storage so the canonical cpu chain works
-// directly.
+// RPython `bhimpl_getarrayitem_vable_*`:
+//   fielddescr.get_vinfo().clear_vable_token(vable)
+//   array = cpu.bh_getfield_gc_r(vable, fielddescr)
+//   return cpu.bh_getarrayitem_gc_*(array, index, arraydescr)
 /// Resolve `bh.virtualizable_info` to a non-null reference and clear the
 /// vable token on `vable`.  RPython parity: every
 /// `BlackholeInterpreter.bhimpl_{get,set}field_vable_*` and
@@ -11626,7 +11623,26 @@ fn vable_clear_token_and_get_vinfo(
     vinfo
 }
 
-// Virtualizable array operations (`blackhole.py:1374-1409`)
+/// Decode the vable-array descr pair after the register operands and
+/// clear the token.
+///
+/// `bhimpl_getarrayitem_vable_*` / `bhimpl_setarrayitem_vable_*` /
+/// `bhimpl_arraylen_vable` all start
+/// `fielddescr.get_vinfo().clear_vable_token(vable)` then load the array
+/// through `cpu.bh_getfield_gc_r`.
+fn take_vable_array_descrs<'a>(
+    bh: &'a BlackholeInterpreter,
+    vable: i64,
+    code: &[u8],
+    descr_pos: usize,
+) -> (BhDescr, &'a BhDescr, usize) {
+    vable_clear_token_and_get_vinfo(bh, vable);
+    let (field_descr, _array_idx, p) = read_descr_vable_array(bh, code, descr_pos);
+    let (array_descr, pos) = read_descr(bh, code, p);
+    (field_descr, array_descr, pos)
+}
+
+// Virtualizable array operations (`bhimpl_getarrayitem_vable_*`)
 fn handler_getarrayitem_vable_i(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -11634,14 +11650,11 @@ fn handler_getarrayitem_vable_i(
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 2);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    let value =
-        unsafe { crate::virtualizable::vable_read_array_item(vable as *const u8, ainfo, index) };
-    bh.registers_i[code[p] as usize] = value;
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 2);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.registers_i[code[p] as usize] =
+        bh.cpu()
+            .bh_getarrayitem_gc_i(array.0 as i64, index, array_descr);
     Ok(p + 1)
 }
 fn handler_getarrayitem_vable_r(
@@ -11652,13 +11665,12 @@ fn handler_getarrayitem_vable_r(
     let nbody_debug = crate::nbody_debug_enabled();
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 2);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    let value =
-        unsafe { crate::virtualizable::vable_read_array_item(vable as *const u8, ainfo, index) };
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 2);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    let value = bh
+        .cpu()
+        .bh_getarrayitem_gc_r(array.0 as i64, index, array_descr)
+        .0 as i64;
     if nbody_debug && matches!(index, 5 | 6 | 8 | 9) {
         eprintln!(
             "[nbody-debug][bh-vable-get-r] position={} last_opcode_position={} index={} value={:#x}",
@@ -11676,14 +11688,10 @@ fn handler_setarrayitem_vable_i(
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_i[code[p + 2] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 3);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    unsafe {
-        crate::virtualizable::vable_write_array_item(vable as *mut u8, ainfo, index, value);
-    }
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 3);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.cpu()
+        .bh_setarrayitem_gc_i(array.0 as i64, index, value, array_descr);
     Ok(p)
 }
 fn handler_setarrayitem_vable_r(
@@ -11695,20 +11703,20 @@ fn handler_setarrayitem_vable_r(
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_r[code[p + 2] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 3);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 3);
     if nbody_debug && matches!(index, 5 | 6 | 8 | 9) {
         eprintln!(
             "[nbody-debug][bh-vable-set-r] position={} last_opcode_position={} index={} value={:#x}",
             bh.position, bh.last_opcode_position, index, value as usize
         );
     }
-    unsafe {
-        crate::virtualizable::vable_write_array_item(vable as *mut u8, ainfo, index, value);
-    }
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.cpu().bh_setarrayitem_gc_r(
+        array.0 as i64,
+        index,
+        majit_ir::GcRef(value as usize),
+        array_descr,
+    );
     Ok(p)
 }
 fn handler_arraylen_vable(
@@ -11717,13 +11725,9 @@ fn handler_arraylen_vable(
     p: usize,
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 1);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    let len = unsafe { crate::virtualizable::bhimpl_arraylen_vable(vable as *const u8, ainfo) };
-    bh.registers_i[code[p] as usize] = len as i64;
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 1);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.registers_i[code[p] as usize] = bh.cpu().bh_arraylen_gc(array.0 as i64, array_descr);
     Ok(p + 1)
 }
 
@@ -12304,10 +12308,6 @@ fn handler_newlist_hint(
     Ok(p + 1)
 }
 // blackhole.py bhimpl_getarrayitem_vable_f
-// TODO mirrored from `handler_getarrayitem_vable_i`
-// header — pyre's W_ListObject EmbeddedArray storage requires direct
-// `vable_read_array_item`.  `registers_f` stores the f64 bit-pattern
-// in i64, so the universal i64 read path round-trips losslessly.
 fn handler_getarrayitem_vable_f(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -12315,14 +12315,12 @@ fn handler_getarrayitem_vable_f(
 ) -> Result<usize, DispatchError> {
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 2);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    let value =
-        unsafe { crate::virtualizable::vable_read_array_item(vable as *const u8, ainfo, index) };
-    bh.registers_f[code[p] as usize] = value;
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 2);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.registers_f[code[p] as usize] = bh
+        .cpu()
+        .bh_getarrayitem_gc_f(array.0 as i64, index, array_descr)
+        .to_bits() as i64;
     Ok(p + 1)
 }
 // blackhole.py bhimpl_setarrayitem_vable_f
@@ -12334,14 +12332,14 @@ fn handler_setarrayitem_vable_f(
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize];
     let value = bh.registers_f[code[p + 2] as usize];
-    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, p) = read_descr(bh, code, p + 3);
-    let array_idx = field_descr.as_vable_array_index();
-    let (_, p) = read_descr(bh, code, p);
-    let ainfo = &vinfo.array_fields[array_idx];
-    unsafe {
-        crate::virtualizable::vable_write_array_item(vable as *mut u8, ainfo, index, value);
-    }
+    let (field_descr, array_descr, p) = take_vable_array_descrs(bh, vable, code, p + 3);
+    let array = bh.cpu().bh_getfield_gc_r(vable, &field_descr);
+    bh.cpu().bh_setarrayitem_gc_f(
+        array.0 as i64,
+        index,
+        f64::from_bits(value as u64),
+        array_descr,
+    );
     Ok(p)
 }
 // blackhole.py bhimpl_getlistitem_gc_f

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -60,9 +60,9 @@ fn jitcode_may_force_effect_info() -> majit_ir::effectinfo::EffectInfo {
 /// `Int` does NOT follow the word.  It names the interpreter's integer
 /// *bank*, whose values are `i64` (`majit_ir::value::Type` doc), and the
 /// storage a descr describes is the source declaration, not the bank: a
-/// `jit_interp` `[int; virt]` array is backed by the caller's `Vec<i64>`
-/// (`majit/examples/spcount/src/main.rs`'s `StackState`) and an `int` struct
-/// field by an `i64` (`majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs`'s
+/// `jit_interp` `[int; virt]` `VirtArray<i64>` stores `i64` items, and an
+/// `int` struct field is an `i64`
+/// (`majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs`'s
 /// `InlineTypedNode`).
 /// Narrowing those to 4 on wasm32 strides past half of every item and
 /// truncates the value.  `Float` is `f64` on every target for the same
@@ -5678,13 +5678,21 @@ impl JitCodeBuilder {
         is_item_signed: bool,
     ) -> u16 {
         self.add_bh_descr(CanonicalBhDescr::Array {
-            base_size: std::mem::size_of::<usize>(),
+            // `Ptr(GcArray)` after `make_sure_not_resized`: length at 0,
+            // items at the payload offset. Ref items sit at the target
+            // word (`FixedObjectArray`). Int/float items sit at
+            // `VirtArray::<i64>::ITEMS_OFFSET` (element-aligned past the
+            // length word — 8 on every target, including wasm32).
+            base_size: match item_type {
+                majit_ir::value::Type::Ref => std::mem::size_of::<usize>(),
+                _ => crate::virt_array::VirtArray::<i64>::ITEMS_OFFSET,
+            },
             // A `[ref; virt]` array's runtime twin reads its item size from
             // `pyre_object::ITEMS_BLOCK_TOKEN`
             // (`pyre-jit-trace virtualizable_gen.rs`), which is
             // `size_of::<PyObjectRef>()`; a literal 8 makes the two descr
             // universes disagree on wasm32.  A `[int; virt]` array keeps 8 —
-            // it is backed by the caller's `Vec<i64>`, not by words.
+            // the interpreter integer bank is `i64` on every target.
             itemsize: scalar_size(item_type),
             len_offset: Some(0),
             type_id: 0,

--- a/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
+++ b/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
@@ -19,6 +19,7 @@
 //! index is N` from `PUSH`, or reach a `stackpos` of `usize::MAX` from `POP`:
 //! a torn stack pointer.
 
+use majit_metainterp::virt_array::VirtArray;
 pub type Bytecode = [u8];
 
 const PUSH: u8 = 2; // [PUSH, imm]: push a signed-byte immediate
@@ -33,7 +34,7 @@ const PUSHARG: u8 = 22; // push the input argument
 
 struct StackState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -53,7 +54,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let mut state = StackState {
         stackpos: 0,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
     {
         use majit_metainterp::JitState as _;

--- a/majit/majit-metainterp/tests/degraded_arm_refusal_kind.rs
+++ b/majit/majit-metainterp/tests/degraded_arm_refusal_kind.rs
@@ -65,7 +65,7 @@ const TLR_ALLOCATE: &str = "arm body writes a green this lowering path cannot \
                             carry back to the caller (lowering stopped at this \
                             statement; any further blockers follow): pc += 1; || \
                             arm body has a statement the lowerer cannot express: \
-                            state.regs = vec! [0; n];";
+                            state.regs = VirtArray :: filled(0, n);";
 
 /// `lower_stmt.rs`'s `lower_return_stmt` — the sibling guard to `break`/`continue`.
 const SRC_ENCLOSED_RETURN: &str =
@@ -232,7 +232,7 @@ fn an_accumulated_reason_reports_every_blocker() {
          longer matches the one the recorded string was minted with"
     );
     assert!(
-        TLR_ALLOCATE.contains("state.regs = vec! [0; n];"),
+        TLR_ALLOCATE.contains("state.regs = VirtArray :: filled(0, n);"),
         "the member behind the head must still name the reallocation — that \
          statement is the only thing this reason reports that nothing else does"
     );

--- a/majit/majit-metainterp/tests/jit_interp_block_arm_break.rs
+++ b/majit/majit-metainterp/tests/jit_interp_block_arm_break.rs
@@ -4,6 +4,7 @@
 //! A block arm is lowered statement by statement, so an unsupported terminal
 //! `break` must degrade the arm instead of being discarded as inert.
 
+use majit_metainterp::virt_array::VirtArray;
 use majit_metainterp::{Assembler, JitCode, JitDriver};
 
 pub type Bytecode = [u8];
@@ -23,7 +24,7 @@ const OP_TICK: u8 = 4;
 const OP_END: u8 = 5;
 
 struct BlockBreakState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -39,7 +40,7 @@ fn dispatch_block_break(program: &Bytecode, threshold: u32) -> i64 {
     let mut driver: JitDriver<BlockBreakState> = JitDriver::new(threshold);
     let mut pc: usize = 0;
     let mut state = BlockBreakState {
-        regs: vec![0i64; 2],
+        regs: VirtArray::filled(0i64, 2),
     };
     state.regs[0] = program[program.len() - 1] as i64;
     {

--- a/majit/majit-metainterp/tests/jit_interp_compound_assign_lowering.rs
+++ b/majit/majit-metainterp/tests/jit_interp_compound_assign_lowering.rs
@@ -4,6 +4,7 @@
 //! The fixture varies compound assignment, computed indexing, and same-slot
 //! read-modify-write independently against a common control.
 
+use majit_metainterp::virt_array::VirtArray;
 use majit_metainterp::{Assembler, JitCode, JitDriver};
 
 pub type Bytecode = [u8];
@@ -15,7 +16,7 @@ const OP_PLAIN_COMPUTEDIDX: u8 = 4;
 const OP_COMPOUND_COMPUTEDIDX: u8 = 5;
 
 struct CompoundAssignState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -31,7 +32,7 @@ fn dispatch_compound_assign(program: &Bytecode, threshold: u32) -> i64 {
     let mut driver: JitDriver<CompoundAssignState> = JitDriver::new(threshold);
     let mut pc: usize = 0;
     let mut state = CompoundAssignState {
-        regs: vec![0i64; 4],
+        regs: VirtArray::filled(0i64, 4),
     };
     {
         use majit_metainterp::JitState as _;
@@ -97,13 +98,14 @@ fn install() -> JitCode {
 /// Two machines over the SAME state type still collide on `impl JitState`.
 mod float_control {
     use super::Bytecode;
+    use majit_metainterp::virt_array::VirtArray;
     use majit_metainterp::{Assembler, JitCode, JitDriver};
 
     const OP_FADD_ASSIGN: u8 = 1;
     const OP_FREM_ASSIGN: u8 = 2;
 
     struct FloatCompoundState {
-        fregs: Vec<f64>,
+        fregs: VirtArray<f64>,
     }
 
     /// Float compound assignments supported by `opcode_for_assign_binop_f`
@@ -122,7 +124,7 @@ mod float_control {
         let mut driver: JitDriver<FloatCompoundState> = JitDriver::new(threshold);
         let mut pc: usize = 0;
         let mut state = FloatCompoundState {
-            fregs: vec![0.0f64; 4],
+            fregs: VirtArray::filled(0.0f64, 4),
         };
         {
             use majit_metainterp::JitState as _;

--- a/majit/majit-metainterp/tests/jit_interp_degraded_arm_accumulates_refusals.rs
+++ b/majit/majit-metainterp/tests/jit_interp_degraded_arm_accumulates_refusals.rs
@@ -1,6 +1,7 @@
 //! Verifies that an arm with multiple lowering blockers records every refusal
 //! in encounter order and that refusal classification handles each member.
 
+use majit_metainterp::virt_array::VirtArray;
 use majit_metainterp::{
     Assembler, JitCode, JitDriver, REFUSAL_SEPARATOR, RefusalKind, refusal_kind, refusal_kinds,
 };
@@ -17,7 +18,7 @@ const OP_BACK: u8 = 2;
 const OP_REALLOC_THEN_BREAK: u8 = 3;
 
 struct AccumState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -33,7 +34,7 @@ fn dispatch_accum(program: &Bytecode, threshold: u32) -> i64 {
     let mut driver: JitDriver<AccumState> = JitDriver::new(threshold);
     let mut pc: usize = 0;
     let mut state = AccumState {
-        regs: vec![0i64; 2],
+        regs: VirtArray::filled(0i64, 2),
     };
     state.regs[0] = program[program.len() - 1] as i64;
     {
@@ -61,7 +62,7 @@ fn dispatch_accum(program: &Bytecode, threshold: u32) -> i64 {
             OP_REALLOC_THEN_BREAK => {
                 // Blocker 1 — whole-array reallocation has no lowering.
                 // `UnlowerableStmt`, the chain's 4th test.
-                state.regs = vec![0i64; 2];
+                state.regs = VirtArray::filled(0i64, 2);
                 // Blocker 2 — an enclosed `break` cannot be lowered in place.
                 // `EnclosedBreakContinue`, the chain's 2nd test.
                 if state.regs[0] == 0 {
@@ -122,7 +123,7 @@ fn both_blockers_are_reported() {
          and the `break` inside the `if`; reason={reason:?}"
     );
     assert!(
-        reason.contains("state.regs = vec!") && reason.contains("break"),
+        reason.contains("state.regs =") && reason.contains("filled") && reason.contains("break"),
         "each member must still name its own offending statement; reason={reason:?}"
     );
 }

--- a/majit/majit-metainterp/tests/jit_interp_degraded_stub_abort_resume.rs
+++ b/majit/majit-metainterp/tests/jit_interp_degraded_stub_abort_resume.rs
@@ -5,6 +5,7 @@
 //! advance, so resuming at the following byte would decode an operand as a new
 //! opcode and produce a wrong result.
 
+use majit_metainterp::virt_array::VirtArray;
 use majit_metainterp::{Assembler, JitCode, JitDriver};
 
 pub type Bytecode = [u8];
@@ -33,7 +34,7 @@ fn bump_via_ptr(base: usize, idx: i64, by: i64) {
 }
 
 struct StubResumeState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -49,7 +50,7 @@ fn dispatch_stub_resume(program: &Bytecode, threshold: u32, n: i64) -> i64 {
     let mut driver: JitDriver<StubResumeState> = JitDriver::new(threshold);
     let mut pc: usize = 0;
     let mut state = StubResumeState {
-        regs: vec![0i64; 2],
+        regs: VirtArray::filled(0i64, 2),
     };
     state.regs[0] = n;
     {

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -2775,6 +2775,7 @@ mod degraded_arm_is_named_at_install {
     use majit_metainterp::jitcode::insns::{
         BC_ABORT, BC_CONVERT_FLOAT_BYTES_TO_LONGLONG, BC_CONVERT_LONGLONG_BYTES_TO_FLOAT,
     };
+    use majit_metainterp::virt_array::VirtArray;
     use majit_metainterp::{Assembler, JitCode, JitDriver};
 
     const OP_ADD: u8 = 1;
@@ -2786,8 +2787,8 @@ mod degraded_arm_is_named_at_install {
     const OP_FREM_ASSIGN: u8 = 7;
 
     struct DegradedArmState {
-        regs: Vec<i64>,
-        fregs: Vec<f64>,
+        regs: VirtArray<i64>,
+        fregs: VirtArray<f64>,
     }
 
     #[majit_macros::jit_interp(
@@ -2804,8 +2805,8 @@ mod degraded_arm_is_named_at_install {
         let mut driver: JitDriver<DegradedArmState> = JitDriver::new(threshold);
         let mut pc: usize = 0;
         let mut state = DegradedArmState {
-            regs: vec![0i64; 4],
-            fregs: vec![0.0f64; 4],
+            regs: VirtArray::filled(0i64, 4),
+            fregs: VirtArray::filled(0.0f64, 4),
         };
         {
             use majit_metainterp::JitState as _;

--- a/majit/majit-metainterp/tests/jit_interp_entry_values_are_the_word_form_paired.rs
+++ b/majit/majit-metainterp/tests/jit_interp_entry_values_are_the_word_form_paired.rs
@@ -9,6 +9,7 @@
 //! routes — int scalar, virt array (its identity slot), ref scalar, float
 //! scalar.
 
+use majit_metainterp::virt_array::VirtArray;
 use majit_metainterp::{JitDriver, JitState};
 
 pub type Bytecode = [u8];
@@ -20,7 +21,7 @@ struct Cell {
 
 struct EveryKindState {
     total: i64,
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     head: usize,
     weight: f64,
 }
@@ -46,7 +47,7 @@ fn dispatch_every_kind(program: &Bytecode, threshold: u32) -> i64 {
     let mut pc: usize = 0;
     let mut state = EveryKindState {
         total: 0,
-        regs: vec![0i64; 2],
+        regs: VirtArray::filled(0i64, 2),
         head: 0,
         weight: 0.0,
     };
@@ -72,7 +73,7 @@ fn the_entry_values_are_the_word_form_paired() {
     };
     let state = EveryKindState {
         total: -3,
-        regs: vec![11, i64::MIN],
+        regs: VirtArray::from_slice(&[11, i64::MIN]),
         head: &mut cell as *mut Cell as usize,
         weight: -0.75,
     };

--- a/majit/majit-metainterp/tests/jit_interp_fixed_array_identity_slot.rs
+++ b/majit/majit-metainterp/tests/jit_interp_fixed_array_identity_slot.rs
@@ -31,13 +31,14 @@ fn expected(limit: i64) -> i64 {
 mod fixed_array_before_virt_array {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
     use majit_metainterp::JitState as _;
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct FixedAndVirt {
         ret: i64,
         cells: Vec<i64>,
-        iregs: Vec<i64>,
+        iregs: VirtArray<i64>,
     }
 
     #[majit_macros::jit_interp(
@@ -61,7 +62,7 @@ mod fixed_array_before_virt_array {
         let mut state = FixedAndVirt {
             ret: 0,
             cells: vec![0i64, 0i64],
-            iregs: vec![0i64, limit, 0i64],
+            iregs: VirtArray::from_slice(&[0i64, limit, 0i64]),
         };
         {
             use majit_metainterp::JitState as _;
@@ -113,7 +114,7 @@ mod fixed_array_before_virt_array {
         let state = FixedAndVirt {
             ret: 0,
             cells: vec![0i64, 0i64],
-            iregs: vec![0i64, 4, 0i64],
+            iregs: VirtArray::from_slice(&[0i64, 4, 0i64]),
         };
         let program: &Bytecode = &super::count_program();
         let meta = state.build_meta(0, program);

--- a/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
+++ b/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
@@ -166,10 +166,11 @@ mod scalar_toplevel {
 mod virt_array {
     use super::{Bytecode, all_jitcode_bodies};
     use majit_metainterp::jitcode::insns::{BC_GETARRAYITEM_VABLE_F, BC_SETARRAYITEM_VABLE_F};
+    use majit_metainterp::virt_array::VirtArray;
     use majit_metainterp::{Assembler, JitDriver};
 
     struct FloatArrayState {
-        regs: Vec<f64>,
+        regs: VirtArray<f64>,
     }
 
     const OP_NOP: u8 = 0;
@@ -185,7 +186,9 @@ mod virt_array {
     fn float_array_minimal(program: &Bytecode, threshold: u32) -> i64 {
         let mut driver: JitDriver<FloatArrayState> = JitDriver::new(threshold);
         let mut pc: usize = 0;
-        let mut state = FloatArrayState { regs: vec![0.0; 2] };
+        let mut state = FloatArrayState {
+            regs: VirtArray::filled(0.0, 2),
+        };
         {
             use majit_metainterp::JitState as _;
             state
@@ -398,13 +401,14 @@ mod scalar_float_slot_reserve {
 // downstream catches it. Pin the suffix relation directly.
 mod virt_array_with_float_scalar {
     use super::Bytecode;
+    use majit_metainterp::virt_array::VirtArray;
     use majit_metainterp::{JitDriver, JitState};
 
     struct MixedState {
         sp: i64,
         cells: Vec<i64>,
         acc: f64,
-        stack: Vec<i64>,
+        stack: VirtArray<i64>,
     }
 
     const OP_NOP: u8 = 0;
@@ -428,7 +432,7 @@ mod virt_array_with_float_scalar {
             sp: 0,
             cells: vec![0; 2],
             acc: 0.0,
-            stack: vec![0; 2],
+            stack: VirtArray::filled(0, 2),
         };
         {
             use majit_metainterp::JitState as _;
@@ -462,7 +466,7 @@ mod virt_array_with_float_scalar {
             sp: 0,
             cells: vec![0; 2],
             acc: 0.0,
-            stack: vec![0; 2],
+            stack: VirtArray::filled(0, 2),
         };
         let program: &Bytecode = &[OP_NOP, OP_STEP];
         let meta = state.build_meta(0, program);
@@ -512,7 +516,7 @@ mod virt_array_with_float_scalar {
             sp: 0,
             cells: vec![0; 2],
             acc: 0.0,
-            stack: vec![0; 2],
+            stack: VirtArray::filled(0, 2),
         };
         let program: &Bytecode = &[OP_NOP, OP_STEP];
         let meta = state.build_meta(0, program);
@@ -536,7 +540,7 @@ mod virt_array_with_float_scalar {
             sp: 7,
             cells: vec![11, 13],
             acc: 1.5,
-            stack: vec![0; 2],
+            stack: VirtArray::filled(0, 2),
         };
         let program: &Bytecode = &[OP_NOP, OP_STEP];
         let meta = state.build_meta(0, program);

--- a/majit/majit-metainterp/tests/jit_interp_green_key_helper.rs
+++ b/majit/majit-metainterp/tests/jit_interp_green_key_helper.rs
@@ -18,6 +18,7 @@
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use majit_metainterp::JitDriver;
+use majit_metainterp::virt_array::VirtArray;
 
 /// What the run's own probe answered, and how many loops it compiled.
 ///
@@ -39,7 +40,7 @@ const OP_END: u8 = 3;
 const LOOP_HEADER: usize = 0;
 
 struct GreenKeyState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -55,7 +56,7 @@ fn dispatch_green_key(program: &Bytecode, threshold: u32) -> i64 {
     let mut driver: JitDriver<GreenKeyState> = JitDriver::new(threshold);
     let mut pc: usize = 0;
     let mut state = GreenKeyState {
-        regs: vec![0i64; 1],
+        regs: VirtArray::filled(0i64, 1),
     };
     state.regs[0] = program[program.len() - 1] as i64;
     {

--- a/majit/majit-metainterp/tests/jit_interp_label_entry_deopt_resume.rs
+++ b/majit/majit-metainterp/tests/jit_interp_label_entry_deopt_resume.rs
@@ -5,6 +5,7 @@
 //! the header and the blackhole's green program counter.
 
 use core::sync::atomic::{AtomicU32, Ordering};
+use majit_metainterp::virt_array::VirtArray;
 
 pub type Bytecode = [i64];
 
@@ -49,7 +50,7 @@ static COMPILES: AtomicU32 = AtomicU32::new(0);
 static PROBE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 struct VmState {
-    regs: Vec<i64>,
+    regs: VirtArray<i64>,
     ret: i64,
 }
 
@@ -71,7 +72,7 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
     });
     let mut pc: usize = 0;
     let mut state = VmState {
-        regs: vec![0; NUM_REGS],
+        regs: VirtArray::filled(0, NUM_REGS),
         ret: 0,
     };
     {
@@ -128,7 +129,7 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
 
 /// The same bytecode with no driver, no merge point and no `can_enter_jit`.
 fn clean_interp(program: &Bytecode) -> i64 {
-    let mut regs = vec![0i64; NUM_REGS];
+    let mut regs = VirtArray::filled(0i64, NUM_REGS);
     let mut pc = 0usize;
     loop {
         match program[pc] {

--- a/majit/majit-metainterp/tests/jit_interp_match_const_patterns.rs
+++ b/majit/majit-metainterp/tests/jit_interp_match_const_patterns.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use majit_ir::OpCode;
 use majit_metainterp::JitDriver;
+use majit_metainterp::virt_array::VirtArray;
 
 static COMPILES: AtomicUsize = AtomicUsize::new(0);
 static COMPILED: Mutex<Vec<OpCode>> = Mutex::new(Vec::new());
@@ -57,7 +58,7 @@ fn classify(tag: i64) -> i64 {
 }
 
 struct TagState {
-    tags: Vec<i64>,
+    tags: VirtArray<i64>,
     pos: i64,
     acc: i64,
     ticks: i64,
@@ -96,7 +97,7 @@ fn dispatch_tags(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
     });
     let mut pc: usize = 0;
     let mut state = TagState {
-        tags: TAGS.to_vec(),
+        tags: VirtArray::from_slice(&TAGS),
         pos: 0i64,
         acc: 0i64,
         ticks,

--- a/majit/majit-metainterp/tests/jit_interp_two_machines_one_module.rs
+++ b/majit/majit-metainterp/tests/jit_interp_two_machines_one_module.rs
@@ -22,6 +22,7 @@
 //! `impl JitState for #state_type` (E0119). Unique idents buy co-residence only
 //! for machines whose `state` types differ.
 
+use majit_metainterp::virt_array::VirtArray;
 pub type Bytecode = [u8];
 
 const C_ADD: u8 = 1; // acc += n; n -= 1
@@ -116,7 +117,7 @@ fn counter_program() -> Vec<u8> {
 // emitted here and nowhere else in this file.
 struct StackState {
     stackpos: i64,
-    stack: Vec<i64>,
+    stack: VirtArray<i64>,
 }
 
 #[majit_macros::jit_interp(
@@ -136,7 +137,7 @@ pub fn mainloop_stack(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 
     let mut pc: usize = 0;
     let mut state = StackState {
         stackpos: 0,
-        stack: vec![0i64; program.len()],
+        stack: VirtArray::filled(0i64, program.len()),
     };
     {
         use majit_metainterp::JitState as _;

--- a/majit/majit-metainterp/tests/jit_interp_two_virt_arrays_with_scalar.rs
+++ b/majit/majit-metainterp/tests/jit_interp_two_virt_arrays_with_scalar.rs
@@ -27,12 +27,13 @@ fn expected(limit: i64) -> i64 {
 /// Control with two virtualizable arrays and no scalar preceding the identity.
 mod two_arrays_no_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct TwoArrays {
-        iregs: Vec<i64>,
-        fregs: Vec<f64>,
+        iregs: VirtArray<i64>,
+        fregs: VirtArray<f64>,
     }
 
     #[majit_macros::jit_interp(
@@ -53,8 +54,8 @@ mod two_arrays_no_scalar {
         });
         let mut pc: usize = 0;
         let mut state = TwoArrays {
-            iregs: vec![0i64, limit],
-            fregs: vec![0.0f64],
+            iregs: VirtArray::from_slice(&[0i64, limit]),
+            fregs: VirtArray::from_slice(&[0.0f64]),
         };
         {
             use majit_metainterp::JitState as _;
@@ -119,11 +120,12 @@ mod two_arrays_no_scalar {
 /// differs from a passing one in exactly one declaration.
 mod one_array_with_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct OneArrayScalar {
-        iregs: Vec<i64>,
+        iregs: VirtArray<i64>,
         acc: i64,
         ret: i64,
     }
@@ -147,7 +149,7 @@ mod one_array_with_scalar {
         });
         let mut pc: usize = 0;
         let mut state = OneArrayScalar {
-            iregs: vec![0i64, limit],
+            iregs: VirtArray::from_slice(&[0i64, limit]),
             acc: 0,
             ret: 0,
         };
@@ -215,12 +217,13 @@ mod one_array_with_scalar {
 /// `int` scalar instead of in element 0 of the int array.
 mod two_arrays_with_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct TwoArraysScalar {
-        iregs: Vec<i64>,
-        fregs: Vec<f64>,
+        iregs: VirtArray<i64>,
+        fregs: VirtArray<f64>,
         ret: i64,
     }
 
@@ -243,8 +246,8 @@ mod two_arrays_with_scalar {
         });
         let mut pc: usize = 0;
         let mut state = TwoArraysScalar {
-            iregs: vec![0i64, limit],
-            fregs: vec![0.0f64],
+            iregs: VirtArray::from_slice(&[0i64, limit]),
+            fregs: VirtArray::from_slice(&[0.0f64]),
             ret: 0,
         };
         {
@@ -316,12 +319,13 @@ mod two_arrays_with_scalar {
 /// leaves open, and separates "two arrays" from "two arrays of mixed types".
 mod two_int_arrays_with_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct TwoIntArraysScalar {
-        iregs: Vec<i64>,
-        aregs: Vec<i64>,
+        iregs: VirtArray<i64>,
+        aregs: VirtArray<i64>,
         ret: i64,
     }
 
@@ -344,8 +348,8 @@ mod two_int_arrays_with_scalar {
         });
         let mut pc: usize = 0;
         let mut state = TwoIntArraysScalar {
-            iregs: vec![0i64, limit],
-            aregs: vec![0i64],
+            iregs: VirtArray::from_slice(&[0i64, limit]),
+            aregs: VirtArray::from_slice(&[0i64]),
             ret: 0,
         };
         {
@@ -411,11 +415,12 @@ mod two_int_arrays_with_scalar {
 /// "flat slot 0 holds a passthrough scalar", it fails.
 mod one_array_dead_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct OneArrayDeadScalar {
-        iregs: Vec<i64>,
+        iregs: VirtArray<i64>,
         ret: i64,
     }
 
@@ -437,7 +442,7 @@ mod one_array_dead_scalar {
         });
         let mut pc: usize = 0;
         let mut state = OneArrayDeadScalar {
-            iregs: vec![0i64, limit, 0i64],
+            iregs: VirtArray::from_slice(&[0i64, limit, 0i64]),
             ret: 0,
         };
         {
@@ -503,13 +508,14 @@ mod one_array_dead_scalar {
 /// is the passthrough scalar at slot 0, it compiles.
 mod two_arrays_live_scalar {
     use super::{AtomicU32, Bytecode, OP_ACC, OP_INC, OP_JUMP_BACK, OP_RETURN, Ordering};
+    use majit_metainterp::virt_array::VirtArray;
 
     static COMPILES: AtomicU32 = AtomicU32::new(0);
 
     struct TwoArraysLiveScalar {
         acc: i64,
-        iregs: Vec<i64>,
-        fregs: Vec<f64>,
+        iregs: VirtArray<i64>,
+        fregs: VirtArray<f64>,
     }
 
     #[majit_macros::jit_interp(
@@ -532,8 +538,8 @@ mod two_arrays_live_scalar {
         let mut pc: usize = 0;
         let mut state = TwoArraysLiveScalar {
             acc: 0,
-            iregs: vec![0i64, limit],
-            fregs: vec![0.0f64],
+            iregs: VirtArray::from_slice(&[0i64, limit]),
+            fregs: VirtArray::from_slice(&[0.0f64]),
         };
         {
             use majit_metainterp::JitState as _;

--- a/majit/majit-metainterp/tests/vable_array_blackhole_cpu.rs
+++ b/majit/majit-metainterp/tests/vable_array_blackhole_cpu.rs
@@ -1,0 +1,120 @@
+//! DirectPointer vable arrays resume through the PyPy CPU chain.
+//!
+//! `bhimpl_getarrayitem_vable_*` / `bhimpl_arraylen_vable` /
+//! `bhimpl_setarrayitem_vable_*` do
+//! `clear_vable_token` → `cpu.bh_getfield_gc_r` → `cpu.bh_getarrayitem_gc_*`
+//! (or `bh_arraylen_gc` / `bh_setarrayitem_gc_*`). `VirtArray` is
+//! `Ptr(GcArray)` after `make_sure_not_resized` (`virtualizable.py`), so
+//! that chain must be the one that answers.
+
+use majit_metainterp::blackhole::{BlackholeInterpBuilder, wire_bhimpl_handlers};
+use majit_metainterp::jitcode::{self, JitCodeBuilder};
+use majit_metainterp::virt_array::{VirtArray, register_virt_array_field};
+use majit_metainterp::virtualizable::{VableArrayStorage, VirtualizableInfo};
+
+#[cfg(all(feature = "cranelift", not(feature = "dynasm")))]
+use majit_backend_cranelift::CraneliftBackend as TestBackend;
+#[cfg(feature = "dynasm")]
+use majit_backend_dynasm::runner::DynasmBackend as TestBackend;
+
+struct State {
+    regs: VirtArray<i64>,
+}
+
+fn data_ptr(p: *mut u8) -> *mut i64 {
+    unsafe { (*(p as *mut State)).regs.as_mut_ptr() }
+}
+
+fn len(p: *const u8) -> usize {
+    unsafe { (*(p as *const State)).regs.len() }
+}
+
+fn build_vinfo() -> VirtualizableInfo {
+    let mut info = VirtualizableInfo::without_vable_token();
+    register_virt_array_field(
+        &mut info,
+        "regs",
+        majit_ir::Type::Int,
+        std::mem::size_of::<i64>(),
+        std::mem::offset_of!(State, regs),
+        data_ptr,
+        len,
+        |s: &State| &s.regs,
+    );
+    assert_eq!(
+        info.array_fields[0].storage,
+        VableArrayStorage::DirectPointer
+    );
+    info
+}
+
+fn bh_builder() -> BlackholeInterpBuilder {
+    let mut entries: indexmap::IndexMap<String, u8> = jitcode::wellknown_bh_insns()
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), *value))
+        .collect();
+    entries.extend(
+        jitcode::extension_insns()
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value)),
+    );
+    let mut builder = BlackholeInterpBuilder::new();
+    builder.setup_insns(&entries);
+    wire_bhimpl_handlers(&mut builder);
+    builder
+}
+
+#[test]
+fn getarrayitem_vable_i_reads_a_block_through_the_cpu_chain() {
+    let cpu = TestBackend::new();
+    let mut builder = bh_builder();
+    builder.set_cpu(&cpu);
+
+    let mut b = JitCodeBuilder::new();
+    b.vable_getarrayitem_int_with_base(2, 0, 0, 1);
+    b.int_return(2);
+    let jitcode = std::sync::Arc::new(b.finish());
+
+    let info = build_vinfo();
+    let mut state = State {
+        regs: VirtArray::from_slice(&[10i64, 20, 30]),
+    };
+
+    let mut bh = builder.acquire_interp();
+    bh.virtualizable_info = &info;
+    bh.setposition(jitcode, 0);
+    bh.registers_r[0] = &mut state as *mut State as i64;
+    bh.registers_i[1] = 2;
+    let _ = bh.run();
+
+    assert_eq!(bh.tmpreg_i, 30);
+}
+
+#[test]
+fn setarrayitem_vable_i_then_arraylen_vable_use_the_cpu_chain() {
+    let cpu = TestBackend::new();
+    let mut builder = bh_builder();
+    builder.set_cpu(&cpu);
+
+    let mut b = JitCodeBuilder::new();
+    b.vable_setarrayitem_int_with_base(0, 0, 1, 2);
+    b.vable_arraylen_with_base(3, 0, 0);
+    b.int_return(3);
+    let jitcode = std::sync::Arc::new(b.finish());
+
+    let info = build_vinfo();
+    let mut state = State {
+        regs: VirtArray::from_slice(&[10i64, 20, 30]),
+    };
+
+    let mut bh = builder.acquire_interp();
+    bh.virtualizable_info = &info;
+    bh.setposition(jitcode, 0);
+    bh.registers_r[0] = &mut state as *mut State as i64;
+    bh.registers_i[1] = 1;
+    bh.registers_i[2] = 99;
+    let _ = bh.run();
+
+    assert_eq!(state.regs.to_vec(), vec![10, 99, 30]);
+    assert_eq!(bh.tmpreg_i, 3);
+}


### PR DESCRIPTION
## Summary

- `bhimpl_getarrayitem_vable_*` / `bhimpl_setarrayitem_vable_*` / `bhimpl_arraylen_vable` now follow PyPy: `clear_vable_token` → `cpu.bh_getfield_gc_r` → `bh_getarrayitem_gc_*` / `bh_setarrayitem_gc_*` / `bh_arraylen_gc`.
- `jit_interp` `[int; virt]` / `[float; virt]` fields use `VirtArray` so the array field is `Ptr(GcArray)` after `make_sure_not_resized`.
- Assembler int/float vable `arraydescr.base_size` is `VirtArray::<i64>::ITEMS_OFFSET` so wasm32 length-word vs i64 alignment agrees.
- Added `tests/vable_array_blackhole_cpu.rs` for the DirectPointer CPU chain.

## Test plan

- [x] `cargo test --all --no-default-features --features dynasm`

## Follow-ups (not this PR)

- `tiny2` still uses `Vec` (`RustVec`). Its observer `jit_merge_point!()` disagrees with the compiled-entry heap reload on fib; that portal does not resume `getarrayitem_vable_*`.
- `arraybase_vable` is pyre-only and still uses the storage helpers.
- `EmbeddedArray` / `add_rust_vec_array_field` remain for tests and the `virtualizable!` Embedded arm. Blackhole no longer dispatches through them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expanded virtualizable array support across interpreter examples and execution state, including stacks, tapes, registers, and floating-point registers.
  - Improved handling of virtualizable-array access, updates, and length operations for more consistent runtime behavior.
  - Corrected array layout handling across supported item types and platforms.

- **Tests**
  - Added coverage for virtualizable-array operations and CPU execution paths.
  - Updated interpreter fixtures and assertions to reflect the new array representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->