### PR TITLE
Fix frame storage and wasm barriers; consolidate root tests

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2060,6 +2060,22 @@ fn emit_jitframe_write_barrier(
     residual_type_base: Option<u32>,
     wb: &WriteBarrierHelpers,
 ) {
+    if residual_type_base.is_none() && jit_call_idx.is_none() {
+        return;
+    }
+    // aarch64/assembler.py _reload_frame_if_necessary invokes
+    // _write_barrier_fastpath(is_frame=True): frames never use card marking.
+    // Off-GC frames reserve a zeroed header too (alloc_off_gc_jitframe), so
+    // their flag-byte read is valid and does not enter the guarded helper.
+    sink.local_get(0);
+    sink.i32_const(majit_backend::jitframe::FIRST_ITEM_OFFSET as i32);
+    sink.i32_sub();
+    sink.i32_const(wb.flag_byteofs);
+    sink.i32_add();
+    sink.i32_load8_u(memarg(0, 0));
+    sink.i32_const(i32::from(wb.if_flag));
+    sink.i32_and();
+    sink.if_(BlockType::Empty);
     if let Some(base) = residual_type_base {
         sink.local_get(0);
         sink.i32_const(majit_backend::jitframe::FIRST_ITEM_OFFSET as i32);
@@ -2068,6 +2084,7 @@ fn emit_jitframe_write_barrier(
         sink.i32_const(wb.fn_ptr as i32);
         sink.call_indirect(0, base + 1);
         sink.drop();
+        sink.end();
         return;
     }
     let Some(jit_call) = jit_call_idx else {
@@ -2086,6 +2103,7 @@ fn emit_jitframe_write_barrier(
     sink.i64_extend_i32_u();
     sink.i64_store(mem64(STATIC_CALL_ARGS_OFS));
     emit_jit_call(sink, jit_call);
+    sink.end();
 }
 
 /// Per-value def / last-use op positions over the trace, used to filter the

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -828,7 +828,7 @@ fn build_module_with_write_barrier_target(
 }
 
 #[test]
-fn jitframe_barrier_reserves_arity_one_for_zero_argument_residuals() {
+fn jitframe_barrier_checks_flags_and_reserves_arity_one_for_zero_argument_residuals() {
     const WB_TARGET: i64 = 127;
     let call = make_op(
         OpCode::CallMayForceI,
@@ -854,6 +854,28 @@ fn jitframe_barrier_reserves_arity_one_for_zero_argument_residuals() {
     );
     assert_eq!(direct_write_barrier_call_count(&bytes, WB_TARGET as i32), 1);
     validate_wasm(&bytes);
+    // _reload_frame_if_necessary's frame fastpath must guard the helper;
+    // otherwise every collecting call searches the managed heap even when
+    // the frame has already been remembered (or has a zeroed off-GC header).
+    let flag = i32::from(codegen::WriteBarrierHelpers::for_current_gc(WB_TARGET, 0).if_flag);
+    let mut flag_checks = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let ops = body
+                .get_operators_reader()
+                .unwrap()
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            for window in ops.windows(4) {
+                if matches!(window, [wasmparser::Operator::I32Load8U { .. }, wasmparser::Operator::I32Const { value }, wasmparser::Operator::I32And, wasmparser::Operator::If { .. }] if *value == flag)
+                {
+                    flag_checks += 1;
+                }
+            }
+        }
+    }
+    assert_eq!(flag_checks, 1);
 }
 
 #[test]

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -2011,7 +2011,7 @@ mod tests {
     }
 
     #[test]
-    fn scoped_extra_areas_keep_outer_roots_and_retire_by_owner() {
+    fn scoped_extra_areas_forward_and_retire_on_drop_or_unwind() {
         unsafe fn walk_cell(data: *const (), visitor: &mut dyn FnMut(&mut GcRef)) {
             let slot = unsafe { &*(data as *const Cell<GcRef>) };
             let mut value = slot.get();
@@ -2040,23 +2040,12 @@ mod tests {
         seen.clear();
         walk_my_extra_areas(|root| seen.push(root.0));
         assert_eq!(seen, [0x2080]);
-        drop(inner_guard);
-        walk_my_extra_areas(|_| panic!("retired root still visible"));
-        unregister_mutator();
-    }
-
-    #[test]
-    fn scoped_extra_area_unwinds_before_owner_storage_dies() {
-        unsafe fn no_roots(_: *const (), _: &mut dyn FnMut(&mut GcRef)) {}
-        let _lock = TEST_MUTEX.lock();
-        register_mutator();
-        let result = std::panic::catch_unwind(|| {
-            let _guard =
-                unsafe { MutatorExtraAreaGuard::new(no_roots, std::ptr::null(), "unwind") };
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _guard = inner_guard;
             panic!("test unwind");
-        });
+        }));
         assert!(result.is_err());
-        // Teardown asserts that no scoped area remains registered.
+        walk_my_extra_areas(|_| panic!("retired root still visible"));
         unregister_mutator();
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/util.rs
+++ b/majit/majit-metainterp/src/optimizeopt/util.rs
@@ -180,25 +180,25 @@ mod tests {
     }
 
     #[test]
-    fn args_dict_shares_identity_and_uses_typed_constant_equality() {
+    fn args_dict_isolates_fresh_caches_and_uses_typed_constant_equality() {
         use majit_ir::Value;
         let dict = super::args_dict();
-        let compiler = dict.clone();
         dict.insert(vec![Value::Float(0.0)], Value::Int(1));
         dict.insert(vec![Value::Float(-0.0)], Value::Int(2));
         dict.insert(vec![Value::Int(0)], Value::Int(3));
         let nan = f64::from_bits(0x7ff8000000000001);
         dict.insert(vec![Value::Float(nan)], Value::Int(4));
-        assert_eq!(compiler.get(&[Value::Float(0.0)]), Some(Value::Int(1)));
-        assert_eq!(compiler.get(&[Value::Float(-0.0)]), Some(Value::Int(2)));
-        assert_eq!(compiler.get(&[Value::Int(0)]), Some(Value::Int(3)));
-        assert_eq!(compiler.get(&[Value::Float(nan)]), Some(Value::Int(4)));
+        assert_eq!(dict.get(&[Value::Float(0.0)]), Some(Value::Int(1)));
+        assert_eq!(dict.get(&[Value::Float(-0.0)]), Some(Value::Int(2)));
+        assert_eq!(dict.get(&[Value::Int(0)]), Some(Value::Int(3)));
+        let fresh = super::args_dict();
+        assert_eq!(fresh.get(&[Value::Int(0)]), None);
+        fresh.insert(vec![Value::Int(0)], Value::Int(5));
+        assert_eq!(dict.get(&[Value::Int(0)]), Some(Value::Int(3)));
+        assert_eq!(dict.get(&[Value::Float(nan)]), Some(Value::Int(4)));
         assert_eq!(
-            compiler.get(&[Value::Float(f64::from_bits(nan.to_bits() + 1))]),
+            dict.get(&[Value::Float(f64::from_bits(nan.to_bits() + 1))]),
             None
         );
-        compiler.insert(vec![], Value::Int(5));
-        assert_eq!(dict.get(&[]), Some(Value::Int(5)));
-        assert_eq!(super::args_dict().get(&[]), None);
     }
 }

--- a/majit/majit-metainterp/tests/call_pure_roots.rs
+++ b/majit/majit-metainterp/tests/call_pure_roots.rs
@@ -78,12 +78,6 @@ fn cache_constants_survive_movement_handoff_and_retire_with_the_last_owner() {
     assert_eq!(root_count(), initial_roots + 3);
     drop(optimizer);
     assert_eq!(root_count(), initial_roots);
-    assert_eq!(
-        args_dict().get(&[Value::Int(7)]),
-        None,
-        "new attempt starts empty"
-    );
-
     majit_gc::set_active_gc_id_or_identityhash(None);
     shadow_stack::unregister_mutator();
     gc_sync::unregister_thread();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/register_bank.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/register_bank.rs
@@ -84,14 +84,6 @@ impl RegisterValues for RegisterBank {
 }
 
 impl RegisterBank {
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            (Some(a), Some(b)) => Rc::ptr_eq(a, b),
-            (None, None) => true,
-            _ => false,
-        }
-    }
-
     pub fn new(values: impl IntoIterator<Item = OpRef>) -> Self {
         let slots: Vec<_> = values.into_iter().map(Cell::new).collect();
         let num_regs = slots.len();
@@ -163,17 +155,6 @@ impl RegisterBank {
         self.0.iter().flat_map(|slots| slots.iter().map(Cell::get))
     }
 
-    /// Trace the frame's actual slots, as RPython's GC traces MIFrame's list.
-    /// The root walker only calls this synchronously on the owner or while
-    /// all foreign mutators are quiesced. It never clones/drops the Rc owner.
-    pub(crate) fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-        for slot in self.0.iter().flat_map(|slots| slots.iter()) {
-            let mut value = slot.get();
-            value.walk_const_ptr_refs_mut(visitor);
-            slot.set(value);
-        }
-    }
-
     pub fn replace_active_box(&self, old: OpRef, new: OpRef) {
         // pyjitpl.py MIFrame.replace_active_box_in_frame stops at num_regs,
         // not num_regs_and_consts: replacement must not rewrite constants.
@@ -190,67 +171,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn active_replacement_preserves_the_constant_suffix() {
-        let old = OpRef::const_ptr(majit_ir::GcRef(0x1000));
-        let new = OpRef::input_arg_ref(0);
-        let bank = RegisterBank::with_constants([old, old], 1);
-        bank.clone().replace_active_box(old, new);
-        assert_eq!(bank.to_vec(), [new, old]);
-        let constants_only = RegisterBank::with_constants([old], 0);
-        constants_only.replace_active_box(old, new);
-        assert_eq!(constants_only.to_vec(), [old]);
-    }
-
-    #[test]
-    fn empty_bank_has_no_shared_allocation() {
-        let bank = RegisterBank::new([]);
-        assert!(bank.is_empty());
-        assert!(bank.0.is_none());
-        assert_eq!(bank.get(0), None);
-    }
-
-    #[test]
-    fn paused_and_active_access_share_the_frame_owned_slots() {
-        let old = OpRef::input_arg_float(0);
-        let new = OpRef::input_arg_float(1);
-        let owner = RegisterBank::new([old]);
-        let paused = owner.clone();
-        owner.set(0, new);
-        paused.replace_active_box(new, old);
-        assert_eq!(owner.get(0), Some(old));
-        drop(owner);
-        paused.replace_active_box(old, new);
-        assert_eq!(paused.get(0), Some(new));
-    }
-
-    #[test]
-    fn int_replacement_updates_each_live_alias_immediately() {
-        let old = OpRef::input_arg_int(0);
-        let new = OpRef::input_arg_int(1);
-        let frame = RegisterBank::new([old, old]);
-        let paused = frame.clone();
-        frame.set(1, new);
-        paused.replace_active_box(old, new);
-        assert_eq!(frame.to_vec(), vec![new, new]);
-        drop(frame);
-        paused.replace_active_box(new, old);
-        assert_eq!(paused.to_vec(), vec![old, old]);
-    }
-
-    #[test]
-    fn gc_root_forwards_shared_ref_slots_and_retains_their_owner() {
-        use majit_ir::GcRef;
-        let old = OpRef::const_ptr(GcRef(0x1000));
-        let frame = RegisterBank::new([old, OpRef::input_arg_ref(0)]);
-        let root = frame.clone();
-        assert!(frame.ptr_eq(&root));
-        assert!(!frame.ptr_eq(&RegisterBank::new([old])));
-        root.walk_const_ptr_refs(&mut |ptr| ptr.0 += 0x1000);
-        assert_eq!(frame.get(0), Some(OpRef::const_ptr(GcRef(0x2000))));
-        frame.set(0, old);
-        drop(frame);
-        root.walk_const_ptr_refs(&mut |ptr| ptr.0 += 0x1000);
-        assert_eq!(root.get(0), Some(OpRef::const_ptr(GcRef(0x2000))));
-        assert_eq!(root.get(1), Some(OpRef::input_arg_ref(0)));
+    fn shared_replacement_updates_live_aliases_but_preserves_constants() {
+        // MIFrame.setup leaves absent register lists unallocated.
+        let empty = RegisterBank::new([]);
+        assert!(empty.0.is_none());
+        // pyjitpl.py MIFrame.replace_active_box_in_frame: all three banks
+        // replace every live alias, stopping before the constant suffix.
+        for (old, new) in [
+            (
+                OpRef::const_ptr(majit_ir::GcRef(0x1000)),
+                OpRef::input_arg_ref(0),
+            ),
+            (OpRef::const_int(7), OpRef::input_arg_int(0)),
+            (OpRef::const_float(2.5), OpRef::input_arg_float(0)),
+        ] {
+            let owner = RegisterBank::with_constants([old, old, old], 2);
+            let paused = owner.clone();
+            owner.set(1, new);
+            paused.replace_active_box(old, new);
+            assert_eq!(owner.to_vec(), [new, new, old]);
+            drop(owner);
+            paused.replace_active_box(new, old);
+            assert_eq!(paused.to_vec(), [old, old, old]);
+            let constants_only = RegisterBank::with_constants([old], 0);
+            constants_only.replace_active_box(old, new);
+            assert_eq!(constants_only.to_vec(), [old]);
+        }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -357,39 +357,39 @@ mod frame_replacement_tests {
     }
 
     #[test]
-    fn replace_box_rewrites_bound_paused_banks_immediately() {
-        let old = OpRef::input_arg_ref(0);
-        let standard = OpRef::input_arg_ref(1);
+    fn paused_replacement_retains_and_updates_all_typed_banks() {
+        let old = [
+            OpRef::input_arg_ref(0),
+            OpRef::input_arg_int(0),
+            OpRef::input_arg_float(0),
+        ];
+        let new = [
+            OpRef::input_arg_ref(1),
+            OpRef::input_arg_int(1),
+            OpRef::input_arg_float(1),
+        ];
         let session = std::cell::RefCell::new(WalkSession::default());
         let parent = FrameBoxReplacements::new(&session);
-        let regs = RegisterBank::new([old]);
-        let ints = RegisterBank::default();
-        let floats = RegisterBank::default();
-        parent.bind_banks(&regs, &ints, &floats);
-        replace_box_in_paused_frames(&mut session.borrow_mut(), old, standard);
-        assert_eq!(regs.to_vec(), vec![standard]);
-    }
-
-    #[test]
-    fn paused_float_bank_keeps_ownership_across_active_writes() {
-        let old = OpRef::input_arg_float(0);
-        let new = OpRef::input_arg_float(1);
-        let session = std::cell::RefCell::new(WalkSession::default());
-        let parent = FrameBoxReplacements::new(&session);
-        let bank = RegisterBank::new([old]);
-        parent.bind_banks(&RegisterBank::default(), &RegisterBank::default(), &bank);
+        let banks = old.map(|value| RegisterBank::new([value, value]));
+        parent.bind_banks(&banks[0], &banks[1], &banks[2]);
         parent.set_listening(false);
-        bank.set(0, new);
+        for (bank, value) in banks.iter().zip(new) {
+            bank.set(0, value);
+        }
         parent.set_listening(true);
-        replace_box_in_paused_frames(&mut session.borrow_mut(), new, old);
-        assert_eq!(bank.get(0), Some(old));
-        drop(bank);
+        for i in 0..3 {
+            replace_box_in_paused_frames(&mut session.borrow_mut(), old[i], new[i]);
+            assert_eq!(banks[i].to_vec(), [new[i], new[i]]);
+        }
+        drop(banks);
         // Registration owns the storage, not a pointer into the dropped owner.
-        replace_box_in_paused_frames(&mut session.borrow_mut(), old, new);
-        assert_eq!(
-            parent.0.banks_f.borrow().as_ref().unwrap().get(0),
-            Some(new)
-        );
+        for (bank, (old, new)) in [&parent.0.banks_r, &parent.0.banks_i, &parent.0.banks_f]
+            .into_iter()
+            .zip(old.into_iter().zip(new))
+        {
+            replace_box_in_paused_frames(&mut session.borrow_mut(), new, old);
+            assert_eq!(bank.borrow().as_ref().unwrap().to_vec(), [old, old]);
+        }
     }
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -6887,7 +6887,7 @@ mod tests {
         let inner = Box::new(PyreSym::new_uninit(OpRef::NONE));
         outer.registers_r.replace(vec![ptr(0x1000)]);
         inner.registers_r.replace(vec![ptr(0x2000)]);
-        let outer_bank = RegisterBank::new([ptr(0x3000)]);
+        let outer_bank = RegisterBank::new([ptr(0x3000), OpRef::input_arg_ref(0)]);
         let inner_bank = RegisterBank::new([ptr(0x4000)]);
         // Do not expose sentinel addresses to another test's real collector.
         let _stw = majit_gc::gc_sync::quiesce_mutators();
@@ -6912,6 +6912,7 @@ mod tests {
         assert_eq!(seen, [0x1000, 0x3000, 0x2000, 0x4000]);
         assert_eq!(outer.registers_r.to_vec(), [ptr(0x1080)]);
         assert_eq!(outer_bank.get(0), Some(ptr(0x3080)));
+        assert_eq!(outer_bank.get(1), Some(OpRef::input_arg_ref(0)));
         assert_eq!(inner.registers_r.to_vec(), [ptr(0x2080)]);
         assert_eq!(inner_bank.get(0), Some(ptr(0x4080)));
 


### PR DESCRIPTION
## Summary

- Repair two stale generator/callee accesses to frame-owned storage after the
  RegisterBank/WalkFrameState migration.
- Match PyPy's JITFRAME write-barrier fastpath on wasm: inspect the collector's
  flag before calling the existing guarded helper, including safe off-GC frames.
- Consolidate overlapping scoped-root, shared-register-bank and cache tests.
  Preserve real moving-GC coverage, fresh-cache independence, typed aliases,
  constant-suffix protection and unwind cleanup. Tests introduced by the prior
  root-ownership work reduce from23 to17; no jitstats baselines or performance
  allowances change.

The runtime repairs and test consolidation are separate commits. This follows
the already-merged force/root work in #1751; it does not claim that all
translator ownership adaptations have disappeared.

## Upstream references

- `pyjitpl.py MIFrame.setup_call` and frame-owned registers.
- `aarch64/assembler.py Assembler._reload_frame_if_necessary` and
  `x86/assembler.py Assembler._write_barrier_fastpath`.
- `optimizeopt/util.py args_dict` and registered shadow-stack root lifetimes.

Independent latest-main review found no new regressions. The wasm branch
encoding and shared Rust register storage were verified as adaptations that
preserve these upstream contracts.

## Verification

- Re-extracted LLBC on main `c6f2f9493c5`, without fingerprint bypasses.
- `cargo test --all --no-default-features --features dynasm`: 9,340 passed.
- `cargo test --all --no-default-features --features cranelift`: 9,318 passed.
- Bare `python3 pyre/check.py`: dynasm 549/549, cranelift 549/549, wasm 542/542.
- Strict CPython filters on each native backend: pickle 3 modules, threading
  2 modules, all PASS; no crashes or timeouts.
- `cargo fmt --all -- --check`, majit ownership boundary and all 539 fixture
  headers pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection write-barrier handling by ensuring barriers run only for frames that require them.
  - Improved reliability when managing nested roots, paused frames, and register storage during collection and unwinding.
  - Prevented unintended sharing between newly created argument dictionaries, preserving independent state and value comparisons.

- **Refactor**
  - Streamlined internal register and frame-state handling without changing user-visible behavior.

- **Tests**
  - Expanded coverage for write barriers, root forwarding, typed register banks, and panic/unwinding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->