### PR TITLE
gc, jit: MiniMark-owned tables and orthodox bridge resume

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4501,6 +4501,32 @@ thread_local! {
         std::cell::RefCell::new(indexmap::IndexMap::new());
 }
 
+/// RAII guard that restores `GC_TABLE_BASE` / `GC_TABLE_VAR_INDEX` on Drop
+/// so nested compiles (bridge compilation re-entry) keep their own table
+/// base and rematerialize map. Same reason as `OprefVarMapGuard`.
+struct GcTableCompileGuard {
+    saved_base: usize,
+    saved_index: indexmap::IndexMap<u32, u32>,
+}
+
+impl GcTableCompileGuard {
+    fn enter(new_base: usize) -> Self {
+        let saved_base = GC_TABLE_BASE.with(|cell| cell.replace(new_base));
+        let saved_index = GC_TABLE_VAR_INDEX.with(|cell| std::mem::take(&mut *cell.borrow_mut()));
+        Self {
+            saved_base,
+            saved_index,
+        }
+    }
+}
+
+impl Drop for GcTableCompileGuard {
+    fn drop(&mut self) {
+        GC_TABLE_BASE.with(|cell| cell.set(self.saved_base));
+        GC_TABLE_VAR_INDEX.with(|cell| *cell.borrow_mut() = std::mem::take(&mut self.saved_index));
+    }
+}
+
 fn record_gc_table_var(var_idx: u32, table_index: u32) {
     GC_TABLE_VAR_INDEX.with(|cell| {
         cell.borrow_mut().insert(var_idx, table_index);
@@ -9642,8 +9668,7 @@ impl CraneliftBackend {
         // Empty list ⇒ no table, base stays 0.
         let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
         let gc_table_base = gc_table.as_ref().map_or(0usize, |t| t.base_addr());
-        GC_TABLE_BASE.with(|cell| cell.set(gc_table_base));
-        GC_TABLE_VAR_INDEX.with(|cell| cell.borrow_mut().clear());
+        let _gc_table_guard = GcTableCompileGuard::enter(gc_table_base);
         // RPython parity: regalloc asserts that every Box used as an
         // argument or in fail_args is bound to a register or stack
         // location before code emission begins. The pyre/Cranelift

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4491,6 +4491,39 @@ thread_local! {
     /// When an OpRef collides (in both constants map and op-result set),
     /// the variable takes precedence over the constant.
     static OP_RESULT_VARS: std::cell::RefCell<Option<indexmap::IndexSet<u32>>> = const { std::cell::RefCell::new(None) };
+    /// `assembler.py` `genop_load_from_gc_table` base for this compile.
+    static GC_TABLE_BASE: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    /// Vars that are `LoadFromGcTable` results (or SameAs of one), keyed by
+    /// OpRef raw. rewrite.py clears `gcrefs_recently_loaded` at LABEL, so a
+    /// later failarg must rematerialize the load rather than reuse a
+    /// preamble SSA value that is not a LABEL arg.
+    static GC_TABLE_VAR_INDEX: std::cell::RefCell<indexmap::IndexMap<u32, u32>> =
+        std::cell::RefCell::new(indexmap::IndexMap::new());
+}
+
+fn record_gc_table_var(var_idx: u32, table_index: u32) {
+    GC_TABLE_VAR_INDEX.with(|cell| {
+        cell.borrow_mut().insert(var_idx, table_index);
+    });
+}
+
+fn gc_table_index_for_var(var_idx: u32) -> Option<u32> {
+    GC_TABLE_VAR_INDEX.with(|cell| cell.borrow().get(&var_idx).copied())
+}
+
+fn emit_load_gc_table_slot(
+    builder: &mut FunctionBuilder,
+    ptr_type: cranelift_codegen::ir::Type,
+    table_index: u32,
+) -> CValue {
+    let base = GC_TABLE_BASE.with(std::cell::Cell::get);
+    let base_v = builder.ins().iconst(cl_types::I64, base as i64);
+    let index_v = builder.ins().iconst(cl_types::I64, table_index as i64);
+    let byte_ofs = builder.ins().ishl_imm_u(index_v, 3);
+    let slot_addr = builder.ins().iadd(base_v, byte_ofs);
+    builder
+        .ins()
+        .load(ptr_type, MemFlagsData::trusted(), slot_addr, 0)
 }
 
 fn opref_is_op_result_var(opref: OpRef) -> bool {
@@ -5733,6 +5766,16 @@ fn resolve_failarg_opref(
     // a fail-arg reference constant whose object can move must be reloaded
     // through GC-forwarded resume data, not frozen as an immediate.
     guard_constptr_immediate(opref);
+    // rewrite.py clears `gcrefs_recently_loaded` at LABEL. A failarg that
+    // is a table load (or SameAs of one) defined in the preamble is not a
+    // LABEL arg, so rematerialize `genop_load_from_gc_table` here instead
+    // of `use_var` of a preamble SSA value the back-edge does not carry.
+    if !opref.is_none()
+        && !opref.is_constant()
+        && let Some(table_index) = gc_table_index_for_var(opref.raw())
+    {
+        return emit_load_gc_table_slot(builder, cl_types::I64, table_index);
+    }
     // Inline-Const fast path: history.py/268/314 — Const Box value
     // is inline. Stale-ref reload only applies to op-result variables
     // (regalloc-assigned slots), never to constants.
@@ -9599,6 +9642,8 @@ impl CraneliftBackend {
         // Empty list ⇒ no table, base stays 0.
         let gc_table = (!gcrefs.is_empty()).then(|| majit_gc::GcTable::from_gcrefs(&gcrefs));
         let gc_table_base = gc_table.as_ref().map_or(0usize, |t| t.base_addr());
+        GC_TABLE_BASE.with(|cell| cell.set(gc_table_base));
+        GC_TABLE_VAR_INDEX.with(|cell| cell.borrow_mut().clear());
         // RPython parity: regalloc asserts that every Box used as an
         // argument or in fail_args is bound to a register or stack
         // location before code emission begins. The pyre/Cranelift
@@ -11298,7 +11343,14 @@ impl CraneliftBackend {
                 // ── Identity / cast ──
                 OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF | OpCode::CastOpaquePtr => {
                     let a = if op.num_args() > 0 {
-                        resolve_opref(&mut builder, &constants, op.arg(0).to_opref())
+                        let src = op.arg(0).to_opref();
+                        if !src.is_none()
+                            && !src.is_constant()
+                            && let Some(table_index) = gc_table_index_for_var(src.raw())
+                        {
+                            record_gc_table_var(vi, table_index);
+                        }
+                        resolve_opref(&mut builder, &constants, src)
                     } else if let Some(&c) = constants.get(&vi) {
                         builder.ins().iconst(cl_types::I64, c)
                     } else {
@@ -15716,13 +15768,11 @@ impl CraneliftBackend {
                 // each load observes the relocated object. Cranelift folds
                 // `base + (const_index << 3)` to a single address.
                 OpCode::LoadFromGcTable => {
-                    let index = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let base = builder.ins().iconst(cl_types::I64, gc_table_base as i64);
-                    let byte_ofs = builder.ins().ishl_imm_u(index, 3);
-                    let slot_addr = builder.ins().iadd(base, byte_ofs);
-                    let value = builder
-                        .ins()
-                        .load(ptr_type, MemFlagsData::trusted(), slot_addr, 0);
+                    let table_index = lookup_const_i64(&constants, op.arg(0).to_opref())
+                        .expect("LoadFromGcTable index is ConstInt")
+                        as u32;
+                    record_gc_table_var(vi, table_index);
+                    let value = emit_load_gc_table_slot(&mut builder, ptr_type, table_index);
                     builder.def_var(var(vi), value);
                 }
 
@@ -20337,12 +20387,7 @@ mod tests {
 
     /// gcreftracer.py gcrefs_trace: a later `assemble_bridge` must read the
     /// forwarded reference constant, just as the already compiled owner does.
-    ///
-    /// Still ignored: after a nursery collect the owner's slot forwards, but
-    /// `compile_bridge` then leaves `slot(0) == 0`. That is not the old
-    /// process-global pending-list steal (tables now live on the MiniMark).
     #[test]
-    #[ignore = "compile_bridge zeroes the forwarded owner slot; not pending-list steal"]
     fn owner_preserves_reference_constant_after_collection() {
         let mut gc = MiniMarkGC::with_config(GcConfig {
             nursery_size: 65536,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16120,9 +16120,12 @@ impl CraneliftBackend {
         table: Arc<majit_gc::GcTable>,
     ) {
         if let Some(clt) = token.compiled_loop_token() {
-            let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = table.clone();
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
+        // `gcreftracer.py` `llop.gc_writebarrier(tr)`: the table enters
+        // this MiniMark's remembered set for one minor.
+        let _ = with_cranelift_gc(|gc| gc.remember_gc_table(&table));
     }
 }
 
@@ -20332,16 +20335,15 @@ mod tests {
         assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xB12D_6001);
     }
 
-    /// gcreftracer.py gcrefs_trace: re-emission must read the forwarded
-    /// reference constant, just as the already compiled owner does.
+    /// gcreftracer.py gcrefs_trace: a later `assemble_bridge` must read the
+    /// forwarded reference constant, just as the already compiled owner does.
     ///
-    /// Parallel MiniMarks share `PENDING_MINOR_TABLES` and the published
-    /// nursery window, so a sibling collection can leave this table's
-    /// slot unmoved. Run serially:
-    /// `cargo test -p majit-backend-cranelift merged_owner_preserves -- --ignored --test-threads=1`
+    /// Still ignored: after a nursery collect the owner's slot forwards, but
+    /// `compile_bridge` then leaves `slot(0) == 0`. That is not the old
+    /// process-global pending-list steal (tables now live on the MiniMark).
     #[test]
-    #[ignore = "needs an exclusive MiniMark; sibling collections steal the pending-table list"]
-    fn merged_owner_preserves_reference_constant_after_collection() {
+    #[ignore = "compile_bridge zeroes the forwarded owner slot; not pending-list steal"]
+    fn owner_preserves_reference_constant_after_collection() {
         let mut gc = MiniMarkGC::with_config(GcConfig {
             nursery_size: 65536,
             large_object_threshold: 1024,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1876,9 +1876,12 @@ impl DynasmBackend {
         table: Arc<majit_gc::GcTable>,
     ) {
         if let Some(clt) = token.compiled_loop_token() {
-            let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = table.clone();
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
+        // `gcreftracer.py` `llop.gc_writebarrier(tr)`: the table enters
+        // this MiniMark's remembered set for one minor.
+        let _ = with_dynasm_active_gc_mut(|gc| gc.remember_gc_table(&table));
     }
 
     // `set_constants_pool`, `set_next_trace_id`, and `set_next_header_pc`

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2762,7 +2762,7 @@ impl WasmBackend {
 
     fn register_gc_table(token: &JitCellToken, table: Arc<majit_gc::GcTable>) {
         if let Some(clt) = token.compiled_loop_token() {
-            let tracer: Arc<dyn std::any::Any + Send + Sync> = table;
+            let tracer: Arc<dyn std::any::Any + Send + Sync> = table.clone();
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
     }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2765,6 +2765,9 @@ impl WasmBackend {
             let tracer: Arc<dyn std::any::Any + Send + Sync> = table.clone();
             clt.asmmemmgr_gcreftracers.lock().push(tracer);
         }
+        // `gcreftracer.py` `llop.gc_writebarrier(tr)`: the table enters
+        // this MiniMark's remembered set for one minor.
+        let _ = with_wasm_active_gc_mut(|gc| gc.remember_gc_table(&table));
     }
 
     /// Validate that every constant OpRef appearing as an arg is resolvable.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -10,6 +10,7 @@ use majit_ir::GcRef;
 use parking_lot::RwLock;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
 /// Monotonic source for the durations the collector reports to its hooks.
 ///
 /// `wasm32-unknown-unknown` has no clock: `Instant::now` panics with "time not
@@ -951,6 +952,12 @@ pub struct MiniMarkGC {
     /// temporary mistake; the next minor collection removes it again, in
     /// [`Self::remove_young_arrays_from_old_objects_pointing_to_young`].
     old_objects_pointing_to_young: Vec<usize>,
+    /// `gcreftracer.py` `llop.gc_writebarrier(tr)` analogue. A `GCREFTRACER`
+    /// is an ordinary old object upstream, so writing its slots puts *that*
+    /// MiniMark's `old_objects_pointing_to_young` on the hook for one minor.
+    /// pyre's tables are Rust-owned, so the same remembered-set entry lives
+    /// here instead of a process-global list.
+    pending_gc_tables: Vec<Weak<crate::GcTable>>,
     /// incminimark.py:355 `prebuilt_root_objects = AddressStack()`.
     /// Immortal objects enter exactly once, when their first pointer write
     /// clears NO_HEAP_PTRS in the write barrier.
@@ -1293,6 +1300,7 @@ impl MiniMarkGC {
             jitframe_type_id: None,
             roots: RootSet::new(),
             old_objects_pointing_to_young: Vec::new(),
+            pending_gc_tables: Vec::new(),
             prebuilt_root_objects: Vec::new(),
             root_snapshot_capacity: std::cell::Cell::new(0),
             totalroots_rpy: 0,
@@ -3453,6 +3461,10 @@ impl MiniMarkGC {
         if !self.probably_young_objects_with_finalizers.is_empty() {
             self.deal_with_young_objects_with_finalizers();
         }
+
+        // GCREFTRACER write-barrier analogue: tables remembered on *this*
+        // MiniMark, consumed once like `old_objects_pointing_to_young`.
+        self.collect_pending_gc_tables_to_nursery();
 
         // incminimark.py:1843-1862: while True loop —
         // collect_cardrefs_to_nursery, then collect_oldrefs_to_nursery.
@@ -8150,6 +8162,20 @@ impl MiniMarkGC {
     /// append the object to the remembered set (`old_objects_pointing_to_young`)
     /// and clear GCFLAG_TRACK_YOUNG_PTRS. Callers have already verified the flag
     /// (the inline COND_CALL_GC_WB test, or `do_write_barrier`).
+    /// `gcreftracer.py` `llop.gc_writebarrier(tr)`.
+    pub fn remember_gc_table(&mut self, table: &Arc<crate::GcTable>) {
+        self.pending_gc_tables.push(Arc::downgrade(table));
+    }
+
+    /// Drain this MiniMark's table remembered set. Same consume as
+    /// `collect_oldrefs_to_nursery` on `old_objects_pointing_to_young`.
+    fn collect_pending_gc_tables_to_nursery(&mut self) {
+        let pending = std::mem::take(&mut self.pending_gc_tables);
+        for table in pending.into_iter().filter_map(|w| w.upgrade()) {
+            table.trace(&mut |r| self.drag_out_root(r));
+        }
+    }
+
     fn remember_young_pointer(&mut self, obj: GcRef) {
         // incminimark.py does not special-case STATE_SWEEPING in its barrier.
         // After the seam, every retained entry names a VISITED survivor. A new
@@ -8828,6 +8854,10 @@ impl Default for MiniMarkGC {
 }
 
 impl GcAllocator for MiniMarkGC {
+    fn remember_gc_table(&mut self, table: &Arc<crate::GcTable>) {
+        MiniMarkGC::remember_gc_table(self, table);
+    }
+
     fn writebarrier_before_move(&mut self, obj: GcRef) {
         MiniMarkGC::writebarrier_before_move(self, obj.0);
     }

--- a/majit/majit-gc/src/gcreftracer.rs
+++ b/majit/majit-gc/src/gcreftracer.rs
@@ -116,17 +116,6 @@ static LIVE_GC_TABLES: RwLock<Vec<Weak<GcTable>>> = RwLock::new(Vec::new());
 #[cfg(test)]
 static GC_TABLE_WALK_LOCK: RwLock<()> = RwLock::new(());
 
-/// Tables built since the last minor collection. `GCREFTRACER` is an
-/// ordinary old object upstream: writing its slots at construction puts it
-/// on that MiniMark's `old_objects_pointing_to_young` for exactly one
-/// minor, which promotes every referent it holds; later minors skip it
-/// because the slots are never written again. A major marks through every
-/// live tracer. This list is that remembered set, but process-global —
-/// it belongs on the collector. [`walk_all_gc_tables_inner`] drains it on
-/// a minor walk and walks the whole registry on a major one.
-static PENDING_MINOR_TABLES: parking_lot::Mutex<Vec<Weak<GcTable>>> =
-    parking_lot::Mutex::new(Vec::new());
-
 impl GcTable {
     /// Build a per-loop table from the rewrite's gcref output list and
     /// register it for GC forwarding.
@@ -183,7 +172,6 @@ impl GcTable {
     fn register(table: GcTable) -> Arc<GcTable> {
         let table = Arc::new(table);
         register_table(&table);
-        PENDING_MINOR_TABLES.lock().push(Arc::downgrade(&table));
         table
     }
 
@@ -265,23 +253,11 @@ fn walk_all_gc_tables(visitor: &mut dyn FnMut(&mut GcRef)) {
 /// already holds the write side observes the registry without re-entering
 /// the lock.
 fn walk_all_gc_tables_inner(visitor: &mut dyn FnMut(&mut GcRef)) {
-    // A minor collection reaches only the tables the remembered set names
-    // (see `PENDING_MINOR_TABLES`); every other live table already holds
-    // promoted referents, which a minor collection does not move.
+    // A minor reaches only the tables that MiniMark remembered
+    // (`pending_gc_tables`, the `old_objects_pointing_to_young` analogue).
+    // That drain lives on the collecting MiniMark, not here.
     if crate::shadow_stack::extra_root_walk_kind() == crate::shadow_stack::ExtraRootWalkKind::Minor
     {
-        // Remembered-set drain, same as MiniMark's
-        // `old_objects_pointing_to_young`: this minor consumes the tables
-        // that recorded a young store since the last one. A later write
-        // re-registers. `take` is that consume — there is no test/prod
-        // split. Parallel MiniMarks sharing this process-global list is a
-        // harness isolation defect (the list belongs on the collector);
-        // cloning it would leave the set undrained and let two visitors
-        // `trace` the same unsynchronized slots.
-        let pending = std::mem::take(&mut *PENDING_MINOR_TABLES.lock());
-        for table in pending.iter().filter_map(Weak::upgrade) {
-            table.trace(visitor);
-        }
         return;
     }
     // Snapshot the live tables under a read guard, then release the lock
@@ -409,5 +385,36 @@ mod tests {
         }
         // The Arc dropped; the registry's Weak no longer upgrades.
         assert_eq!(count_sentinels(), 0, "freed table must not be walked");
+    }
+
+    #[test]
+    fn pending_gc_tables_stay_on_the_remembering_minimark() {
+        let mut owner = crate::collector::MiniMarkGC::with_config(crate::collector::GcConfig {
+            nursery_size: 65536,
+            large_object_threshold: 1024,
+            ..crate::collector::GcConfig::default()
+        });
+        let type_id = owner.register_type(crate::TypeInfo::simple(16));
+        let root = owner.alloc_with_type(type_id, 16);
+        unsafe { *(root.0 as *mut u64) = 0xA11C_E700 };
+        let table = GcTable::from_gcrefs(&[root]);
+        owner.remember_gc_table(&table);
+
+        let mut sibling = crate::collector::MiniMarkGC::with_config(crate::collector::GcConfig {
+            nursery_size: 65536,
+            large_object_threshold: 1024,
+            ..crate::collector::GcConfig::default()
+        });
+        sibling.do_collect_nursery();
+        assert_eq!(
+            table.slot(0),
+            root,
+            "a sibling MiniMark must not drain this collector's table"
+        );
+
+        owner.do_collect_nursery();
+        let moved = table.slot(0);
+        assert_ne!(moved, root, "the owning MiniMark forwards the slot");
+        assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xA11C_E700);
     }
 }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1121,6 +1121,10 @@ pub trait GcAllocator: Send {
         self.write_barrier(obj);
     }
 
+    /// `gcreftracer.py` `llop.gc_writebarrier(tr)`: a newly written table
+    /// enters this collector's remembered set for one minor.
+    fn remember_gc_table(&mut self, _table: &std::sync::Arc<crate::GcTable>) {}
+
     /// Whether the GC supports optimized conditional write barriers.
     ///
     /// When true, the JIT emits COND_CALL_GC_WB (inline flag test +
@@ -1477,6 +1481,10 @@ pub struct GcHandle;
 unsafe impl Send for GcHandle {}
 
 impl GcAllocator for GcHandle {
+    fn remember_gc_table(&mut self, table: &std::sync::Arc<crate::GcTable>) {
+        gc_sync::gc_op(|gc| gc.remember_gc_table(table));
+    }
+
     fn alloc_nursery(&mut self, size: usize) -> GcRef {
         gc_sync::gc_op(|gc| gc.alloc_nursery(size))
     }

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -211,25 +211,6 @@ pub fn serialize_optimizer_knowledge(
         let result_tag = tag_box(result, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(result_tag as i32);
     }
-
-    // Trailing int-bound section. Pyre's bridge does not retrace the
-    // loop COMPARE the way PyPy does; the bound the loop already
-    // proved on each integer failarg rides here. Empty when nothing
-    // was proved. Older rd_numb without this section is still read:
-    // deserialize treats EOF as no bounds.
-    let filtered_bounds: Vec<(OpRef, i64, i64)> = knowledge
-        .int_bounds
-        .iter()
-        .copied()
-        .filter(|&(op, _, _)| env.is_const(op) || available_boxes.contains(&op))
-        .collect();
-    numb_state.append_int(filtered_bounds.len() as i64);
-    for (op, lower, upper) in &filtered_bounds {
-        let op_tag = tag_box(*op, &numb_state.liveboxes, memo, env, new_liveboxes)?;
-        numb_state.writer.append_short(op_tag as i32);
-        numb_state.append_int(*lower);
-        numb_state.append_int(*upper);
-    }
     Ok(())
 }
 
@@ -381,22 +362,6 @@ pub fn deserialize_optimizer_knowledge(
     // bridgeopt.py:184-185: optimizer.optrewrite.deserialize_optrewrite(...)
     if !result_loopinvariant.is_empty() {
         optimizer.import_loopinvariant_knowledge(&result_loopinvariant);
-    }
-
-    // Optional trailing section: older rd_numb stops after loopinvariant.
-    if reader.has_more() {
-        let length = reader.next_item();
-        for _ in 0..length {
-            let tagged = reader.next_item() as i16;
-            let box1 = decode_box(tagged, rd_consts, liveboxes);
-            let lower = reader.next_item() as i64;
-            let upper = reader.next_item() as i64;
-            let opref = decoded_box_to_opref(&box1, ctx);
-            if let Some(arg_box) = ctx.get_box_replacement_operand_opt(opref) {
-                let imported = majit_ir::intbound::IntBound::new(lower, upper, 0, u64::MAX);
-                let _ = ctx.with_intbound_mut(&arg_box, |bm| bm.intersect(&imported));
-            }
-        }
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5754,35 +5754,10 @@ impl Optimizer {
         // directly at serialization time in resume.rs via env.has_known_class(),
         // matching RPython's per-livebox getptrinfo(box).get_known_class(cpu).
 
-        // Pyre-only trailing resume section. PyPy's bridge retraces from
-        // the loop COMPARE and re-proves the bound; pyre's resume starts
-        // after that compare, so the bound the loop already has on each
-        // integer failarg has to travel with the guard.
-        let mut int_bounds = Vec::new();
-        for &arg in failargs {
-            if arg.is_none() || arg.is_constant() {
-                continue;
-            }
-            let Some(arg_box) = ctx.get_box_replacement_operand_opt(arg) else {
-                continue;
-            };
-            if !matches!(ctx.opref_type(arg_box.to_opref()), Some(Type::Int)) {
-                continue;
-            }
-            let Some(bound) = ctx.peek_intbound_box(&arg_box) else {
-                continue;
-            };
-            if bound.is_unbounded() {
-                continue;
-            }
-            int_bounds.push((arg_box.to_opref(), bound.lower, bound.upper));
-        }
-
         crate::resume::OptimizerKnowledgeForResume {
             heap_fields,
             heap_arrayitems,
             loopinvariant_results,
-            int_bounds,
         }
     }
 

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -4906,12 +4906,6 @@ pub struct OptimizerKnowledgeForResume {
     pub heap_arrayitems: Vec<(majit_ir::OpRef, i64, i32, majit_ir::OpRef)>,
     /// (const_func_ptr, result_opref) loop-invariant call results.
     pub loopinvariant_results: Vec<(i64, majit_ir::OpRef)>,
-    /// Integer failarg bounds the loop already proved. PyPy's bridge
-    /// retraces from the loop COMPARE and re-establishes them via
-    /// `IntLt`; pyre's resume starts after that compare, so the bound
-    /// has to ride with the guard. Optional trailing section: readers
-    /// treat EOF as empty.
-    pub int_bounds: Vec<(majit_ir::OpRef, i64, i64)>,
 }
 
 impl OptimizerKnowledgeForResume {
@@ -4919,7 +4913,6 @@ impl OptimizerKnowledgeForResume {
         self.heap_fields.is_empty()
             && self.heap_arrayitems.is_empty()
             && self.loopinvariant_results.is_empty()
-            && self.int_bounds.is_empty()
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7458,8 +7458,11 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     // `typedef::type` falls back to the kind registry when `w_class` is
     // still the generic BaseException stub (`w_exception_new` internals).
     // The match walked that registry class; pin the kind field so a
-    // different ExcKind cannot reuse this fold. A GuardValue on `w_class`
-    // would pin the stub and fail at runtime.
+    // different ExcKind cannot reuse this fold. A GuardValue on the
+    // registry class would pin a pointer the slot does not hold and fail
+    // at runtime. Pin the stub itself as well: a user subclass of the
+    // same kind (`class MyError(ValueError)`) shares `ob_type` and
+    // `ExcKind` but not `w_class`.
     let pin_kind_instead_of_w_class = !std::ptr::eq(unsafe { (*exc).w_class }, exc_class);
     // `eval::check_exc_match_against` = `exception_match(type(exc), match)`
     // (eval.rs), walking the exception class MRO and accepting a tuple of
@@ -7527,6 +7530,7 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
             ctx.trace_ctx
                 .heap_cache_mut()
                 .replace_box(kind_op, expected);
+            walker_guard_exact_w_class(ctx, op_pc, exc_op, unsafe { (*exc).w_class })?;
         } else {
             let w_class_op =
                 walker_record_getfield_gc_r_uncached(ctx, exc_op, crate::descr::w_class_descr());


### PR DESCRIPTION
## Summary

Follow-up to #1725. Four commits:

- `GcTable` remembered-set entries go on the collecting MiniMark (`gcreftracer.py` `llop.gc_writebarrier`), not a process-global list. Minor drain is `pending_gc_tables` next to `old_objects_pointing_to_young`.
- Resume no longer carries a trailing IntBound section. `bridgeopt.py` only serializes class, heap, and loopinvariant knowledge. `append_int` is i16 and cannot hold `IntBound::nonnegative()`. Loop JUMP still exports bounds via `export_arg_int_bounds`.
- Stub-backed `except` folds pin `w_class` as the stub as well as `ExcKind`, so a user subclass of the same kind cannot reuse the recorded match.
- Cranelift rematerializes `LoadFromGcTable` at failargs after LABEL (`rewrite.py` drops `gcrefs_recently_loaded` there). A preamble table load is not a LABEL arg; `use_var` of that SSA value was reading a dead register.

PyPy re-proves integer bounds on a bridge by inlining the short preamble's COMPARE+GUARD (`unroll.py` `inline_short_preamble` → `send_extra_operation` → `postprocess_GUARD_TRUE` → `propagate_bounds_backward`). That path is already in `unroll.rs` / `intbounds.rs`. This PR only removes the resume-data shortcut that sat next to it.

## Self-review

AI-assisted. COMPARE retrace was checked against `unroll.py` `optimize_bridge` / `inline_short_preamble` and `intbounds.py` `_postprocess_guard_true_false_value`; no new retrace pass was added because that wiring is already present.

Cranelift `compiler::tests`: 151 passed. `gcreftracer` unit tests: 4 passed. `majit-metainterp` typechecks with `--features dynasm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage collection reliability for tables referenced by compiled code, including across minor collections and loop transitions.
  - Fixed rematerialization of garbage-collected table values when resuming compiled execution.
  - Improved exception specialization for user-defined exception subclasses.

- **Performance**
  - Streamlined optimizer resume data by removing persisted integer-bound information that is no longer retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->