### PR TITLE
gc: pin minted objects across later allocations

### DIFF
--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -187,23 +187,28 @@ fn structseq_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let cls = unsafe { (*inst).w_class };
     // `tuple(self)` — the positional body as a plain tuple.
     let n = unsafe { pyre_object::w_tuple_len(inst) };
-    let mut items: Vec<PyObjectRef> = Vec::with_capacity(n);
+    let mut items = pyre_object::gc_roots::RootedItems::new();
     for i in 0..n {
         items.push(
             unsafe { pyre_object::w_tuple_getitem(inst, i as i64) }
                 .unwrap_or_else(pyre_object::w_none),
         );
     }
-    let body_tuple = pyre_object::w_tuple_new(items);
+    let body_tuple = pyre_object::w_tuple_new(items.take());
     // `self.__dict__` carries the named-only extras for reconstruction.
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(body_tuple);
     let w_dict = crate::baseobjspace::getdict_native(inst);
-    let dict = if w_dict.is_null() {
+    fields.push(if w_dict.is_null() {
         pyre_object::w_dict_new()
     } else {
         w_dict
-    };
-    let inner = pyre_object::w_tuple_new(vec![body_tuple, dict]);
-    Ok(pyre_object::w_tuple_new(vec![cls, inner]))
+    });
+    let inner = pyre_object::w_tuple_new(fields.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(cls);
+    result.push(inner);
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 /// CPython 3.14 `structseq___replace__` — copy the positional body and

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3278,17 +3278,24 @@ pub(crate) fn dict_view_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         if reverse {
             entries.reverse();
         }
-        let mut items = Vec::new();
+        let mut items = pyre_object::gc_roots::RootedItems::new();
         for (k, v) in entries.into_iter().skip(index) {
-            let item = match kind {
-                pyre_object::dictmultiobject::DictViewKind::Keys => k,
-                pyre_object::dictmultiobject::DictViewKind::Values => v,
-                pyre_object::dictmultiobject::DictViewKind::Items => w_tuple_new(vec![k, v]),
-            };
-            items.push(item);
+            match kind {
+                pyre_object::dictmultiobject::DictViewKind::Keys => items.push(k),
+                pyre_object::dictmultiobject::DictViewKind::Values => items.push(v),
+                pyre_object::dictmultiobject::DictViewKind::Items => {
+                    items.push(w_tuple_new(vec![k, v]))
+                }
+            }
         }
-        let state = w_tuple_new(vec![w_list_new(items)]);
-        Ok(w_tuple_new(vec![builtin_callable("iter"), state]))
+        let list = w_list_new(items.take());
+        let mut state = pyre_object::gc_roots::RootedItems::new();
+        state.push(list);
+        let state = w_tuple_new(state.take());
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(builtin_callable("iter"));
+        result.push(state);
+        Ok(w_tuple_new(result.take()))
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8102,11 +8102,13 @@ fn base_exception_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
         .unwrap_or_else(|| crate::baseobjspace::exception_getclass(w_self));
     let w_args = unsafe { pyre_object::interp_exceptions::w_exception_get_args(w_self) };
     let w_dict = unsafe { pyre_object::interp_exceptions::w_exception_peek_dict(w_self) };
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(cls);
+    result.push(w_args);
     if !w_dict.is_null() && unsafe { pyre_object::w_dict_len(w_dict) } > 0 {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_args, w_dict]))
-    } else {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_args]))
+        result.push(w_dict);
     }
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 /// `BaseException_setstate` / `ImportError_setstate` reject a non-dict state
@@ -8305,11 +8307,13 @@ fn import_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let cls = pyre_object::gc_roots::shadow_stack_get(base + 1);
     let w_args = pyre_object::gc_roots::shadow_stack_get(base + 2);
     let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(cls);
+    result.push(w_args);
     if unsafe { pyre_object::w_dict_len(w_dict) } > 0 {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_args, w_dict]))
-    } else {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_args]))
+        result.push(w_dict);
     }
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 /// `interp_exceptions.py W_ImportError.descr_setstate` plus
@@ -8396,11 +8400,13 @@ fn os_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
     let w_full_args = pyre_object::w_tuple_new(items);
     let w_dict = unsafe { interp_exceptions::w_exception_peek_dict(w_self) };
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(cls);
+    result.push(w_full_args);
     if !w_dict.is_null() && unsafe { pyre_object::w_dict_len(w_dict) } > 0 {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_full_args, w_dict]))
-    } else {
-        Ok(pyre_object::w_tuple_new(vec![cls, w_full_args]))
+        result.push(w_dict);
     }
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 /// `ImportError.__init__` — consume the `name` / `path` / `name_from`

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1293,11 +1293,16 @@ pub unsafe fn descr_builtin_function_reduce(obj: PyObjectRef) -> crate::PyResult
         && !unsafe { pyre_object::is_none(w_self) }
         && !unsafe { pyre_object::is_module(w_self) }
     {
-        let name = pyre_object::w_str_new(unsafe { crate::function_get_name(obj) });
-        return Ok(pyre_object::w_tuple_new(vec![
-            crate::baseobjspace::builtin_callable("getattr"),
-            pyre_object::w_tuple_new(vec![w_self, name]),
-        ]));
+        let mut args = pyre_object::gc_roots::RootedItems::new();
+        args.push(w_self);
+        args.push(pyre_object::w_str_new(unsafe {
+            crate::function_get_name(obj)
+        }));
+        let args = pyre_object::w_tuple_new(args.take());
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(crate::baseobjspace::builtin_callable("getattr"));
+        result.push(args);
+        return Ok(pyre_object::w_tuple_new(result.take()));
     }
     Ok(pyre_object::w_str_from_wtf8(unsafe {
         function_get_qualname(obj)
@@ -3588,10 +3593,14 @@ pub unsafe fn descr_method__reduce__(obj: PyObjectRef) -> Result<PyObjectRef, cr
     let function = unsafe { pyre_object::w_method_get_func(obj) };
     let instance = unsafe { pyre_object::w_method_get_self(obj) };
     let name = crate::baseobjspace::getattr_str(function, "__name__")?;
-    Ok(pyre_object::w_tuple_new(vec![
-        crate::baseobjspace::builtin_callable("getattr"),
-        pyre_object::w_tuple_new(vec![instance, name]),
-    ]))
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(instance);
+    args.push(name);
+    let args = pyre_object::w_tuple_new(args.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(crate::baseobjspace::builtin_callable("getattr"));
+    result.push(args);
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -977,27 +977,33 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
             // one liveness pin covers it to the end of the call.
             let roots = pyre_object::gc_roots::push_roots();
             let first = roots.pin_root(first);
-            let rest = parts
-                .into_iter()
-                .map(|part| match part {
-                    FieldNamePart::Attribute(s) => pyre_object::w_tuple_new(vec![
-                        pyre_object::w_bool_from(true),
-                        pyre_object::w_str_from_wtf8(s),
-                    ]),
-                    FieldNamePart::Index(n) => pyre_object::w_tuple_new(vec![
-                        pyre_object::w_bool_from(false),
-                        pyre_object::w_int_new(n as i64),
-                    ]),
-                    FieldNamePart::StringIndex(s) => pyre_object::w_tuple_new(vec![
-                        pyre_object::w_bool_from(false),
-                        pyre_object::w_str_from_wtf8(s),
-                    ]),
-                })
-                .collect();
-            Ok(pyre_object::w_tuple_new(vec![
-                first,
-                pyre_object::w_list_new(rest),
-            ]))
+            let mut rest = pyre_object::gc_roots::RootedItems::new();
+            for part in parts {
+                let entry = {
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    match part {
+                        FieldNamePart::Attribute(s) => {
+                            fields.push(pyre_object::w_bool_from(true));
+                            fields.push(pyre_object::w_str_from_wtf8(s));
+                        }
+                        FieldNamePart::Index(n) => {
+                            fields.push(pyre_object::w_bool_from(false));
+                            fields.push(pyre_object::w_int_new(n as i64));
+                        }
+                        FieldNamePart::StringIndex(s) => {
+                            fields.push(pyre_object::w_bool_from(false));
+                            fields.push(pyre_object::w_str_from_wtf8(s));
+                        }
+                    }
+                    pyre_object::w_tuple_new(fields.take())
+                };
+                rest.push(entry);
+            }
+            let rest_list = pyre_object::w_list_new(rest.take());
+            let mut result = pyre_object::gc_roots::RootedItems::new();
+            result.push(first);
+            result.push(rest_list);
+            Ok(pyre_object::w_tuple_new(result.take()))
         }),
     );
     Ok(())

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1550,10 +1550,10 @@ fn init_tracemalloc(ns: PyObjectRef) -> Result<(), crate::PyError> {
         ns,
         "get_traced_memory",
         crate::make_builtin_function("get_traced_memory", |_| {
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(0),
-                pyre_object::w_int_new(0),
-            ]))
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_int_new(0));
+            fields.push(pyre_object::w_int_new(0));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }),
     );
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cerrno.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cerrno.rs
@@ -74,7 +74,7 @@ pub fn getwinerror(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let message = crate::PyError::win32_strerror(code);
     // `w_tuple_new` allocates, so the message needs a root of its own rather
     // than only the Rust local.
-    let _ = roots.pin_root(pyre_object::w_str_new(&message));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&message));
     Ok(pyre_object::w_tuple_new(vec![
         roots.get(code_slot),
         roots.get(code_slot + 1),

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypestruct.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypestruct.rs
@@ -437,7 +437,10 @@ pub fn fget_fields(ct: &W_CType) -> Result<PyObjectRef, PyError> {
     }
     for (name, w_field) in fields_dict_items(ct)? {
         if let Some(i) = fields.iter().position(|&f| f == w_field) {
-            let w_pair = pyre_object::w_tuple_new(vec![pyre_object::w_str_new(&name), w_field]);
+            let mut pair = pyre_object::gc_roots::RootedItems::new();
+            pair.push(pyre_object::w_str_new_managed(&name));
+            pair.push(w_field);
+            let w_pair = pyre_object::w_tuple_new(pair.take());
             roots.set(base + i, w_pair);
         }
     }

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -191,8 +191,32 @@ fn codec_error_arg(args: &[PyObjectRef]) -> Result<CodecException, crate::PyErro
         .and_then(check_exception)
 }
 
+/// Pins each result field as it is produced. An array literal would mint
+/// every field first, so a later allocation could sweep an earlier
+/// collectable string or bytes object.
+struct RootedTuple {
+    items: gc_roots::RootedItems,
+}
+
+fn rooted_tuple() -> RootedTuple {
+    RootedTuple {
+        items: gc_roots::RootedItems::new(),
+    }
+}
+
+impl RootedTuple {
+    fn arg(mut self, item: PyObjectRef) -> Self {
+        self.items.push(item);
+        self
+    }
+
+    fn finish(self) -> PyObjectRef {
+        w_tuple_new(self.items.take())
+    }
+}
+
 fn codec_result(replacement: PyObjectRef, position: PyObjectRef) -> PyObjectRef {
-    w_tuple_new(vec![replacement, position])
+    rooted_tuple().arg(replacement).arg(position).finish()
 }
 
 fn strict_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -965,10 +989,10 @@ fn encode_with_name(
         encode_method,
         &[w_str_new(encoding), w_str_new(&errors)],
     )?;
-    Ok(w_tuple_new(vec![
-        encoded,
-        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(encoded)
+        .arg(w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64))
+        .finish())
 }
 
 fn decode_with_name(
@@ -993,7 +1017,10 @@ fn decode_with_name(
         decode_method,
         &[w_str_new(encoding), w_str_new(&errors)],
     )?;
-    Ok(w_tuple_new(vec![decoded, w_int_new(consumed as i64)]))
+    Ok(rooted_tuple()
+        .arg(decoded)
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 /// `bufferstr_w`: the read-only bytes of a decoder input.
@@ -1047,11 +1074,11 @@ fn utf16_32_ex_decode_impl(
         &errors,
         crate::baseobjspace::is_true(w_final)?,
     )?;
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(decoded),
-        w_int_new(consumed as i64),
-        w_int_new(bo as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(decoded))
+        .arg(w_int_new(consumed as i64))
+        .arg(w_int_new(bo as i64))
+        .finish())
 }
 
 /// PyPy `make_decoder_wrapper` for the two-value UTF-16/32 decoder entry
@@ -1076,10 +1103,10 @@ fn utf16_32_decode_impl(
         &errors,
         crate::baseobjspace::is_true(w_final)?,
     )?;
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(decoded),
-        w_int_new(consumed as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(decoded))
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 /// PyPy `interp_codecs.utf_8_decode`, including its incremental consumed
@@ -1101,10 +1128,10 @@ fn utf8_decode_impl(
         crate::baseobjspace::is_true(w_final)?,
         errors == "surrogatepass",
     )?;
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(decoded),
-        w_int_new(consumed as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(decoded))
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 /// `charmapencode_lookup` — map one code point through the encoding table and
@@ -1284,10 +1311,10 @@ fn charmap_encode_impl(
     // Pinned because minting the bytes below can collect and move it.
     let _ = pyre_object::gc_roots::pin_root(w_int_new(char_count as i64));
     let w_encoded = w_bytes_from_bytes(&out);
-    Ok(w_tuple_new(vec![
-        w_encoded,
-        pyre_object::gc_roots::shadow_stack_get(sp + 2),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_encoded)
+        .arg(pyre_object::gc_roots::shadow_stack_get(sp + 2))
+        .finish())
 }
 
 /// `charmapdecode_lookup` — read one byte's entry out of a decoding table.
@@ -1439,10 +1466,10 @@ fn charmap_decode_impl(
             }
         }
     }
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(out),
-        w_int_new(orig_len as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(out))
+        .arg(w_int_new(orig_len as i64))
+        .finish())
 }
 
 fn utf7_is_base64(b: u8) -> bool {
@@ -1571,10 +1598,10 @@ fn utf7_encode_impl(
     if in_shift {
         out.push(b'-');
     }
-    Ok(w_tuple_new(vec![
-        w_bytes_from_bytes(&out),
-        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_bytes_from_bytes(&out))
+        .arg(w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64))
+        .finish())
 }
 
 /// Route a utf-7 decode error through the requested handler, shaped like
@@ -1782,10 +1809,10 @@ fn utf7_decode_impl(
         consumed = startinpos;
         out.truncate(shift_out_start);
     }
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(out),
-        w_int_new(consumed as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(out))
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 fn push_ascii_hex_escape(out: &mut Vec<u8>, prefix: u8, cp: u32, digits: usize) {
@@ -1818,10 +1845,10 @@ fn unicode_escape_encode_impl(
             c => push_ascii_hex_escape(&mut out, b'U', c, 8),
         }
     }
-    Ok(w_tuple_new(vec![
-        w_bytes_from_bytes(&out),
-        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_bytes_from_bytes(&out))
+        .arg(w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64))
+        .finish())
 }
 
 fn unicode_escape_error(
@@ -2137,10 +2164,10 @@ fn unicode_escape_decode_impl(
     if let Some(message) = first_escape_warning {
         crate::warn::warn_deprecation(&message)?;
     }
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(out),
-        w_int_new(pos as i64 + pos_delta),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(out))
+        .arg(w_int_new(pos as i64 + pos_delta))
+        .finish())
 }
 
 /// `unicode_escape_decode`'s raw counterpart: only `\uXXXX` and
@@ -2155,10 +2182,10 @@ fn raw_unicode_escape_decode_impl(
     let errors_s = codec_errors_arg("raw_unicode_escape_decode", 2, errors)?;
     let (out, consumed) =
         crate::type_methods::decode_raw_unicode_escape_stateful(&data, &errors_s, final_)?;
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(out),
-        w_int_new(consumed as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(out))
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 /// `interp_codecs.py escape_decode` / `_PyString_DecodeEscape` — the
@@ -2272,10 +2299,10 @@ fn escape_decode_impl(
     if let Some(message) = first_escape_warning {
         crate::warn::warn_deprecation(&message)?;
     }
-    Ok(w_tuple_new(vec![
-        w_bytes_from_bytes(&out),
-        w_int_new(data.len() as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_bytes_from_bytes(&out))
+        .arg(w_int_new(data.len() as i64))
+        .finish())
 }
 
 /// `interp_codecs.py escape_encode` / `string_escape_encode(data,
@@ -2301,10 +2328,10 @@ fn escape_encode_impl(
             value => out.extend_from_slice(format!("\\x{value:02x}").as_bytes()),
         }
     }
-    Ok(w_tuple_new(vec![
-        w_bytes_from_bytes(&out),
-        w_int_new(data.len() as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_bytes_from_bytes(&out))
+        .arg(w_int_new(data.len() as i64))
+        .finish())
 }
 
 fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2369,10 +2396,10 @@ fn code_page_encode_impl(
     }
     let errors = code_page_errors(name, position + 1, w_errors)?;
     let bytes = crate::unicodehelper_win32::encode_code_page(code_page, w_str, &errors)?;
-    Ok(w_tuple_new(vec![
-        pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
-        w_int_new(unsafe { w_str_len(w_str) } as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
+        .arg(w_int_new(unsafe { w_str_len(w_str) } as i64))
+        .finish())
 }
 
 /// `_codecs.code_page_decode` - `(str, bytes consumed)`.
@@ -2393,10 +2420,10 @@ fn code_page_decode_impl(
     // `final` is the caller promising that no continuation is coming, so the
     // whole buffer reads as consumed: nothing is being held back for one.
     let consumed = if is_final { data.len() } else { consumed };
-    Ok(w_tuple_new(vec![
-        w_str_from_wtf8_managed(text),
-        w_int_new(consumed as i64),
-    ]))
+    Ok(rooted_tuple()
+        .arg(w_str_from_wtf8_managed(text))
+        .arg(w_int_new(consumed as i64))
+        .finish())
 }
 
 /// Strip the keyword marker these positional-only entry points cannot take.
@@ -2483,10 +2510,10 @@ crate::py_module! {
                 decode_input_bytes(data)?
             };
             let _errors = codec_errors_arg("readbuffer_encode", 2, errors)?;
-            Ok(w_tuple_new(vec![
-                pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
-                w_int_new(bytes.len() as i64),
-            ]))
+            Ok(rooted_tuple()
+                .arg(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
+                .arg(w_int_new(bytes.len() as i64))
+                .finish())
         }
         fn ascii_encode(
             obj: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -1251,13 +1251,27 @@ impl W_Deque {
         let args = if unsafe { is_none(m) } {
             w_tuple_new(vec![])
         } else {
-            w_tuple_new(vec![w_tuple_new(vec![]), m])
+            let empty = w_tuple_new(vec![]);
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(empty);
+            fields.push(m);
+            w_tuple_new(fields.take())
         };
+        let _roots = pyre_object::gc_roots::push_roots();
+        let args_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(args);
         let state = crate::reduce_protocol::object_getstate_default(self_obj)?;
+        let state_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(state);
         // interp_deque.py W_Deque.reduce calls `space.iter(self)`, preserving
         // subclass __iter__ overrides (including an override that raises).
         let items = crate::baseobjspace::iter(self_obj)?;
-        Ok(w_tuple_new(vec![ty, args, state, items]))
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(ty);
+        result.push(pyre_object::gc_roots::shadow_stack_get(args_slot));
+        result.push(pyre_object::gc_roots::shadow_stack_get(state_slot));
+        result.push(items);
+        Ok(w_tuple_new(result.take()))
     }
     fn __len__(&self) -> i64 {
         let self_obj = self as *const W_Deque as PyObjectRef;

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -417,7 +417,14 @@ pub mod deque_iter {
             let consumed = W_Deque::from_obj(self.deque)
                 .map(|deque| deque.len - self.counter)
                 .unwrap_or(0);
-            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+            let mut state = pyre_object::gc_roots::RootedItems::new();
+            state.push(self.deque);
+            state.push(w_int_new(consumed));
+            let state = w_tuple_new(state.take());
+            let mut result = pyre_object::gc_roots::RootedItems::new();
+            result.push(ty);
+            result.push(state);
+            w_tuple_new(result.take())
         }
     }
 
@@ -537,7 +544,14 @@ pub mod deque_rev_iter {
             let consumed = W_Deque::from_obj(self.deque)
                 .map(|deque| deque.len - self.counter)
                 .unwrap_or(0);
-            w_tuple_new(vec![ty, w_tuple_new(vec![self.deque, w_int_new(consumed)])])
+            let mut state = pyre_object::gc_roots::RootedItems::new();
+            state.push(self.deque);
+            state.push(w_int_new(consumed));
+            let state = w_tuple_new(state.take());
+            let mut result = pyre_object::gc_roots::RootedItems::new();
+            result.push(ty);
+            result.push(state);
+            w_tuple_new(result.take())
         }
     }
 

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -438,7 +438,7 @@ impl W_Hmac {
             .ok_or_else(|| unsupported_digestmod("unsupported hash type"))?;
         let _roots = gc_roots::push_roots();
         let name_slot = gc_roots::shadow_stack_len();
-        let _ = gc_roots::pin_root(w_str_new(&format!("hmac-{name}")));
+        let _ = gc_roots::pin_root(w_str_new_managed(&format!("hmac-{name}")));
         let obj = W_Hmac::allocate_stable(W_Hmac {
             ob: PyObject::default(),
             name: gc_roots::shadow_stack_get(name_slot),

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -616,10 +616,10 @@ impl W_TextIOWrapper {
         if cookie.start_pos == 0 && cookie.dec_flags == 0 {
             super::call_method_result(self.w_decoder, "reset", &[])?;
         } else {
-            let state = w_tuple_new(vec![
-                pyre_object::bytesobject::w_bytes_empty(),
-                w_int_new(cookie.dec_flags as i64),
-            ]);
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::bytesobject::w_bytes_empty());
+            fields.push(w_int_new(cookie.dec_flags as i64));
+            let state = w_tuple_new(fields.take());
             super::call_method_result(self.w_decoder, "setstate", &[state])?;
         }
         Ok(())

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -616,10 +616,10 @@ fn scanner_call_impl(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyR
         byte_index,
     )?;
     let _ = gc_roots::pin_root(value);
-    Ok(pyre_object::w_tuple_new(vec![
-        gc_roots::shadow_stack_get(slot + 3),
-        pyre_object::w_int_new(next as i64),
-    ]))
+    let mut fields = gc_roots::RootedItems::new();
+    fields.push(gc_roots::shadow_stack_get(slot + 3));
+    fields.push(pyre_object::w_int_new(next as i64));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 // CPython 3.14 Modules/_json.c:PyInit__json uses PyType_FromSpec;

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -199,10 +199,11 @@ fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
     let put_str = |k: &str, b: &[u8]| put(k, crate::typedef::charp2uni(b));
     let put_int = |k: &str, v: i64| put(k, pyre_object::w_int_new(v));
     let put_grouping = |k: &str, v: &[i64]| {
-        put(
-            k,
-            pyre_object::w_list_new(v.iter().map(|&x| pyre_object::w_int_new(x)).collect()),
-        )
+        let mut items = pyre_object::gc_roots::RootedItems::new();
+        for &x in v {
+            items.push(pyre_object::w_int_new(x));
+        }
+        put(k, pyre_object::w_list_new(items.take()))
     };
     put_str("decimal_point", &c.decimal_point);
     put_str("thousands_sep", &c.thousands_sep);
@@ -407,19 +408,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 };
                 let language = windows_default_locale_component(LOCALE_SISO639LANGNAME);
                 let territory = windows_default_locale_component(LOCALE_SISO3166CTRYNAME);
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
                 let locale = match (language, territory) {
                     (Some(language), Some(territory)) => {
                         pyre_object::w_str_new_managed(&format!("{language}_{territory}"))
                     }
                     _ => pyre_object::w_none(),
                 };
+                fields.push(locale);
                 // The active ANSI code page, spelled `cp<n>` whatever it is:
                 // code page 65001 answers `cp65001`, not `utf-8`.  Mapping it
                 // to a codec name is `locale.getdefaultlocale`'s job, not this
                 // hook's.
                 let codepage = active_acp();
-                let encoding = pyre_object::w_str_new_managed(&format!("cp{codepage}"));
-                Ok(pyre_object::w_tuple_new(vec![locale, encoding]))
+                fields.push(pyre_object::w_str_new_managed(&format!("cp{codepage}")));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             0,
         ),

--- a/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
@@ -388,10 +388,10 @@ fn raw_encode(args: &[PyObjectRef]) -> crate::PyResult {
     let errors = crate::baseobjspace::text_w(roots.get(base + 2))?.to_owned();
     let final_input = crate::baseobjspace::is_true(roots.get(base + 3))?;
     let (output, consumed) = encode_impl(&name, roots.get(base + 1), &errors, final_input)?;
-    Ok(w_tuple_new(vec![
-        pyre_object::bytesobject::w_bytes_from_bytes(&output),
-        w_int_new(consumed as i64),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&output));
+    fields.push(w_int_new(consumed as i64));
+    Ok(w_tuple_new(fields.take()))
 }
 
 fn codec_call_control(
@@ -437,10 +437,10 @@ fn raw_encode_stateful(args: &[PyObjectRef]) -> crate::PyResult {
         Some(&state),
         Some(w_state),
     )?;
-    Ok(w_tuple_new(vec![
-        pyre_object::bytesobject::w_bytes_from_bytes(&output),
-        w_int_new(consumed as i64),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&output));
+    fields.push(w_int_new(consumed as i64));
+    Ok(w_tuple_new(fields.take()))
 }
 
 fn raw_decode(args: &[PyObjectRef]) -> crate::PyResult {
@@ -451,10 +451,10 @@ fn raw_decode(args: &[PyObjectRef]) -> crate::PyResult {
     let input = codec_input_bytes(roots.get(base + 1))?;
     let final_input = crate::baseobjspace::is_true(roots.get(base + 3))?;
     let (output, consumed) = decode_impl(&name, &input, &errors, final_input)?;
-    Ok(w_tuple_new(vec![
-        pyre_object::unicodeobject::w_str_from_wtf8_managed(output),
-        w_int_new(consumed as i64),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::unicodeobject::w_str_from_wtf8_managed(output));
+    fields.push(w_int_new(consumed as i64));
+    Ok(w_tuple_new(fields.take()))
 }
 
 fn raw_decode_stateful(args: &[PyObjectRef]) -> crate::PyResult {
@@ -472,10 +472,10 @@ fn raw_decode_stateful(args: &[PyObjectRef]) -> crate::PyResult {
         Some(&state),
         Some(w_state),
     )?;
-    Ok(w_tuple_new(vec![
-        pyre_object::unicodeobject::w_str_from_wtf8_managed(output),
-        w_int_new(consumed as i64),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::unicodeobject::w_str_from_wtf8_managed(output));
+    fields.push(w_int_new(consumed as i64));
+    Ok(w_tuple_new(fields.take()))
 }
 
 fn raw_initial_state(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
@@ -303,21 +303,25 @@ fn unparse_address(
     )
     .map_err(|_| crate::PyError::value_error("recvfrom returned unsupported address family"))?
     {
-        host_overlapped::SocketAddress::V4 { host, port } => Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(&host),
-            pyre_object::w_int_new(port as i64),
-        ])),
+        host_overlapped::SocketAddress::V4 { host, port } => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_str_new_managed(&host));
+            fields.push(pyre_object::w_int_new(port as i64));
+            Ok(pyre_object::w_tuple_new(fields.take()))
+        }
         host_overlapped::SocketAddress::V6 {
             host,
             port,
             flowinfo,
             scope_id,
-        } => Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new(&host),
-            pyre_object::w_int_new(port as i64),
-            pyre_object::w_int_new(flowinfo as i64),
-            pyre_object::w_int_new(scope_id as i64),
-        ])),
+        } => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_str_new_managed(&host));
+            fields.push(pyre_object::w_int_new(port as i64));
+            fields.push(pyre_object::w_int_new(flowinfo as i64));
+            fields.push(pyre_object::w_int_new(scope_id as i64));
+            Ok(pyre_object::w_tuple_new(fields.take()))
+        }
     }
 }
 
@@ -483,7 +487,10 @@ fn overlapped_getresult(args: &[PyObjectRef]) -> crate::PyResult {
                 destination[..count].copy_from_slice(&state.buffer[..count]);
                 pyre_object::w_int_new(count as i64)
             };
-            let result = pyre_object::w_tuple_new(vec![first, address]);
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(first);
+            fields.push(address);
+            let result = pyre_object::w_tuple_new(fields.take());
             this(obj)?.w_result = result;
             pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
             Ok(result)

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -354,10 +354,10 @@ pub(crate) fn compat_map(
     };
     // Build the (module, name) key before touching the cached slots, then read
     // each mapping slot immediately before its probe.
-    let key = pyre_object::tupleobject::w_tuple_new(vec![
-        pyre_object::w_str_new_managed(module),
-        pyre_object::w_str_new_managed(name),
-    ]);
+    let mut key_items = pyre_object::gc_roots::RootedItems::new();
+    key_items.push(pyre_object::w_str_new_managed(module));
+    key_items.push(pyre_object::w_str_new_managed(name));
+    let key = pyre_object::tupleobject::w_tuple_new(key_items.take());
     // `finditem` below is generic: a replaced or non-dict `*_MAPPING` routes
     // through `getitem`, which can run Python and drive a collection. Pin the
     // freshly built key so a collection there cannot sweep it mid-lookup — the

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -3116,10 +3116,10 @@ fn save_toplevel_by_name(
 fn extension_code(module_name: &str, name: &str) -> Option<i64> {
     let copyreg = import_module("copyreg").ok()?;
     let registry = crate::baseobjspace::getattr_str(copyreg, "_extension_registry").ok()?;
-    let key = pyre_object::tupleobject::w_tuple_new(vec![
-        pyre_object::w_str_new_managed(module_name),
-        pyre_object::w_str_new_managed(name),
-    ]);
+    let mut key_items = pyre_object::gc_roots::RootedItems::new();
+    key_items.push(pyre_object::w_str_new_managed(module_name));
+    key_items.push(pyre_object::w_str_new_managed(name));
+    let key = pyre_object::tupleobject::w_tuple_new(key_items.take());
     let code = unsafe { pyre_object::w_dict_lookup(registry, key) }?;
     crate::baseobjspace::int_w(code).ok()
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -965,11 +965,11 @@ mod memo_proxy {
                 if obj.is_null() {
                     continue;
                 }
-                // `(index, obj)` — `w_tuple_new` pins its inputs across the malloc.
-                let tup = pyre_object::tupleobject::w_tuple_new(vec![
-                    pyre_object::w_int_new(i as i64),
-                    obj,
-                ]);
+                // `(index, obj)` — pin the boxed index before the tuple malloc.
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(i as i64));
+                fields.push(obj);
+                let tup = pyre_object::tupleobject::w_tuple_new(fields.take());
                 let _ = pyre_object::gc_roots::pin_root(tup);
                 let tup_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 // id(obj) read from the (relocated) tuple element.
@@ -1508,7 +1508,9 @@ fn save_type(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     let w_type = builtin_attr("type")?;
     let _ = pyre_object::gc_roots::pin_root(w_type);
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let w_args = pyre_object::tupleobject::w_tuple_new(vec![singleton]);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(singleton);
+    let w_args = pyre_object::tupleobject::w_tuple_new(fields.take());
     let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     save_reduce(
@@ -1742,10 +1744,10 @@ fn save_bytes(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
         let codecs = import_module("codecs")?;
         let w_encode = crate::baseobjspace::getattr_str(codecs, "encode")?;
         let w_decoded = call_meth(w_obj, "decode", &[pyre_object::w_str_new("latin1")])?;
-        let w_args = pyre_object::tupleobject::w_tuple_new(vec![
-            w_decoded,
-            pyre_object::w_str_new("latin1"),
-        ]);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_decoded);
+        fields.push(pyre_object::w_str_new("latin1"));
+        let w_args = pyre_object::tupleobject::w_tuple_new(fields.take());
         return save_reduce(ctx, buf, &[w_encode, w_args], Some(w_obj));
     }
     let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
@@ -1974,7 +1976,9 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
         // save_reduce(set, (list(obj),)).
         let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
         let w_list = pyre_object::listobject::w_list_new(items);
-        let w_args = pyre_object::tupleobject::w_tuple_new(vec![w_list]);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_list);
+        let w_args = pyre_object::tupleobject::w_tuple_new(fields.take());
         let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
         return save_reduce(ctx, buf, &[w_set_type, w_args], Some(w_obj));
     }
@@ -2057,7 +2061,9 @@ fn save_frozenset(
         // save_reduce(frozenset, (list(obj),)).
         let items = unsafe { pyre_object::setobject::w_set_items(w_obj) };
         let w_list = pyre_object::listobject::w_list_new(items);
-        let w_args = pyre_object::tupleobject::w_tuple_new(vec![w_list]);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_list);
+        let w_args = pyre_object::tupleobject::w_tuple_new(fields.take());
         let w_frozenset_type =
             crate::typedef::gettypeobject(&pyre_object::setobject::FROZENSET_TYPE);
         return save_reduce(ctx, buf, &[w_frozenset_type, w_args], Some(w_obj));
@@ -2108,8 +2114,9 @@ fn save_bytearray(
         let w_args = if data.is_empty() {
             pyre_object::tupleobject::w_tuple_new(Vec::new())
         } else {
-            let w_bytes = pyre_object::w_bytes_from_bytes(data);
-            pyre_object::tupleobject::w_tuple_new(vec![w_bytes])
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_bytes_from_bytes(data));
+            pyre_object::tupleobject::w_tuple_new(fields.take())
         };
         return save_reduce(ctx, buf, &[w_bytearray_type, w_args], Some(w_obj));
     }

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -1707,14 +1707,12 @@ fn audit_find_class(module: &str, name: &str) -> Result<(), PyError> {
     if let Ok(sys) = import_module("sys")
         && let Ok(audit) = crate::baseobjspace::getattr_str(sys, "audit")
     {
-        call_fn(
-            audit,
-            &[
-                pyre_object::w_str_new("pickle.find_class"),
-                pyre_object::w_str_new_managed(module),
-                pyre_object::w_str_new_managed(name),
-            ],
-        )?;
+        let _roots = pyre_object::gc_roots::push_roots();
+        let audit = _roots.pin_root(audit);
+        let w_event = _roots.pin_root(pyre_object::w_str_new("pickle.find_class"));
+        let w_module = _roots.pin_root(pyre_object::w_str_new_managed(module));
+        let w_name = _roots.pin_root(pyre_object::w_str_new_managed(name));
+        call_fn(audit, &[w_event, w_module, w_name])?;
     }
     Ok(())
 }
@@ -1804,10 +1802,15 @@ fn decode_string(slot: usize, data: &[u8]) -> Result<PyObjectRef, PyError> {
     let _ = pyre_object::gc_roots::pin_root(w_encoding);
     let e = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_errors = pyre_object::w_str_new_managed(&errors);
+    let _ = pyre_object::gc_roots::pin_root(w_errors);
+    let err_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     call_meth(
         pyre_object::gc_roots::shadow_stack_get(b),
         "decode",
-        &[pyre_object::gc_roots::shadow_stack_get(e), w_errors],
+        &[
+            pyre_object::gc_roots::shadow_stack_get(e),
+            pyre_object::gc_roots::shadow_stack_get(err_slot),
+        ],
     )
 }
 

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1994,10 +1994,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     libc::fcntl(fds[0], libc::F_SETFD, libc::FD_CLOEXEC);
                     libc::fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC);
                 }
-                Ok(pyre_object::w_tuple_new(vec![
-                    socket_from_fd(fds[0], family, ty, proto)?,
-                    socket_from_fd(fds[1], family, ty, proto)?,
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(socket_from_fd(fds[0], family, ty, proto)?);
+                fields.push(socket_from_fd(fds[1], family, ty, proto)?);
+                Ok(pyre_object::w_tuple_new(fields.take()))
             }),
         );
 
@@ -2174,28 +2174,34 @@ fn unpack_hostent(he: *mut rffi::Hostent) -> Result<pyre_object::PyObjectRef, cr
                 index += 1;
             }
         }
-        let aliases = alias_strings
-            .iter()
-            .map(|alias| pyre_object::w_str_new_managed(alias))
-            .collect();
-        let addrs = addr_strings
-            .iter()
-            .map(|addr| pyre_object::w_str_new_managed(addr))
-            .collect();
         // `w_list_new` roots the items it is handed, not the header it returns,
         // and that header is a movable nursery object (`rlist.py:116 LIST =
         // GcStruct`). Each list therefore stays pinned across the allocation
         // that follows it and is re-read from its slot afterwards.
-        let _roots = pyre_object::gc_roots::push_roots();
+        let _headers = pyre_object::gc_roots::push_roots();
+        let aliases = {
+            let mut items = pyre_object::gc_roots::RootedItems::new();
+            for alias in &alias_strings {
+                items.push(pyre_object::w_str_new_managed(alias));
+            }
+            pyre_object::w_list_new(items.take())
+        };
         let aliases_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(aliases));
+        let _ = pyre_object::gc_roots::pin_root(aliases);
+        let addrs = {
+            let mut items = pyre_object::gc_roots::RootedItems::new();
+            for addr in &addr_strings {
+                items.push(pyre_object::w_str_new_managed(addr));
+            }
+            pyre_object::w_list_new(items.take())
+        };
         let addrs_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(addrs));
-        Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new_managed(&name),
-            pyre_object::gc_roots::shadow_stack_get(aliases_slot),
-            pyre_object::gc_roots::shadow_stack_get(addrs_slot),
-        ]))
+        let _ = pyre_object::gc_roots::pin_root(addrs);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&name));
+        fields.push(pyre_object::gc_roots::shadow_stack_get(aliases_slot));
+        fields.push(pyre_object::gc_roots::shadow_stack_get(addrs_slot));
+        Ok(pyre_object::w_tuple_new(fields.take()))
     }
 }
 
@@ -2570,10 +2576,10 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         .to_string_lossy()
                         .into_owned()
                 };
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_str_new_managed(&host_s),
-                    pyre_object::w_str_new_managed(&serv_s),
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_str_new_managed(&host_s));
+                fields.push(pyre_object::w_str_new_managed(&serv_s));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             2,
         ),
@@ -3180,10 +3186,14 @@ fn windows_if_nameindex() -> Result<pyre_object::PyObjectRef, crate::PyError> {
                 return Err(win32(status));
             }
             let end = name.iter().position(|&unit| unit == 0).unwrap_or(name.len());
-            let entry = pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(i64::from(row.InterfaceIndex)),
-                pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(&name[..end])),
-            ]);
+            let entry = {
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(i64::from(row.InterfaceIndex)));
+                fields.push(pyre_object::w_str_from_wtf8(
+                    rustpython_wtf8::Wtf8Buf::from_wide(&name[..end]),
+                ));
+                pyre_object::w_tuple_new(fields.take())
+            };
             unsafe {
                 pyre_object::listobject::w_list_append(
                     pyre_object::gc_roots::shadow_stack_get(list_slot),
@@ -3394,10 +3404,10 @@ fn unpack_bluetooth_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObj
 
     let bth: bt::SOCKADDR_BTH =
         unsafe { core::ptr::read_unaligned(storage as *const _ as *const bt::SOCKADDR_BTH) };
-    pyre_object::w_tuple_new(vec![
-        pyre_object::w_str_new_managed(&bdaddr_string(bth.btAddr)),
-        pyre_object::w_int_new(i64::from(bth.port)),
-    ])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_str_new_managed(&bdaddr_string(bth.btAddr)));
+    fields.push(pyre_object::w_int_new(i64::from(bth.port)));
+    pyre_object::w_tuple_new(fields.take())
 }
 
 /// `HV_PROTOCOL_RAW` — the only protocol an `AF_HYPERV` socket is opened with.
@@ -3520,10 +3530,10 @@ fn unpack_hyperv_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObject
     let hv = unsafe { &*(storage as *const _ as *const SockaddrHv) };
     let vm_id = hyperv_guid_string(&hv.vm_id);
     let service_id = hyperv_guid_string(&hv.service_id);
-    pyre_object::w_tuple_new(vec![
-        pyre_object::w_str_new_managed(&vm_id),
-        pyre_object::w_str_new_managed(&service_id),
-    ])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_str_new_managed(&vm_id));
+    fields.push(pyre_object::w_str_new_managed(&service_id));
+    pyre_object::w_tuple_new(fields.take())
 }
 
 /// `_PyLong_UInt16_Converter` / `_PyLong_UInt32_Converter`, the argument
@@ -3954,10 +3964,10 @@ fn unpack_inet_addr(
             unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned() }
         };
         let port = u16::from_be(sin.sin_port) as i64;
-        pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new_managed(&host),
-            pyre_object::w_int_new(port),
-        ])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&host));
+        fields.push(pyre_object::w_int_new(port));
+        pyre_object::w_tuple_new(fields.take())
     } else if family == rffi::AF_INET6 {
         let sin6 = unsafe { &*(storage as *const _ as *const rffi::sockaddr_in6) };
         let mut buf = [0u8; 64];
@@ -3975,12 +3985,12 @@ fn unpack_inet_addr(
             unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned() }
         };
         let port = u16::from_be(sin6.sin6_port) as i64;
-        pyre_object::w_tuple_new(vec![
-            pyre_object::w_str_new_managed(&host),
-            pyre_object::w_int_new(port),
-            pyre_object::w_int_new(u32::from_be(sin6.sin6_flowinfo) as i64),
-            pyre_object::w_int_new(rffi::sockaddr_in6_get_scope_id(sin6) as i64),
-        ])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&host));
+        fields.push(pyre_object::w_int_new(port));
+        fields.push(pyre_object::w_int_new(u32::from_be(sin6.sin6_flowinfo) as i64));
+        fields.push(pyre_object::w_int_new(rffi::sockaddr_in6_get_scope_id(sin6) as i64));
+        pyre_object::w_tuple_new(fields.take())
     } else {
         #[cfg(unix)]
         if family == libc::AF_UNIX {
@@ -4459,9 +4469,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 // already closed over an exec (rsocket uses
                 // accept4(SOCK_CLOEXEC) on Linux; this is the portable path).
                 rffi::set_cloexec(cfd);
-                let new_sock = socket_from_fd(cfd, family, ty, proto)?;
-                let addr = unpack_inet_addr(&storage, slen);
-                Ok(pyre_object::w_tuple_new(vec![new_sock, addr]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(socket_from_fd(cfd, family, ty, proto)?);
+                fields.push(unpack_inet_addr(&storage, slen));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             1,
         ),
@@ -4501,11 +4512,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     crate::module::signal::interp_signal::checksignals_now()?;
                 };
                 rffi::set_cloexec(cfd);
-                let addr = unpack_inet_addr(&storage, slen);
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_int_new(rffi::socket_to_i64(cfd)),
-                    addr,
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(rffi::socket_to_i64(cfd)));
+                fields.push(unpack_inet_addr(&storage, slen));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             1,
         ),
@@ -4893,11 +4903,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 crate::module::signal::interp_signal::checksignals_now()?;
             };
             buf.truncate(got as usize);
-            let addr = unpack_inet_addr(&storage, slen);
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::bytesobject::w_bytes_from_bytes(&buf),
-                addr,
-            ]))
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&buf));
+            fields.push(unpack_inet_addr(&storage, slen));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }),
     ) };
 
@@ -5048,11 +5057,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 // (`converted_error` eintr_retry).
                 crate::module::signal::interp_signal::checksignals_now()?;
             };
-            let addr = unpack_inet_addr(&storage, slen);
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(got as i64),
-                addr,
-            ]))
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_int_new(got as i64));
+            fields.push(unpack_inet_addr(&storage, slen));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }),
     ) };
 
@@ -5203,13 +5211,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     }
                 }
             }
-            let addr = unpack_inet_addr(&storage, msg_namelen);
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::bytesobject::w_bytes_from_bytes(&data),
-                pyre_object::w_list_new(anc_items.take()),
-                pyre_object::w_int_new(msg_flags as i64),
-                addr,
-            ]))
+            let anc_list = pyre_object::w_list_new(anc_items.take());
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&data));
+            fields.push(anc_list);
+            fields.push(pyre_object::w_int_new(msg_flags as i64));
+            fields.push(unpack_inet_addr(&storage, msg_namelen));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }),
     ) };
 
@@ -5362,13 +5370,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     }
                 }
             }
-            let addr = unpack_inet_addr(&storage, msg_namelen);
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(got as i64),
-                pyre_object::w_list_new(anc_items.take()),
-                pyre_object::w_int_new(msg_flags as i64),
-                addr,
-            ]))
+            let anc_list = pyre_object::w_list_new(anc_items.take());
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_int_new(got as i64));
+            fields.push(anc_list);
+            fields.push(pyre_object::w_int_new(msg_flags as i64));
+            fields.push(unpack_inet_addr(&storage, msg_namelen));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }),
     ) };
 

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -1903,12 +1903,18 @@ fn sre_match_groupdict(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 fn sre_match_regs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let m = sre_match_receiver(args)?;
     let n = unsafe { (*m).spans_len };
-    let mut regs = Vec::with_capacity(n);
+    let mut regs = pyre_object::gc_roots::RootedItems::new();
     for gi in 0..n {
         let (start, end) = unsafe { w_sre_match_get_span(m as PyObjectRef, gi) }.unwrap_or((-1, -1));
-        regs.push(w_tuple_new(vec![w_int_new(start), w_int_new(end)]));
+        let pair = {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_int_new(start));
+            fields.push(w_int_new(end));
+            w_tuple_new(fields.take())
+        };
+        regs.push(pair);
     }
-    Ok(w_tuple_new(regs))
+    Ok(w_tuple_new(regs.take()))
 }
 
 /// `start_w` (interp_sre.py).
@@ -1929,7 +1935,10 @@ fn sre_match_end(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn sre_match_span(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let m = sre_match_self(args)?;
     let (start, end) = do_span(m, args.get(1).copied())?;
-    Ok(w_tuple_new(vec![w_int_new(start), w_int_new(end)]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_int_new(start));
+    fields.push(w_int_new(end));
+    Ok(w_tuple_new(fields.take()))
 }
 
 /// `descr_getitem` (interp_sre.py) — `m[index]` resolves the

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2423,11 +2423,11 @@ mod ssl_socket_methods {
             };
             let version =
                 unsafe { pyre_native::ssl::connection_version(self.backend) }.unwrap_or("unknown");
-            w_list_new(vec![w_tuple_new(vec![
-                w_str_new(&name),
-                w_str_new(version),
-                w_int_new(bits as i64),
-            ])])
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_str_new_managed(&name));
+            fields.push(w_str_new_managed(version));
+            fields.push(w_int_new(bits as i64));
+            w_list_new(vec![w_tuple_new(fields.take())])
         }
 
         fn cipher(&self) -> PyObjectRef {
@@ -2442,11 +2442,11 @@ mod ssl_socket_methods {
             else {
                 return w_none();
             };
-            w_tuple_new(vec![
-                w_str_new(&name),
-                w_str_new(version),
-                w_int_new(bits as i64),
-            ])
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_str_new_managed(&name));
+            fields.push(w_str_new_managed(version));
+            fields.push(w_int_new(bits as i64));
+            w_tuple_new(fields.take())
         }
 
         fn getpeercert(
@@ -2817,12 +2817,12 @@ fn rand_bytes(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn oid_tuple(entry: pyre_native::ssl::OidInfo) -> PyObjectRef {
-    w_tuple_new(vec![
-        w_int_new(i64::from(entry.nid)),
-        w_str_new(entry.short_name),
-        w_str_new(entry.long_name),
-        entry.oid.map(w_str_new).unwrap_or_else(w_none),
-    ])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_int_new(i64::from(entry.nid)));
+    fields.push(w_str_new_managed(entry.short_name));
+    fields.push(w_str_new_managed(entry.long_name));
+    fields.push(entry.oid.map(w_str_new_managed).unwrap_or_else(w_none));
+    w_tuple_new(fields.take())
 }
 
 fn txt2obj(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2868,12 +2868,12 @@ fn nid2obj(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn get_default_verify_paths(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (cert_file, cert_dir) = pyre_native::ssl::default_verify_paths();
-    Ok(w_tuple_new(vec![
-        w_str_new("SSL_CERT_FILE"),
-        w_str_new(&cert_file),
-        w_str_new("SSL_CERT_DIR"),
-        w_str_new(&cert_dir),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_str_new("SSL_CERT_FILE"));
+    fields.push(w_str_new_managed(&cert_file));
+    fields.push(w_str_new("SSL_CERT_DIR"));
+    fields.push(w_str_new_managed(&cert_dir));
+    Ok(w_tuple_new(fields.take()))
 }
 
 /// The Windows system-certificate-store readers behind `ssl.enum_certificates`

--- a/pyre/pyre-interpreter/src/module/_symtable/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_symtable/mod.rs
@@ -135,15 +135,15 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table.line_number as i64));
     let line_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
-    pyre_object::tupleobject::w_tuple_new(vec![
-        pyre_object::gc_roots::shadow_stack_get(name_slot),
-        pyre_object::gc_roots::shadow_stack_get(type_slot),
-        pyre_object::gc_roots::shadow_stack_get(line_slot),
-        pyre_object::w_bool_from(table.is_nested),
-        pyre_object::gc_roots::shadow_stack_get(symbols_slot),
-        pyre_object::gc_roots::shadow_stack_get(varnames_slot),
-        pyre_object::gc_roots::shadow_stack_get(children_slot),
-    ])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::gc_roots::shadow_stack_get(name_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(type_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(line_slot));
+    fields.push(pyre_object::w_bool_from(table.is_nested));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(symbols_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(varnames_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(children_slot));
+    pyre_object::tupleobject::w_tuple_new(fields.take())
 }
 
 fn symtable_data(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -398,10 +398,10 @@ fn update_registry(
     let registry_slot = pin_root_slot(registry);
     let text_slot = pin_root_slot(text);
     let category_slot = pin_root_slot(category);
-    let key = w_tuple_new(vec![
-        pyre_object::gc_roots::shadow_stack_get(text_slot),
-        pyre_object::gc_roots::shadow_stack_get(category_slot),
-    ]);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::gc_roots::shadow_stack_get(text_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(category_slot));
+    let key = w_tuple_new(fields.take());
     let key_slot = pin_root_slot(key);
     already_warned(
         pyre_object::gc_roots::shadow_stack_get(registry_slot),
@@ -745,11 +745,11 @@ pub(crate) fn do_warn_explicit(
     let text_slot = pin_root_slot(text);
     let message_slot = pin_root_slot(message);
     let category_slot = pin_root_slot(category);
-    let key = w_tuple_new(vec![
-        pyre_object::gc_roots::shadow_stack_get(text_slot),
-        pyre_object::gc_roots::shadow_stack_get(category_slot),
-        w_int_new(lineno),
-    ]);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::gc_roots::shadow_stack_get(text_slot));
+    fields.push(pyre_object::gc_roots::shadow_stack_get(category_slot));
+    fields.push(w_int_new(lineno));
+    let key = w_tuple_new(fields.take());
     let key_slot = pin_root_slot(key);
     let registry = pyre_object::gc_roots::shadow_stack_get(registry_slot);
     let has_registry = !registry.is_null() && unsafe { !is_none(registry) };

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -104,13 +104,13 @@ fn get_once_registry() -> Result<PyObjectRef, PyError> {
 }
 
 fn create_filter(category: PyObjectRef, action: &str, module: Option<&str>) -> PyObjectRef {
-    w_tuple_new(vec![
-        w_str_new(action),
-        w_none(),
-        category,
-        module.map(w_str_new).unwrap_or_else(w_none),
-        w_int_new(0),
-    ])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_str_new(action));
+    fields.push(w_none());
+    fields.push(category);
+    fields.push(module.map(w_str_new).unwrap_or_else(w_none));
+    fields.push(w_int_new(0));
+    w_tuple_new(fields.take())
 }
 
 fn warning_class(name: &str) -> PyObjectRef {

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -709,16 +709,13 @@ pub fn PeekNamedPipe(
     )?;
     let peeked = host_winapi::peek_named_pipe(pipe, (size != 0).then_some(size))
         .map_err(super::win32_err)?;
-    let available = w_int_new(i64::from(peeked.available));
-    let left = w_int_new(i64::from(peeked.left_this_message));
-    Ok(match peeked.data {
-        Some(data) => w_tuple_new(vec![
-            pyre_object::bytesobject::w_bytes_from_bytes(&data),
-            available,
-            left,
-        ]),
-        None => w_tuple_new(vec![available, left]),
-    })
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    if let Some(data) = peeked.data {
+        fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&data));
+    }
+    fields.push(w_int_new(i64::from(peeked.available)));
+    fields.push(w_int_new(i64::from(peeked.left_this_message)));
+    Ok(w_tuple_new(fields.take()))
 }
 
 // ── file mappings ──

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -245,7 +245,10 @@ mod process {
             },
         )?;
         let (read, write) = host_winapi::create_pipe(size).map_err(win32_err)?;
-        Ok(w_tuple_new(vec![w_handle(read), w_handle(write)]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_handle(read));
+        fields.push(w_handle(write));
+        Ok(w_tuple_new(fields.take()))
     }
 
     /// `_winapi.DuplicateHandle(source_process, source, target_process,
@@ -530,12 +533,12 @@ mod process {
             handles,
         )
         .map_err(win32_err)?;
-        Ok(w_tuple_new(vec![
-            w_handle(info.process),
-            w_handle(info.thread),
-            w_int_new(info.process_id as i64),
-            w_int_new(info.thread_id as i64),
-        ]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_handle(info.process));
+        fields.push(w_handle(info.thread));
+        fields.push(w_int_new(info.process_id as i64));
+        fields.push(w_int_new(info.thread_id as i64));
+        Ok(w_tuple_new(fields.take()))
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
@@ -378,10 +378,10 @@ pub fn read_file(
             host_winapi::read_file(handle, size)
         }
         .map_err(win32_err)?;
-        return Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::bytesobject::w_bytes_from_bytes(&result.data),
-            pyre_object::w_int_new(i64::from(result.error)),
-        ]));
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&result.data));
+        fields.push(pyre_object::w_int_new(i64::from(result.error)));
+        return Ok(pyre_object::w_tuple_new(fields.take()));
     }
     let backend = new_native(handle)?;
     let error = {
@@ -401,10 +401,10 @@ pub fn read_file(
         ERROR_IO_PENDING => backend.lock().pending = true,
         _ => return Err(super::win32_code(error)),
     }
-    Ok(pyre_object::w_tuple_new(vec![
-        w_overlapped(backend),
-        pyre_object::w_int_new(i64::from(error)),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_overlapped(backend));
+    fields.push(pyre_object::w_int_new(i64::from(error)));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 /// `_winapi.WriteFile(handle, buffer, overlapped=False)` -> `(written, error)`,
@@ -424,10 +424,10 @@ pub fn write_file(
             host_winapi::write_file(handle, data)
         }
         .map_err(win32_err)?;
-        return Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_int_new(i64::from(result.written)),
-            pyre_object::w_int_new(i64::from(result.error)),
-        ]));
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_int_new(i64::from(result.written)));
+        fields.push(pyre_object::w_int_new(i64::from(result.error)));
+        return Ok(pyre_object::w_tuple_new(fields.take()));
     }
     let backend = new_native(handle)?;
     let error = {
@@ -448,8 +448,8 @@ pub fn write_file(
         ERROR_IO_PENDING => backend.lock().pending = true,
         _ => return Err(super::win32_code(error)),
     }
-    Ok(pyre_object::w_tuple_new(vec![
-        w_overlapped(backend),
-        pyre_object::w_int_new(i64::from(error)),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_overlapped(backend));
+    fields.push(pyre_object::w_int_new(i64::from(error)));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }

--- a/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
@@ -175,10 +175,10 @@ fn overlapped_get_result(args: &[PyObjectRef]) -> crate::PyResult {
     if state.completed && state.transfer == Transfer::Read {
         state.buffer.truncate(transferred as usize);
     }
-    Ok(pyre_object::w_tuple_new(vec![
-        pyre_object::w_int_new(i64::from(transferred)),
-        pyre_object::w_int_new(i64::from(error)),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_int_new(i64::from(transferred)));
+    fields.push(pyre_object::w_int_new(i64::from(error)));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 /// `Overlapped.getbuffer()` -> what a completed read produced, or `None` when

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -1915,31 +1915,44 @@ fn array_reduce_ex_method(args: &[PyObjectRef]) -> PyResult {
     let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
     let typecode = unsafe { arr::w_array_typecode(obj) };
     let tc = typecode as char;
-    let w_typecode = pyre_object::w_str_new_managed(&tc.to_string());
+    let _roots = pyre_object::gc_roots::push_roots();
+    let typecode_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(&tc.to_string()));
     let w_dict =
         crate::baseobjspace::findattr_result(obj, "__dict__")?.unwrap_or_else(pyre_object::w_none);
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     let mformat = array_machine_format_code(typecode, unsafe { arr::w_array_itemsize(obj) });
     if protocol < 3 || mformat == UNKNOWN_FORMAT {
         let w_items = array_tolist_method(&[obj])?;
-        let ctor_args = pyre_object::w_tuple_new(vec![w_typecode, w_items]);
-        return Ok(pyre_object::w_tuple_new(vec![w_type, ctor_args, w_dict]));
+        let mut ctor = pyre_object::gc_roots::RootedItems::new();
+        ctor.push(pyre_object::gc_roots::shadow_stack_get(typecode_slot));
+        ctor.push(w_items);
+        let ctor_args = pyre_object::w_tuple_new(ctor.take());
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(w_type);
+        result.push(ctor_args);
+        result.push(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+        return Ok(pyre_object::w_tuple_new(result.take()));
     }
 
     let module = crate::importing::get_sys_module("array")
         .ok_or_else(|| PyError::runtime_error("array module not initialized"))?;
     let reconstructor = crate::baseobjspace::getattr_str(module, "_array_reconstructor")?;
+    let reconstructor_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(reconstructor);
     let w_bytes = array_tobytes_method(&[obj])?;
-    let ctor_args = pyre_object::w_tuple_new(vec![
-        w_type,
-        w_typecode,
-        pyre_object::w_int_new(mformat),
-        w_bytes,
-    ]);
-    Ok(pyre_object::w_tuple_new(vec![
-        reconstructor,
-        ctor_args,
-        w_dict,
-    ]))
+    let mut ctor = pyre_object::gc_roots::RootedItems::new();
+    ctor.push(w_type);
+    ctor.push(pyre_object::gc_roots::shadow_stack_get(typecode_slot));
+    ctor.push(pyre_object::w_int_new(mformat));
+    ctor.push(w_bytes);
+    let ctor_args = pyre_object::w_tuple_new(ctor.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(pyre_object::gc_roots::shadow_stack_get(reconstructor_slot));
+    result.push(ctor_args);
+    result.push(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 fn decode_uint(bytes: &[u8], big_endian: bool) -> u64 {

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -1540,10 +1540,10 @@ fn array_buffer_info_method(args: &[PyObjectRef]) -> PyResult {
     } else {
         pyre_object::longobject::w_long_new(BigInt::from(addr))
     };
-    Ok(pyre_object::w_tuple_new(vec![
-        w_addr,
-        pyre_object::w_int_new(len),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_addr);
+    fields.push(pyre_object::w_int_new(len));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 fn array_byteswap_method(args: &[PyObjectRef]) -> PyResult {

--- a/pyre/pyre-interpreter/src/module/cmath/interp_cmath.rs
+++ b/pyre/pyre-interpreter/src/module/cmath/interp_cmath.rs
@@ -93,10 +93,10 @@ pub fn phase(args: &[PyObjectRef]) -> PyResult {
 /// `wrapped_polar` — `(r, phi)` tuple.
 pub fn polar(args: &[PyObjectRef]) -> PyResult {
     let (r, phi) = pmc::polar(unpack(args[0])?).map_err(map_err)?;
-    Ok(w_tuple_new(vec![
-        floatobject::w_float_new(r),
-        floatobject::w_float_new(phi),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(floatobject::w_float_new(r));
+    fields.push(floatobject::w_float_new(phi));
+    Ok(w_tuple_new(fields.take()))
 }
 
 /// `wrapped_rect` — arguments go through `space.float_w`, so a complex

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1037,10 +1037,12 @@ fn gc_stats_public_type() -> PyObjectRef {
             "__repr__",
             crate::make_builtin_function_with_arity("__repr__", gc_stats_repr, 1),
         );
+        let bases_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(pyre_object::w_tuple_new(vec![crate::typedef::w_object()]));
         let args = [
             crate::typedef::w_type(),
             w_str_new("GcStats"),
-            pyre_object::w_tuple_new(vec![crate::typedef::w_object()]),
+            pyre_object::gc_roots::shadow_stack_get(bases_slot),
             roots.get(ns_slot),
         ];
         crate::builtins::type_descr_new(&args).expect("construct app_referents.GcStats") as usize

--- a/pyre/pyre-interpreter/src/module/grp/grp.rs
+++ b/pyre/pyre-interpreter/src/module/grp/grp.rs
@@ -29,20 +29,24 @@ fn struct_group_type() -> pyre_object::PyObjectRef {
 pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyError> {
     #[cfg(feature = "host_env")]
     fn make_struct_group(g: &rustpython_host_env::grp::Group) -> pyre_object::PyObjectRef {
-        let mem_items: Vec<pyre_object::PyObjectRef> = g
-            .mem
-            .iter()
-            .map(|s| pyre_object::w_str_new_managed(s))
-            .collect();
-        crate::_structseq::new_instance(
-            struct_group_type(),
-            vec![
-                pyre_object::w_str_new_managed(&g.name),
-                pyre_object::w_str_new_managed(&g.passwd),
-                pyre_object::w_int_new(g.gid as i64),
-                pyre_object::w_list_new(mem_items),
-            ],
-        )
+        // Each `w_str_new_managed` is collectable.  A plain Vec is not a
+        // root, so later member/name allocations can sweep earlier strings
+        // before `new_instance` pins its argument vector.  Pin each mint
+        // as it is produced; close the member bracket before the field
+        // bracket (`RootedItems` cannot grow under another open set).
+        let mem_list = {
+            let mut mem = pyre_object::gc_roots::RootedItems::new();
+            for s in &g.mem {
+                mem.push(pyre_object::w_str_new_managed(s));
+            }
+            pyre_object::w_list_new(mem.take())
+        };
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&g.name));
+        fields.push(pyre_object::w_str_new_managed(&g.passwd));
+        fields.push(pyre_object::w_int_new(g.gid as i64));
+        fields.push(mem_list);
+        crate::_structseq::new_instance(struct_group_type(), fields.take())
     }
     // `lib_pypy/grp.py:21-34 _group_from_gstruct` libc backend, used when
     // the host_env abstraction layer is disabled.
@@ -55,23 +59,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
             }
         }
-        let mut mem_items: Vec<pyre_object::PyObjectRef> = Vec::new();
-        let mut p = (*g).gr_mem;
-        if !p.is_null() {
-            while !(*p).is_null() {
-                mem_items.push(pyre_object::w_str_new_managed(&cstr(*p)));
-                p = p.add(1);
+        let mem_list = {
+            let mut mem = pyre_object::gc_roots::RootedItems::new();
+            let mut p = (*g).gr_mem;
+            if !p.is_null() {
+                while !(*p).is_null() {
+                    mem.push(pyre_object::w_str_new_managed(&cstr(*p)));
+                    p = p.add(1);
+                }
             }
-        }
-        crate::_structseq::new_instance(
-            struct_group_type(),
-            vec![
-                pyre_object::w_str_new_managed(&cstr((*g).gr_name)),
-                pyre_object::w_str_new_managed(&cstr((*g).gr_passwd)),
-                pyre_object::w_int_new((*g).gr_gid as i64),
-                pyre_object::w_list_new(mem_items),
-            ],
-        )
+            pyre_object::w_list_new(mem.take())
+        };
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&cstr((*g).gr_name)));
+        fields.push(pyre_object::w_str_new_managed(&cstr((*g).gr_passwd)));
+        fields.push(pyre_object::w_int_new((*g).gr_gid as i64));
+        fields.push(mem_list);
+        crate::_structseq::new_instance(struct_group_type(), fields.take())
     }
     // `lib_pypy/grp.py:14-20 class struct_group` — exposed as
     // `grp.struct_group`; every result type uses this same class.

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -1670,10 +1670,10 @@ pub fn frexp(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     let (m, e) = pymath::math::frexp(try_get_double(args[0])?);
-    Ok(w_tuple_new(vec![
-        floatobject::w_float_new(m),
-        w_int_new(e as i64),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(floatobject::w_float_new(m));
+    fields.push(w_int_new(e as i64));
+    Ok(w_tuple_new(fields.take()))
 }
 
 pub fn ldexp(args: &[PyObjectRef]) -> PyResult {
@@ -1722,10 +1722,10 @@ pub fn modf(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     let (frac, integer) = pymath::math::modf(try_get_double(args[0])?);
-    Ok(w_tuple_new(vec![
-        floatobject::w_float_new(frac),
-        floatobject::w_float_new(integer),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(floatobject::w_float_new(frac));
+    fields.push(floatobject::w_float_new(integer));
+    Ok(w_tuple_new(fields.take()))
 }
 
 pub fn nextafter(args: &[PyObjectRef]) -> PyResult {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -7192,10 +7192,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 |_| match host_posix::pipe() {
                     Ok((rfd, wfd)) => {
                         use std::os::fd::IntoRawFd;
-                        Ok(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_int_new(rfd.into_raw_fd() as i64),
-                            pyre_object::w_int_new(wfd.into_raw_fd() as i64),
-                        ]))
+                        let mut fields = pyre_object::gc_roots::RootedItems::new();
+                        fields.push(pyre_object::w_int_new(rfd.into_raw_fd() as i64));
+                        fields.push(pyre_object::w_int_new(wfd.into_raw_fd() as i64));
+                        Ok(pyre_object::w_tuple_new(fields.take()))
                     }
                     Err(e) => Err(io_err(e, "")),
                 },
@@ -7230,10 +7230,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     match host_posix::pipe2(flags) {
                         Ok((rfd, wfd)) => {
                             use std::os::fd::IntoRawFd;
-                            Ok(pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new(rfd.into_raw_fd() as i64),
-                                pyre_object::w_int_new(wfd.into_raw_fd() as i64),
-                            ]))
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(rfd.into_raw_fd() as i64));
+                            fields.push(pyre_object::w_int_new(wfd.into_raw_fd() as i64));
+                            Ok(pyre_object::w_tuple_new(fields.take()))
                         }
                         Err(e) => Err(io_err(e, "")),
                     }
@@ -9885,11 +9885,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 |_| {
                     let [l1, l5, l15] =
                         rustpython_host_env::time::getloadavg().map_err(|e| io_err(e, ""))?;
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_float_new(l1),
-                        pyre_object::w_float_new(l5),
-                        pyre_object::w_float_new(l15),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_float_new(l1));
+                    fields.push(pyre_object::w_float_new(l5));
+                    fields.push(pyre_object::w_float_new(l15));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 0,
             ),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1096,7 +1096,7 @@ fn wide_result(units: &[u16], as_bytes: bool) -> PyObjectRef {
     if as_bytes {
         pyre_object::w_bytes_from_bytes(&crate::gateway::fsencode_wtf8_total(&text))
     } else {
-        pyre_object::w_str_from_wtf8(text)
+        pyre_object::w_str_from_wtf8_managed(text)
     }
 }
 
@@ -1359,11 +1359,11 @@ mod win_nt {
         if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
             return Err(io_err(&std::io::Error::last_os_error(), ""));
         }
-        Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_int_new(info.dwVolumeSerialNumber as i64),
-            pyre_object::w_int_new(info.nFileIndexHigh as i64),
-            pyre_object::w_int_new(info.nFileIndexLow as i64),
-        ]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_int_new(info.dwVolumeSerialNumber as i64));
+        fields.push(pyre_object::w_int_new(info.nFileIndexHigh as i64));
+        fields.push(pyre_object::w_int_new(info.nFileIndexLow as i64));
+        Ok(pyre_object::w_tuple_new(fields.take()))
     }
 
     /// shutil.disk_usage helper — (total, free) bytes. host_env::getdiskusage
@@ -1378,10 +1378,12 @@ mod win_nt {
             host_nt::getdiskusage(&path)
         };
         match usage {
-            Ok((total, free)) => Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(total as i64),
-                pyre_object::w_int_new(free as i64),
-            ])),
+            Ok((total, free)) => {
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(total as i64));
+                fields.push(pyre_object::w_int_new(free as i64));
+                Ok(pyre_object::w_tuple_new(fields.take()))
+            }
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }
@@ -4169,10 +4171,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 // this one stays in the text domain rather than the byte one.
                 let path = crate::gateway::fsdecode_filename_wtf8(&path);
                 let (root, tail) = split_root(&path);
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_str_from_wtf8(root.to_wtf8_buf()),
-                    pyre_object::w_str_from_wtf8(tail.to_wtf8_buf()),
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_str_from_wtf8_managed(root.to_wtf8_buf()));
+                fields.push(pyre_object::w_str_from_wtf8_managed(tail.to_wtf8_buf()));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             "($module, /, path)",
             "Removes everything after the root on Win32.",
@@ -4195,11 +4197,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     nonstrict_wide_path(bound[0].expect("p is required"), "_path_splitroot_ex")?;
                 let units = &wide[..wide.len() - 1];
                 let (drvsize, rootsize) = skiproot(units, HOST_SEPS);
-                Ok(pyre_object::w_tuple_new(vec![
-                    wide_result(&units[..drvsize], as_bytes),
-                    wide_result(&units[drvsize..drvsize + rootsize], as_bytes),
-                    wide_result(&units[drvsize + rootsize..], as_bytes),
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(wide_result(&units[..drvsize], as_bytes));
+                fields.push(wide_result(&units[drvsize..drvsize + rootsize], as_bytes));
+                fields.push(wide_result(&units[drvsize + rootsize..], as_bytes));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             "($module, /, p)",
             "Split a pathname into drive, root and tail.\n\nThe tail contains \
@@ -7982,18 +7984,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");
                             drop(fork_serial);
-                            Ok(pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new(0),
-                                pyre_object::w_int_new(master_fd as i64),
-                            ]))
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(0));
+                            fields.push(pyre_object::w_int_new(master_fd as i64));
+                            Ok(pyre_object::w_tuple_new(fields.take()))
                         }
                         Ok(pid) => {
                             run_fork_callbacks("parent");
                             drop(fork_serial);
-                            Ok(pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new(pid as i64),
-                                pyre_object::w_int_new(master_fd as i64),
-                            ]))
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(pid as i64));
+                            fields.push(pyre_object::w_int_new(master_fd as i64));
+                            Ok(pyre_object::w_tuple_new(fields.take()))
                         }
                         Err(error) => {
                             run_fork_callbacks("parent");
@@ -8253,10 +8255,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             Err(e) => crate::builtins::eintr_retry_with(e, |e| io_err(e, ""))?,
                         }
                     };
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(res as i64),
-                        pyre_object::w_int_new(status as i64),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(res as i64));
+                    fields.push(pyre_object::w_int_new(status as i64));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 2,
             ),
@@ -8283,10 +8285,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             Err(e) => crate::builtins::eintr_retry_with(e, |e| io_err(e, ""))?,
                         }
                     };
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(res as i64),
-                        pyre_object::w_int_new(status as i64),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(res as i64));
+                    fields.push(pyre_object::w_int_new(status as i64));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 0,
             ),
@@ -11141,10 +11143,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 |_| {
                     use std::os::fd::IntoRawFd;
                     let (master, slave) = host_posix::openpty().map_err(|e| io_err(e, ""))?;
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(master.into_raw_fd() as i64),
-                        pyre_object::w_int_new(slave.into_raw_fd() as i64),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(master.into_raw_fd() as i64));
+                    fields.push(pyre_object::w_int_new(slave.into_raw_fd() as i64));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 0,
             ),
@@ -11159,11 +11161,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "getresuid",
                 |_| {
                     let (r, e, s) = host_posix::getresuid().map_err(|e| io_err(e, ""))?;
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(r as i64),
-                        pyre_object::w_int_new(e as i64),
-                        pyre_object::w_int_new(s as i64),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(r as i64));
+                    fields.push(pyre_object::w_int_new(e as i64));
+                    fields.push(pyre_object::w_int_new(s as i64));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 0,
             ),
@@ -11178,11 +11180,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "getresgid",
                 |_| {
                     let (r, e, s) = host_posix::getresgid().map_err(|e| io_err(e, ""))?;
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(r as i64),
-                        pyre_object::w_int_new(e as i64),
-                        pyre_object::w_int_new(s as i64),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(r as i64));
+                    fields.push(pyre_object::w_int_new(e as i64));
+                    fields.push(pyre_object::w_int_new(s as i64));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 0,
             ),
@@ -12257,10 +12259,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::make_builtin_function_with_arity(
                 "pipe",
                 |_| match host_nt::pipe() {
-                    Ok((read_fd, write_fd)) => Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(read_fd as i64),
-                        pyre_object::w_int_new(write_fd as i64),
-                    ])),
+                    Ok((read_fd, write_fd)) => {
+                        let mut fields = pyre_object::gc_roots::RootedItems::new();
+                        fields.push(pyre_object::w_int_new(read_fd as i64));
+                        fields.push(pyre_object::w_int_new(write_fd as i64));
+                        Ok(pyre_object::w_tuple_new(fields.take()))
+                    }
                     Err(e) => Err(errno_err(crt_errno_of(&e), "")),
                 },
                 0,
@@ -12461,10 +12465,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         // -- an exit code above `INT_MAX`, which
                         // `ExitProcess` takes, is a positive number here and
                         // not a negative `int`.
-                        Ok((pid, status)) => Ok(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_int_new(pid as i64),
-                            pyre_object::w_int_new((status as u32 as i64) << 8),
-                        ])),
+                        Ok((pid, status)) => {
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(pid as i64));
+                            fields.push(pyre_object::w_int_new((status as u32 as i64) << 8));
+                            Ok(pyre_object::w_tuple_new(fields.take()))
+                        }
                         Err(e) => Err(errno_err(crt_errno_of(&e), "")),
                     }
                 },

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -6706,15 +6706,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     String::new(),
                     std::env::consts::ARCH.to_string(),
                 );
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_str_new_managed(&sysname));
+                fields.push(pyre_object::w_str_new_managed(&nodename));
+                fields.push(pyre_object::w_str_new_managed(&release));
+                fields.push(pyre_object::w_str_new_managed(&version));
+                fields.push(pyre_object::w_str_new_managed(&machine));
                 Ok(crate::_structseq::new_instance(
                     uname_result_seq_type(),
-                    vec![
-                        pyre_object::w_str_new_managed(&sysname),
-                        pyre_object::w_str_new_managed(&nodename),
-                        pyre_object::w_str_new_managed(&release),
-                        pyre_object::w_str_new_managed(&version),
-                        pyre_object::w_str_new_managed(&machine),
-                    ],
+                    fields.take(),
                 ))
             },
             0,

--- a/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
+++ b/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
@@ -78,18 +78,15 @@ fn pwd_uid_converter(w_uid: pyre_object::PyObjectRef) -> Result<libc::uid_t, cra
 pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyError> {
     #[cfg(feature = "host_env")]
     fn make_struct_passwd(pw: &rustpython_host_env::pwd::Passwd) -> pyre_object::PyObjectRef {
-        crate::_structseq::new_instance(
-            struct_passwd_type(),
-            vec![
-                pyre_object::w_str_new_managed(&pw.name),
-                pyre_object::w_str_new_managed(&pw.passwd),
-                pyre_object::w_int_new(pw.uid as i64),
-                pyre_object::w_int_new(pw.gid as i64),
-                pyre_object::w_str_new_managed(&pw.gecos),
-                pyre_object::w_str_new_managed(&pw.dir),
-                pyre_object::w_str_new_managed(&pw.shell),
-            ],
-        )
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&pw.name));
+        fields.push(pyre_object::w_str_new_managed(&pw.passwd));
+        fields.push(pyre_object::w_int_new(pw.uid as i64));
+        fields.push(pyre_object::w_int_new(pw.gid as i64));
+        fields.push(pyre_object::w_str_new_managed(&pw.gecos));
+        fields.push(pyre_object::w_str_new_managed(&pw.dir));
+        fields.push(pyre_object::w_str_new_managed(&pw.shell));
+        crate::_structseq::new_instance(struct_passwd_type(), fields.take())
     }
     // `interp_pwd.py make_struct_passwd` libc backend, used when
     // the host_env abstraction layer is disabled.  Mirrors the same
@@ -103,18 +100,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
             }
         }
-        crate::_structseq::new_instance(
-            struct_passwd_type(),
-            vec![
-                pyre_object::w_str_new_managed(&cstr((*pw).pw_name)),
-                pyre_object::w_str_new_managed(&cstr((*pw).pw_passwd)),
-                pyre_object::w_int_new((*pw).pw_uid as i64),
-                pyre_object::w_int_new((*pw).pw_gid as i64),
-                pyre_object::w_str_new_managed(&cstr((*pw).pw_gecos)),
-                pyre_object::w_str_new_managed(&cstr((*pw).pw_dir)),
-                pyre_object::w_str_new_managed(&cstr((*pw).pw_shell)),
-            ],
-        )
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_str_new_managed(&cstr((*pw).pw_name)));
+        fields.push(pyre_object::w_str_new_managed(&cstr((*pw).pw_passwd)));
+        fields.push(pyre_object::w_int_new((*pw).pw_uid as i64));
+        fields.push(pyre_object::w_int_new((*pw).pw_gid as i64));
+        fields.push(pyre_object::w_str_new_managed(&cstr((*pw).pw_gecos)));
+        fields.push(pyre_object::w_str_new_managed(&cstr((*pw).pw_dir)));
+        fields.push(pyre_object::w_str_new_managed(&cstr((*pw).pw_shell)));
+        crate::_structseq::new_instance(struct_passwd_type(), fields.take())
     }
     // `app_pwd.py class struct_passwd(metaclass=structseqtype)`.
     crate::module_ns_store(ns, "struct_passwd", struct_passwd_type());

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -60,6 +60,26 @@ struct MiniXmlParser<'a> {
     char_buffer: String,
 }
 
+/// Pins each handler argument as it is produced. An array literal would
+/// mint every argument first, so a later allocation could sweep an earlier
+/// managed string before any root existed.
+struct HandlerArgs<'p, 'a> {
+    parser: &'p mut MiniXmlParser<'a>,
+    name: &'static str,
+    items: pyre_object::gc_roots::RootedItems,
+}
+
+impl<'p, 'a> HandlerArgs<'p, 'a> {
+    fn arg(mut self, item: PyObjectRef) -> Self {
+        self.items.push(item);
+        self
+    }
+
+    fn call(self) -> Result<(), crate::PyError> {
+        self.parser.call_handler(self.name, &self.items.take())
+    }
+}
+
 impl<'a> MiniXmlParser<'a> {
     fn new(parser: PyObjectRef, input: &'a str, isfinal: bool, suppress_until: usize) -> Self {
         Self {
@@ -275,10 +295,11 @@ impl<'a> MiniXmlParser<'a> {
         } {
             validate_decl_encoding(&enc).map_err(|m| self.make_error(m))?;
         }
-        self.call_handler(
-            "XmlDeclHandler",
-            &[w_str_new_managed(&version), encoding, standalone],
-        )?;
+        self.handler_args("XmlDeclHandler")
+            .arg(w_str_new_managed(&version))
+            .arg(encoding)
+            .arg(standalone)
+            .call()?;
         if unsafe { is_int(standalone) && w_int_get_value(standalone) == 0 } {
             crate::baseobjspace::setdictvalue_native(
                 self.parser,
@@ -305,7 +326,9 @@ impl<'a> MiniXmlParser<'a> {
             self.bump_char();
         }
         self.set_event_position(event_pos);
-        self.call_handler("CommentHandler", &[w_str_new_managed(&text)])
+        self.handler_args("CommentHandler")
+            .arg(w_str_new_managed(&text))
+            .call()
     }
 
     fn parse_pi(&mut self) -> Result<(), crate::PyError> {
@@ -326,10 +349,10 @@ impl<'a> MiniXmlParser<'a> {
             self.bump_char();
         }
         self.set_event_position(event_pos);
-        self.call_handler(
-            "ProcessingInstructionHandler",
-            &[w_str_new_managed(&target), w_str_new_managed(&data)],
-        )
+        self.handler_args("ProcessingInstructionHandler")
+            .arg(w_str_new_managed(&target))
+            .arg(w_str_new_managed(&data))
+            .call()
     }
 
     fn parse_cdata(&mut self) -> Result<(), crate::PyError> {
@@ -399,17 +422,21 @@ impl<'a> MiniXmlParser<'a> {
         if self.consume("[") {
             has_internal_subset = true;
             self.set_event_position(event_pos);
-            self.call_handler(
-                "StartDoctypeDeclHandler",
-                &[w_str_new_managed(&name), sysid, pubid, w_int_new(1)],
-            )?;
+            self.handler_args("StartDoctypeDeclHandler")
+                .arg(w_str_new_managed(&name))
+                .arg(sysid)
+                .arg(pubid)
+                .arg(w_int_new(1))
+                .call()?;
             self.parse_internal_subset()?;
         } else {
             self.set_event_position(event_pos);
-            self.call_handler(
-                "StartDoctypeDeclHandler",
-                &[w_str_new_managed(&name), sysid, pubid, w_int_new(0)],
-            )?;
+            self.handler_args("StartDoctypeDeclHandler")
+                .arg(w_str_new_managed(&name))
+                .arg(sysid)
+                .arg(pubid)
+                .arg(w_int_new(0))
+                .call()?;
         }
         self.skip_ws();
         self.expect(">")?;
@@ -509,24 +536,24 @@ impl<'a> MiniXmlParser<'a> {
         let _ = &mut base;
         self.set_event_position(event_pos);
         if !unsafe { is_none(notation) } {
-            self.call_handler(
-                "UnparsedEntityDeclHandler",
-                &[w_str_new_managed(&name), base, sysid, pubid, notation],
-            )?;
+            self.handler_args("UnparsedEntityDeclHandler")
+                .arg(w_str_new_managed(&name))
+                .arg(base)
+                .arg(sysid)
+                .arg(pubid)
+                .arg(notation)
+                .call()?;
             return Ok(());
         }
-        self.call_handler(
-            "EntityDeclHandler",
-            &[
-                w_str_new_managed(&name),
-                w_int_new(is_param),
-                value,
-                base,
-                sysid,
-                pubid,
-                notation,
-            ],
-        )
+        self.handler_args("EntityDeclHandler")
+            .arg(w_str_new_managed(&name))
+            .arg(w_int_new(is_param))
+            .arg(value)
+            .arg(base)
+            .arg(sysid)
+            .arg(pubid)
+            .arg(notation)
+            .call()
     }
 
     fn skip_parameter_entity_ref(&mut self) -> Result<(), crate::PyError> {
@@ -572,7 +599,10 @@ impl<'a> MiniXmlParser<'a> {
         ]);
         let model = roots.pin_root(model);
         self.set_event_position(event_pos);
-        self.call_handler("ElementDeclHandler", &[w_str_new_managed(&name), model])
+        self.handler_args("ElementDeclHandler")
+            .arg(w_str_new_managed(&name))
+            .arg(model)
+            .call()
     }
 
     fn parse_attlist_decl(&mut self) -> Result<(), crate::PyError> {
@@ -602,16 +632,13 @@ impl<'a> MiniXmlParser<'a> {
                 0
             };
             self.set_event_position(event_pos);
-            self.call_handler(
-                "AttlistDeclHandler",
-                &[
-                    w_str_new_managed(&elem),
-                    w_str_new_managed(&attr),
-                    w_str_new_managed(&kind),
-                    w_none(),
-                    w_int_new(required),
-                ],
-            )?;
+            self.handler_args("AttlistDeclHandler")
+                .arg(w_str_new_managed(&elem))
+                .arg(w_str_new_managed(&attr))
+                .arg(w_str_new_managed(&kind))
+                .arg(w_none())
+                .arg(w_int_new(required))
+                .call()?;
         }
     }
 
@@ -646,10 +673,12 @@ impl<'a> MiniXmlParser<'a> {
         }
         self.skip_until_gt()?;
         self.set_event_position(event_pos);
-        self.call_handler(
-            "NotationDeclHandler",
-            &[w_str_new_managed(&name), w_none(), sysid, pubid],
-        )
+        self.handler_args("NotationDeclHandler")
+            .arg(w_str_new_managed(&name))
+            .arg(w_none())
+            .arg(sysid)
+            .arg(pubid)
+            .call()
     }
 
     fn skip_declaration(&mut self) -> Result<(), crate::PyError> {
@@ -895,6 +924,14 @@ impl<'a> MiniXmlParser<'a> {
         self.call_handler_raw("CharacterDataHandler", &[w_str_new_managed(&text)])
     }
 
+    fn handler_args(&mut self, name: &'static str) -> HandlerArgs<'_, 'a> {
+        HandlerArgs {
+            parser: self,
+            name,
+            items: pyre_object::gc_roots::RootedItems::new(),
+        }
+    }
+
     fn call_handler(&mut self, name: &str, args: &[PyObjectRef]) -> Result<(), crate::PyError> {
         // The handler lookup below is a full `getattr`, and the flush hands
         // buffered text to a Python handler; both run Python and so can collect,
@@ -1024,10 +1061,10 @@ impl<'a> MiniXmlParser<'a> {
                 } else {
                     w_str_new_managed(&prefix)
                 };
-                self.call_handler(
-                    "StartNamespaceDeclHandler",
-                    &[w_prefix, w_str_new_managed(value)],
-                )?;
+                self.handler_args("StartNamespaceDeclHandler")
+                    .arg(w_prefix)
+                    .arg(w_str_new_managed(value))
+                    .call()?;
             }
         }
         Ok(())
@@ -1138,11 +1175,11 @@ impl<'a> MiniXmlParser<'a> {
                         .map_err(|_| "error in processing external entity reference".to_string())?;
                 }
                 _ if content => {
-                    self.call_handler(
-                        "SkippedEntityHandler",
-                        &[w_str_new_managed(ent), w_int_new(0)],
-                    )
-                    .map_err(|_| "undefined entity".to_string())?;
+                    self.handler_args("SkippedEntityHandler")
+                        .arg(w_str_new_managed(ent))
+                        .arg(w_int_new(0))
+                        .call()
+                        .map_err(|_| "undefined entity".to_string())?;
                 }
                 _ => return Err("undefined entity".to_string()),
             }

--- a/pyre/pyre-interpreter/src/module/resource/resource.rs
+++ b/pyre/pyre-interpreter/src/module/resource/resource.rs
@@ -2,7 +2,6 @@
 //!
 //! Verbatim move of the inline block previously in importing.rs.
 
-
 /// `lib_pypy/resource.py:15-37 class struct_rusage(
 /// metaclass=structseqtype)` — process-wide cached subclass-of-tuple
 /// type.
@@ -11,26 +10,26 @@ static STRUCT_RUSAGE_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new
 fn struct_rusage_type() -> pyre_object::PyObjectRef {
     *STRUCT_RUSAGE_TYPE.get_or_init(|| {
         crate::_structseq::make_struct_seq(
-                "resource.struct_rusage",
-                &[
-                    "ru_utime",
-                    "ru_stime",
-                    "ru_maxrss",
-                    "ru_ixrss",
-                    "ru_idrss",
-                    "ru_isrss",
-                    "ru_minflt",
-                    "ru_majflt",
-                    "ru_nswap",
-                    "ru_inblock",
-                    "ru_oublock",
-                    "ru_msgsnd",
-                    "ru_msgrcv",
-                    "ru_nsignals",
-                    "ru_nvcsw",
-                    "ru_nivcsw",
-                ],
-            ) as usize
+            "resource.struct_rusage",
+            &[
+                "ru_utime",
+                "ru_stime",
+                "ru_maxrss",
+                "ru_ixrss",
+                "ru_idrss",
+                "ru_isrss",
+                "ru_minflt",
+                "ru_majflt",
+                "ru_nswap",
+                "ru_inblock",
+                "ru_oublock",
+                "ru_msgsnd",
+                "ru_msgrcv",
+                "ru_nsignals",
+                "ru_nvcsw",
+                "ru_nivcsw",
+            ],
+        ) as usize
     }) as pyre_object::PyObjectRef
 }
 
@@ -142,17 +141,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     };
                     match rustpython_host_env::resource::getrlimit(res) {
                         Ok(rl) => {
-                            Ok(pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new(rl.rlim_cur as i64),
-                                pyre_object::w_int_new(rl.rlim_max as i64),
-                            ]))
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(rl.rlim_cur as i64));
+                            fields.push(pyre_object::w_int_new(rl.rlim_max as i64));
+                            Ok(pyre_object::w_tuple_new(fields.take()))
                         }
-                        Err(e) => {
-                            Err(crate::PyError::os_error_with_errno(
-                                e.raw_os_error().unwrap_or(0),
-                                format!("getrlimit: {e}"),
-                            ))
-                        }
+                        Err(e) => Err(crate::PyError::os_error_with_errno(
+                            e.raw_os_error().unwrap_or(0),
+                            format!("getrlimit: {e}"),
+                        )),
                     }
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -41,7 +41,9 @@ pub(crate) fn filedescriptor_w(w_fd: PyObjectRef) -> Result<i32, crate::PyError>
             })?;
             let res = crate::call::call_function_impl_result(fileno, &[])?;
             if !pyre_object::is_int_or_long(res) {
-                return Err(crate::PyError::type_error("fileno() returned a non-integer"));
+                return Err(crate::PyError::type_error(
+                    "fileno() returned a non-integer",
+                ));
             }
             res
         };
@@ -215,17 +217,17 @@ impl Poll {
         self.running = false;
         let _ = ret;
 
-        let retval: Vec<PyObjectRef> = pollfds
-            .iter()
-            .filter(|pfd| pfd.revents != 0)
-            .map(|pfd| {
-                pyre_object::w_tuple_new(vec![
-                    pyre_object::w_int_new(pfd.fd as i64),
-                    pyre_object::w_int_new(pfd.revents as i64),
-                ])
-            })
-            .collect();
-        Ok(pyre_object::w_list_new(retval))
+        let mut retval = pyre_object::gc_roots::RootedItems::new();
+        for pfd in pollfds.iter().filter(|pfd| pfd.revents != 0) {
+            let entry = {
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(pfd.fd as i64));
+                fields.push(pyre_object::w_int_new(pfd.revents as i64));
+                pyre_object::w_tuple_new(fields.take())
+            };
+            retval.push(entry);
+        }
+        Ok(pyre_object::w_list_new(retval.take()))
     }
 }
 
@@ -407,9 +409,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         std::time::Duration::try_from_secs_f64(s)
                             .ok()
                             .and_then(|d| std::time::Instant::now().checked_add(d))
-                            .ok_or_else(|| {
-                                crate::PyError::value_error("timeout is too large")
-                            })?,
+                            .ok_or_else(|| crate::PyError::value_error("timeout is too large"))?,
                     ),
                 };
                 let mut rset = host_select::FdSet::new();

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -784,10 +784,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         )));
                     }
                 }
-                #[cfg(all(
-                    unix,
-                    any(not(feature = "host_env"), feature = "sandbox")
-                ))]
+                #[cfg(all(unix, any(not(feature = "host_env"), feature = "sandbox")))]
                 unsafe {
                     let mut st: libc::stat = std::mem::zeroed();
                     let bad_fd = libc::fstat(fd, &mut st) != 0;
@@ -1134,10 +1131,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                             errno_exception("signal.ItimerError", e.raw_os_error().unwrap_or(0))
                         })?;
                     let (delay, interval) = rustpython_host_env::signal::itimerval_to_tuple(&old);
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_float_new(delay),
-                        pyre_object::w_float_new(interval),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_float_new(delay));
+                    fields.push(pyre_object::w_float_new(interval));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 }
                 #[cfg(not(feature = "host_env"))]
                 {
@@ -1176,10 +1173,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                         })?;
                         let (delay, interval) =
                             rustpython_host_env::signal::itimerval_to_tuple(&it);
-                        Ok(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_float_new(delay),
-                            pyre_object::w_float_new(interval),
-                        ]))
+                        let mut fields = pyre_object::gc_roots::RootedItems::new();
+                        fields.push(pyre_object::w_float_new(delay));
+                        fields.push(pyre_object::w_float_new(interval));
+                        Ok(pyre_object::w_tuple_new(fields.take()))
                     }
                     #[cfg(not(feature = "host_env"))]
                     {

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -4,7 +4,6 @@
 //! the host_env real impl and the no-host_env stub are renamed to
 //! `register_module` so moduledef::init can call a single name.
 
-
 /// `interp_termios.py convert_error` — every termios syscall
 /// failure is raised as the cached module exception `termios.error`
 /// (`wrap_oserror(space, e, w_exception_class=w_error)`), not a bare
@@ -67,9 +66,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     ));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                let t = host_termios::tcgetattr(fd).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                let t = host_termios::tcgetattr(fd)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 let ispeed = host_termios::cfgetispeed(&t);
                 let ospeed = host_termios::cfgetospeed(&t);
                 let cc_list = make_cc_bytes(&t.c_cc[..]);
@@ -137,19 +135,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             let cc_obj = fields[6];
 
             // Start from the current settings so we preserve any platform-private fields.
-            let mut t = host_termios::tcgetattr(fd).map_err(|e| {
-                termios_converted_error(e.raw_os_error().unwrap_or(0))
-            })?;
+            let mut t = host_termios::tcgetattr(fd)
+                .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
             t.c_iflag = iflag;
             t.c_oflag = oflag;
             t.c_cflag = cflag;
             t.c_lflag = lflag;
-            host_termios::cfsetispeed(&mut t, ispeed).map_err(|e| {
-                termios_converted_error(e.raw_os_error().unwrap_or(0))
-            })?;
-            host_termios::cfsetospeed(&mut t, ospeed).map_err(|e| {
-                termios_converted_error(e.raw_os_error().unwrap_or(0))
-            })?;
+            host_termios::cfsetispeed(&mut t, ispeed)
+                .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
+            host_termios::cfsetospeed(&mut t, ospeed)
+                .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
 
             // interp_termios.py:30-33 — c_cc is any iterable; an int element
             // goes through bytes([x]) (range 0..=255), a bytes element keeps
@@ -184,9 +179,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 };
                 t.c_cc[i] = byte;
             }
-            host_termios::tcsetattr(fd, when, &t).map_err(|e| {
-                termios_converted_error(e.raw_os_error().unwrap_or(0))
-            })?;
+            host_termios::tcsetattr(fd, when, &t)
+                .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
             Ok(pyre_object::w_none())
         }),
     );
@@ -205,9 +199,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 // `@unwrap_spec(duration=int)`.
                 let dur = crate::baseobjspace::int_w(args[1])? as i32;
-                host_termios::tcsendbreak(fd, dur).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                host_termios::tcsendbreak(fd, dur)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 Ok(pyre_object::w_none())
             },
             2,
@@ -224,9 +217,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     return Err(crate::PyError::type_error("tcdrain() requires 1 argument"));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                host_termios::tcdrain(fd).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                host_termios::tcdrain(fd)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 Ok(pyre_object::w_none())
             },
             1,
@@ -245,9 +237,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 // `@unwrap_spec(queue=int)`.
                 let q = crate::baseobjspace::int_w(args[1])? as i32;
-                host_termios::tcflush(fd, q).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                host_termios::tcflush(fd, q)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 Ok(pyre_object::w_none())
             },
             2,
@@ -266,9 +257,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 // `@unwrap_spec(action=int)`.
                 let action = crate::baseobjspace::int_w(args[1])? as i32;
-                host_termios::tcflow(fd, action).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                host_termios::tcflow(fd, action)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 Ok(pyre_object::w_none())
             },
             2,
@@ -287,15 +277,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     ));
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                let (rows, cols) = host_termios::tcgetwinsize(fd).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                let (rows, cols) = host_termios::tcgetwinsize(fd)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 // PyPy `interp_termios.tcgetwinsize` returns
                 // `(ws_row, ws_col)`.
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_int_new(rows as i64),
-                    pyre_object::w_int_new(cols as i64),
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(rows as i64));
+                fields.push(pyre_object::w_int_new(cols as i64));
+                Ok(pyre_object::w_tuple_new(fields.take()))
             },
             1,
         ),
@@ -318,9 +307,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 // from unpackiterable) is reported as a TypeError.
                 let winsz = crate::baseobjspace::unpackiterable(args[1], 2).map_err(|e| {
                     if e.kind == crate::PyErrorKind::ValueError {
-                        crate::PyError::type_error(
-                            "tcsetwinsize: argument 2 must be a 2-sequence",
-                        )
+                        crate::PyError::type_error("tcsetwinsize: argument 2 must be a 2-sequence")
                     } else {
                         e
                     }
@@ -329,18 +316,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let cols = crate::baseobjspace::int_w(winsz[1])?;
                 // PyPy `interp_termios.tcsetwinsize` performs this overflow
                 // guard before setting the window size.
-                let rows = u16::try_from(rows).map_err(|_| {
-                    crate::PyError::overflow_error("winsize value(s) out of range")
-                })?;
-                let cols = u16::try_from(cols).map_err(|_| {
-                    crate::PyError::overflow_error("winsize value(s) out of range")
-                })?;
+                let rows = u16::try_from(rows)
+                    .map_err(|_| crate::PyError::overflow_error("winsize value(s) out of range"))?;
+                let cols = u16::try_from(cols)
+                    .map_err(|_| crate::PyError::overflow_error("winsize value(s) out of range"))?;
                 // `host_termios::tcsetwinsize` performs the same initial
                 // TIOCGWINSZ that `interp_termios.tcsetwinsize` does,
                 // preserving `ws_xpixel` / `ws_ypixel` across the set.
-                host_termios::tcsetwinsize(fd, rows, cols).map_err(|e| {
-                    termios_converted_error(e.raw_os_error().unwrap_or(0))
-                })?;
+                host_termios::tcsetwinsize(fd, rows, cols)
+                    .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 Ok(pyre_object::w_none())
             },
             2,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1238,7 +1238,10 @@ mod rlock_class {
                     "cannot release un-acquired lock",
                 ));
             }
-            let saved = w_tuple_new(vec![w_int_new(state.count), w_int_new(state.owner)]);
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_int_new(state.count));
+            fields.push(w_int_new(state.owner));
+            let saved = w_tuple_new(fields.take());
             state.count = 0;
             state.owner = 0;
             self.ready.notify_one();

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -851,7 +851,12 @@ mod imp {
         let key = as_hkey(pos[0], false)?;
         let name = wide_or_empty(opt_text(pos[1], "QueryValueEx", "2")?)?;
         match host_reg::query_value_bytes(key, &name) {
-            Ok((data, typ)) => Ok(w_tuple_new(vec![reg2py(&data, typ), w_int_new(typ as i64)])),
+            Ok((data, typ)) => {
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(reg2py(&data, typ));
+                fields.push(w_int_new(typ as i64));
+                Ok(w_tuple_new(fields.take()))
+            }
             Err(code) => Err(win_err(code)),
         }
     }
@@ -930,22 +935,24 @@ mod imp {
                 .iter()
                 .position(|&unit| unit == 0)
                 .unwrap_or(name.len());
-            return Ok(w_tuple_new(vec![
-                w_str_from_wtf8(Wtf8Buf::from_wide(&name[..end])),
-                reg2py(&data[..data_len as usize], typ),
-                w_int_new(typ as i64),
-            ]));
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_str_from_wtf8_managed(Wtf8Buf::from_wide(&name[..end])));
+            fields.push(reg2py(&data[..data_len as usize], typ));
+            fields.push(w_int_new(typ as i64));
+            return Ok(w_tuple_new(fields.take()));
         }
     }
 
     fn query_info_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let key = as_hkey(single_arg(args, "QueryInfoKey")?, false)?;
         match host_reg::query_info_key_full(key) {
-            Ok(info) => Ok(w_tuple_new(vec![
-                w_int_new(info.sub_keys as i64),
-                w_int_new(info.values as i64),
-                w_int_new(info.last_write_time as i64),
-            ])),
+            Ok(info) => {
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(w_int_new(info.sub_keys as i64));
+                fields.push(w_int_new(info.values as i64));
+                fields.push(w_int_new(info.last_write_time as i64));
+                Ok(w_tuple_new(fields.take()))
+            }
             Err(code) => Err(win_err(code)),
         }
     }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1120,10 +1120,10 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 .expect("divisor was checked nonzero");
             let q = RBigIntGcRoot::new(q);
             let r = RBigIntGcRoot::new(r);
-            return Ok(w_tuple_new(vec![
-                bigint_result(q.translated_alias()),
-                bigint_result(r.translated_alias()),
-            ]));
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(bigint_result(q.translated_alias()));
+            fields.push(bigint_result(r.translated_alias()));
+            return Ok(w_tuple_new(fields.take()));
         }
         let mut q = va / vb;
         let mut r = va % vb;
@@ -1131,7 +1131,10 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             q -= 1;
             r += vb;
         }
-        return Ok(w_tuple_new(vec![w_int_new(q), w_int_new(r)]));
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(q));
+        fields.push(w_int_new(r));
+        return Ok(w_tuple_new(fields.take()));
     }
 
     // longobject.py `_make_descr_binop(_divmod, _int_divmod)` preserves a
@@ -1174,12 +1177,15 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         } else {
             w_long_new(r.translated_alias())
         };
-        Ok(w_tuple_new(vec![w_q, w_r]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_q);
+        fields.push(w_r);
+        Ok(w_tuple_new(fields.take()))
     } else {
-        Ok(w_tuple_new(vec![
-            bigint_result(q.translated_alias()),
-            bigint_result(r.translated_alias()),
-        ]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(bigint_result(q.translated_alias()));
+        fields.push(bigint_result(r.translated_alias()));
+        Ok(w_tuple_new(fields.take()))
     }
 }
 
@@ -4268,7 +4274,10 @@ pub(crate) fn divmod_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 let y = as_float(b);
                 reject_float_coercion_overflow(b, y)?;
                 let (q, r) = float_divmod_w(x, y)?;
-                return Ok(w_tuple_new(vec![w_float_new(q), w_float_new(r)]));
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(w_float_new(q));
+                fields.push(w_float_new(r));
+                return Ok(w_tuple_new(fields.take()));
             }
             return integer_divmod_pair(a, b);
         }
@@ -4832,7 +4841,10 @@ pub fn divmod(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
                 let y = as_float(b);
                 reject_float_coercion_overflow(b, y)?;
                 let (q, r) = float_divmod_w(x, y)?;
-                return Ok(w_tuple_new(vec![w_float_new(q), w_float_new(r)]));
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(w_float_new(q));
+                fields.push(w_float_new(r));
+                return Ok(w_tuple_new(fields.take()));
             }
             return integer_divmod_pair(a, b);
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4678,23 +4678,23 @@ impl PyFrame {
     /// PyPy-compatible pickle state helper.
     #[inline]
     pub fn _reduce_state(&self) -> PyObjectRef {
-        pyre_object::w_tuple_new(vec![
-            pyre_object::w_none(),
-            pyre_object::w_none(),
-            pyre_object::w_none(),
-            pyre_object::w_int_new(self.last_instr as i64),
-            pyre_object::w_int_new(self.valuestackdepth as i64),
-        ])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_none());
+        fields.push(pyre_object::w_none());
+        fields.push(pyre_object::w_none());
+        fields.push(pyre_object::w_int_new(self.last_instr as i64));
+        fields.push(pyre_object::w_int_new(self.valuestackdepth as i64));
+        pyre_object::w_tuple_new(fields.take())
     }
 
     /// PyPy-compatible `descr__reduce__`.
     #[inline]
     pub fn descr__reduce__(&self) -> PyObjectRef {
-        pyre_object::w_tuple_new(vec![
-            pyre_object::w_none(),
-            pyre_object::w_none(),
-            self._reduce_state(),
-        ])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_none());
+        fields.push(pyre_object::w_none());
+        fields.push(self._reduce_state());
+        pyre_object::w_tuple_new(fields.take())
     }
 
     /// PyPy-compatible `descr__setstate__`.

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -178,7 +178,10 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
     if unsafe { pyre_object::is_none(w_slots) } {
         return Ok(w_ret);
     }
-    Ok(pyre_object::w_tuple_new(vec![w_ret, w_slots]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_ret);
+    fields.push(w_slots);
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 /// objectobject.py `_getnewargs(space, w_obj)` — returns
@@ -285,7 +288,9 @@ pub fn set_reduce(w_obj: PyObjectRef) -> PyResult {
         pyre_object::setobject::w_set_items(pyre_object::gc_roots::shadow_stack_get(obj_slot))
     };
     let w_list = pyre_object::listobject::w_list_new(items);
-    let w_args = pyre_object::w_tuple_new(vec![w_list]);
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(w_list);
+    let w_args = pyre_object::w_tuple_new(args.take());
     let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -7312,12 +7312,15 @@ fn dict_update_pair_note(mut err: crate::PyError, idx: usize) -> crate::PyError 
     if err.kind != crate::PyErrorKind::TypeError {
         return err;
     }
-    let exc = err.to_exc_object();
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    let exc = _roots.pin_root(err.to_exc_object());
     err.exc_object = exc;
-    let note = w_str_new_managed(&format!(
+    let note = _roots.pin_root(w_str_new_managed(&format!(
         "Cannot convert dictionary update sequence element #{idx} to a sequence"
-    ));
+    )));
     unsafe {
+        let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         let dict = pyre_object::interp_exceptions::w_exception_getdict(exc);
         let notes = match w_dict_getitem_str(dict, "__notes__") {
             Some(notes) if crate::baseobjspace::isinstance_list_w(notes) => notes,
@@ -7332,6 +7335,7 @@ fn dict_update_pair_note(mut err: crate::PyError, idx: usize) -> crate::PyError 
         };
         w_list_append(notes, note);
     }
+    err.exc_object = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     err
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6403,11 +6403,13 @@ pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         return Err(crate::PyError::value_error("empty separator"));
     }
     match wtf8_find_bounded(s, sep, 0, s.len()) {
-        Some(i) => Ok(w_tuple_new(vec![
-            wtf8_slice_str(&s[..i]),
-            args[1],
-            wtf8_slice_str(&s[i + sep.len()..]),
-        ])),
+        Some(i) => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(wtf8_slice_str(&s[..i]));
+            fields.push(args[1]);
+            fields.push(wtf8_slice_str(&s[i + sep.len()..]));
+            Ok(w_tuple_new(fields.take()))
+        }
         None => Ok(w_tuple_new(vec![args[0], w_str_new(""), w_str_new("")])),
     }
 }
@@ -6427,11 +6429,13 @@ pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         return Err(crate::PyError::value_error("empty separator"));
     }
     match wtf8_rfind_bounded(s, sep, 0, s.len()) {
-        Some(i) => Ok(w_tuple_new(vec![
-            wtf8_slice_str(&s[..i]),
-            args[1],
-            wtf8_slice_str(&s[i + sep.len()..]),
-        ])),
+        Some(i) => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(wtf8_slice_str(&s[..i]));
+            fields.push(args[1]);
+            fields.push(wtf8_slice_str(&s[i + sep.len()..]));
+            Ok(w_tuple_new(fields.take()))
+        }
         None => Ok(w_tuple_new(vec![w_str_new(""), w_str_new(""), args[0]])),
     }
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7241,9 +7241,9 @@ fn init_str_type(ns: PyObjectRef) {
                 "__getnewargs__",
                 |args| {
                     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_str_from_wtf8(s.to_owned()),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_str_from_wtf8_managed(s.to_owned()));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 1,
             ),
@@ -15931,11 +15931,16 @@ pub(crate) fn slot_wrapper_check_instance(
 /// protocols 0 and 1.
 fn descr_reduce(descr: PyObjectRef) -> crate::PyResult {
     let owner = unsafe { crate::function::fget_func_objclass(descr)? };
-    let name = pyre_object::w_str_new(unsafe { crate::function::function_get_name(descr) });
-    Ok(pyre_object::w_tuple_new(vec![
-        crate::baseobjspace::builtin_callable("getattr"),
-        pyre_object::w_tuple_new(vec![owner, name]),
-    ]))
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(owner);
+    args.push(pyre_object::w_str_new(unsafe {
+        crate::function::function_get_name(descr)
+    }));
+    let args = pyre_object::w_tuple_new(args.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(crate::baseobjspace::builtin_callable("getattr"));
+    result.push(args);
+    Ok(pyre_object::w_tuple_new(result.take()))
 }
 
 fn init_slot_wrapper_type(ns: PyObjectRef) {
@@ -17350,12 +17355,16 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         ));
                     }
                     let owner = unsafe { pyre_object::w_member_get_cls(member) };
-                    let name =
-                        pyre_object::w_str_new(unsafe { pyre_object::w_member_get_name(member) });
-                    Ok(pyre_object::w_tuple_new(vec![
-                        crate::baseobjspace::builtin_callable("getattr"),
-                        pyre_object::w_tuple_new(vec![owner, name]),
-                    ]))
+                    let mut args = pyre_object::gc_roots::RootedItems::new();
+                    args.push(owner);
+                    args.push(pyre_object::w_str_new(unsafe {
+                        pyre_object::w_member_get_name(member)
+                    }));
+                    let args = pyre_object::w_tuple_new(args.take());
+                    let mut result = pyre_object::gc_roots::RootedItems::new();
+                    result.push(crate::baseobjspace::builtin_callable("getattr"));
+                    result.push(args);
+                    Ok(pyre_object::w_tuple_new(result.take()))
                 },
                 1,
             ),
@@ -19779,10 +19788,10 @@ fn init_int_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "as_integer_ratio",
                 |args| {
-                    Ok(pyre_object::w_tuple_new(vec![
-                        int_as_plain_int(args),
-                        pyre_object::w_int_new(1),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(int_as_plain_int(args));
+                    fields.push(pyre_object::w_int_new(1));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 1,
             ),
@@ -20353,10 +20362,10 @@ fn init_complex_type(ns: PyObjectRef) {
                     };
                     // complexobject.py descr___getnewargs__: two base floats,
                     // preserving the sign bits of zero components.
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_float_new(re),
-                        pyre_object::w_float_new(im),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_float_new(re));
+                    fields.push(pyre_object::w_float_new(im));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 1,
             ),
@@ -20959,10 +20968,10 @@ fn float_descr_as_integer_ratio(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
             pyre_object::w_long_new(b)
         }
     };
-    Ok(pyre_object::w_tuple_new(vec![
-        to_pyint(numer),
-        to_pyint(denom),
-    ]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(to_pyint(numer));
+    fields.push(to_pyint(denom));
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 /// RPython `rpython/rlib/rfloat.py float_as_rbigint_ratio`.
@@ -22858,9 +22867,9 @@ fn init_bytes_type(ns: PyObjectRef) {
                 "__getnewargs__",
                 |args| {
                     let data = unsafe { pyre_object::w_bytes_data(args[0]) };
-                    Ok(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_bytes_from_bytes(data),
-                    ]))
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_bytes_from_bytes(data));
+                    Ok(pyre_object::w_tuple_new(fields.take()))
                 },
                 1,
             ),
@@ -23894,11 +23903,11 @@ fn bytes_partition(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, c
             } else {
                 new_bytes_like(args[0], sep)
             };
-            Ok(pyre_object::w_tuple_new(vec![
-                new_bytes_like(args[0], &data[..i]),
-                middle,
-                new_bytes_like(args[0], &data[i + sep.len()..]),
-            ]))
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(new_bytes_like(args[0], &data[..i]));
+            fields.push(middle);
+            fields.push(new_bytes_like(args[0], &data[i + sep.len()..]));
+            Ok(pyre_object::w_tuple_new(fields.take()))
         }
         None => {
             // `cut_bytes_like` keeps a bytearray receiver out of the result
@@ -23907,9 +23916,17 @@ fn bytes_partition(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, c
             let whole = cut_bytes_like(args[0], data);
             let empty = || empty_bytes_like(args[0]);
             if forward {
-                Ok(pyre_object::w_tuple_new(vec![whole, empty(), empty()]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(whole);
+                fields.push(empty());
+                fields.push(empty());
+                Ok(pyre_object::w_tuple_new(fields.take()))
             } else {
-                Ok(pyre_object::w_tuple_new(vec![empty(), empty(), whole]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(empty());
+                fields.push(empty());
+                fields.push(whole);
+                Ok(pyre_object::w_tuple_new(fields.take()))
             }
         }
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -26169,18 +26169,30 @@ fn bytearray_reduce_impl(
     let args = if data.is_empty() {
         w_tuple_new(vec![])
     } else if protocol.is_some_and(|p| p >= 3) {
-        w_tuple_new(vec![pyre_object::bytesobject::w_bytes_from_bytes(data)])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::bytesobject::w_bytes_from_bytes(data));
+        w_tuple_new(fields.take())
     } else {
         // bytearrayobject.py:221-233 — legacy protocols carry a latin-1
         // unicode string plus the explicit codec name.
         let latin1: String = data.iter().map(|&b| char::from(b)).collect();
-        w_tuple_new(vec![w_str_new(&latin1), w_str_new("latin-1")])
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_str_new(&latin1));
+        fields.push(w_str_new("latin-1"));
+        w_tuple_new(fields.take())
     };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(args);
     let cls = crate::typedef::r#type(obj)
         .map(|p| p.as_ptr())
         .unwrap_or_else(|| gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE));
     let state = crate::reduce_protocol::object_getstate_default(obj)?;
-    Ok(w_tuple_new(vec![cls, args, state]))
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(cls);
+    result.push(pyre_object::gc_roots::shadow_stack_get(args_slot));
+    result.push(state);
+    Ok(w_tuple_new(result.take()))
 }
 
 fn bytearray_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -28901,11 +28913,14 @@ fn set_iter_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         let w_set = pyre_object::w_set_iter_get_set(args[0]);
         let startlen = pyre_object::w_set_iter_get_startlen(args[0]);
         if w_set.is_null() {
-            let state = pyre_object::w_tuple_new(vec![pyre_object::w_list_new(vec![])]);
-            return Ok(pyre_object::w_tuple_new(vec![
-                crate::baseobjspace::builtin_callable("iter"),
-                state,
-            ]));
+            let empty = pyre_object::w_list_new(vec![]);
+            let mut state = pyre_object::gc_roots::RootedItems::new();
+            state.push(empty);
+            let state = pyre_object::w_tuple_new(state.take());
+            let mut result = pyre_object::gc_roots::RootedItems::new();
+            result.push(crate::baseobjspace::builtin_callable("iter"));
+            result.push(state);
+            return Ok(pyre_object::w_tuple_new(result.take()));
         }
         if startlen == usize::MAX || pyre_object::w_set_len(w_set) != startlen {
             return Err(crate::PyError::new(
@@ -28922,11 +28937,14 @@ fn set_iter_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             }
             i = slot + 1;
         }
-        let state = pyre_object::w_tuple_new(vec![pyre_object::w_list_new(remaining)]);
-        Ok(pyre_object::w_tuple_new(vec![
-            crate::baseobjspace::builtin_callable("iter"),
-            state,
-        ]))
+        let list = pyre_object::w_list_new(remaining);
+        let mut state = pyre_object::gc_roots::RootedItems::new();
+        state.push(list);
+        let state = pyre_object::w_tuple_new(state.take());
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(crate::baseobjspace::builtin_callable("iter"));
+        result.push(state);
+        Ok(pyre_object::w_tuple_new(result.take()))
     }
 }
 


### PR DESCRIPTION
A plain `Vec<PyObjectRef>` and an array literal are not GC roots. A later `w_str_new_managed` / `w_tuple_new` / `w_list_new` can therefore sweep an earlier collectable object that still only lives in that native vector.

This series pins each minted field as it is produced (`RootedItems` / `pin_root`) before the container allocation, and converts leftover per-call strings to `w_str_new_managed`.

Covered in this branch:
- structseq / grp / pwd / uname / pickle keys and reduce paths
- pyexpat handler args (incremental pin, not array-literal evaluation)
- `_socket` hostent/addr/recv/accept tuples
- `_codecs` / `_multibytecodec` encode-decode results
- divmod, `str`/`bytes` partition, exception/descriptor/array/deque reduce
- posix / winapi / select / ssl / winreg / overlapped / hashlib HMAC names

Startup and interned `w_str_new` stays for constants and clinic defaults.

Assisted-by: Claude