### PR TITLE
blackhole: refuse non-DirectPointer vable arrays

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -11636,9 +11636,21 @@ fn take_vable_array_descrs<'a>(
     code: &[u8],
     descr_pos: usize,
 ) -> (BhDescr, &'a BhDescr, usize) {
-    vable_clear_token_and_get_vinfo(bh, vable);
-    let (field_descr, _array_idx, p) = read_descr_vable_array(bh, code, descr_pos);
+    let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
+    let (field_descr, array_idx, p) = read_descr_vable_array(bh, code, descr_pos);
     let (array_descr, pos) = read_descr(bh, code, p);
+    // `virtualizable.py` `make_sure_not_resized`: the array field is
+    // `Ptr(GcArray)`, so `bh_getfield_gc_r` + `bh_getarrayitem_gc_*` is
+    // the only layout `bhimpl_*array*_vable` may touch. `RustVec` /
+    // `EmbeddedArray` would make `bh_getfield_gc_r` load a container
+    // metadata word as the array pointer.
+    match vinfo.array_fields.get(array_idx).map(|a| &a.storage) {
+        Some(crate::virtualizable::VableArrayStorage::DirectPointer) => {}
+        other => panic!(
+            "bhimpl_*array*_vable requires Ptr(GcArray) DirectPointer \
+             (virtualizable.py make_sure_not_resized); got {other:?}"
+        ),
+    }
     (field_descr, array_descr, pos)
 }
 

--- a/majit/majit-metainterp/tests/vable_array_blackhole_cpu.rs
+++ b/majit/majit-metainterp/tests/vable_array_blackhole_cpu.rs
@@ -118,3 +118,58 @@ fn setarrayitem_vable_i_then_arraylen_vable_use_the_cpu_chain() {
     assert_eq!(state.regs.to_vec(), vec![10, 99, 30]);
     assert_eq!(bh.tmpreg_i, 3);
 }
+
+struct VecState {
+    regs: Vec<i64>,
+}
+
+fn vec_data_ptr(p: *mut u8) -> *mut i64 {
+    unsafe { (*(p as *mut VecState)).regs.as_mut_ptr() }
+}
+
+fn vec_len(p: *const u8) -> usize {
+    unsafe { (*(p as *const VecState)).regs.len() }
+}
+
+/// `bhimpl_getarrayitem_vable_*` only accepts `Ptr(GcArray)`. A `Vec`
+/// field registers `RustVec`; the CPU chain must refuse it rather than
+/// load a `Vec` metadata word as the array pointer.
+#[test]
+#[should_panic(expected = "DirectPointer")]
+fn rustvec_getarrayitem_vable_i_refuses_the_cpu_chain() {
+    let cpu = TestBackend::new();
+    let mut builder = bh_builder();
+    builder.set_cpu(&cpu);
+
+    let mut info = VirtualizableInfo::without_vable_token();
+    register_virt_array_field(
+        &mut info,
+        "regs",
+        majit_ir::Type::Int,
+        std::mem::size_of::<i64>(),
+        std::mem::offset_of!(VecState, regs),
+        vec_data_ptr,
+        vec_len,
+        |s: &VecState| &s.regs,
+    );
+    assert!(matches!(
+        info.array_fields[0].storage,
+        VableArrayStorage::RustVec { .. }
+    ));
+
+    let mut b = JitCodeBuilder::new();
+    b.vable_getarrayitem_int_with_base(2, 0, 0, 1);
+    b.int_return(2);
+    let jitcode = std::sync::Arc::new(b.finish());
+
+    let mut state = VecState {
+        regs: vec![10i64, 20, 30],
+    };
+
+    let mut bh = builder.acquire_interp();
+    bh.virtualizable_info = &info;
+    bh.setposition(jitcode, 0);
+    bh.registers_r[0] = &mut state as *mut VecState as i64;
+    bh.registers_i[1] = 2;
+    let _ = bh.run();
+}


### PR DESCRIPTION
## Summary

Line-by-line contrast of `rpython/jit/metainterp/blackhole.py` against `majit/majit-metainterp/src/blackhole.rs` (every `bhimpl_*`, plus `setposition` / `run` / `_copy_data_from_miframe` / `convert_and_run_from_pyjitpl` / builder).

The remaining observable bug was Codex P2 on merged #1756: after the CPU-chain port, `bhimpl_{get,set}arrayitem_vable_*` / `bhimpl_arraylen_vable` ran `clear_vable_token` → `bh_getfield_gc_r` → `bh_getarrayitem_gc_*` even when the field was `RustVec` or `EmbeddedArray`. PyPy `virtualizable.py` `make_sure_not_resized` makes that field `Ptr(GcArray)` only; a `Vec` metadata word would be loaded as the array pointer.

`take_vable_array_descrs` now panics unless `VableArrayStorage::DirectPointer`. Production `PyFrame` locals and jit_interp `[int; virt]` / `[float; virt]` are already Direct/`VirtArray`.

Documented pyre-only machinery (`abort_permanent`, `state_field`, `BailToInterpreter`, `call_assembler_*_ext`, `arraybase_vable`) is unchanged.

## Test

- `rustvec_getarrayitem_vable_i_refuses_the_cpu_chain` — shipped `bh.run()` on a `Vec`/`RustVec` vinfo panics with `DirectPointer`
- existing DirectPointer CPU-chain tests still pass
- `cargo test --all --no-default-features --features dynasm` exit 0