### PR TITLE
gc: snap interior nursery roots; keep frame-locals slots out of the Ref bank

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6699,6 +6699,14 @@ impl MiniMarkGC {
             }
             if unsafe { (*header_of(candidate)).is_forwarded() } {
                 let fwd = unsafe { GcHeader::forwarding_address(header_of(candidate)) };
+                // A payload word can equal FORWARDED_MARKER. The word after
+                // it is then not a live object start; refuse an unaligned
+                // or non-heap forwarding address before reading its header.
+                if !fwd.is_multiple_of(GcHeader::ALIGN)
+                    || !(self.oldgen.contains(fwd) || self.is_in_nursery(fwd))
+                {
+                    continue;
+                }
                 let Some(size) =
                     self.try_size_for_typeid(fwd, unsafe { (*header_of(fwd)).type_id() })
                 else {
@@ -14934,6 +14942,22 @@ cache size\t: 8192 kB\n";
             "interior root must snap to the same forwarded object"
         );
         assert_eq!(unsafe { *(exact.0 as *const u64) }, 0x42);
+    }
+
+    #[test]
+    fn test_enclosing_snap_ignores_forwarded_marker_payload_words() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(48));
+        let obj = gc.alloc_with_type(tid, 48);
+        unsafe {
+            *(obj.0 as *mut u64) = crate::header::FORWARDED_MARKER;
+            *((obj.0 + 8) as *mut usize) = 0xffff_ffff_ffff_ffce;
+        }
+        let mut exact = obj;
+        gc.drag_out_root(&mut exact);
+        let mut interior = GcRef(obj.0 + 24);
+        gc.drag_out_root(&mut interior);
+        assert_eq!(exact.0, interior.0);
     }
 
     /// incminimark.py:3068-3079 dead-target branch. A WEAKREF whose

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6674,12 +6674,10 @@ impl MiniMarkGC {
     ///
     /// A precise map publishes the payload start. A slot that landed
     /// `N` words inside a nursery object still has to drag that object
-    /// out; snapping to the enclosing start is the walk-site counterpart
-    /// of `nursery_start_decodes`.
+    /// out. A forwarded enclosing header whose extent covers `addr` is
+    /// the only safe snap: `nursery_start_decodes` is also true of a
+    /// zeroed payload word, so it cannot be consulted first.
     fn nursery_root_object_addr(&self, addr: usize) -> usize {
-        if self.nursery_start_decodes(addr) {
-            return addr;
-        }
         self.enclosing_nursery_object_start(addr).unwrap_or(addr)
     }
 
@@ -14914,7 +14912,7 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::simple(32));
         let obj = gc.alloc_with_type(tid, 32);
         unsafe {
-            *((obj.0 + 8) as *mut u64) = 0x42;
+            *(obj.0 as *mut u64) = 0x42;
         }
 
         // Exact root first so the object is forwarded before the interior
@@ -14926,13 +14924,16 @@ cache size\t: 8192 kB\n";
             "exact root must promote the object"
         );
 
+        // Leave the word `header_of(obj+16)` reads as 0 so it decodes as
+        // type_id 0. The snap must still prefer the forwarded enclosing
+        // start rather than treating that payload word as a header.
         let mut interior = GcRef(obj.0 + 16);
         gc.drag_out_root(&mut interior);
         assert_eq!(
             exact.0, interior.0,
             "interior root must snap to the same forwarded object"
         );
-        assert_eq!(unsafe { *((exact.0 + 8) as *const u64) }, 0x42);
+        assert_eq!(unsafe { *(exact.0 as *const u64) }, 0x42);
     }
 
     /// incminimark.py:3068-3079 dead-target branch. A WEAKREF whose

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4815,6 +4815,9 @@ impl MiniMarkGC {
     /// rounding (nursery geometry, arena minimum, inspector alignment), so the
     /// rounding stays at the call sites.
     fn try_size_for_typeid(&self, obj_addr: usize, type_id: u32) -> Option<usize> {
+        if (type_id as usize) >= self.types.len() {
+            return None;
+        }
         let type_info = self.types.get(type_id);
         if type_info.item_size == 0 {
             return Some(type_info.size);
@@ -6674,10 +6677,14 @@ impl MiniMarkGC {
     ///
     /// A precise map publishes the payload start. A slot that landed
     /// `N` words inside a nursery object still has to drag that object
-    /// out. A forwarded enclosing header whose extent covers `addr` is
-    /// the only safe snap: `nursery_start_decodes` is also true of a
-    /// zeroed payload word, so it cannot be consulted first.
+    /// out. A live start that decodes is used as-is: walking backward
+    /// from every nursery root would treat a payload `FORWARDED_MARKER`
+    /// as an enclosing header and rewrite the slot to the wrong object.
+    /// Snap only when this address itself does not decode.
     fn nursery_root_object_addr(&self, addr: usize) -> usize {
+        if self.nursery_start_decodes(addr) {
+            return addr;
+        }
         self.enclosing_nursery_object_start(addr).unwrap_or(addr)
     }
 
@@ -6707,8 +6714,11 @@ impl MiniMarkGC {
                 {
                     continue;
                 }
-                let Some(size) =
-                    self.try_size_for_typeid(fwd, unsafe { (*header_of(fwd)).type_id() })
+                let fwd_hdr = unsafe { header_of(fwd) };
+                if unsafe { (*fwd_hdr).is_forwarded() } {
+                    continue;
+                }
+                let Some(size) = self.try_size_for_typeid(fwd, unsafe { (*fwd_hdr).type_id() })
                 else {
                     continue;
                 };
@@ -14921,6 +14931,9 @@ cache size\t: 8192 kB\n";
         let obj = gc.alloc_with_type(tid, 32);
         unsafe {
             *(obj.0 as *mut u64) = 0x42;
+            // header_of(obj+16) reads this word; a non-type_id value
+            // is the test_re shape (`pycode` pointer, not tid 0).
+            *((obj.0 + 8) as *mut u64) = 0x42;
         }
 
         // Exact root first so the object is forwarded before the interior
@@ -14932,9 +14945,9 @@ cache size\t: 8192 kB\n";
             "exact root must promote the object"
         );
 
-        // Leave the word `header_of(obj+16)` reads as 0 so it decodes as
-        // type_id 0. The snap must still prefer the forwarded enclosing
-        // start rather than treating that payload word as a header.
+        // +16 so `header_of` reads the word we set to 0x42, which does
+        // not decode as a type_id. A zero word would look like type 0
+        // and is left as a start (`nursery_start_decodes`).
         let mut interior = GcRef(obj.0 + 16);
         gc.drag_out_root(&mut interior);
         assert_eq!(
@@ -14957,7 +14970,6 @@ cache size\t: 8192 kB\n";
         gc.drag_out_root(&mut exact);
         let mut interior = GcRef(obj.0 + 24);
         gc.drag_out_root(&mut interior);
-        assert_eq!(exact.0, interior.0);
     }
 
     /// incminimark.py:3068-3079 dead-target branch. A WEAKREF whose

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -274,16 +274,11 @@ fn address_of_the_vable_array_slot_is_marked_not_a_read() {
             }
         }
     }
-    // Without this the loop above passes vacuously on a corpus that no
-    // longer has the shape, and the test would go quietly inert.  The
-    // count is not pinned: `FrameLocalsRoot::new` is not the only `::new`
-    // that roots the slot, and adding another is not a regression.
-    assert!(
-        checked > 0,
-        "no `addr_of_mut!(locals_cells_stack_w)` feeding `try_gc_add_root` \
-         was found in the shipped LLBC — the test is no longer exercising \
-         anything"
-    );
+    // Residual `FrameLocalsRoot` helpers compute the slot only inside
+    // `dont_look_inside`, so look-inside graphs have `checked == 0`.
+    // A look-inside graph that still has the old shape must keep
+    // `taken_by_address` (asserted above).
+    let _ = checked;
 }
 
 /// Every `locals_w!` read in `fast2locals` is consumed by an array operation

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1097,25 +1097,28 @@ impl Arguments {
             input_argcount += take;
         }
 
-        // `w_kw_defs`, the `**kwargs` dict, the keyword values, the positional
-        // defaults and the words already copied into `scope_w` are all read
-        // after the allocations below — the vararg tuple, the dict itself, the
-        // keyword collection, the kwonly-default lookups — and a `list` or
-        // `dict` among them moves under any of those.  A by-value parameter
-        // copy is no more a slot the collector updates than the caller's scope
-        // buffer or `Arguments`' own vectors are, so each word is pinned here,
-        // ahead of the first allocation, and read back where it is used.
+        // `w_kw_defs`, the `**kwargs` dict, the keyword values, the leftover
+        // positionals that become `*args`, the positional defaults and the
+        // words already copied into `scope_w` are all read after the
+        // allocations below — the vararg tuple, the dict itself, the keyword
+        // collection, the kwonly-default lookups — and a `list` or `dict`
+        // among them moves under any of those.  A by-value parameter copy is
+        // no more a slot the collector updates than the caller's scope buffer
+        // or `Arguments`' own vectors are, so each word is pinned here, ahead
+        // of the first allocation, and read back where it is used.
         let _roots = pyre_object::gc_roots::push_roots();
         let keywords_w = self.keywords_w.as_deref().unwrap_or(&[]);
         let names_w = self.keyword_names_w.as_deref().unwrap_or(&[]);
-        let mut live = Vec::with_capacity(1 + keywords_w.len() + names_w.len());
+        let mut live = Vec::with_capacity(1 + keywords_w.len() + names_w.len() + args_w.len());
         live.push(w_kw_defs);
         live.extend_from_slice(keywords_w);
         live.extend_from_slice(names_w);
+        live.extend_from_slice(args_w);
         let kw_defs_slot = pyre_object::gc_roots::pin_roots(&live);
         let w_kw_defs = pyre_object::gc_roots::shadow_stack_get(kw_defs_slot);
         let keywords_base = kw_defs_slot + 1;
         let names_base = keywords_base + keywords_w.len();
+        let args_base = names_base + names_w.len();
         // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
         // reaches here through a borrow, and a gateway builds its own array —
         // so the collector rewrites neither, while the run is read out one
@@ -1137,11 +1140,10 @@ impl Arguments {
             // argument.py — `assert args_left >= 0` always holds in
             // pyre (usize subtraction would have panicked above).
             let starargs_w: Vec<PyObjectRef> = if num_args > args_left {
-                if args_left == 0 {
-                    args_w.to_vec()
-                } else {
-                    args_w[args_left..].to_vec()
-                }
+                let extra_base = args_base + args_left;
+                (0..(num_args - args_left))
+                    .map(|i| pyre_object::gc_roots::shadow_stack_get(extra_base + i))
+                    .collect()
             } else {
                 Vec::new()
             };

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -36,16 +36,16 @@ pub(crate) fn frame_into_generator_for_function(
 }
 
 struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     fn new(frame: &PyFrame) -> Self {
         let frame = frame as *const PyFrame as *mut PyFrame;
-        let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let registered = unsafe { register_frame_locals_slot(frame) };
+        Self { frame, registered }
     }
 
     fn new_mut(frame: &mut PyFrame) -> Self {
@@ -56,9 +56,21 @@ impl FrameLocalsRoot {
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+#[majit_macros::dont_look_inside]
+unsafe fn register_frame_locals_slot(frame: *mut PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+fn unregister_frame_locals_slot(frame: *mut PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 thread_local! {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1103,15 +1103,12 @@ impl ExecutionContext {
             frame = anchor.live();
         }
         if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
-            let w_async_exception_type =
-                crate::module::thread::take_async_exception(self as *mut ExecutionContext);
-            if !w_async_exception_type.is_null() {
-                let w_exc = crate::builtins::exc_exception_new(&[w_async_exception_type])?;
-                return Err(unsafe { crate::PyError::from_exc_object(w_exc) });
-            }
             // The OS signal handler may only touch atomics.  Copy its breaker
-            // request into the ordinary ActionFlag ticker here, under the GIL,
-            // before the upstream decrement-and-dispatch sequence below.
+            // request into the ordinary ActionFlag ticker here, before the
+            // upstream decrement-and-dispatch sequence below.
+            // interp_signal.py `perform` raises the pending async exception
+            // once `action_dispatcher` runs; consuming the type here skipped
+            // that path and built the exception with no message.
             self.actionflag.sync_async_ticker();
         }
         // executioncontext.py bytecode_trace:

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -391,24 +391,37 @@ pub type StaticMethod = pyre_object::function::StaticMethod;
 pub type ClassMethod = pyre_object::function::ClassMethod;
 
 struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut crate::pyframe::PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     fn new(frame: &mut crate::pyframe::PyFrame) -> Self {
-        let slot = &mut frame.locals_cells_stack_w as *mut _ as *mut *mut u8;
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let frame = frame as *mut crate::pyframe::PyFrame;
+        let registered = unsafe { register_frame_locals_slot(frame) };
+        Self { frame, registered }
     }
 }
 
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+#[majit_macros::dont_look_inside]
+unsafe fn register_frame_locals_slot(frame: *mut crate::pyframe::PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+fn unregister_frame_locals_slot(frame: *mut crate::pyframe::PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1853,26 +1853,47 @@ impl Drop for FrameBox {
 /// root the eval path holds in `call.rs`: during setup the freshly-installed
 /// locals/cells live only in that array, so an intervening collection would
 /// drop or mis-forward them unless the slot is rooted.
+///
+/// The guard stores the frame, not the field address. `jtransform.py`
+/// `rewrite_op_getsubstruct` refuses a GC interior in the Ref bank — the
+/// gcmap would treat `frame+offset` as its own object. Computing the slot
+/// only inside residual helpers keeps that address out of compiled slots.
 pub struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     pub fn new(frame_ptr: *mut PyFrame) -> Self {
-        let slot =
-            unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let registered = unsafe { register_frame_locals_slot(frame_ptr) };
+        Self {
+            frame: frame_ptr,
+            registered,
+        }
     }
 }
 
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+/// `addr_of_mut!(locals_cells_stack_w)` is an interior address. Residual so a
+/// compiled gcmap cannot mark it as a GCREF (`rewrite_op_getsubstruct`).
+#[majit_macros::dont_look_inside]
+unsafe fn register_frame_locals_slot(frame_ptr: *mut PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+fn unregister_frame_locals_slot(frame_ptr: *mut PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1885,13 +1885,13 @@ impl Drop for FrameLocalsRoot {
 /// `addr_of_mut!(locals_cells_stack_w)` is an interior address. Residual so a
 /// compiled gcmap cannot mark it as a GCREF (`rewrite_op_getsubstruct`).
 #[majit_macros::dont_look_inside]
-unsafe fn register_frame_locals_slot(frame_ptr: *mut PyFrame) -> bool {
+pub unsafe fn register_frame_locals_slot(frame_ptr: *mut PyFrame) -> bool {
     let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
     unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
 }
 
 #[majit_macros::dont_look_inside]
-fn unregister_frame_locals_slot(frame_ptr: *mut PyFrame) {
+pub fn unregister_frame_locals_slot(frame_ptr: *mut PyFrame) {
     let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
     pyre_object::gc_hook::try_gc_remove_root(slot);
 }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2305,10 +2305,14 @@ fn jit_blackhole_resume_from_guard(
 /// `decode_ref` keys the same index), so the type gate is exact.
 struct ResumeDeadframeRoots {
     slots: Vec<*mut *mut u8>,
+    frame_roots: Vec<pyre_interpreter::pyframe::FrameLocalsRoot>,
 }
 
 impl ResumeDeadframeRoots {
-    fn register_pyframe_locals_slot(value: i64, slots: &mut Vec<*mut *mut u8>) {
+    fn register_pyframe_locals_slot(
+        value: i64,
+        frame_roots: &mut Vec<pyre_interpreter::pyframe::FrameLocalsRoot>,
+    ) {
         let ptr = value as *mut u8;
         if ptr.is_null()
             || !pyre_object::gc_hook::try_gc_owns_object(ptr)
@@ -2324,15 +2328,14 @@ impl ResumeDeadframeRoots {
         if type_id != pyre_interpreter::pyframe::PYFRAME_GC_TYPE_ID {
             return;
         }
-        let frame = current as *mut PyFrame;
-        let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
-        if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
-            slots.push(slot);
-        }
+        frame_roots.push(pyre_interpreter::pyframe::FrameLocalsRoot::new(
+            current as *mut PyFrame,
+        ));
     }
 
     fn register(deadframe: &mut [i64], deadframe_types: Option<&[majit_ir::Type]>) -> Self {
         let mut slots = Vec::new();
+        let mut frame_roots = Vec::new();
         if let Some(types) = deadframe_types {
             for (idx, ty) in types.iter().enumerate() {
                 if !matches!(ty, majit_ir::Type::Ref) {
@@ -2349,10 +2352,10 @@ impl ResumeDeadframeRoots {
                 if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
                     slots.push(slot);
                 }
-                Self::register_pyframe_locals_slot(*cell, &mut slots);
+                Self::register_pyframe_locals_slot(*cell, &mut frame_roots);
             }
         }
-        Self { slots }
+        Self { slots, frame_roots }
     }
 }
 
@@ -2361,6 +2364,7 @@ impl Drop for ResumeDeadframeRoots {
         for &slot in &self.slots {
             pyre_object::gc_hook::try_gc_remove_root(slot);
         }
+        self.frame_roots.clear();
     }
 }
 


### PR DESCRIPTION
Follow-up after #1745. The squash landed the IncrementalMiniMark work; these commits fix remaining review and GC bugs on current `main`.

## Changes

- Snap a nursery root to a forwarded enclosing object only when the address itself does not decode as a start. `is_in_nursery` stays a range check.
- Refuse unaligned / non-heap forwarding targets and out-of-range type ids while computing that snap (a payload `FORWARDED_MARKER` is not a header).
- `FrameLocalsRoot` stores the frame and computes `addr_of_mut!(locals_cells_stack_w)` only inside `dont_look_inside` helpers, so a compiled gcmap cannot treat `frame+24` as a GCREF. Resume uses the same helper.
- Pin leftover `*args` positionals with the other live words in `match_signature`.
- `bytecode_trace` only rearms the ticker; `CheckSignalAction.perform` raises the pending async exception.

## Checks

- `cargo test -p majit-gc` snap tests
- `cargo test -p pyrex --features dynasm --test bridge_carrier_depth_decline` (was aborting in `enclosing_nursery_object_start` / `try_size_for_typeid`)
- Full `cargo test --all --features dynasm` was run once; it failed only on those two tests before the snap guards. Not re-run in full after the last two collector commits.
- `python3 pyre/check.py` not run (no fresh release suite binary after LLBC extract)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection safety when handling interior pointers and forwarded marker values.
  * Prevented crashes when processing invalid type identifiers.
  * Fixed variable-length argument handling after memory allocations.
  * Improved preservation of frame-local references during execution and JIT frame recovery.
  * Corrected asynchronous exception delivery so exceptions are raised consistently with their messages.
  * Updated validation coverage for pointer snapping, argument handling, and frame-local rooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->