### PR TITLE
wasm: publish CA jf_gcmap after entry home stores

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1723,6 +1723,41 @@ pub fn label_ref_capture_slots(inputargs: &[InputArg], ops: &[Op]) -> usize {
     LabelResumeData::collect(inputargs, ops).ref_slots
 }
 
+/// Mark the homes this module initializes: the used ordinary prefix and the
+/// LABEL-capture tail. Frozen geometry reserves extra ordinary slots so a
+/// later bridge can fit; those unused reserved words stay unmarked so
+/// recycled nursery bytes are not traced. assembler.py writes `jf_gcmap`
+/// for live slots only.
+pub(crate) fn build_home_gcmap(
+    frame: FrameGeometry,
+    used_ordinary: usize,
+    used_labels: usize,
+) -> Box<[usize]> {
+    let sign = std::mem::size_of::<isize>();
+    let bits_per_word = std::mem::size_of::<usize>() * 8;
+    let ordinary = used_ordinary.min(frame.ordinary_home_slots());
+    let label_base = frame.ordinary_home_slots();
+    let label_n = used_labels.min(frame.label_ref_slots);
+    if ordinary == 0 && label_n == 0 {
+        // One empty data word: a non-null jf_gcmap that traces nothing.
+        return vec![1usize, 0usize].into_boxed_slice();
+    }
+    let last_h = if label_n == 0 {
+        ordinary.saturating_sub(1)
+    } else {
+        label_base + label_n - 1
+    };
+    let last_index = (frame.home_slot_base as usize + last_h * 8) / sign;
+    let num_words = last_index / bits_per_word + 1;
+    let mut buf = vec![0usize; 1 + num_words];
+    buf[0] = num_words;
+    for h in (0..ordinary).chain(label_base..label_base + label_n) {
+        let index = (frame.home_slot_base as usize + h * 8) / sign;
+        buf[1 + index / bits_per_word] |= 1usize << (index % bits_per_word);
+    }
+    buf.into_boxed_slice()
+}
+
 /// First free value position — one past the highest id any value reference in
 /// the trace occupies (input args, op results, and every op argument, including
 /// a folded value the constants pool alone binds).
@@ -3763,10 +3798,18 @@ pub struct CaParams {
     /// `None` retains the helpers (including under gc_stress).
     pub inline: Option<CaInlineParams>,
     /// `build_home_gcmap` pointer published after the fresh-entry home/input
-    /// stores. The map marks only initialized ordinary homes plus LABEL
-    /// captures. Zero leaves `jf_gcmap` unset in the generated module (tests).
+    /// stores. Used only when [`Self::compute_home_gcmap`] is false. Zero
+    /// leaves `jf_gcmap` unset in the generated module (tests).
     /// assembler.py writes `jf_gcmap` at safepoints once those slots are live.
     pub home_gcmap_ptr: i64,
+    /// When set, leak a map from this module's `RefHomes` and LABEL captures
+    /// (raised to the `home_gcmap_min_*` floors) instead of
+    /// [`Self::home_gcmap_ptr`]. Re-emission and out-of-line bridges need
+    /// the floors so a later keyed tail-call cannot drop the source loop's
+    /// already-initialized homes.
+    pub compute_home_gcmap: bool,
+    pub home_gcmap_min_ordinary: usize,
+    pub home_gcmap_min_labels: usize,
 }
 
 /// Per-CALL_ASSEMBLER target dispatch baked into the corresponding wasm arm.
@@ -5845,7 +5888,15 @@ fn build_function(
     }
     // assembler.py writes `jf_gcmap` at safepoints once the slots are live.
     // CA alloc left the map null so leftover item words were not traced.
-    emit_publish_home_gcmap(&mut sink, ca.home_gcmap_ptr);
+    let publish_ptr = if ca.compute_home_gcmap {
+        let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
+        let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
+        Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
+            as usize as i64
+    } else {
+        ca.home_gcmap_ptr
+    };
+    emit_publish_home_gcmap(&mut sink, publish_ptr);
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -431,7 +431,8 @@ pub struct FrameGeometry {
     /// resume-at-LABEL live-ins.  Ordinary per-trace Ref homes grow upward
     /// from `home_slot_base`; these captures grow from the frozen boundary and
     /// therefore survive execution of a chained bridge, whose own home map may
-    /// use the low slots.  The whole home region remains covered by jf_gcmap.
+    /// use the low slots.  The published `jf_gcmap` marks the used ordinary
+    /// prefix plus these captures, not the unused reserved tail.
     pub label_ref_slots: usize,
     /// Start of the GUARD_NOT_FORCED(_2) failarg spill area. It contains one
     /// i64 slot per value slot and is disjoint from exits, dispatch, homes and
@@ -3762,7 +3763,8 @@ pub struct CaParams {
     /// `None` retains the helpers (including under gc_stress).
     pub inline: Option<CaInlineParams>,
     /// `build_home_gcmap` pointer published after the fresh-entry home/input
-    /// stores. Zero leaves `jf_gcmap` unset in the generated module (tests).
+    /// stores. The map marks only initialized ordinary homes plus LABEL
+    /// captures. Zero leaves `jf_gcmap` unset in the generated module (tests).
     /// assembler.py writes `jf_gcmap` at safepoints once those slots are live.
     pub home_gcmap_ptr: i64,
 }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5118,6 +5118,17 @@ pub fn build_wasm_module(
             scanned
         }
     };
+    // `emit_publish_home_gcmap` `call_indirect`s `wasm_jit_union_gcmap`
+    // at `residual_type_base + 2`. A reload-only census is arity 0, a
+    // write-barrier-only census arity 1; either leaves that slot missing
+    // or pointing at a later incompatible type.
+    let residual_max_arity = if (ca.compute_home_gcmap || ca.home_gcmap_ptr != 0)
+        && let Some(max) = residual_max_arity
+    {
+        Some(max.max(2))
+    } else {
+        residual_max_arity
+    };
     // Typed float residual calls use their descr's faithful wasm ABI instead
     // of the uniform i64 helper family. Preserve first-use order so a given
     // trace gets stable type indices while declaring each signature once.

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2633,18 +2633,18 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
 /// Publish `build_home_gcmap` on the live frame (`local 0` is the items
 /// base). `ptr == 0` is the test path that never installs a map.
 ///
-/// Store is monotonic in the marked-bit set: a later module publishes only
-/// when the live `jf_gcmap` is null or this map covers every bit the live
-/// map marks. `push_gcmap` writes the live set; ABI (`bridge_entry_arity`)
-/// is not a proxy for that extent — a parameter bridge can mark more homes
-/// than its source, and a retained frame-entry bridge can mark fewer than
-/// an owner that grew after it was compiled.
+/// Ordinary homes and LABEL captures grow independently, so the live map
+/// and this module's map can be incomparable. With a residual type family
+/// the store is their bitwise union (`wasm_jit_union_gcmap`). Without one
+/// (host tests) the store is still monotonic: publish this map only when
+/// it covers every live bit.
 fn emit_publish_home_gcmap(
     sink: &mut PeepSink<'_, '_>,
     ptr: i64,
     map: &[usize],
     old_local: u32,
     idx_local: u32,
+    residual_type_base: Option<u32>,
 ) {
     if ptr == 0 || map.len() < 2 {
         return;
@@ -2689,8 +2689,21 @@ fn emit_publish_home_gcmap(
     sink.if_(BlockType::Empty);
     publish(sink);
     sink.else_();
-    // `old_local` is the live map. Cover-check each of its words against
-    // this module's map; leftover bits mean the live map is wider.
+    if let Some(base) = residual_type_base {
+        // `(i64, i64) -> i64` at `residual_type_base + 2`.
+        let union_fn = crate::wasm_jit_union_gcmap as *const () as usize as i64;
+        emit_hdr(sink);
+        sink.local_get(old_local);
+        sink.i64_extend_i32_u();
+        sink.i64_const(ptr);
+        sink.i32_const(union_fn as i32);
+        sink.call_indirect(0, base + 2);
+        emit_word_store(sink, JF_GCMAP_OFS as u64);
+        sink.end();
+        return;
+    }
+    // Host-test fallback: no residual type family. Cover-check each live
+    // word against this module's map; leftover bits keep the live map.
     sink.block(BlockType::Empty); // $keep
     sink.block(BlockType::Empty); // $publish_ok
     for (i, &new_word) in new_words.iter().enumerate() {
@@ -6066,6 +6079,7 @@ fn build_function(
         &publish_map,
         gcmap_old_local,
         gcmap_idx_local,
+        residual_type_base,
     );
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
@@ -6159,6 +6173,7 @@ fn build_function(
                 &publish_map,
                 gcmap_old_local,
                 gcmap_idx_local,
+                residual_type_base,
             );
             // Resume loader: a loop-closing bridge wrote each label arg into
             // frame slot i (positionally, matching the in-loop JUMP move);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4228,7 +4228,7 @@ pub struct AllocHelpers {
     pub fmod_fn_ptr: i64,
 }
 
-type BuildWasmModuleOutput = (Vec<u8>, Vec<GuardExit>, usize);
+type BuildWasmModuleOutput = (Vec<u8>, Vec<GuardExit>, usize, usize);
 
 /// Counts entries into an out-of-line bridge module and calls out once there
 /// have been enough of them to pay for merging that bridge into its owner.
@@ -5308,7 +5308,8 @@ pub fn build_wasm_module(
     }
     module.section(&codes);
 
-    Ok((module.finish(), guards, num_ref_homes))
+    let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
+    Ok((module.finish(), guards, num_ref_homes, used_labels))
 }
 
 fn build_label_param_shim(wide_func_idx: u32) -> Function {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3810,6 +3810,11 @@ pub struct CaParams {
     pub compute_home_gcmap: bool,
     pub home_gcmap_min_ordinary: usize,
     pub home_gcmap_min_labels: usize,
+    /// True when `home_gcmap_min_*` is a previous publication's floor
+    /// (re-emission or a bridge that must cover the source loop). False
+    /// on a first compile, where min=0 must not wipe live homes on keyed
+    /// resume. Distinguishes a 0→N merge from an initial compile.
+    pub home_gcmap_has_prior: bool,
 }
 
 /// Per-CALL_ASSEMBLER target dispatch baked into the corresponding wasm arm.
@@ -5718,10 +5723,10 @@ fn build_function(
     let publish_ptr = if ca.compute_home_gcmap {
         let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
         let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
-        // A first compile has min=0; those homes were cleared on the original
-        // key-0 entry. Only a merge that grew the map past a previous floor
-        // leaves newly marked slots uninitialized on a keyed resume.
-        if ca.home_gcmap_min_ordinary > 0 && used_ordinary > ca.home_gcmap_min_ordinary {
+        // A first compile has no prior map. A re-emission or bridge may
+        // grow past a previous floor of zero, so `min > 0` is not the
+        // signal — `has_prior` is.
+        if ca.home_gcmap_has_prior && used_ordinary > ca.home_gcmap_min_ordinary {
             emit_null_home_slots(
                 &mut sink,
                 frame,
@@ -5730,7 +5735,7 @@ fn build_function(
             );
         }
         let label_base = frame.ordinary_home_slots() as u64;
-        if ca.home_gcmap_min_labels > 0 && used_labels > ca.home_gcmap_min_labels {
+        if ca.home_gcmap_has_prior && used_labels > ca.home_gcmap_min_labels {
             emit_null_home_slots(
                 &mut sink,
                 frame,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5734,15 +5734,10 @@ fn build_function(
                 |_| true,
             );
         }
-        let label_base = frame.ordinary_home_slots() as u64;
-        if ca.home_gcmap_has_prior && used_labels > ca.home_gcmap_min_labels {
-            emit_null_home_slots(
-                &mut sink,
-                frame,
-                label_base + ca.home_gcmap_min_labels as u64..label_base + used_labels as u64,
-                |_| true,
-            );
-        }
+        // LABEL captures stay on keyed resume: a bridge with more captures
+        // than its source writes them on the first crossing, and a later
+        // keyed tail-call restores from those slots. Key-0 still clears
+        // the full used-label range below.
         Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
             as usize as i64
     } else {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2632,14 +2632,38 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
 
 /// Publish `build_home_gcmap` on the live frame (`local 0` is the items
 /// base). `ptr == 0` is the test path that never installs a map.
-fn emit_publish_home_gcmap(sink: &mut PeepSink<'_, '_>, ptr: i64) {
+///
+/// `only_if_null` is for an out-of-line bridge: the owner already published
+/// a used-home map, and replacing it with this module's (possibly shorter)
+/// prefix would unmark homes the owner grew after this bridge was compiled.
+/// `push_gcmap` writes the live set; a later module must not shrink it.
+fn emit_publish_home_gcmap(sink: &mut PeepSink<'_, '_>, ptr: i64, only_if_null: bool) {
     if ptr == 0 {
         return;
     }
-    use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JF_GCMAP_OFS};
-    sink.local_get(0);
-    sink.i32_const(FIRST_ITEM_OFFSET as i32);
-    sink.i32_sub();
+    use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JF_GCMAP_OFS, SIZEOFSIGNED};
+    let emit_hdr = |sink: &mut PeepSink<'_, '_>| {
+        sink.local_get(0);
+        sink.i32_const(FIRST_ITEM_OFFSET as i32);
+        sink.i32_sub();
+    };
+    if only_if_null {
+        emit_hdr(sink);
+        if SIZEOFSIGNED == 4 {
+            sink.i32_load(memarg(JF_GCMAP_OFS as u64, 2));
+            sink.i32_eqz();
+        } else {
+            sink.i64_load(memarg(JF_GCMAP_OFS as u64, 3));
+            sink.i64_eqz();
+        }
+        sink.if_(BlockType::Empty);
+        emit_hdr(sink);
+        sink.i64_const(ptr);
+        emit_word_store(sink, JF_GCMAP_OFS as u64);
+        sink.end();
+        return;
+    }
+    emit_hdr(sink);
     sink.i64_const(ptr);
     emit_word_store(sink, JF_GCMAP_OFS as u64);
 }
@@ -5947,7 +5971,8 @@ fn build_function(
     }
     // assembler.py `push_gcmap`: the map goes up once the slots it marks
     // are live or null. Keyed resume publishes in the loader instead.
-    emit_publish_home_gcmap(&mut sink, publish_ptr);
+    // A bridge keeps a map the owner already published.
+    emit_publish_home_gcmap(&mut sink, publish_ptr, bridge_entry_arity.is_some());
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {
@@ -6034,7 +6059,7 @@ fn build_function(
             // nulled before `br_table`; remaining marked homes already
             // hold the previous module's values. Publish before the
             // loader stores, matching `push_gcmap` at a live safepoint.
-            emit_publish_home_gcmap(&mut sink, publish_ptr);
+            emit_publish_home_gcmap(&mut sink, publish_ptr, false);
             // Resume loader: a loop-closing bridge wrote each label arg into
             // frame slot i (positionally, matching the in-loop JUMP move);
             // load them into the label-arg locals and refresh their Ref

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3815,13 +3815,12 @@ pub struct CaParams {
     /// on a first compile, where min=0 must not wipe live homes on keyed
     /// resume. Distinguishes a 0→N merge from an initial compile.
     pub home_gcmap_has_prior: bool,
-    /// True only for a loop re-emission that may mark more LABEL-capture
-    /// homes than the previous publication. Those new slots were never
-    /// stored on a recycled CALL_ASSEMBLER frame that keyed in from an
-    /// older bridge, so they must be nulled before the widened map is
-    /// installed. A compiled bridge with more captures than its source
-    /// leaves this false: it writes those slots on the first crossing
-    /// and a later keyed tail-call restores them.
+    /// True only when a re-emitted module must null newly marked LABEL
+    /// homes for a keyed caller whose map did not include them. Re-emission
+    /// itself leaves this false and drops stale owner bridges when the
+    /// merged extent grows; key-0 still clears the full used-label range.
+    /// A compiled bridge with more captures than its source also leaves
+    /// this false: it writes those slots on the first crossing.
     pub home_gcmap_null_grown_labels: bool,
 }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2633,39 +2633,124 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
 /// Publish `build_home_gcmap` on the live frame (`local 0` is the items
 /// base). `ptr == 0` is the test path that never installs a map.
 ///
-/// `only_if_null` is for an out-of-line bridge: the owner already published
-/// a used-home map, and replacing it with this module's (possibly shorter)
-/// prefix would unmark homes the owner grew after this bridge was compiled.
-/// `push_gcmap` writes the live set; a later module must not shrink it.
-fn emit_publish_home_gcmap(sink: &mut PeepSink<'_, '_>, ptr: i64, only_if_null: bool) {
-    if ptr == 0 {
+/// Store is monotonic in the marked-bit set: a later module publishes only
+/// when the live `jf_gcmap` is null or this map covers every bit the live
+/// map marks. `push_gcmap` writes the live set; ABI (`bridge_entry_arity`)
+/// is not a proxy for that extent — a parameter bridge can mark more homes
+/// than its source, and a retained frame-entry bridge can mark fewer than
+/// an owner that grew after it was compiled.
+fn emit_publish_home_gcmap(
+    sink: &mut PeepSink<'_, '_>,
+    ptr: i64,
+    map: &[usize],
+    old_local: u32,
+    idx_local: u32,
+) {
+    if ptr == 0 || map.len() < 2 {
         return;
     }
     use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JF_GCMAP_OFS, SIZEOFSIGNED};
+    let word = std::mem::size_of::<usize>() as u32;
+    let n_new = map[0];
+    let new_words = &map[1..];
     let emit_hdr = |sink: &mut PeepSink<'_, '_>| {
         sink.local_get(0);
         sink.i32_const(FIRST_ITEM_OFFSET as i32);
         sink.i32_sub();
     };
-    if only_if_null {
-        emit_hdr(sink);
-        if SIZEOFSIGNED == 4 {
-            sink.i32_load(memarg(JF_GCMAP_OFS as u64, 2));
-            sink.i32_eqz();
+    let load_usize = |sink: &mut PeepSink<'_, '_>, offset: u64| {
+        if word == 4 {
+            sink.i32_load(memarg(offset, 2));
         } else {
-            sink.i64_load(memarg(JF_GCMAP_OFS as u64, 3));
-            sink.i64_eqz();
+            sink.i64_load(memarg(offset, 3));
         }
-        sink.if_(BlockType::Empty);
+    };
+    let const_usize = |sink: &mut PeepSink<'_, '_>, value: usize| {
+        if word == 4 {
+            sink.i32_const(value as i32);
+        } else {
+            sink.i64_const(value as i64);
+        }
+    };
+    let publish = |sink: &mut PeepSink<'_, '_>| {
         emit_hdr(sink);
         sink.i64_const(ptr);
         emit_word_store(sink, JF_GCMAP_OFS as u64);
-        sink.end();
-        return;
-    }
+    };
     emit_hdr(sink);
-    sink.i64_const(ptr);
-    emit_word_store(sink, JF_GCMAP_OFS as u64);
+    if SIZEOFSIGNED == 4 {
+        sink.i32_load(memarg(JF_GCMAP_OFS as u64, 2));
+    } else {
+        sink.i64_load(memarg(JF_GCMAP_OFS as u64, 3));
+        sink.i32_wrap_i64();
+    }
+    sink.local_tee(old_local);
+    sink.i32_eqz();
+    sink.if_(BlockType::Empty);
+    publish(sink);
+    sink.else_();
+    // `old_local` is the live map. Cover-check each of its words against
+    // this module's map; leftover bits mean the live map is wider.
+    sink.block(BlockType::Empty); // $keep
+    sink.block(BlockType::Empty); // $publish_ok
+    for (i, &new_word) in new_words.iter().enumerate() {
+        sink.local_get(old_local);
+        load_usize(sink, 0);
+        if word == 8 {
+            sink.i32_wrap_i64();
+        }
+        sink.i32_const(i as i32);
+        sink.i32_gt_u();
+        sink.if_(BlockType::Empty);
+        sink.local_get(old_local);
+        load_usize(sink, (1 + i as u32) as u64 * word as u64);
+        const_usize(sink, !new_word);
+        if word == 4 {
+            sink.i32_and();
+        } else {
+            sink.i64_and();
+            sink.i64_eqz();
+            sink.i32_eqz();
+        }
+        sink.br_if(2);
+        sink.end();
+    }
+    sink.i32_const(n_new as i32);
+    sink.local_set(idx_local);
+    sink.loop_(BlockType::Empty);
+    sink.local_get(idx_local);
+    sink.local_get(old_local);
+    load_usize(sink, 0);
+    if word == 8 {
+        sink.i32_wrap_i64();
+    }
+    sink.i32_lt_u();
+    sink.i32_eqz();
+    sink.br_if(1);
+    sink.local_get(old_local);
+    sink.local_get(idx_local);
+    sink.i32_const(1);
+    sink.i32_add();
+    sink.i32_const(word.trailing_zeros() as i32);
+    sink.i32_shl();
+    sink.i32_add();
+    load_usize(sink, 0);
+    if word == 8 {
+        sink.i64_eqz();
+        sink.i32_eqz();
+    }
+    sink.br_if(2);
+    sink.local_get(idx_local);
+    sink.i32_const(1);
+    sink.i32_add();
+    sink.local_set(idx_local);
+    sink.br(0);
+    sink.end();
+    sink.br(0);
+    sink.end();
+    publish(sink);
+    sink.end();
+    sink.end();
 }
 
 fn emit_word_store(sink: &mut PeepSink<'_, '_>, offset: u64) {
@@ -5668,6 +5753,8 @@ fn build_function(
     // it and branch back into the dispatch; without it the key is consumed
     // straight off the frame load.
     let resume_key_local = trace_entry_key_local + u32::from(trace_entry_needs_key_local);
+    let gcmap_old_local = resume_key_local + u32::from(resume_dispatch);
+    let gcmap_idx_local = gcmap_old_local + 1;
     debug_assert_eq!(bridge_slot_local, ovf_flag_local + 1);
     debug_assert_eq!(ca_cfp_local, bridge_slot_local + 1);
     debug_assert_eq!(ca_fi_local, ca_cfp_local + 1);
@@ -5732,7 +5819,8 @@ fn build_function(
         base_i32_locals
             + extra_alloc_i32
             + u32::from(trace_entry_needs_key_local)
-            + u32::from(resume_dispatch),
+            + u32::from(resume_dispatch)
+            + 2,
         ValType::I32,
     ));
     let mut func = Function::new(locals);
@@ -5755,9 +5843,10 @@ fn build_function(
     // that after the entry stores. A keyed LABEL resume branches past
     // those stores, so it publishes in the resume loader after the
     // grown-slot null below.
+    let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
+    let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
+    let publish_map = build_home_gcmap(frame, used_ordinary, used_labels);
     let publish_ptr = if ca.compute_home_gcmap {
-        let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
-        let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
         // A first compile has no prior map. A re-emission or bridge may
         // grow past a previous floor of zero, so `min > 0` is not the
         // signal — `has_prior` is.
@@ -5971,8 +6060,13 @@ fn build_function(
     }
     // assembler.py `push_gcmap`: the map goes up once the slots it marks
     // are live or null. Keyed resume publishes in the loader instead.
-    // A bridge keeps a map the owner already published.
-    emit_publish_home_gcmap(&mut sink, publish_ptr, bridge_entry_arity.is_some());
+    emit_publish_home_gcmap(
+        &mut sink,
+        publish_ptr,
+        &publish_map,
+        gcmap_old_local,
+        gcmap_idx_local,
+    );
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {
@@ -6059,7 +6153,13 @@ fn build_function(
             // nulled before `br_table`; remaining marked homes already
             // hold the previous module's values. Publish before the
             // loader stores, matching `push_gcmap` at a live safepoint.
-            emit_publish_home_gcmap(&mut sink, publish_ptr, false);
+            emit_publish_home_gcmap(
+                &mut sink,
+                publish_ptr,
+                &publish_map,
+                gcmap_old_local,
+                gcmap_idx_local,
+            );
             // Resume loader: a loop-closing bridge wrote each label arg into
             // frame slot i (positionally, matching the in-loop JUMP move);
             // load them into the label-arg locals and refresh their Ref

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3941,8 +3941,8 @@ pub struct CaParams {
     pub home_gcmap_has_prior: bool,
     /// True only when a re-emitted module must null newly marked LABEL
     /// homes for a keyed caller whose map did not include them. Re-emission
-    /// itself leaves this false and drops stale owner bridges when the
-    /// merged extent grows; key-0 still clears the full used-label range.
+    /// itself leaves this false and drops stale owner attachments when
+    /// the LABEL tail grows; key-0 still clears the full used-label range.
     /// A compiled bridge with more captures than its source also leaves
     /// this false: it writes those slots on the first crossing.
     pub home_gcmap_null_grown_labels: bool,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5711,6 +5711,20 @@ fn build_function(
         sink.local_set(value_types.local(raw));
     }
 
+    // Every entry path, including a keyed LABEL resume, must install this
+    // module's map. A loop-closing bridge compiled before a merge still
+    // carries its old prefix map; the keyed resume branches past the
+    // key-0 publish below, so do it here before `br_table`.
+    let publish_ptr = if ca.compute_home_gcmap {
+        let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
+        let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
+        Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
+            as usize as i64
+    } else {
+        ca.home_gcmap_ptr
+    };
+    emit_publish_home_gcmap(&mut sink, publish_ptr);
+
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
     // preamble runs once on entry, the LABEL is the loop-back target, and
     // JUMP branches back to it. Emit the `loop` at the LABEL selected by the
@@ -5886,17 +5900,6 @@ fn build_function(
             sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
         }
     }
-    // assembler.py writes `jf_gcmap` at safepoints once the slots are live.
-    // CA alloc left the map null so leftover item words were not traced.
-    let publish_ptr = if ca.compute_home_gcmap {
-        let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
-        let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
-        Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
-            as usize as i64
-    } else {
-        ca.home_gcmap_ptr
-    };
-    emit_publish_home_gcmap(&mut sink, publish_ptr);
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3798,9 +3798,11 @@ pub struct CaParams {
     /// `None` retains the helpers (including under gc_stress).
     pub inline: Option<CaInlineParams>,
     /// `build_home_gcmap` pointer published after the fresh-entry home/input
-    /// stores. Used only when [`Self::compute_home_gcmap`] is false. Zero
-    /// leaves `jf_gcmap` unset in the generated module (tests).
-    /// assembler.py writes `jf_gcmap` at safepoints once those slots are live.
+    /// stores, and again on each keyed LABEL resume after those slots are
+    /// already valid or newly marked ones have been nulled. Used only when
+    /// [`Self::compute_home_gcmap`] is false. Zero leaves `jf_gcmap` unset
+    /// in the generated module (tests). assembler.py writes `jf_gcmap` at
+    /// safepoints once those slots are live.
     pub home_gcmap_ptr: i64,
     /// When set, leak a map from this module's `RefHomes` and LABEL captures
     /// (raised to the `home_gcmap_min_*` floors) instead of
@@ -5724,10 +5726,11 @@ fn build_function(
         sink.local_set(value_types.local(raw));
     }
 
-    // Every entry path, including a keyed LABEL resume, must install this
-    // module's map. A loop-closing bridge compiled before a merge still
-    // carries its old prefix map; the keyed resume branches past the
-    // key-0 clear below, so null any newly marked homes first.
+    // Build the map now; publish it only after the slots it marks are
+    // null or written (`push_gcmap` at a live safepoint). Key-0 does
+    // that after the entry stores. A keyed LABEL resume branches past
+    // those stores, so it publishes in the resume loader after the
+    // grown-slot null below.
     let publish_ptr = if ca.compute_home_gcmap {
         let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
         let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
@@ -5766,7 +5769,6 @@ fn build_function(
     } else {
         ca.home_gcmap_ptr
     };
-    emit_publish_home_gcmap(&mut sink, publish_ptr);
 
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
     // preamble runs once on entry, the LABEL is the loop-back target, and
@@ -5882,13 +5884,13 @@ fn build_function(
         emit_trace_entry_census(&mut sink, census, bridge_slot_local, None);
     }
 
-    // Fresh entry owns key 0. `build_home_gcmap` marks every frozen home,
-    // including the chain-padding slots a later bridge may use and the high
-    // LABEL-capture homes. The nursery bump leaves `jf_gcmap` null and does
-    // not fill items, so unused padding still holds recycled nursery bytes;
-    // those must be null before the map is published. A resume dispatch
-    // branches past this code, preserving captures written when the source
-    // loop first crossed the LABEL.
+    // Fresh entry owns key 0. `build_home_gcmap` marks the used ordinary
+    // prefix and the LABEL-capture tail, not reserved chain-padding.
+    // The nursery bump leaves `jf_gcmap` null and does not fill items, so
+    // unused marked homes still hold recycled nursery bytes; those must
+    // be null before the map is published. A resume dispatch branches
+    // past this code, preserving captures written when the source loop
+    // first crossed the LABEL, and publishes in the resume loader.
     // A home the input loop fills below needs no null first: its store follows
     // immediately and nothing between the two allocates, so no collection can
     // read the slot while it is stale. Homes no input fills keep their clear
@@ -5943,6 +5945,9 @@ fn build_function(
             sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
         }
     }
+    // assembler.py `push_gcmap`: the map goes up once the slots it marks
+    // are live or null. Keyed resume publishes in the loader instead.
+    emit_publish_home_gcmap(&mut sink, publish_ptr);
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {
@@ -6025,6 +6030,11 @@ fn build_function(
             }
             sink.br(1); // segment done -> past_loader_j, over the resume loader
             sink.end(); // end C_j (the br_table lands here for key j+1)
+            // Keyed resume skipped the key-0 stores. Grown slots were
+            // nulled before `br_table`; remaining marked homes already
+            // hold the previous module's values. Publish before the
+            // loader stores, matching `push_gcmap` at a live safepoint.
+            emit_publish_home_gcmap(&mut sink, publish_ptr);
             // Resume loader: a loop-closing bridge wrote each label arg into
             // frame slot i (positionally, matching the in-loop JUMP move);
             // load them into the label-arg locals and refresh their Ref

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3815,6 +3815,14 @@ pub struct CaParams {
     /// on a first compile, where min=0 must not wipe live homes on keyed
     /// resume. Distinguishes a 0→N merge from an initial compile.
     pub home_gcmap_has_prior: bool,
+    /// True only for a loop re-emission that may mark more LABEL-capture
+    /// homes than the previous publication. Those new slots were never
+    /// stored on a recycled CALL_ASSEMBLER frame that keyed in from an
+    /// older bridge, so they must be nulled before the widened map is
+    /// installed. A compiled bridge with more captures than its source
+    /// leaves this false: it writes those slots on the first crossing
+    /// and a later keyed tail-call restores them.
+    pub home_gcmap_null_grown_labels: bool,
 }
 
 /// Per-CALL_ASSEMBLER target dispatch baked into the corresponding wasm arm.
@@ -5735,10 +5743,25 @@ fn build_function(
                 |_| true,
             );
         }
-        // LABEL captures stay on keyed resume: a bridge with more captures
-        // than its source writes them on the first crossing, and a later
-        // keyed tail-call restores from those slots. Key-0 still clears
-        // the full used-label range below.
+        // Re-emission may mark a longer LABEL tail than the previous
+        // publication. Those new slots are region-only captures the live
+        // frame never stored; null them before the widened map is
+        // published. Previously published captures stay: a bridge that
+        // grew past its source writes them on the first crossing, and a
+        // later keyed tail-call restores from those slots. Key-0 still
+        // clears the full used-label range below.
+        if ca.home_gcmap_has_prior
+            && ca.home_gcmap_null_grown_labels
+            && used_labels > ca.home_gcmap_min_labels
+        {
+            let label_base = frame.ordinary_home_slots() as u64;
+            emit_null_home_slots(
+                &mut sink,
+                frame,
+                label_base + ca.home_gcmap_min_labels as u64..label_base + used_labels as u64,
+                |_| true,
+            );
+        }
         Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
             as usize as i64
     } else {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5714,10 +5714,30 @@ fn build_function(
     // Every entry path, including a keyed LABEL resume, must install this
     // module's map. A loop-closing bridge compiled before a merge still
     // carries its old prefix map; the keyed resume branches past the
-    // key-0 publish below, so do it here before `br_table`.
+    // key-0 clear below, so null any newly marked homes first.
     let publish_ptr = if ca.compute_home_gcmap {
         let used_ordinary = ref_homes.len().max(ca.home_gcmap_min_ordinary);
         let used_labels = label_resume.ref_slots.max(ca.home_gcmap_min_labels);
+        // A first compile has min=0; those homes were cleared on the original
+        // key-0 entry. Only a merge that grew the map past a previous floor
+        // leaves newly marked slots uninitialized on a keyed resume.
+        if ca.home_gcmap_min_ordinary > 0 && used_ordinary > ca.home_gcmap_min_ordinary {
+            emit_null_home_slots(
+                &mut sink,
+                frame,
+                ca.home_gcmap_min_ordinary as u64..used_ordinary as u64,
+                |_| true,
+            );
+        }
+        let label_base = frame.ordinary_home_slots() as u64;
+        if ca.home_gcmap_min_labels > 0 && used_labels > ca.home_gcmap_min_labels {
+            emit_null_home_slots(
+                &mut sink,
+                frame,
+                label_base + ca.home_gcmap_min_labels as u64..label_base + used_labels as u64,
+                |_| true,
+            );
+        }
         Box::leak(build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
             as usize as i64
     } else {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2594,6 +2594,20 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
     sink.i32_add();
 }
 
+/// Publish `build_home_gcmap` on the live frame (`local 0` is the items
+/// base). `ptr == 0` is the test path that never installs a map.
+fn emit_publish_home_gcmap(sink: &mut PeepSink<'_, '_>, ptr: i64) {
+    if ptr == 0 {
+        return;
+    }
+    use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JF_GCMAP_OFS};
+    sink.local_get(0);
+    sink.i32_const(FIRST_ITEM_OFFSET as i32);
+    sink.i32_sub();
+    sink.i64_const(ptr);
+    emit_word_store(sink, JF_GCMAP_OFS as u64);
+}
+
 fn emit_word_store(sink: &mut PeepSink<'_, '_>, offset: u64) {
     if majit_backend::jitframe::SIZEOFSIGNED == 4 {
         sink.i32_wrap_i64();
@@ -2822,7 +2836,9 @@ fn emit_ca_malloc_cond_varsize_frame(
         emit_word_store(sink, ofs as u64);
     }
     // rewrite.rs after `gen_malloc_nursery_varsize_frame`: write
-    // `jf_frame` length and `jf_gcmap`.
+    // `jf_frame` length. Leave `jf_gcmap` null — assembler.py publishes
+    // the map at safepoints once homes are live. The callee entry stores
+    // `home_gcmap_ptr` after its home/input stores.
     sink.local_get(alloc_scratch_local);
     sink.local_get(ca_target_local);
     sink.i64_load32_u(memarg(crate::failguard::WASM_CA_TARGET_FRAME_BYTES_OFS, 2));
@@ -3745,9 +3761,10 @@ pub struct CaParams {
     /// Active-GC state for the direct CA-only inline allocation/frame path.
     /// `None` retains the helpers (including under gc_stress).
     pub inline: Option<CaInlineParams>,
-    /// Per-loop `jf_gcmap` installed at key-0 entry after homes are nulled.
-    /// Zero leaves the map the allocator (or `execute_token`) already stored.
-    pub entry_gcmap_ptr: i64,
+    /// `build_home_gcmap` pointer published after the fresh-entry home/input
+    /// stores. Zero leaves `jf_gcmap` unset in the generated module (tests).
+    /// assembler.py writes `jf_gcmap` at safepoints once those slots are live.
+    pub home_gcmap_ptr: i64,
 }
 
 /// Per-CALL_ASSEMBLER target dispatch baked into the corresponding wasm arm.
@@ -5824,20 +5841,9 @@ fn build_function(
             sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
         }
     }
-    if ca.entry_gcmap_ptr != 0 {
-        // Frozen homes are now null or the entry Refs. Publish the map
-        // the allocator left unset so a later collection can walk them.
-        sink.local_get(0);
-        sink.i32_const(majit_backend::jitframe::FIRST_ITEM_OFFSET as i32);
-        sink.i32_sub();
-        sink.i64_const(ca.entry_gcmap_ptr);
-        if majit_backend::jitframe::SIZEOFSIGNED == 4 {
-            sink.i32_wrap_i64();
-            sink.i32_store(memarg(majit_backend::jitframe::JF_GCMAP_OFS as u64, 2));
-        } else {
-            sink.i64_store(memarg(majit_backend::jitframe::JF_GCMAP_OFS as u64, 3));
-        }
-    }
+    // assembler.py writes `jf_gcmap` at safepoints once the slots are live.
+    // CA alloc left the map null so leftover item words were not traced.
+    emit_publish_home_gcmap(&mut sink, ca.home_gcmap_ptr);
     // Past the entry loader, so the count is one per entry on the same path
     // the inputs are loaded on.
     if let Some((probe, type_idx)) = inline_trip {

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1113,8 +1113,9 @@ pub struct CompiledWasmLoop {
     pub num_ref_homes: Cell<usize>,
     /// LABEL-capture homes this loop actually initialized. Frozen geometry
     /// may reserve more; a later bridge's published map must still cover
-    /// these so a keyed tail-call cannot drop them.
-    pub used_label_homes: usize,
+    /// these so a keyed tail-call cannot drop them. `Cell` so `reemit_loop`
+    /// can raise it when a merge publishes a wider capture tail.
+    pub used_label_homes: Cell<usize>,
     /// Geometry frozen when this token was first compiled. Every bridge
     /// chained onto it is emitted against this exact layout.
     pub frame: crate::codegen::FrameGeometry,

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -394,6 +394,13 @@ mod tests {
         super::retract_label_target_if_handle(id, 9);
         assert!(super::label_target(id).is_none());
     }
+
+    #[test]
+    fn retarget_slots_skips_the_owner_and_zero() {
+        // Native has no host table; the helper must still ignore the
+        // owner's own slot and a missing handle without panicking.
+        super::retarget_slots_to_module([0, 4, 4], 4, b"\0asm");
+    }
 }
 
 /// A resumable `LABEL` of a compiled loop, published in `LABEL_TARGETS` so a
@@ -1081,6 +1088,30 @@ pub fn retract_label_target_if_handle(descr_id: usize, func_handle: u32) {
     {
         map.remove(&descr_id);
         crate::BRIDGE_DIAG[22].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Point retired table slots at `wasm_bytes` so a caller that baked
+/// `return_call_indirect(slot)` enters the replacement module.
+/// `assembler.py` `patch_jump_for_descr` rewrites the jump; wasm
+/// modules are immutable, so the slot is the patch site
+/// (`glue::replace_module` also rewrites the reserved wide half).
+pub(crate) fn retarget_slots_to_module(
+    slots: impl IntoIterator<Item = u32>,
+    owner_handle: u32,
+    wasm_bytes: &[u8],
+) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        for slot in slots {
+            if slot != 0 && slot != owner_handle {
+                let _ = crate::glue::replace_module(slot, wasm_bytes);
+            }
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = (slots, owner_handle, wasm_bytes);
     }
 }
 

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1061,8 +1061,10 @@ pub struct ChainedTraceMeta {
     pub guard_fail_arg_counts: Vec<usize>,
     /// Whether this trace's guard epilogue has typed parameter dispatch arms.
     pub bridge_param_dispatch: bool,
-    /// Ordinary Ref homes this out-of-line bridge published. A nested
-    /// sub-bridge must floor its map to this, not the root loop's count.
+    /// Ordinary Ref homes this bridge published. After the bridge is
+    /// inlined, this is the merged stream's extent — `RefHomes::collect`
+    /// reassigns across that stream, so the standalone count is too short.
+    /// A nested sub-bridge floors its map to this.
     pub num_ref_homes: usize,
     /// LABEL-capture homes this bridge published.
     pub used_label_homes: usize,

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1103,7 +1103,7 @@ pub struct CompiledWasmLoop {
     /// Number of Ref-typed values given a home slot in the frame's Ref-home
     /// region (`codegen::HOME_SLOT_BASE`). `execute_token` sizes the host
     /// frame to include this region and registers each home slot as a GC root.
-    pub num_ref_homes: usize,
+    pub num_ref_homes: Cell<usize>,
     /// LABEL-capture homes this loop actually initialized. Frozen geometry
     /// may reserve more; a later bridge's published map must still cover
     /// these so a keyed tail-call cannot drop them.
@@ -1114,7 +1114,8 @@ pub struct CompiledWasmLoop {
     /// Per-loop `jf_gcmap` for the Ref-home region.  Like RPython's assembler
     /// gcmap allocation, this remains valid after `execute_token` returns: a
     /// virtualizable token can keep that JITFRAME alive and force it later.
-    pub home_gcmap_ptr: usize,
+    /// `Cell` so `reemit_loop` can replace it when a merge widens RefHomes.
+    pub home_gcmap_ptr: Cell<usize>,
     /// Base address (shared linear memory) of this loop's per-guard bridge-slot
     /// cell array — one i32 per `fail_index`, `0` = no bridge. The trace's
     /// epilogue reads `cells[fail_index]` and `compile_bridge` writes a bridge's

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1061,6 +1061,11 @@ pub struct ChainedTraceMeta {
     pub guard_fail_arg_counts: Vec<usize>,
     /// Whether this trace's guard epilogue has typed parameter dispatch arms.
     pub bridge_param_dispatch: bool,
+    /// Ordinary Ref homes this out-of-line bridge published. A nested
+    /// sub-bridge must floor its map to this, not the root loop's count.
+    pub num_ref_homes: usize,
+    /// LABEL-capture homes this bridge published.
+    pub used_label_homes: usize,
 }
 
 /// Compiled wasm loop metadata, stored in `JitCellToken.compiled`.

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1227,6 +1227,11 @@ pub struct CompiledWasmLoop {
     /// table slot here. `0` when the trace has no in-module dispatch (native, or
     /// a guardless / straight-line trace).
     pub bridge_cells_base: Cell<u32>,
+    /// Cell array of a retained pre-growth owner module. When the LABEL
+    /// tail grows, the replacement is installed at a new table slot and
+    /// this stays the array the old module still reads. `0` until that
+    /// split. `compile_bridge` writes both aliases.
+    pub retained_owner_cells_base: Cell<u32>,
     /// Byte length of the module this loop was last emitted as, own ops and
     /// every merged region together. A merge re-emits the whole owner, so this
     /// is what the next merge charges cranelift, and

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -367,6 +367,33 @@ mod tests {
         drop(frame);
         assert_eq!(roots.load(Ordering::SeqCst), before);
     }
+
+    fn dummy_label_target(func_handle: u32) -> super::LabelTarget {
+        super::LabelTarget {
+            func_handle,
+            wide_slot: 0,
+            key: 0,
+            num_args: 0,
+            resume_safe: true,
+            requires_own_frame: false,
+            is_last_label: true,
+            frame: crate::codegen::FrameGeometry::fixed(),
+        }
+    }
+
+    #[test]
+    fn retract_label_target_keeps_a_replacement_handle() {
+        let id = 0x7e71_ac10_usize;
+        super::publish_label_target(id, dummy_label_target(7));
+        super::retract_label_target_if_handle(id, 7);
+        assert!(super::label_target(id).is_none());
+
+        super::publish_label_target(id, dummy_label_target(9));
+        super::retract_label_target_if_handle(id, 7);
+        assert_eq!(super::label_target(id).map(|t| t.func_handle), Some(9));
+        super::retract_label_target_if_handle(id, 9);
+        assert!(super::label_target(id).is_none());
+    }
 }
 
 /// A resumable `LABEL` of a compiled loop, published in `LABEL_TARGETS` so a
@@ -1040,6 +1067,23 @@ pub fn publish_label_target(descr_id: usize, target: LabelTarget) {
         .insert(descr_id, target);
 }
 
+/// Retract a published label if it still names `func_handle`.
+/// Same handle guard as [`CompiledWasmLoop::drop`]: a later publish that
+/// re-stamped the same descr onto a different slot keeps the replacement.
+pub fn retract_label_target_if_handle(descr_id: usize, func_handle: u32) {
+    if descr_id == 0 || func_handle == 0 {
+        return;
+    }
+    let mut reg = LABEL_TARGETS.lock();
+    if let Some(map) = reg.as_mut()
+        && let Some(t) = map.get(&descr_id)
+        && t.func_handle == func_handle
+    {
+        map.remove(&descr_id);
+        crate::BRIDGE_DIAG[22].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Guard-dispatch metadata of a bridge chained onto a loop, kept on the
 /// source loop's `CompiledWasmLoop.chained_trace_meta` keyed by the bridge's
 /// backend `trace_id`. Lets `compile_bridge` chain a NESTED sub-bridge onto a
@@ -1209,7 +1253,8 @@ pub struct CompiledWasmLoop {
     pub reemitted: Cell<bool>,
     /// `(descr identity, table slot)` for every label published by a bridge
     /// chained onto this loop. The bridge module lives as long as its source
-    /// loop, so `Drop` retracts entries that still name that bridge's slot.
+    /// loop, so `Drop` and `retract_bridge_label_targets_for_slots` retract
+    /// entries that still name that bridge's slot.
     pub bridge_owned_label_targets: RefCell<Vec<(usize, u32)>>,
     /// Set when `compile_bridge` accepts a self-recursive `CallAssemblerR`
     /// bridge (`PYRE_WASM_CA`) for this loop. While set, `compile_bridge`
@@ -1254,6 +1299,30 @@ impl CompiledWasmLoop {
             .asmmemmgr_gcreftracers
             .lock()
             .push(tracer);
+    }
+
+    /// Retract `LABEL_TARGETS` rows and `bridge_owned_label_targets`
+    /// entries whose table slot is being retired. A frame-entry bridge
+    /// that published a LABEL can still be selected by a later JUMP
+    /// after its guard cell is cleared; that immutable module still
+    /// carries the pre-growth home map.
+    pub(crate) fn retract_bridge_label_targets_for_slots(
+        &self,
+        slots: impl IntoIterator<Item = u32>,
+    ) {
+        let retired: Vec<u32> = slots.into_iter().filter(|&slot| slot != 0).collect();
+        if retired.is_empty() {
+            return;
+        }
+        let owned = self.bridge_owned_label_targets.borrow().clone();
+        for (id, slot) in owned {
+            if retired.contains(&slot) {
+                retract_label_target_if_handle(id, slot);
+            }
+        }
+        self.bridge_owned_label_targets
+            .borrow_mut()
+            .retain(|(_, slot)| !retired.contains(slot));
     }
 
     /// Materialize a lazily-installed root trace.  The wasm host is
@@ -1302,23 +1371,12 @@ impl Drop for CompiledWasmLoop {
         // `func_handle`: a recompile that re-stamped the same descr onto its
         // replacement loop has already overwritten the entry, which must
         // survive the old loop's drop.
-        let mut reg = LABEL_TARGETS.lock();
-        if let Some(map) = reg.as_mut() {
-            for (id, func_handle) in self
-                .label_descrs
-                .iter()
-                .copied()
-                .map(|id| (id, self.func_handle.get()))
-                .chain(self.bridge_owned_label_targets.get_mut().iter().copied())
-            {
-                if id != 0
-                    && let Some(t) = map.get(&id)
-                    && t.func_handle == func_handle
-                {
-                    map.remove(&id);
-                    crate::BRIDGE_DIAG[22].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
-            }
+        let handle = self.func_handle.get();
+        for id in self.label_descrs.iter().copied() {
+            retract_label_target_if_handle(id, handle);
+        }
+        for (id, slot) in self.bridge_owned_label_targets.get_mut().iter().copied() {
+            retract_label_target_if_handle(id, slot);
         }
     }
 }

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1104,6 +1104,10 @@ pub struct CompiledWasmLoop {
     /// region (`codegen::HOME_SLOT_BASE`). `execute_token` sizes the host
     /// frame to include this region and registers each home slot as a GC root.
     pub num_ref_homes: usize,
+    /// LABEL-capture homes this loop actually initialized. Frozen geometry
+    /// may reserve more; a later bridge's published map must still cover
+    /// these so a keyed tail-call cannot drop them.
+    pub used_label_homes: usize,
     /// Geometry frozen when this token was first compiled. Every bridge
     /// chained onto it is emitted against this exact layout.
     pub frame: crate::codegen::FrameGeometry,

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1091,6 +1091,23 @@ pub fn retract_label_target_if_handle(descr_id: usize, func_handle: u32) {
     }
 }
 
+pub(crate) fn write_bridge_cell(base: u32, fail_index: u32, slot: u32) {
+    #[cfg(target_arch = "wasm32")]
+    if base != 0 {
+        let cell = (base as usize + fail_index as usize * 4) as *mut u32;
+        unsafe { core::ptr::write(cell, slot) };
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = (base, fail_index, slot);
+}
+
+pub(crate) fn write_bridge_cell_aliases(primary: u32, retained: u32, fail_index: u32, slot: u32) {
+    write_bridge_cell(primary, fail_index, slot);
+    if retained != 0 && retained != primary {
+        write_bridge_cell(retained, fail_index, slot);
+    }
+}
+
 /// Point retired table slots at `wasm_bytes` so a caller that baked
 /// `return_call_indirect(slot)` enters the replacement module.
 /// `assembler.py` `patch_jump_for_descr` rewrites the jump; wasm
@@ -1126,6 +1143,11 @@ pub struct ChainedTraceMeta {
     /// Base address of the bridge's per-guard bridge-slot cell array
     /// (`CompiledWasmLoop::bridge_cells_base` analog); `0` = no dispatch.
     pub cells_base: u32,
+    /// Cell array baked into a retained standalone copy of this bridge
+    /// after it was inlined. `reemit_loop` points `cells_base` at the
+    /// merged-region slice; inbound JUMPs still run the old module, which
+    /// reads this alias. `0` = no retained copy.
+    pub retained_cells_base: u32,
     /// Cell count = the bridge's own guard count.
     pub num_cells: usize,
     /// Per-guard, per-fail-arg induction-advance flags

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3142,6 +3142,12 @@ impl WasmBackend {
                 // dependencies registered afterwards attach to a flag the merged
                 // code never loads and a mutated field leaves the fold in place.
                 owner.record_bridge_invalidation_flag(owner.invalidation_flag());
+                // `bridge_slots` no longer names these — they were removed
+                // above so re-emission cannot replay them. Retract their
+                // LABEL_TARGETS rows here; `reemit_loop` only sees slots
+                // that are still attached.
+                let retired: Vec<u32> = old_bridge_slots.iter().map(|&(_, slot)| slot).collect();
+                source_loop.retract_bridge_label_targets_for_slots(retired);
                 return true;
             }
             Err(error) => {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1990,7 +1990,7 @@ fn wasm_write_barrier_helpers() -> codegen::WriteBarrierHelpers {
 /// mixed-geometry frames from distinct CA bridges are each forwarded by their
 /// own geometry — no shared coarse single-stride scan that mis-reads a larger
 /// frame's interior as a smaller frame's slots.
-pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, gcmap_ptr: i64) -> i64 {
+pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, _gcmap_ptr: i64) -> i64 {
     use majit_backend::jitframe::JitFrame;
     assert!(frame_bytes >= 0);
     assert_eq!(frame_bytes as usize % std::mem::size_of::<isize>(), 0);
@@ -2020,7 +2020,11 @@ pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, gcmap_ptr: i64) -> i
         // decoded as a fail-index by `install_post_finish_force_gcmap`.
         std::ptr::write_bytes(jf as *mut u8, 0, alloc_size);
         JitFrame::init(jf, std::ptr::null(), depth);
-        (*jf).jf_gcmap = gcmap_ptr as *const u8;
+        // assembler.py publishes `jf_gcmap` at safepoints once homes are
+        // live. The callee entry stores `home_gcmap_ptr` after its
+        // home/input stores. Installing the map here would trace leftover
+        // item words (`invalid type_id` in `copy_nursery_object`).
+        (*jf).jf_gcmap = std::ptr::null();
     }
     majit_gc::shadow_stack::push_jf(jf_ref);
     jf_ref.0 as i64
@@ -4148,10 +4152,6 @@ impl majit_backend::Backend for WasmBackend {
                 label_ref_slots,
             ),
         };
-        // Leaked before codegen so the key-0 prologue can publish it after
-        // nulling the frozen home region, instead of the CA bump filling
-        // the whole item area.
-        let home_gcmap_ptr = Box::leak(build_home_gcmap(frame)).as_ptr() as *const usize as usize;
         // `x86/assembler.py::assemble_loop` installs the generated frame
         // depth on the token's `CompiledLoopToken.frame_info`.  CALL_ASSEMBLER
         // redirect later propagates the replacement depth through that exact
@@ -4204,6 +4204,10 @@ impl majit_backend::Backend for WasmBackend {
         let fail_index_base = reserve_fail_descrs(guard_exit_count);
         let (bridge_cells_base, bridge_cells_owner) = codegen::alloc_bridge_cells(guard_exit_count);
         let bridge_param_dispatch = bridge_param_dispatch_for(guard_exit_count);
+        // assembler.py keeps `_finish_gcmap` with the compiled loop. Leak
+        // before the module build so the fresh-entry path can publish it
+        // after home/input stores, matching a safepoint write.
+        let home_gcmap_ptr = Box::leak(build_home_gcmap(frame)).as_ptr() as *const usize as usize;
         let module_inputs = codegen::ModuleBuildInputs {
             inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
             // Keep these rewritten operations exactly as intern_ref_constants
@@ -4235,7 +4239,7 @@ impl majit_backend::Backend for WasmBackend {
                 || codegen::CaParams {
                     ca_reload_fn_ptr: body_reload_fn_ptr(),
                     jf_top_addr: jf_top_addr(),
-                    entry_gcmap_ptr: home_gcmap_ptr as i64,
+                    home_gcmap_ptr: home_gcmap_ptr as i64,
                     ..codegen::CaParams::default()
                 },
                 |targets| codegen::CaParams {
@@ -4249,7 +4253,7 @@ impl majit_backend::Backend for WasmBackend {
                         as i64,
                     inline: ca_inline_params(ca_max_frame_bytes(targets)),
                     jf_top_addr: jf_top_addr(),
-                    entry_gcmap_ptr: home_gcmap_ptr as i64,
+                    home_gcmap_ptr: home_gcmap_ptr as i64,
                 },
             ),
         };
@@ -5159,6 +5163,8 @@ impl majit_backend::Backend for WasmBackend {
         // CALL_ASSEMBLER: the CA arm allocates a fresh callee using the target
         // token's frozen geometry. The earlier frame-fit decline guarantees a
         // movable callee cannot execute a trampoline-lowered op.
+        let home_gcmap_ptr =
+            Box::leak(build_home_gcmap(source_frame)).as_ptr() as *const usize as usize;
         let ca_params = if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
                 emit_ca: true,
@@ -5176,12 +5182,14 @@ impl majit_backend::Backend for WasmBackend {
                 // per-op callee frame in this trace.
                 inline: ca_inline_params(ca_max_frame_bytes(targets)),
                 jf_top_addr: jf_top_addr(),
+                home_gcmap_ptr: home_gcmap_ptr as i64,
                 ..codegen::CaParams::default()
             }
         } else {
             codegen::CaParams {
                 ca_reload_fn_ptr: body_reload_fn_ptr(),
                 jf_top_addr: jf_top_addr(),
+                home_gcmap_ptr: home_gcmap_ptr as i64,
                 ..codegen::CaParams::default()
             }
         };

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3218,7 +3218,11 @@ impl WasmBackend {
         inputs.bridge_cells_base = new_cells_base;
         inputs.ca.compute_home_gcmap = true;
         inputs.ca.home_gcmap_has_prior = true;
-        inputs.ca.home_gcmap_null_grown_labels = true;
+        // Do not null grown LABEL homes on every keyed entry. A later
+        // loop-closing bridge writes those captures and tail-calls back;
+        // zeroing them here would restore nulls. Stale pre-growth bridges
+        // are dropped below when the merged extent grows. Key-0 still
+        // clears the full used-label range.
         inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
         inputs.ca.home_gcmap_min_labels = compiled.used_label_homes.get();
         let (wasm_bytes, guard_exits, merged_ref_homes, merged_labels) =
@@ -3287,12 +3291,20 @@ impl WasmBackend {
                 *start += guard_growth;
             }
         }
+        let old_homes = compiled.num_ref_homes.get();
+        let old_labels = compiled.used_label_homes.get();
+        let widened = merged_ref_homes.max(old_homes);
+        let widened_labels = merged_labels.max(old_labels);
+        let owner_extent_grew = old_homes < widened || old_labels < widened_labels;
         #[cfg(target_arch = "wasm32")]
-        if new_cells_base != 0 {
+        if new_cells_base != 0 && !owner_extent_grew {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {
                 let cell = (new_cells_base as usize + fail_index as usize * 4) as *mut u32;
                 unsafe { core::ptr::write(cell, bridge_slot) };
             }
+        }
+        if owner_extent_grew {
+            compiled.bridge_slots.borrow_mut().clear();
         }
         if let Some(owner) = new_cells_owner {
             compiled._bridge_owned_cells.borrow_mut().push(owner);
@@ -3300,8 +3312,6 @@ impl WasmBackend {
         compiled.bridge_cells_base.set(new_cells_base);
         compiled.module_bytes.set(code_size as u32);
         compiled.num_guard_cells.set(guard_exits.len());
-        let widened = merged_ref_homes.max(compiled.num_ref_homes.get());
-        let widened_labels = merged_labels.max(compiled.used_label_homes.get());
         compiled.num_ref_homes.set(widened);
         compiled.used_label_homes.set(widened_labels);
         compiled

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3402,13 +3402,21 @@ impl WasmBackend {
             for region in &inputs.inlined_bridges {
                 let count = codegen::guard_exit_count(&region.inputargs, &region.ops);
                 let exits = &guard_exits[offset..offset + count];
-                let (prev_homes, prev_labels) = metas
+                let (prev_homes, prev_labels, retained_cells_base) = metas
                     .get(&region.trace_id)
-                    .map(|m| (m.num_ref_homes, m.used_label_homes))
+                    .map(|m| {
+                        let retained = if m.retained_cells_base != 0 {
+                            m.retained_cells_base
+                        } else {
+                            m.cells_base
+                        };
+                        (m.num_ref_homes, m.used_label_homes, retained)
+                    })
                     .unwrap_or_else(|| {
                         (
                             codegen::count_ref_homes(&region.inputargs, &region.ops),
                             codegen::label_ref_capture_slots(&region.inputargs, &region.ops),
+                            0,
                         )
                     });
                 // `RefHomes::collect` reassigns across the merged stream, so
@@ -3424,22 +3432,25 @@ impl WasmBackend {
                     // was just reallocated. Replay still-valid nested
                     // sub-bridges into the new cells; unreplayed, a guard
                     // deopts and retraces a bridge it can never reach.
-                    #[cfg(target_arch = "wasm32")]
                     for (&(trace_id, fail_index), &bridge_slot) in
                         compiled.chained_bridge_slots.borrow().iter()
                     {
                         if trace_id != region.trace_id || fail_index as usize >= count {
                             continue;
                         }
-                        let cell = (new_cells_base as usize + (offset + fail_index as usize) * 4)
-                            as *mut u32;
-                        unsafe { core::ptr::write(cell, bridge_slot) };
+                        crate::failguard::write_bridge_cell_aliases(
+                            new_cells_base + offset as u32 * 4,
+                            retained_cells_base,
+                            fail_index,
+                            bridge_slot,
+                        );
                     }
                 }
                 metas.insert(
                     region.trace_id,
                     ChainedTraceMeta {
                         cells_base: new_cells_base + offset as u32 * 4,
+                        retained_cells_base,
                         num_cells: count,
                         guard_fail_arg_advanced: guard_fail_args_advanced(&region.ops, exits),
                         guard_fail_arg_counts: exits
@@ -4742,6 +4753,7 @@ impl majit_backend::Backend for WasmBackend {
             let guard = if is_direct {
                 Some((
                     source_loop.bridge_cells_base.get(),
+                    0u32,
                     source_loop.num_guard_cells.get(),
                     source_loop
                         .guard_fail_arg_advanced
@@ -4762,6 +4774,7 @@ impl majit_backend::Backend for WasmBackend {
                     .map(|m| {
                         (
                             m.cells_base,
+                            m.retained_cells_base,
                             m.num_cells,
                             m.guard_fail_arg_advanced
                                 .get(source_fail_index as usize)
@@ -4791,6 +4804,7 @@ impl majit_backend::Backend for WasmBackend {
         // installing an unreachable bridge module.
         let Some((
             source_cells_base,
+            source_retained_cells_base,
             source_num_cells,
             source_fail_arg_advanced,
             source_fail_arg_count,
@@ -5526,6 +5540,7 @@ impl majit_backend::Backend for WasmBackend {
                 trace_id,
                 ChainedTraceMeta {
                     cells_base: bridge_cells_base,
+                    retained_cells_base: 0,
                     num_cells: guard_exits.len(),
                     guard_fail_arg_advanced: guard_fail_args_advanced(ops, &guard_exits),
                     guard_fail_arg_counts: guard_exits
@@ -5623,9 +5638,12 @@ impl majit_backend::Backend for WasmBackend {
             if unsafe { core::ptr::read(cell) } != 0 {
                 diag_bump(29); // this guard already had a reachable bridge
             }
-            unsafe {
-                core::ptr::write(cell, bridge_slot);
-            }
+            crate::failguard::write_bridge_cell_aliases(
+                source_cells_base,
+                source_retained_cells_base,
+                source_fail_index,
+                bridge_slot,
+            );
             // Retained module replacement and loop-closing bridge inlining
             // restore this cell after allocating a fresh dispatch array.
             if reemit_enabled() || inline_bridge_enabled() {
@@ -5649,7 +5667,7 @@ impl majit_backend::Backend for WasmBackend {
             }
         }
         #[cfg(not(target_arch = "wasm32"))]
-        let _ = (source_cells_base, bridge_slot);
+        let _ = (source_cells_base, source_retained_cells_base, bridge_slot);
 
         let code_size = wasm_bytes.len();
         // `asmmemmgr.py:37`, as in `compile_loop` above: a bridge's module is a

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3328,6 +3328,15 @@ impl WasmBackend {
                         unsafe { core::ptr::write(cell, bridge_slot) };
                     }
                 }
+                let (num_ref_homes, used_label_homes) = metas
+                    .get(&region.trace_id)
+                    .map(|m| (m.num_ref_homes, m.used_label_homes))
+                    .unwrap_or_else(|| {
+                        (
+                            codegen::count_ref_homes(&region.inputargs, &region.ops),
+                            codegen::label_ref_capture_slots(&region.inputargs, &region.ops),
+                        )
+                    });
                 metas.insert(
                     region.trace_id,
                     ChainedTraceMeta {
@@ -3344,6 +3353,8 @@ impl WasmBackend {
                             })
                             .collect(),
                         bridge_param_dispatch: inputs.bridge_param_dispatch,
+                        num_ref_homes,
+                        used_label_homes,
                     },
                 );
                 offset += count;
@@ -4588,7 +4599,14 @@ impl majit_backend::Backend for WasmBackend {
 
         // Scalars read from the source loop up front, so the immutable borrow of
         // `original_token` is released before the `&mut self` codegen calls.
-        let (source_guard, source_func_handle, source_has_preamble, source_frame, is_direct) = {
+        let (
+            source_guard,
+            source_func_handle,
+            source_has_preamble,
+            source_frame,
+            is_direct,
+            source_used_homes,
+        ) = {
             let source_loop = original_token
                 .compiled
                 .get()
@@ -4606,6 +4624,22 @@ impl majit_backend::Backend for WasmBackend {
             // per-fail-arg advance flags. `None` = foreign trace (declined
             // below, diag 3).
             let is_direct = source_trace_id == source_loop.trace_id;
+            let source_used_homes = if is_direct {
+                (
+                    source_loop.num_ref_homes.get(),
+                    source_loop.used_label_homes,
+                )
+            } else {
+                source_loop
+                    .chained_trace_meta
+                    .borrow()
+                    .get(&source_trace_id)
+                    .map(|m| (m.num_ref_homes, m.used_label_homes))
+                    .unwrap_or((
+                        source_loop.num_ref_homes.get(),
+                        source_loop.used_label_homes,
+                    ))
+            };
             let guard = if is_direct {
                 Some((
                     source_loop.bridge_cells_base.get(),
@@ -4647,6 +4681,7 @@ impl majit_backend::Backend for WasmBackend {
                 source_loop.has_preamble,
                 source_loop.frame,
                 is_direct,
+                source_used_homes,
             )
         };
 
@@ -5169,11 +5204,9 @@ impl majit_backend::Backend for WasmBackend {
         // token's frozen geometry. The earlier frame-fit decline guarantees a
         // movable callee cannot execute a trampoline-lowered op.
         // A keyed tail-call back into the source skips that module's
-        // fresh-entry publish, so this map must cover the source loop's
-        // already-initialized homes.
-        let source_used_homes = compiled_wasm_loop(original_token)
-            .map(|loop_| (loop_.num_ref_homes.get(), loop_.used_label_homes))
-            .unwrap_or((0, 0));
+        // fresh-entry publish, so this map must cover the source trace's
+        // already-initialized homes (the root loop, or the parent
+        // chained bridge when this is a nested sub-bridge).
         let ca_params = if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
                 emit_ca: true,
@@ -5406,6 +5439,9 @@ impl majit_backend::Backend for WasmBackend {
                         })
                         .collect(),
                     bridge_param_dispatch,
+                    num_ref_homes: bridge_ref_homes.max(source_used_homes.0),
+                    used_label_homes: codegen::label_ref_capture_slots(inputargs, ops)
+                        .max(source_used_homes.1),
                 },
             );
             // The bridge module lives as long as this source loop, so hand its

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3325,19 +3325,44 @@ impl WasmBackend {
             })
             .collect();
 
+        // When the LABEL-capture tail grows, do not replace the live
+        // handle in place. Cross-loop and entry bridges on other tokens
+        // already baked `return_call_indirect` against that slot; a
+        // replacement would publish the wider map and restore the new
+        // captures from uninitialized words. Install the grown module
+        // at a new slot. Already-baked inbound JUMPs keep the old
+        // module; `stamp_and_publish_label_targets` and CA dispatch
+        // below name the new slot for later compiles.
+        // `assembler.py` `patch_jump_for_descr` rewrites those jumps
+        // in place; wasm cannot, so the old slot stays the destination.
+        let old_labels_before = compiled.used_label_homes.get();
+        let labels_grew = old_labels_before < merged_labels.max(old_labels_before);
         #[cfg(target_arch = "wasm32")]
-        if glue::replace_module(old_handle, &wasm_bytes) != old_handle {
+        let install_handle = if labels_grew {
+            let new_handle = glue::compile_module_cached(&wasm_bytes);
+            if new_handle == 0 {
+                return Err(BackendError::Unsupported(
+                    "wasm host rejected the re-emitted trace module".into(),
+                ));
+            }
+            compiled.func_handle.set(new_handle);
+            new_handle
+        } else if glue::replace_module(old_handle, &wasm_bytes) != old_handle {
             return Err(BackendError::Unsupported(
                 "wasm host rejected the re-emitted trace module".into(),
             ));
-        }
+        } else {
+            old_handle
+        };
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let _ = wasm_bytes;
+            let _ = (wasm_bytes, labels_grew);
             return Err(BackendError::Unsupported(
                 "wasm backend: no host replacement binding".into(),
             ));
         }
+        #[cfg(not(target_arch = "wasm32"))]
+        let install_handle = old_handle;
 
         // The host has accepted the replacement, so its newly encoded global
         // indices can now be made visible in the registry and local metadata.
@@ -3491,14 +3516,14 @@ impl WasmBackend {
         // LABEL targets bake only the stable table slot, so restamp them for
         // this build. CA dispatch additionally carries the new finish index.
         let _ = stamp_and_publish_label_targets(
-            old_handle,
+            install_handle,
             compiled.frame,
             &inputs.inputargs,
             &inputs.ops,
             inputs.bridge_entry_arity,
         );
         if let Some(mut target) = call_assembler_target(token.number) {
-            target.func_handle = old_handle;
+            target.func_handle = install_handle;
             target.compiled_ptr = compiled as *const CompiledWasmLoop as usize as u64;
             // Never clear a flag an out-of-line bridge already published:
             // re-emission can omit that bridge's ops while the attached
@@ -3507,7 +3532,7 @@ impl WasmBackend {
                 module_has_guard_not_forced_2(&inputs.ops, &inputs.inlined_bridges);
             ca_dispatch_publish(
                 token.number,
-                old_handle,
+                install_handle,
                 target.compiled_ptr as u32,
                 target.callee_frame_bytes,
                 target.dispatch_key_ofs as u32,

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -47,7 +47,8 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
 /// that was never offered: 19 = labels published off a peeled trace, 20 =
 /// published off a non-peeled trace, 21 = a non-peeled trace's first label left
 /// unpublished (no descr, or its arity is not the inputarg count), 22 = a
-/// dropped loop retracted a published entry. 19-21 count loops and
+/// dropped loop or a retired widened bridge retracted a published entry.
+/// 19-21 count loops and
 /// LABEL-bearing bridges alike, since both go through the same publish step
 /// (`x86/assembler.py fixup_target_tokens` runs on either path); a bridge
 /// with no LABEL is not tallied by 21. `compile_loop`'s own outcome
@@ -799,8 +800,8 @@ use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, Value};
 /// Returns `(label_descrs, published_descrs)`: the descr identity of every
 /// LABEL in ordinal order, and the subset actually entered into
 /// `LABEL_TARGETS`. `compile_loop` keeps the first for its own JUMP
-/// resolution; `compile_bridge` hands the second to the source loop so its
-/// `Drop` retracts them.
+/// resolution; `compile_bridge` hands the second to the source loop so
+/// `Drop` and `retract_bridge_label_targets_for_slots` retract them.
 fn stamp_and_publish_label_targets(
     func_handle: u32,
     frame: codegen::FrameGeometry,
@@ -3303,6 +3304,8 @@ impl WasmBackend {
             }
         }
         if owner_extent_grew {
+            let retired: Vec<u32> = compiled.bridge_slots.borrow().values().copied().collect();
+            compiled.retract_bridge_label_targets_for_slots(retired);
             compiled.bridge_slots.borrow_mut().clear();
             let owner_tid = compiled.trace_id;
             compiled
@@ -3349,6 +3352,14 @@ impl WasmBackend {
                 // as live; the next fail retraces against the merged floor.
                 let extent_grew = prev_homes < widened || prev_labels < widened_labels;
                 if extent_grew {
+                    let retired: Vec<u32> = compiled
+                        .chained_bridge_slots
+                        .borrow()
+                        .iter()
+                        .filter(|&(&(tid, _), _)| tid == region.trace_id)
+                        .map(|(_, &slot)| slot)
+                        .collect();
+                    compiled.retract_bridge_label_targets_for_slots(retired);
                     compiled
                         .chained_bridge_slots
                         .borrow_mut()

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3327,14 +3327,20 @@ impl WasmBackend {
                 let used_label_homes = prev_labels.max(widened_labels);
                 // Existing nested sub-bridges still publish the standalone
                 // map. Replaying them after the extent grew would collect
-                // through that short prefix. Drop them so the next fail
-                // retraces against the merged floor.
+                // through that short prefix. Drop the dispatch slots and
+                // the `bridge_descr_ranges` attach record so
+                // `bridge_was_compiled` does not treat the retired module
+                // as live; the next fail retraces against the merged floor.
                 let extent_grew = prev_homes < widened || prev_labels < widened_labels;
                 if extent_grew {
                     compiled
                         .chained_bridge_slots
                         .borrow_mut()
                         .retain(|&(tid, _), _| tid != region.trace_id);
+                    compiled
+                        .bridge_descr_ranges
+                        .borrow_mut()
+                        .retain(|&(tid, _, _, _)| tid != region.trace_id);
                 } else if new_cells_base != 0 {
                     // This region's guards are carved out of the array that
                     // was just reallocated. Replay still-valid nested

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3218,6 +3218,7 @@ impl WasmBackend {
         inputs.bridge_cells_base = new_cells_base;
         inputs.ca.compute_home_gcmap = true;
         inputs.ca.home_gcmap_has_prior = true;
+        inputs.ca.home_gcmap_null_grown_labels = true;
         inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
         inputs.ca.home_gcmap_min_labels = compiled.used_label_homes.get();
         let (wasm_bytes, guard_exits, merged_ref_homes, merged_labels) =

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3290,9 +3290,9 @@ impl WasmBackend {
         inputs.ca.home_gcmap_has_prior = true;
         // Do not null grown LABEL homes on every keyed entry. A later
         // loop-closing bridge writes those captures and tail-calls back;
-        // zeroing them here would restore nulls. Stale pre-growth bridges
-        // are dropped below when the merged extent grows. Key-0 still
-        // clears the full used-label range.
+        // zeroing them here would restore nulls. Pre-growth owner
+        // attachments are dropped below when the LABEL tail grows.
+        // Key-0 still clears the full used-label range.
         inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
         inputs.ca.home_gcmap_min_labels = compiled.used_label_homes.get();
         let (wasm_bytes, guard_exits, merged_ref_homes, merged_labels) =
@@ -3365,7 +3365,6 @@ impl WasmBackend {
         let old_labels = compiled.used_label_homes.get();
         let widened = merged_ref_homes.max(old_homes);
         let widened_labels = merged_labels.max(old_labels);
-        let owner_extent_grew = old_homes < widened || old_labels < widened_labels;
         // Leave retired bridge slots pointing at the old module. Callers
         // baked `return_call_indirect` with that bridge's LABEL key; the
         // replacement owner's `br_table` interprets the same key against
@@ -3373,10 +3372,28 @@ impl WasmBackend {
         // rewrites the jump in place; wasm cannot, so the old module stays
         // the destination. The source-guard cell is already zero, so the
         // inlined region is not also dispatched.
-        // Keep already-compiled bridges. Publication is monotonic in the
-        // marked-bit set, so a narrower bridge map cannot unmark homes
-        // the owner grew. Dropping them here forced `trace_eagerness`
-        // (200) extra guard failures and a new compile.
+        // Keep already-compiled bridges when only ordinary homes grew:
+        // those new slots are nulled at keyed entry, and publication is
+        // monotonic in the marked-bit set. Dropping them forced
+        // `trace_eagerness` (200) extra guard failures.
+        // When the LABEL-capture tail grows, a pre-growth loop-closing
+        // bridge still keys into this replacement and restores the new
+        // captures from uninitialized words. Drop those owner attachments
+        // so the next fail retraces against the merged floor. The region
+        // just inlined is already gone from `bridge_slots`.
+        if old_labels < widened_labels {
+            let dropped: Vec<u32> = compiled.bridge_slots.borrow().keys().copied().collect();
+            compiled.bridge_slots.borrow_mut().clear();
+            if !dropped.is_empty() {
+                let owner_tid = compiled.trace_id;
+                compiled
+                    .bridge_descr_ranges
+                    .borrow_mut()
+                    .retain(|(tid, fail_index, _, _)| {
+                        !(*tid == owner_tid && dropped.contains(fail_index))
+                    });
+            }
+        }
         #[cfg(target_arch = "wasm32")]
         if new_cells_base != 0 {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {
@@ -3384,7 +3401,6 @@ impl WasmBackend {
                 unsafe { core::ptr::write(cell, bridge_slot) };
             }
         }
-        let _ = owner_extent_grew;
         if let Some(owner) = new_cells_owner {
             compiled._bridge_owned_cells.borrow_mut().push(owner);
         }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3144,11 +3144,11 @@ impl WasmBackend {
                 // code never loads and a mutated field leaves the fold in place.
                 owner.record_bridge_invalidation_flag(owner.invalidation_flag());
                 // `bridge_slots` no longer names these — they were removed
-                // above so re-emission cannot replay them. Retract their
-                // LABEL_TARGETS rows here; `reemit_loop` only sees slots
-                // that are still attached. The replacement bytes were
-                // already written into those slots inside re-emission.
-                source_loop.retract_bridge_label_targets_for_slots(extra_retire);
+                // above so re-emission cannot replay them. Keep their
+                // LABEL_TARGETS rows: inbound JUMPs still enter the old
+                // module, whose LABEL dest the replacement owner does not
+                // recreate.
+                let _ = extra_retire;
                 return true;
             }
             Err(error) => {
@@ -3186,7 +3186,7 @@ impl WasmBackend {
     fn reemit_loop_retiring(
         &mut self,
         token: &JitCellToken,
-        extra_retire_slots: &[u32],
+        _extra_retire_slots: &[u32],
     ) -> Result<(), BackendError> {
         let compiled = token
             .compiled
@@ -3312,19 +3312,17 @@ impl WasmBackend {
         let widened = merged_ref_homes.max(old_homes);
         let widened_labels = merged_labels.max(old_labels);
         let owner_extent_grew = old_homes < widened || old_labels < widened_labels;
-        // Bridges removed before re-emission (inlined regions) still have
-        // compiled callers that baked `return_call_indirect` to those
-        // slots. Point the slots at this replacement so they pick up the
-        // new map; x86 patches the jump instead.
-        crate::failguard::retarget_slots_to_module(
-            extra_retire_slots.iter().copied(),
-            old_handle,
-            &wasm_bytes,
-        );
-        // Keep already-compiled bridges. They no longer overwrite a wider
-        // owner map (`emit_publish_home_gcmap` only_if_null). Dropping them
-        // here forced `trace_eagerness` (200) extra guard failures and a
-        // new compile — the SNAPDIFF on this PR.
+        // Leave retired bridge slots pointing at the old module. Callers
+        // baked `return_call_indirect` with that bridge's LABEL key; the
+        // replacement owner's `br_table` interprets the same key against
+        // its own resumable-label prefix. `assembler.py` `patch_jump_for_descr`
+        // rewrites the jump in place; wasm cannot, so the old module stays
+        // the destination. The source-guard cell is already zero, so the
+        // inlined region is not also dispatched.
+        // Keep already-compiled bridges. Publication is monotonic in the
+        // marked-bit set, so a narrower bridge map cannot unmark homes
+        // the owner grew. Dropping them here forced `trace_eagerness`
+        // (200) extra guard failures and a new compile.
         #[cfg(target_arch = "wasm32")]
         if new_cells_base != 0 {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2269,7 +2269,6 @@ fn leak_home_gcmap(
 /// When one already covers the other the covered pointer is returned so a
 /// comparable publish does not leak.
 pub extern "C" fn wasm_jit_union_gcmap(old: i64, new: i64) -> i64 {
-    const MAX_WORDS: usize = 64;
     let old_ptr = old as usize as *const usize;
     let new_ptr = new as usize as *const usize;
     if old_ptr.is_null() {
@@ -2279,8 +2278,8 @@ pub extern "C" fn wasm_jit_union_gcmap(old: i64, new: i64) -> i64 {
         return old;
     }
     unsafe {
-        let n_old = (*old_ptr).min(MAX_WORDS);
-        let n_new = (*new_ptr).min(MAX_WORDS);
+        let n_old = *old_ptr;
+        let n_new = *new_ptr;
         let n_overlap = n_old.min(n_new);
         let mut old_extra = false;
         let mut new_extra = false;
@@ -6221,6 +6220,27 @@ mod tests {
             union as usize as i64,
             "owner is a subset of the union"
         );
+    }
+
+    #[test]
+    fn union_gcmap_keeps_bits_past_sixty_four_words() {
+        // value_slots=16, 4200 homes: last signed index is past 64 data words
+        // on a 64-bit host (`build_home_gcmap` word count).
+        let frame = codegen::FrameGeometry::compact(16, 4200, 2);
+        let owner = codegen::build_home_gcmap(frame, 4100, 0);
+        let bridge = codegen::build_home_gcmap(frame, 3, 2);
+        assert!(owner[0] > 64, "fixture must exceed the old 64-word cap");
+        let union = wasm_jit_union_gcmap(
+            owner.as_ptr() as usize as i64,
+            bridge.as_ptr() as usize as i64,
+        ) as usize as *const usize;
+        let n = unsafe { *union };
+        let words = unsafe { std::slice::from_raw_parts(union, 1 + n) };
+        let sign = std::mem::size_of::<isize>();
+        let idx = |h: usize| (frame.home_slot_base as usize + h * 8) / sign;
+        assert!(gcmap_marks(words, idx(4099)), "high ordinary home");
+        assert!(gcmap_marks(words, idx(4198)), "bridge label 0");
+        assert!(gcmap_marks(words, idx(4199)), "bridge label 1");
     }
 
     #[test]

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3321,28 +3321,18 @@ impl WasmBackend {
             old_handle,
             &wasm_bytes,
         );
+        // Keep already-compiled bridges. They no longer overwrite a wider
+        // owner map (`emit_publish_home_gcmap` only_if_null). Dropping them
+        // here forced `trace_eagerness` (200) extra guard failures and a
+        // new compile — the SNAPDIFF on this PR.
         #[cfg(target_arch = "wasm32")]
-        if new_cells_base != 0 && !owner_extent_grew {
+        if new_cells_base != 0 {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {
                 let cell = (new_cells_base as usize + fail_index as usize * 4) as *mut u32;
                 unsafe { core::ptr::write(cell, bridge_slot) };
             }
         }
-        if owner_extent_grew {
-            let retired: Vec<u32> = compiled.bridge_slots.borrow().values().copied().collect();
-            crate::failguard::retarget_slots_to_module(
-                retired.iter().copied(),
-                old_handle,
-                &wasm_bytes,
-            );
-            compiled.retract_bridge_label_targets_for_slots(retired);
-            compiled.bridge_slots.borrow_mut().clear();
-            let owner_tid = compiled.trace_id;
-            compiled
-                .bridge_descr_ranges
-                .borrow_mut()
-                .retain(|&(tid, _, _, _)| tid != owner_tid);
-        }
+        let _ = owner_extent_grew;
         if let Some(owner) = new_cells_owner {
             compiled._bridge_owned_cells.borrow_mut().push(owner);
         }
@@ -3374,36 +3364,10 @@ impl WasmBackend {
                 // rebased refs now occupy. Floor to the merged extent.
                 let num_ref_homes = prev_homes.max(widened);
                 let used_label_homes = prev_labels.max(widened_labels);
-                // Existing nested sub-bridges still publish the standalone
-                // map. Replaying them after the extent grew would collect
-                // through that short prefix. Drop the dispatch slots and
-                // the `bridge_descr_ranges` attach record so
-                // `bridge_was_compiled` does not treat the retired module
-                // as live; the next fail retraces against the merged floor.
-                let extent_grew = prev_homes < widened || prev_labels < widened_labels;
-                if extent_grew {
-                    let retired: Vec<u32> = compiled
-                        .chained_bridge_slots
-                        .borrow()
-                        .iter()
-                        .filter(|&(&(tid, _), _)| tid == region.trace_id)
-                        .map(|(_, &slot)| slot)
-                        .collect();
-                    crate::failguard::retarget_slots_to_module(
-                        retired.iter().copied(),
-                        old_handle,
-                        &wasm_bytes,
-                    );
-                    compiled.retract_bridge_label_targets_for_slots(retired);
-                    compiled
-                        .chained_bridge_slots
-                        .borrow_mut()
-                        .retain(|&(tid, _), _| tid != region.trace_id);
-                    compiled
-                        .bridge_descr_ranges
-                        .borrow_mut()
-                        .retain(|&(tid, _, _, _)| tid != region.trace_id);
-                } else if new_cells_base != 0 {
+                // Nested sub-bridges keep their dispatch slots. They no
+                // longer overwrite a wider owner map (bridge publish is
+                // null-only), so a grow does not need a retrace.
+                if new_cells_base != 0 {
                     // This region's guards are carved out of the array that
                     // was just reallocated. Replay still-valid nested
                     // sub-bridges into the new cells; unreplayed, a guard

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2260,6 +2260,61 @@ fn leak_home_gcmap(
         as usize
 }
 
+/// Bitwise union of two GCMAP arrays (`[n, word0, ...]`).
+///
+/// Ordinary homes and LABEL captures grow independently, so two live maps
+/// can be incomparable: a retained bridge may mark more LABEL bits while a
+/// re-emitted owner marks more ordinary bits. Returning either pointer
+/// unmarks the other region. `None` of either argument is treated as empty.
+/// When one already covers the other the covered pointer is returned so a
+/// comparable publish does not leak.
+pub extern "C" fn wasm_jit_union_gcmap(old: i64, new: i64) -> i64 {
+    const MAX_WORDS: usize = 64;
+    let old_ptr = old as usize as *const usize;
+    let new_ptr = new as usize as *const usize;
+    if old_ptr.is_null() {
+        return new;
+    }
+    if new_ptr.is_null() {
+        return old;
+    }
+    unsafe {
+        let n_old = (*old_ptr).min(MAX_WORDS);
+        let n_new = (*new_ptr).min(MAX_WORDS);
+        let n_overlap = n_old.min(n_new);
+        let mut old_extra = false;
+        let mut new_extra = false;
+        for i in 0..n_overlap {
+            let o = *old_ptr.add(1 + i);
+            let n = *new_ptr.add(1 + i);
+            old_extra |= o & !n != 0;
+            new_extra |= n & !o != 0;
+        }
+        for i in n_overlap..n_old {
+            old_extra |= *old_ptr.add(1 + i) != 0;
+        }
+        for i in n_overlap..n_new {
+            new_extra |= *new_ptr.add(1 + i) != 0;
+        }
+        if !old_extra {
+            return new;
+        }
+        if !new_extra {
+            return old;
+        }
+        let n = n_old.max(n_new);
+        let mut buf = vec![0usize; 1 + n];
+        buf[0] = n;
+        for i in 0..n_old {
+            buf[1 + i] |= *old_ptr.add(1 + i);
+        }
+        for i in 0..n_new {
+            buf[1 + i] |= *new_ptr.add(1 + i);
+        }
+        Box::leak(buf.into_boxed_slice()).as_ptr() as usize as i64
+    }
+}
+
 /// Allocate the immutable guard-token gcmap which PyPy's
 /// `store_force_descr` retains as `_finish_gcmap`.
 fn leak_gcmap_for_indices(indices: &[u32]) -> usize {
@@ -6139,6 +6194,32 @@ mod tests {
         assert!(
             !gcmap_marks(&narrow, idx(129)),
             "reserved unused label slot"
+        );
+    }
+
+    #[test]
+    fn union_gcmap_covers_incomparable_ordinary_and_label_maps() {
+        let frame = codegen::FrameGeometry::compact(16, 128 + 2, 2);
+        let owner = codegen::build_home_gcmap(frame, 8, 0);
+        let bridge = codegen::build_home_gcmap(frame, 3, 2);
+        let union = wasm_jit_union_gcmap(
+            owner.as_ptr() as usize as i64,
+            bridge.as_ptr() as usize as i64,
+        ) as usize as *const usize;
+        assert!(!union.is_null());
+        let n = unsafe { *union };
+        let words = unsafe { std::slice::from_raw_parts(union, 1 + n) };
+        let sign = std::mem::size_of::<isize>();
+        let idx = |h: usize| (frame.home_slot_base as usize + h * 8) / sign;
+        for h in 0..8 {
+            assert!(gcmap_marks(words, idx(h)), "owner ordinary home {h}");
+        }
+        assert!(gcmap_marks(words, idx(128)), "bridge label 0");
+        assert!(gcmap_marks(words, idx(129)), "bridge label 1");
+        assert_eq!(
+            wasm_jit_union_gcmap(union as usize as i64, owner.as_ptr() as usize as i64),
+            union as usize as i64,
+            "owner is a subset of the union"
         );
     }
 

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2250,35 +2250,13 @@ fn wasm_jitframe_tid() -> u32 {
 /// marked bit, so marking those indices exposes each home's `GcRef` (the high
 /// word stays unmarked). Returns `[data_word_count, word0, ...]` in `usize`
 /// words (GCMAP array layout: `gcmap[0]` = number of data words).
-/// Mark the homes this module initializes: the used ordinary prefix and the
-/// LABEL-capture tail. Frozen geometry reserves
-/// [`FROZEN_CHAIN_REF_HOMES`] ordinary slots so a later bridge can fit;
-/// those unused reserved words stay unmarked so recycled nursery bytes
-/// are not traced. assembler.py writes `jf_gcmap` for live slots only.
-fn build_home_gcmap(frame: codegen::FrameGeometry, used_ordinary: usize) -> Box<[usize]> {
-    let sign = std::mem::size_of::<isize>();
-    let bits_per_word = std::mem::size_of::<usize>() * 8;
-    let ordinary = used_ordinary.min(frame.ordinary_home_slots());
-    let label_base = frame.ordinary_home_slots();
-    let label_n = frame.label_ref_slots;
-    if ordinary == 0 && label_n == 0 {
-        // One empty data word: a non-null jf_gcmap that traces nothing.
-        return vec![1usize, 0usize].into_boxed_slice();
-    }
-    let last_h = if label_n == 0 {
-        ordinary.saturating_sub(1)
-    } else {
-        label_base + label_n - 1
-    };
-    let last_index = (frame.home_slot_base as usize + last_h * 8) / sign;
-    let num_words = last_index / bits_per_word + 1;
-    let mut buf = vec![0usize; 1 + num_words];
-    buf[0] = num_words;
-    for h in (0..ordinary).chain(label_base..label_base + label_n) {
-        let index = (frame.home_slot_base as usize + h * 8) / sign;
-        buf[1 + index / bits_per_word] |= 1usize << (index % bits_per_word);
-    }
-    buf.into_boxed_slice()
+fn leak_home_gcmap(
+    frame: codegen::FrameGeometry,
+    used_ordinary: usize,
+    used_labels: usize,
+) -> usize {
+    Box::leak(codegen::build_home_gcmap(frame, used_ordinary, used_labels)).as_ptr() as *const usize
+        as usize
 }
 
 /// Allocate the immutable guard-token gcmap which PyPy's
@@ -3237,7 +3215,10 @@ impl WasmBackend {
         inputs.fail_index_base = reserve_fail_descrs(merged_guard_count);
         let (new_cells_base, new_cells_owner) = codegen::alloc_bridge_cells(merged_guard_count);
         inputs.bridge_cells_base = new_cells_base;
-        let (wasm_bytes, guard_exits, _) = codegen::build_wasm_module(&inputs)?;
+        inputs.ca.compute_home_gcmap = true;
+        inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes;
+        inputs.ca.home_gcmap_min_labels = compiled.used_label_homes;
+        let (wasm_bytes, guard_exits, merged_ref_homes) = codegen::build_wasm_module(&inputs)?;
         let code_size = wasm_bytes.len();
         let descrs: Vec<Arc<WasmFailDescr>> = guard_exits
             .iter()
@@ -3315,6 +3296,7 @@ impl WasmBackend {
         compiled.bridge_cells_base.set(new_cells_base);
         compiled.module_bytes.set(code_size as u32);
         compiled.num_guard_cells.set(guard_exits.len());
+        let _ = merged_ref_homes;
         {
             let mut metas = compiled.chained_trace_meta.borrow_mut();
             let mut offset = own_guard_count;
@@ -4217,11 +4199,10 @@ impl majit_backend::Backend for WasmBackend {
         let fail_index_base = reserve_fail_descrs(guard_exit_count);
         let (bridge_cells_base, bridge_cells_owner) = codegen::alloc_bridge_cells(guard_exit_count);
         let bridge_param_dispatch = bridge_param_dispatch_for(guard_exit_count);
-        // assembler.py keeps `_finish_gcmap` with the compiled loop. Leak
-        // before the module build so the fresh-entry path can publish it
-        // after home/input stores, matching a safepoint write.
-        let home_gcmap_ptr =
-            Box::leak(build_home_gcmap(frame, raw_num_ref_homes)).as_ptr() as *const usize as usize;
+        // assembler.py keeps `_finish_gcmap` with the compiled loop. The
+        // module leaks the map from its own RefHomes / LABEL captures after
+        // those stores, matching a safepoint write.
+        let used_label_homes = codegen::label_ref_capture_slots(inputargs, ops);
         let module_inputs = codegen::ModuleBuildInputs {
             inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
             // Keep these rewritten operations exactly as intern_ref_constants
@@ -4253,7 +4234,7 @@ impl majit_backend::Backend for WasmBackend {
                 || codegen::CaParams {
                     ca_reload_fn_ptr: body_reload_fn_ptr(),
                     jf_top_addr: jf_top_addr(),
-                    home_gcmap_ptr: home_gcmap_ptr as i64,
+                    compute_home_gcmap: true,
                     ..codegen::CaParams::default()
                 },
                 |targets| codegen::CaParams {
@@ -4267,7 +4248,8 @@ impl majit_backend::Backend for WasmBackend {
                         as i64,
                     inline: ca_inline_params(ca_max_frame_bytes(targets)),
                     jf_top_addr: jf_top_addr(),
-                    home_gcmap_ptr: home_gcmap_ptr as i64,
+                    compute_home_gcmap: true,
+                    ..codegen::CaParams::default()
                 },
             ),
         };
@@ -4280,6 +4262,7 @@ impl majit_backend::Backend for WasmBackend {
                     return Err(err);
                 }
             };
+        let home_gcmap_ptr = leak_home_gcmap(frame, num_ref_homes, used_label_homes);
 
         // Build fail descriptors
         let fail_descrs: Vec<Arc<WasmFailDescr>> = guard_exits
@@ -4405,6 +4388,7 @@ impl majit_backend::Backend for WasmBackend {
             num_inputs: inputargs.len(),
             max_output_slots,
             num_ref_homes,
+            used_label_homes,
             frame,
             home_gcmap_ptr,
             bridge_cells_base: std::cell::Cell::new(bridge_cells_base),
@@ -5177,8 +5161,12 @@ impl majit_backend::Backend for WasmBackend {
         // CALL_ASSEMBLER: the CA arm allocates a fresh callee using the target
         // token's frozen geometry. The earlier frame-fit decline guarantees a
         // movable callee cannot execute a trampoline-lowered op.
-        let home_gcmap_ptr = Box::leak(build_home_gcmap(source_frame, bridge_ref_homes)).as_ptr()
-            as *const usize as usize;
+        // A keyed tail-call back into the source skips that module's
+        // fresh-entry publish, so this map must cover the source loop's
+        // already-initialized homes.
+        let source_used_homes = compiled_wasm_loop(original_token)
+            .map(|loop_| (loop_.num_ref_homes, loop_.used_label_homes))
+            .unwrap_or((0, 0));
         let ca_params = if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
                 emit_ca: true,
@@ -5196,14 +5184,18 @@ impl majit_backend::Backend for WasmBackend {
                 // per-op callee frame in this trace.
                 inline: ca_inline_params(ca_max_frame_bytes(targets)),
                 jf_top_addr: jf_top_addr(),
-                home_gcmap_ptr: home_gcmap_ptr as i64,
+                compute_home_gcmap: true,
+                home_gcmap_min_ordinary: source_used_homes.0,
+                home_gcmap_min_labels: source_used_homes.1,
                 ..codegen::CaParams::default()
             }
         } else {
             codegen::CaParams {
                 ca_reload_fn_ptr: body_reload_fn_ptr(),
                 jf_top_addr: jf_top_addr(),
-                home_gcmap_ptr: home_gcmap_ptr as i64,
+                compute_home_gcmap: true,
+                home_gcmap_min_ordinary: source_used_homes.0,
+                home_gcmap_min_labels: source_used_homes.1,
                 ..codegen::CaParams::default()
             }
         };
@@ -6042,7 +6034,7 @@ mod tests {
     fn home_gcmap_marks_used_homes_and_label_captures_only() {
         let sign = std::mem::size_of::<isize>();
         let frame = codegen::FrameGeometry::compact(16, 128 + 2, 2);
-        let map = build_home_gcmap(frame, 5);
+        let map = codegen::build_home_gcmap(frame, 5, 2);
         let idx = |h: usize| (frame.home_slot_base as usize + h * 8) / sign;
         for h in 0..5 {
             assert!(gcmap_marks(&map, idx(h)), "used ordinary home {h}");
@@ -6052,6 +6044,12 @@ mod tests {
         }
         assert!(gcmap_marks(&map, idx(128)), "label capture 0");
         assert!(gcmap_marks(&map, idx(129)), "label capture 1");
+        let narrow = codegen::build_home_gcmap(frame, 5, 1);
+        assert!(gcmap_marks(&narrow, idx(128)), "actual label capture");
+        assert!(
+            !gcmap_marks(&narrow, idx(129)),
+            "reserved unused label slot"
+        );
     }
 
     #[test]

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -621,7 +621,6 @@ pub fn last_compile_err_len() -> u32 {
 /// `i` is out of range.
 pub fn last_compile_err_byte(i: u32) -> u32 {
     LAST_COMPILE_ERR_SNAP.with(|snap| snap.borrow().get(i as usize).copied().unwrap_or(0) as u32)
-
 }
 
 /// Number of JIT trace entries made from the guest.
@@ -3305,6 +3304,11 @@ impl WasmBackend {
         }
         if owner_extent_grew {
             compiled.bridge_slots.borrow_mut().clear();
+            let owner_tid = compiled.trace_id;
+            compiled
+                .bridge_descr_ranges
+                .borrow_mut()
+                .retain(|&(tid, _, _, _)| tid != owner_tid);
         }
         if let Some(owner) = new_cells_owner {
             compiled._bridge_owned_cells.borrow_mut().push(owner);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3216,6 +3216,7 @@ impl WasmBackend {
         let (new_cells_base, new_cells_owner) = codegen::alloc_bridge_cells(merged_guard_count);
         inputs.bridge_cells_base = new_cells_base;
         inputs.ca.compute_home_gcmap = true;
+        inputs.ca.home_gcmap_has_prior = true;
         inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
         inputs.ca.home_gcmap_min_labels = compiled.used_label_homes;
         let (wasm_bytes, guard_exits, merged_ref_homes) = codegen::build_wasm_module(&inputs)?;
@@ -5191,6 +5192,7 @@ impl majit_backend::Backend for WasmBackend {
                 inline: ca_inline_params(ca_max_frame_bytes(targets)),
                 jf_top_addr: jf_top_addr(),
                 compute_home_gcmap: true,
+                home_gcmap_has_prior: true,
                 home_gcmap_min_ordinary: source_used_homes.0,
                 home_gcmap_min_labels: source_used_homes.1,
                 ..codegen::CaParams::default()
@@ -5200,6 +5202,7 @@ impl majit_backend::Backend for WasmBackend {
                 ca_reload_fn_ptr: body_reload_fn_ptr(),
                 jf_top_addr: jf_top_addr(),
                 compute_home_gcmap: true,
+                home_gcmap_has_prior: true,
                 home_gcmap_min_ordinary: source_used_homes.0,
                 home_gcmap_min_labels: source_used_homes.1,
                 ..codegen::CaParams::default()

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3328,7 +3328,7 @@ impl WasmBackend {
                         unsafe { core::ptr::write(cell, bridge_slot) };
                     }
                 }
-                let (num_ref_homes, used_label_homes) = metas
+                let (prev_homes, used_label_homes) = metas
                     .get(&region.trace_id)
                     .map(|m| (m.num_ref_homes, m.used_label_homes))
                     .unwrap_or_else(|| {
@@ -3337,6 +3337,10 @@ impl WasmBackend {
                             codegen::label_ref_capture_slots(&region.inputargs, &region.ops),
                         )
                     });
+                // `RefHomes::collect` reassigns across the merged stream, so
+                // this region's standalone count can sit below the slots its
+                // rebased refs now occupy. Floor to the merged extent.
+                let num_ref_homes = prev_homes.max(widened);
                 metas.insert(
                     region.trace_id,
                     ChainedTraceMeta {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3216,7 +3216,7 @@ impl WasmBackend {
         let (new_cells_base, new_cells_owner) = codegen::alloc_bridge_cells(merged_guard_count);
         inputs.bridge_cells_base = new_cells_base;
         inputs.ca.compute_home_gcmap = true;
-        inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes;
+        inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
         inputs.ca.home_gcmap_min_labels = compiled.used_label_homes;
         let (wasm_bytes, guard_exits, merged_ref_homes) = codegen::build_wasm_module(&inputs)?;
         let code_size = wasm_bytes.len();
@@ -3296,7 +3296,13 @@ impl WasmBackend {
         compiled.bridge_cells_base.set(new_cells_base);
         compiled.module_bytes.set(code_size as u32);
         compiled.num_guard_cells.set(guard_exits.len());
-        let _ = merged_ref_homes;
+        let widened = merged_ref_homes.max(compiled.num_ref_homes.get());
+        compiled.num_ref_homes.set(widened);
+        compiled.home_gcmap_ptr.set(leak_home_gcmap(
+            compiled.frame,
+            widened,
+            compiled.used_label_homes,
+        ));
         {
             let mut metas = compiled.chained_trace_meta.borrow_mut();
             let mut offset = own_guard_count;
@@ -4387,10 +4393,10 @@ impl majit_backend::Backend for WasmBackend {
             fail_descrs: std::cell::RefCell::new(fail_descrs),
             num_inputs: inputargs.len(),
             max_output_slots,
-            num_ref_homes,
+            num_ref_homes: std::cell::Cell::new(num_ref_homes),
             used_label_homes,
             frame,
-            home_gcmap_ptr,
+            home_gcmap_ptr: std::cell::Cell::new(home_gcmap_ptr),
             bridge_cells_base: std::cell::Cell::new(bridge_cells_base),
             module_bytes: std::cell::Cell::new(code_size as u32),
             num_guard_cells: std::cell::Cell::new(guard_exits.len()),
@@ -5165,7 +5171,7 @@ impl majit_backend::Backend for WasmBackend {
         // fresh-entry publish, so this map must cover the source loop's
         // already-initialized homes.
         let source_used_homes = compiled_wasm_loop(original_token)
-            .map(|loop_| (loop_.num_ref_homes, loop_.used_label_homes))
+            .map(|loop_| (loop_.num_ref_homes.get(), loop_.used_label_homes))
             .unwrap_or((0, 0));
         let ca_params = if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
@@ -5699,7 +5705,7 @@ impl majit_backend::Backend for WasmBackend {
                 // owned for the compiled loop's lifetime, because this frame
                 // may remain reachable through a virtualizable token after
                 // the immediate outputs have been read.
-                unsafe { (*jf).jf_gcmap = compiled.home_gcmap_ptr as *const u8 };
+                unsafe { (*jf).jf_gcmap = compiled.home_gcmap_ptr.get() as *const u8 };
 
                 let items_base = jf as usize + FIRST_ITEM_OFFSET;
                 let fsb = codegen::FRAME_SLOT_BASE as usize;
@@ -5768,7 +5774,7 @@ impl majit_backend::Backend for WasmBackend {
             let mut backing = vec![0i64; alloc_size.div_ceil(8)];
             let jf = backing.as_mut_ptr() as *mut majit_backend::jitframe::JitFrame;
             unsafe { majit_backend::jitframe::JitFrame::init(jf, std::ptr::null(), depth) };
-            unsafe { (*jf).jf_gcmap = compiled.home_gcmap_ptr as *const u8 };
+            unsafe { (*jf).jf_gcmap = compiled.home_gcmap_ptr.get() as *const u8 };
             let items = (jf as usize + majit_backend::jitframe::FIRST_ITEM_OFFSET) as *mut i64;
             for (i, arg) in args.iter().enumerate() {
                 let v = match arg {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3346,6 +3346,11 @@ impl WasmBackend {
                 ));
             }
             compiled.func_handle.set(new_handle);
+            if compiled.retained_owner_cells_base.get() == 0 {
+                compiled
+                    .retained_owner_cells_base
+                    .set(compiled.bridge_cells_base.get());
+            }
             new_handle
         } else if glue::replace_module(old_handle, &wasm_bytes) != old_handle {
             return Err(BackendError::Unsupported(
@@ -4561,6 +4566,7 @@ impl majit_backend::Backend for WasmBackend {
             frame,
             home_gcmap_ptr: std::cell::Cell::new(home_gcmap_ptr),
             bridge_cells_base: std::cell::Cell::new(bridge_cells_base),
+            retained_owner_cells_base: std::cell::Cell::new(0),
             module_bytes: std::cell::Cell::new(code_size as u32),
             num_guard_cells: std::cell::Cell::new(guard_exits.len()),
             has_preamble,
@@ -4794,7 +4800,7 @@ impl majit_backend::Backend for WasmBackend {
             let guard = if is_direct {
                 Some((
                     source_loop.bridge_cells_base.get(),
-                    0u32,
+                    source_loop.retained_owner_cells_base.get(),
                     source_loop.num_guard_cells.get(),
                     source_loop
                         .guard_fail_arg_advanced

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -621,6 +621,7 @@ pub fn last_compile_err_len() -> u32 {
 /// `i` is out of range.
 pub fn last_compile_err_byte(i: u32) -> u32 {
     LAST_COMPILE_ERR_SNAP.with(|snap| snap.borrow().get(i as usize).copied().unwrap_or(0) as u32)
+
 }
 
 /// Number of JIT trace entries made from the guest.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3218,8 +3218,9 @@ impl WasmBackend {
         inputs.ca.compute_home_gcmap = true;
         inputs.ca.home_gcmap_has_prior = true;
         inputs.ca.home_gcmap_min_ordinary = compiled.num_ref_homes.get();
-        inputs.ca.home_gcmap_min_labels = compiled.used_label_homes;
-        let (wasm_bytes, guard_exits, merged_ref_homes) = codegen::build_wasm_module(&inputs)?;
+        inputs.ca.home_gcmap_min_labels = compiled.used_label_homes.get();
+        let (wasm_bytes, guard_exits, merged_ref_homes, merged_labels) =
+            codegen::build_wasm_module(&inputs)?;
         let code_size = wasm_bytes.len();
         let descrs: Vec<Arc<WasmFailDescr>> = guard_exits
             .iter()
@@ -3298,37 +3299,19 @@ impl WasmBackend {
         compiled.module_bytes.set(code_size as u32);
         compiled.num_guard_cells.set(guard_exits.len());
         let widened = merged_ref_homes.max(compiled.num_ref_homes.get());
+        let widened_labels = merged_labels.max(compiled.used_label_homes.get());
         compiled.num_ref_homes.set(widened);
-        compiled.home_gcmap_ptr.set(leak_home_gcmap(
-            compiled.frame,
-            widened,
-            compiled.used_label_homes,
-        ));
+        compiled.used_label_homes.set(widened_labels);
+        compiled
+            .home_gcmap_ptr
+            .set(leak_home_gcmap(compiled.frame, widened, widened_labels));
         {
             let mut metas = compiled.chained_trace_meta.borrow_mut();
             let mut offset = own_guard_count;
             for region in &inputs.inlined_bridges {
                 let count = codegen::guard_exit_count(&region.inputargs, &region.ops);
                 let exits = &guard_exits[offset..offset + count];
-                // This region's guards are carved out of the array that was
-                // just reallocated, so every bridge already chained onto one of
-                // them has lost its dispatch entry. Unreplayed, that guard
-                // deopts to the tracer on every failure and retraces a bridge
-                // it can never reach.
-                #[cfg(target_arch = "wasm32")]
-                if new_cells_base != 0 {
-                    for (&(trace_id, fail_index), &bridge_slot) in
-                        compiled.chained_bridge_slots.borrow().iter()
-                    {
-                        if trace_id != region.trace_id || fail_index as usize >= count {
-                            continue;
-                        }
-                        let cell = (new_cells_base as usize + (offset + fail_index as usize) * 4)
-                            as *mut u32;
-                        unsafe { core::ptr::write(cell, bridge_slot) };
-                    }
-                }
-                let (prev_homes, used_label_homes) = metas
+                let (prev_homes, prev_labels) = metas
                     .get(&region.trace_id)
                     .map(|m| (m.num_ref_homes, m.used_label_homes))
                     .unwrap_or_else(|| {
@@ -3341,6 +3324,34 @@ impl WasmBackend {
                 // this region's standalone count can sit below the slots its
                 // rebased refs now occupy. Floor to the merged extent.
                 let num_ref_homes = prev_homes.max(widened);
+                let used_label_homes = prev_labels.max(widened_labels);
+                // Existing nested sub-bridges still publish the standalone
+                // map. Replaying them after the extent grew would collect
+                // through that short prefix. Drop them so the next fail
+                // retraces against the merged floor.
+                let extent_grew = prev_homes < widened || prev_labels < widened_labels;
+                if extent_grew {
+                    compiled
+                        .chained_bridge_slots
+                        .borrow_mut()
+                        .retain(|&(tid, _), _| tid != region.trace_id);
+                } else if new_cells_base != 0 {
+                    // This region's guards are carved out of the array that
+                    // was just reallocated. Replay still-valid nested
+                    // sub-bridges into the new cells; unreplayed, a guard
+                    // deopts and retraces a bridge it can never reach.
+                    #[cfg(target_arch = "wasm32")]
+                    for (&(trace_id, fail_index), &bridge_slot) in
+                        compiled.chained_bridge_slots.borrow().iter()
+                    {
+                        if trace_id != region.trace_id || fail_index as usize >= count {
+                            continue;
+                        }
+                        let cell = (new_cells_base as usize + (offset + fail_index as usize) * 4)
+                            as *mut u32;
+                        unsafe { core::ptr::write(cell, bridge_slot) };
+                    }
+                }
                 metas.insert(
                     region.trace_id,
                     ChainedTraceMeta {
@@ -4275,7 +4286,7 @@ impl majit_backend::Backend for WasmBackend {
                 },
             ),
         };
-        let (wasm_bytes, guard_exits, num_ref_homes) =
+        let (wasm_bytes, guard_exits, num_ref_homes, _used_labels) =
             match codegen::build_wasm_module(&module_inputs) {
                 Ok(built) => built,
                 Err(err) => {
@@ -4410,7 +4421,7 @@ impl majit_backend::Backend for WasmBackend {
             num_inputs: inputargs.len(),
             max_output_slots,
             num_ref_homes: std::cell::Cell::new(num_ref_homes),
-            used_label_homes,
+            used_label_homes: std::cell::Cell::new(used_label_homes),
             frame,
             home_gcmap_ptr: std::cell::Cell::new(home_gcmap_ptr),
             bridge_cells_base: std::cell::Cell::new(bridge_cells_base),
@@ -4631,7 +4642,7 @@ impl majit_backend::Backend for WasmBackend {
             let source_used_homes = if is_direct {
                 (
                     source_loop.num_ref_homes.get(),
-                    source_loop.used_label_homes,
+                    source_loop.used_label_homes.get(),
                 )
             } else {
                 source_loop
@@ -4641,7 +4652,7 @@ impl majit_backend::Backend for WasmBackend {
                     .map(|m| (m.num_ref_homes, m.used_label_homes))
                     .unwrap_or((
                         source_loop.num_ref_homes.get(),
-                        source_loop.used_label_homes,
+                        source_loop.used_label_homes.get(),
                     ))
             };
             let guard = if is_direct {
@@ -5317,7 +5328,7 @@ impl majit_backend::Backend for WasmBackend {
             frame: source_frame,
             ca: ca_params,
         };
-        let (wasm_bytes, guard_exits, _num_ref_homes) =
+        let (wasm_bytes, guard_exits, _num_ref_homes, _used_labels) =
             match codegen::build_wasm_module(&module_inputs) {
                 Ok(built) => built,
                 Err(err) => {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3130,7 +3130,8 @@ impl WasmBackend {
         // on the error path. So install directly and let the build answer,
         // instead of asking it once as a trial and once for real.
         let old_inputs = source_loop.reemit.replace(Some(candidate));
-        match self.reemit_loop(owner) {
+        let extra_retire: Vec<u32> = old_bridge_slots.iter().map(|&(_, slot)| slot).collect();
+        match self.reemit_loop_retiring(owner, &extra_retire) {
             Ok(()) => {
                 diag_bump(31);
                 for _ in 0..attached {
@@ -3145,9 +3146,9 @@ impl WasmBackend {
                 // `bridge_slots` no longer names these — they were removed
                 // above so re-emission cannot replay them. Retract their
                 // LABEL_TARGETS rows here; `reemit_loop` only sees slots
-                // that are still attached.
-                let retired: Vec<u32> = old_bridge_slots.iter().map(|&(_, slot)| slot).collect();
-                source_loop.retract_bridge_label_targets_for_slots(retired);
+                // that are still attached. The replacement bytes were
+                // already written into those slots inside re-emission.
+                source_loop.retract_bridge_label_targets_for_slots(extra_retire);
                 return true;
             }
             Err(error) => {
@@ -3178,6 +3179,15 @@ impl WasmBackend {
     /// second GC reference table or change any reference-constant immediate.
     #[allow(unreachable_code, unused_variables)]
     pub fn reemit_loop(&mut self, token: &JitCellToken) -> Result<(), BackendError> {
+        self.reemit_loop_retiring(token, &[])
+    }
+
+    #[allow(unreachable_code, unused_variables)]
+    fn reemit_loop_retiring(
+        &mut self,
+        token: &JitCellToken,
+        extra_retire_slots: &[u32],
+    ) -> Result<(), BackendError> {
         let compiled = token
             .compiled
             .get()
@@ -3302,6 +3312,15 @@ impl WasmBackend {
         let widened = merged_ref_homes.max(old_homes);
         let widened_labels = merged_labels.max(old_labels);
         let owner_extent_grew = old_homes < widened || old_labels < widened_labels;
+        // Bridges removed before re-emission (inlined regions) still have
+        // compiled callers that baked `return_call_indirect` to those
+        // slots. Point the slots at this replacement so they pick up the
+        // new map; x86 patches the jump instead.
+        crate::failguard::retarget_slots_to_module(
+            extra_retire_slots.iter().copied(),
+            old_handle,
+            &wasm_bytes,
+        );
         #[cfg(target_arch = "wasm32")]
         if new_cells_base != 0 && !owner_extent_grew {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {
@@ -3311,6 +3330,11 @@ impl WasmBackend {
         }
         if owner_extent_grew {
             let retired: Vec<u32> = compiled.bridge_slots.borrow().values().copied().collect();
+            crate::failguard::retarget_slots_to_module(
+                retired.iter().copied(),
+                old_handle,
+                &wasm_bytes,
+            );
             compiled.retract_bridge_label_targets_for_slots(retired);
             compiled.bridge_slots.borrow_mut().clear();
             let owner_tid = compiled.trace_id;
@@ -3365,6 +3389,11 @@ impl WasmBackend {
                         .filter(|&(&(tid, _), _)| tid == region.trace_id)
                         .map(|(_, &slot)| slot)
                         .collect();
+                    crate::failguard::retarget_slots_to_module(
+                        retired.iter().copied(),
+                        old_handle,
+                        &wasm_bytes,
+                    );
                     compiled.retract_bridge_label_targets_for_slots(retired);
                     compiled
                         .chained_bridge_slots

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2250,18 +2250,31 @@ fn wasm_jitframe_tid() -> u32 {
 /// marked bit, so marking those indices exposes each home's `GcRef` (the high
 /// word stays unmarked). Returns `[data_word_count, word0, ...]` in `usize`
 /// words (GCMAP array layout: `gcmap[0]` = number of data words).
-fn build_home_gcmap(frame: codegen::FrameGeometry) -> Box<[usize]> {
+/// Mark the homes this module initializes: the used ordinary prefix and the
+/// LABEL-capture tail. Frozen geometry reserves
+/// [`FROZEN_CHAIN_REF_HOMES`] ordinary slots so a later bridge can fit;
+/// those unused reserved words stay unmarked so recycled nursery bytes
+/// are not traced. assembler.py writes `jf_gcmap` for live slots only.
+fn build_home_gcmap(frame: codegen::FrameGeometry, used_ordinary: usize) -> Box<[usize]> {
     let sign = std::mem::size_of::<isize>();
     let bits_per_word = std::mem::size_of::<usize>() * 8;
-    if frame.home_slots == 0 {
+    let ordinary = used_ordinary.min(frame.ordinary_home_slots());
+    let label_base = frame.ordinary_home_slots();
+    let label_n = frame.label_ref_slots;
+    if ordinary == 0 && label_n == 0 {
         // One empty data word: a non-null jf_gcmap that traces nothing.
         return vec![1usize, 0usize].into_boxed_slice();
     }
-    let last_index = (frame.home_slot_base as usize + (frame.home_slots - 1) * 8) / sign;
+    let last_h = if label_n == 0 {
+        ordinary.saturating_sub(1)
+    } else {
+        label_base + label_n - 1
+    };
+    let last_index = (frame.home_slot_base as usize + last_h * 8) / sign;
     let num_words = last_index / bits_per_word + 1;
     let mut buf = vec![0usize; 1 + num_words];
     buf[0] = num_words;
-    for h in 0..frame.home_slots {
+    for h in (0..ordinary).chain(label_base..label_base + label_n) {
         let index = (frame.home_slot_base as usize + h * 8) / sign;
         buf[1 + index / bits_per_word] |= 1usize << (index % bits_per_word);
     }
@@ -4207,7 +4220,8 @@ impl majit_backend::Backend for WasmBackend {
         // assembler.py keeps `_finish_gcmap` with the compiled loop. Leak
         // before the module build so the fresh-entry path can publish it
         // after home/input stores, matching a safepoint write.
-        let home_gcmap_ptr = Box::leak(build_home_gcmap(frame)).as_ptr() as *const usize as usize;
+        let home_gcmap_ptr =
+            Box::leak(build_home_gcmap(frame, raw_num_ref_homes)).as_ptr() as *const usize as usize;
         let module_inputs = codegen::ModuleBuildInputs {
             inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
             // Keep these rewritten operations exactly as intern_ref_constants
@@ -5163,8 +5177,8 @@ impl majit_backend::Backend for WasmBackend {
         // CALL_ASSEMBLER: the CA arm allocates a fresh callee using the target
         // token's frozen geometry. The earlier frame-fit decline guarantees a
         // movable callee cannot execute a trampoline-lowered op.
-        let home_gcmap_ptr =
-            Box::leak(build_home_gcmap(source_frame)).as_ptr() as *const usize as usize;
+        let home_gcmap_ptr = Box::leak(build_home_gcmap(source_frame, bridge_ref_homes)).as_ptr()
+            as *const usize as usize;
         let ca_params = if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
             codegen::CaParams {
                 emit_ca: true,
@@ -5682,10 +5696,8 @@ impl majit_backend::Backend for WasmBackend {
                 // `JitFrame::init` requires zero-filled storage, which the
                 // native `calloc` entry (`runner.rs` `execute_token`) provides
                 // but the old-gen arena does not — `ArenaCollection::malloc`
-                // deliberately returns recycled bytes. `build_home_gcmap`
-                // marks every Ref home of the frozen geometry, so a home the
-                // trace has not defined yet when a collection lands must read
-                // as null rather than as a stale word.
+                // deliberately returns recycled bytes. Zero the block so a
+                // home the trace has not defined yet reads as null.
                 unsafe {
                     std::ptr::write_bytes(jf as *mut u8, 0, JitFrame::alloc_size(depth));
                     JitFrame::init(jf, std::ptr::null(), depth);
@@ -6019,6 +6031,28 @@ mod tests {
     use majit_gc::collector::MiniMarkGC;
     use majit_gc::trace::TypeInfo;
     use majit_ir::forwarding::bound_operand_from_opref as rb;
+
+    fn gcmap_marks(buf: &[usize], index: usize) -> bool {
+        let bits = usize::BITS as usize;
+        let word = 1 + index / bits;
+        word < buf.len() && (buf[word] & (1usize << (index % bits))) != 0
+    }
+
+    #[test]
+    fn home_gcmap_marks_used_homes_and_label_captures_only() {
+        let sign = std::mem::size_of::<isize>();
+        let frame = codegen::FrameGeometry::compact(16, 128 + 2, 2);
+        let map = build_home_gcmap(frame, 5);
+        let idx = |h: usize| (frame.home_slot_base as usize + h * 8) / sign;
+        for h in 0..5 {
+            assert!(gcmap_marks(&map, idx(h)), "used ordinary home {h}");
+        }
+        for h in 5..128 {
+            assert!(!gcmap_marks(&map, idx(h)), "reserved ordinary home {h}");
+        }
+        assert!(gcmap_marks(&map, idx(128)), "label capture 0");
+        assert!(gcmap_marks(&map, idx(129)), "label capture 1");
+    }
 
     #[test]
     fn parameter_bridge_dispatch_is_bounded_by_guard_population() {

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2909,6 +2909,60 @@ fn compute_home_gcmap_simple_loop_is_valid() {
     validate_wasm(&bytes);
 }
 
+/// A re-emission that grew the LABEL-capture tail must still build when
+/// asked to null only the newly marked slots before publishing.
+#[test]
+fn reemit_nulls_grown_label_homes_and_builds() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Ref, 1),
+    ];
+    let ops = vec![
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_ref(0))]),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::const_int(1)],
+            &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::input_arg_ref(0))]),
+    ];
+    let mut ca = codegen::CaParams::default();
+    ca.compute_home_gcmap = true;
+    ca.home_gcmap_has_prior = true;
+    ca.home_gcmap_null_grown_labels = true;
+    ca.home_gcmap_min_labels = 0;
+    let frame = codegen::FrameGeometry::compact(16, 128 + 2, 2);
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants: indexmap::IndexMap::new(),
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame,
+        ca,
+    };
+    let (bytes, _, _, used_labels) =
+        codegen::build_wasm_module(&inputs).expect("re-emission grown LABEL tail should build");
+    validate_wasm(&bytes);
+    assert!(used_labels >= 1);
+}
+
 /// A peeled loop's start LABEL can still name an import_state source
 /// (`InputArgRef(128)` on attr_delete) after every real use was rewritten
 /// to the folded constant. That argument is the phi destination, not a

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -683,7 +683,7 @@ fn sparse_value_ids_declare_only_addressable_value_locals() {
     validate_wasm(&bytes);
     assert_eq!(
         emitted_local_count(&bytes),
-        inputargs.len() as u32 + 3 + 6 + 1,
+        inputargs.len() as u32 + 3 + 6 + 3,
         "two input values and three sparse ids, plus fixed i64 and i32 locals"
     );
 }
@@ -709,7 +709,7 @@ fn same_as_reuses_its_source_local() {
     validate_wasm(&bytes);
     assert_eq!(
         emitted_local_count(&bytes),
-        inputargs.len() as u32 + 1 + 6 + 1,
+        inputargs.len() as u32 + 1 + 6 + 3,
         "SameAsI shares input 0's local; only IntAdd allocates a result local"
     );
 }
@@ -736,7 +736,7 @@ fn same_as_does_not_alias_a_mutable_label_local() {
     validate_wasm(&bytes);
     assert_eq!(
         emitted_local_count(&bytes),
-        inputargs.len() as u32 + 2 + 6 + 1,
+        inputargs.len() as u32 + 2 + 6 + 3,
         "SameAs must not share the phi local that JUMP rebinds"
     );
 }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2841,6 +2841,181 @@ fn label_ref_phi_without_a_producer_declines() {
 }
 
 #[test]
+fn compute_home_gcmap_simple_loop_is_valid() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(1), OpRef::input_arg_int(0)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(3),
+        ),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(3), const_100],
+            OpRef::int_op(4),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(4)],
+            &[OpRef::int_op(3), OpRef::int_op(2)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
+    ];
+    let mut ca = codegen::CaParams::default();
+    ca.compute_home_gcmap = true;
+    let frame = codegen::FrameGeometry::compact(64, 128 + 2, 2);
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants: constants.clone(),
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame,
+        ca,
+    };
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("compute_home_gcmap loop should build");
+    validate_wasm(&bytes);
+}
+
+/// A peeled loop's start LABEL can still name an import_state source
+/// (`InputArgRef(128)` on attr_delete) after every real use was rewritten
+/// to the folded constant. That argument is the phi destination, not a
+/// read of a never-written local. A later producer past 128 used to make
+/// `unbound_pool_const_seeds` decline the whole module (`value[128]`).
+#[test]
+fn label_arg_import_hole_is_not_an_unbound_read() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let const_1 = OpRef::const_int(1);
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_ref(128))],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(200),
+        ),
+        Op::new(
+            OpCode::Jump,
+            &[rb(OpRef::int_op(200)), rb(OpRef::input_arg_int(1))],
+        ),
+    ];
+    let mut ca = codegen::CaParams::default();
+    ca.compute_home_gcmap = true;
+    let frame = codegen::FrameGeometry::compact(64, 128 + 2, 2);
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants: constants.clone(),
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame,
+        ca,
+    };
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs)
+        .expect("stale LABEL import hole must not decline the module");
+    validate_wasm(&bytes);
+}
+
+/// A real read of an unbound hole (not a LABEL phi name) is still declined.
+#[test]
+fn unbound_non_label_read_of_import_hole_is_declined() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![make_op(
+        OpCode::IntAdd,
+        &[OpRef::input_arg_int(0), OpRef::input_arg_ref(128)],
+        OpRef::int_op(200),
+    )];
+    let err = match codegen::build_wasm_module(&codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants: constants.clone(),
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame: codegen::FrameGeometry::compact(16, 8, 0),
+        ca: codegen::CaParams::default(),
+    }) {
+        Err(err) => err,
+        Ok(_) => panic!("a real read of the hole must still decline"),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("value[128]"),
+        "expected unbound 128 decline, got {msg}"
+    );
+}
+
+#[test]
 fn test_float_ops() {
     let inputargs = vec![
         InputArg::from_type(Type::Float, 0),

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -575,7 +575,7 @@ fn build_module_with_ca(
         frame,
         ca,
     };
-    let (bytes, guards, _) =
+    let (bytes, guards, _, _) =
         codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     (bytes, guards)
 }
@@ -998,7 +998,8 @@ fn build_module_with_write_barrier_target(
         frame: codegen::FrameGeometry::compact(5, 2, 0),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     bytes
 }
 
@@ -1626,7 +1627,7 @@ fn test_cold_guard_recovery_preserves_nonzero_base_and_typed_bits() {
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, guards, _) =
+    let (bytes, guards, _, _) =
         codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     assert_eq!(guards[0].fail_index, FAIL_INDEX_BASE);
 
@@ -1701,7 +1702,7 @@ fn test_empty_trace() {
 /// slots.  Every inline-region repro drives the module exactly this way and
 /// differs only in the exit index it expects.
 fn run_inline_region_trace(inputs: &codegen::ModuleBuildInputs) -> (i64, i64, i64, i64) {
-    let (bytes, _, _) = codegen::build_wasm_module(inputs).expect("non-header region merges");
+    let (bytes, _, _, _) = codegen::build_wasm_module(inputs).expect("non-header region merges");
     validate_wasm(&bytes);
 
     let engine = Engine::default();
@@ -1779,7 +1780,7 @@ fn a_deferred_merge_trips_once_at_its_threshold() {
         dispatch_cell_index: CELL_INDEX,
     });
 
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("the armed module builds");
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).expect("the armed module builds");
     validate_wasm(&bytes);
 
     let engine = Engine::default();
@@ -2062,7 +2063,7 @@ fn inlined_bridge_carrying_an_unarmed_call_assembler_declines() {
             frame: codegen::FrameGeometry::fixed(),
             ca,
         };
-        codegen::build_wasm_module(&inputs).map(|(bytes, _, _)| bytes)
+        codegen::build_wasm_module(&inputs).map(|(bytes, _, _, _)| bytes)
     }
 
     /// The region the decline arms use, with `opcode` producing its one value.
@@ -2641,7 +2642,7 @@ fn inlined_bridge_emission_is_independent_of_the_regions_own_numbering() {
             frame: codegen::FrameGeometry::fixed(),
             ca: codegen::CaParams::default(),
         };
-        codegen::build_wasm_module(&inputs).map(|(bytes, _, _)| bytes)
+        codegen::build_wasm_module(&inputs).map(|(bytes, _, _, _)| bytes)
     }
 
     let colliding = build(2);
@@ -3070,7 +3071,7 @@ fn zero_arity_parameter_entry_is_structurally_type_zero() {
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).unwrap();
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).unwrap();
 
     validate_wasm(&bytes);
     assert_eq!(
@@ -3603,7 +3604,7 @@ fn test_guard_not_invalidated_loads_runtime_flag() {
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, guards, _) =
+    let (bytes, guards, _, _) =
         codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
 
     validate_wasm(&bytes);
@@ -3986,7 +3987,8 @@ fn gc_table_load_inside_a_loop_body_is_emitted_inside_the_loop() {
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
 
     let mut control_stack = Vec::new();
@@ -4432,7 +4434,7 @@ fn build_external_jump_module(
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, guards, _) =
+    let (bytes, guards, _, _) =
         codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     (bytes, guards)
 }
@@ -4650,7 +4652,7 @@ fn build_owner_with_region_closing_at(
             constants: indexmap::IndexMap::new(),
         }],
     );
-    codegen::build_wasm_module(&inputs).map(|(bytes, _, _)| bytes)
+    codegen::build_wasm_module(&inputs).map(|(bytes, _, _, _)| bytes)
 }
 
 /// A region closing at the loop HEADER `br`s to the `loop`, the long-standing
@@ -4926,7 +4928,7 @@ fn test_non_moving_descr_allocates_through_the_oldgen_helper() {
             frame: codegen::FrameGeometry::fixed(),
             ca: codegen::CaParams::default(),
         };
-        let (bytes, _, _) =
+        let (bytes, _, _, _) =
             codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
         validate_wasm(&bytes);
         const_immediates(&bytes)
@@ -5976,7 +5978,7 @@ fn region_closing_at_the_header_permutes_two_ref_label_args() {
         frame: codegen::FrameGeometry::fixed(),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("permuting region merges");
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).expect("permuting region merges");
     validate_wasm(&bytes);
 
     let engine = Engine::default();
@@ -6182,7 +6184,7 @@ fn run_header_region_repro(full_arity: bool, region_guard: RegionGuard) {
         );
         return;
     }
-    let (bytes, _, _) = built.expect("header region merges");
+    let (bytes, _, _, _) = built.expect("header region merges");
     validate_wasm(&bytes);
 
     let engine = Engine::default();
@@ -6504,7 +6506,8 @@ fn build_module_with_barrier_helpers(
         frame: codegen::FrameGeometry::compact(6, 3, 0),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("write barrier module compiles");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("write barrier module compiles");
     validate_wasm(&bytes);
     bytes
 }
@@ -7892,7 +7895,7 @@ fn consecutive_allocations_home_and_reload_before_each_collection() {
         large_threshold: 4096,
         plain_tids: [53].into_iter().collect(),
     });
-    let (bytes, _, homes) = codegen::build_wasm_module(&inputs).unwrap();
+    let (bytes, _, homes, _) = codegen::build_wasm_module(&inputs).unwrap();
     assert_eq!(
         homes, 2,
         "the first two objects cross a subsequent allocation"
@@ -8057,7 +8060,8 @@ fn consecutive_new_ops_share_one_nursery_bump() {
         vec![plain_new(1, 53), plain_new(2, 53), finish_int_arg0()],
         53,
     );
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8076,7 +8080,8 @@ fn news_that_fill_the_nursery_threshold_keep_separate_bumps() {
         ],
         53,
     );
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8110,7 +8115,8 @@ fn inlined_region_new_does_not_join_the_owners_nursery_batch() {
         gc_table_base: 0,
         constants: indexmap::IndexMap::new(),
     }];
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8137,7 +8143,8 @@ fn collecting_op_between_news_keeps_separate_nursery_bumps() {
         vec![plain_new(1, 53), call, plain_new(2, 53), finish_int_arg0()],
         53,
     );
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8168,7 +8175,8 @@ fn setfield_between_news_keeps_one_nursery_bump() {
     let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(1))]);
     finish.setfailargs(smallvec![rb(OpRef::input_arg_int(1))]);
     inputs.ops[3] = finish;
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8190,7 +8198,8 @@ fn new_and_const_newarray_share_one_nursery_bump() {
     if let Some(na) = inputs.nursery.as_mut() {
         na.plain_tids.insert(55);
     }
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8209,7 +8218,8 @@ fn consecutive_const_newarrays_share_one_nursery_bump() {
         ],
         55,
     );
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8242,7 +8252,8 @@ fn runtime_newarray_flushes_the_nursery_batch() {
     if let Some(na) = inputs.nursery.as_mut() {
         na.plain_tids.insert(55);
     }
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8262,7 +8273,8 @@ fn call_malloc_nursery(result: u32, size: i64) -> Op {
 #[test]
 fn call_malloc_nursery_uses_one_inline_bump() {
     let inputs = nursery_new_inputs(vec![call_malloc_nursery(1, 32), finish_int_arg0()], 53);
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(nursery_top_compare_count(&bytes), 1);
 }
@@ -8295,7 +8307,8 @@ fn call_malloc_nursery_and_ptr_increment_share_one_bump() {
         vec![call_malloc_nursery(1, 72), incr, finish_int_arg0()],
         53,
     );
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         nursery_top_compare_count(&bytes),
@@ -8448,7 +8461,8 @@ fn inline_nursery_new_keeps_the_barrier_at_the_slow_path_join() {
         frame: codegen::FrameGeometry::compact(5, 2, 0),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(
         direct_write_barrier_call_count(&bytes, WB_TARGET as i32),
@@ -8457,7 +8471,7 @@ fn inline_nursery_new_keeps_the_barrier_at_the_slow_path_join() {
     );
     let mut control = inputs;
     control.nursery = None;
-    let (bytes, _, _) = codegen::build_wasm_module(&control).unwrap();
+    let (bytes, _, _, _) = codegen::build_wasm_module(&control).unwrap();
     assert_eq!(direct_write_barrier_call_count(&bytes, WB_TARGET as i32), 1);
 }
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -4329,7 +4329,8 @@ fn preamble_gc_table_failarg_is_reloaded_inside_the_loop() {
         frame: codegen::FrameGeometry::compact(5, 3, 1),
         ca: codegen::CaParams::default(),
     };
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
 
     let mut control_stack = Vec::new();
@@ -7991,7 +7992,7 @@ fn threadlocalref_get_lowers_through_the_tls_helper() {
         );
         inputs.inputargs = vec![InputArg::from_type(Type::Int, 0)];
         inputs.alloc.threadlocal_fn_ptr = 0x66;
-        let (bytes, _, _) =
+        let (bytes, _, _, _) =
             codegen::build_wasm_module(&inputs).expect("ThreadlocalrefGet should lower");
         validate_wasm(&bytes);
 
@@ -8511,7 +8512,8 @@ fn call_malloc_nursery_uses_one_inline_bump() {
 #[test]
 fn inline_nursery_new_zeros_its_payload() {
     let inputs = nursery_new_inputs(vec![plain_new(1, 53), finish_int_arg0()], 53);
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
+    let (bytes, _, _, _) =
+        codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     let mut fills = 0;
     count_operators(&bytes, |op| {
@@ -8564,7 +8566,7 @@ fn call_malloc_nursery_variants_lower() {
         OpRef::ref_op(1),
     );
     let inputs = nursery_new_inputs(vec![headerless, finish_int_arg0()], 53);
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("headerless should lower");
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).expect("headerless should lower");
     validate_wasm(&bytes);
     assert_eq!(nursery_top_compare_count(&bytes), 1);
     assert!(const_immediates(&bytes).contains(&0x55));
@@ -8575,7 +8577,7 @@ fn call_malloc_nursery_variants_lower() {
         OpRef::ref_op(1),
     );
     let inputs = nursery_new_inputs(vec![headerless_odd, finish_int_arg0()], 53);
-    let (bytes, _, _) =
+    let (bytes, _, _, _) =
         codegen::build_wasm_module(&inputs).expect("unaligned headerless should lower");
     validate_wasm(&bytes);
     assert!(
@@ -8589,7 +8591,7 @@ fn call_malloc_nursery_variants_lower() {
         OpRef::ref_op(1),
     );
     let inputs = nursery_new_inputs(vec![frame, finish_int_arg0()], 53);
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("varsize frame should lower");
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).expect("varsize frame should lower");
     validate_wasm(&bytes);
     assert_eq!(nursery_top_compare_count(&bytes), 1);
     assert!(const_immediates(&bytes).contains(&0x11));
@@ -8609,7 +8611,7 @@ fn call_malloc_nursery_variants_lower() {
     );
     varsize.setdescr(Arc::new(SimpleArrayDescr::new(1, 16, 8, 53, Type::Int)));
     let inputs = nursery_new_inputs(vec![varsize, finish_int_arg0()], 53);
-    let (bytes, _, _) = codegen::build_wasm_module(&inputs).expect("varsize should lower");
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs).expect("varsize should lower");
     validate_wasm(&bytes);
     assert_eq!(nursery_top_compare_count(&bytes), 0);
     assert!(const_immediates(&bytes).contains(&0x22));
@@ -8619,7 +8621,7 @@ fn call_malloc_nursery_variants_lower() {
 fn newstr_without_a_descr_injects_the_builtin_layout() {
     let newstr = make_op(OpCode::Newstr, &[OpRef::const_int(3)], OpRef::ref_op(1));
     let inputs = nursery_new_inputs(vec![newstr, finish_int_arg0()], 53);
-    let (bytes, _, _) =
+    let (bytes, _, _, _) =
         codegen::build_wasm_module(&inputs).expect("Newstr without descr should inject and lower");
     validate_wasm(&bytes);
     let immediates = const_immediates(&bytes);

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2908,6 +2908,76 @@ fn compute_home_gcmap_simple_loop_is_valid() {
     validate_wasm(&bytes);
 }
 
+#[test]
+fn home_gcmap_union_call_validates_on_a_reload_only_residual_family() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(1), OpRef::input_arg_int(0)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(3),
+        ),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(3), const_100],
+            OpRef::int_op(4),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(4)],
+            &[OpRef::int_op(3), OpRef::int_op(2)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
+    ];
+    let mut ca = codegen::CaParams::default();
+    ca.compute_home_gcmap = true;
+    ca.ca_reload_fn_ptr = 1;
+    let frame = codegen::FrameGeometry::compact(64, 128 + 2, 2);
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants,
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame,
+        ca,
+    };
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs)
+        .expect("reload-only residual family must declare arity 2 for union");
+    validate_wasm(&bytes);
+}
+
 /// A re-emission that grew the LABEL-capture tail must still build when
 /// asked to null only the newly marked slots before publishing.
 #[test]

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2311,10 +2311,9 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
     );
 }
 
-/// `build_home_gcmap` marks every frozen home, not just this trace's live
-/// Ref homes. Recycled nursery bytes in the unused padding must be nulled
-/// before that map is published, or a later minor walk treats them as
-/// young objects (`invalid type_id` from an oldgen type-3 JitFrame).
+/// Key-0 nulls the frozen home region before `jf_gcmap` is published.
+/// Recycled nursery bytes in unused padding must not be live when the
+/// map goes up (`invalid type_id` from an oldgen type-3 JitFrame).
 #[test]
 fn entry_prologue_nulls_the_frozen_home_region() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2967,7 +2967,7 @@ fn reemit_nulls_grown_label_homes_and_builds() {
 /// (`InputArgRef(128)` on attr_delete) after every real use was rewritten
 /// to the folded constant. That argument is the phi destination, not a
 /// read of a never-written local. A later producer past 128 used to make
-/// `unbound_pool_const_seeds` decline the whole module (`value[128]`).
+/// `unbound_pool_const_seeds` decline the whole module.
 #[test]
 fn label_arg_import_hole_is_not_an_unbound_read() {
     let inputargs = vec![
@@ -3064,7 +3064,7 @@ fn unbound_non_label_read_of_import_hole_is_declined() {
     };
     let msg = err.to_string();
     assert!(
-        msg.contains("value[128]"),
+        msg.contains("InputArgRef(128)") && msg.contains("read with no producing op and no"),
         "expected unbound 128 decline, got {msg}"
     );
 }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2344,7 +2344,7 @@ fn entry_prologue_nulls_the_frozen_home_region() {
         external_jump_key: 0,
         frame,
         ca: codegen::CaParams {
-            entry_gcmap_ptr: 0x1000,
+            home_gcmap_ptr: 0x1000,
             ..codegen::CaParams::default()
         },
     };

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -476,13 +476,11 @@ pub extern "C" fn pyre_jit_last_compile_err_byte(i: u32) -> u32 {
     majit_backend_wasm::last_compile_err_byte(i)
 }
 
-
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_jit_last_compile_err_len() -> u32 {
     majit_backend_wasm::last_compile_err_len()
 }
-
 
 /// Packed `(kind, needed, available)` geometry for an inline-module trial that
 /// did not fit its owner's frozen frame. The host formats this diagnostic only.

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -476,11 +476,13 @@ pub extern "C" fn pyre_jit_last_compile_err_byte(i: u32) -> u32 {
     majit_backend_wasm::last_compile_err_byte(i)
 }
 
+
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_jit_last_compile_err_len() -> u32 {
     majit_backend_wasm::last_compile_err_len()
 }
+
 
 /// Packed `(kind, needed, available)` geometry for an inline-module trial that
 /// did not fit its owner's frozen frame. The host formats this diagnostic only.


### PR DESCRIPTION
## Summary

#1750 zeroed recycled CALL_ASSEMBLER frames on the bump by installing `build_callee_gcmap` and `memory.fill`ing `jf_frame` items before the callee wrote homes. That kept `jitframe_trace` off leftover pointers, but it made the nursery bump O(frame) and diverged from assembler.py, which writes `jf_gcmap` at safepoints once those slots are live.

This PR leaves `jf_gcmap` null on both the inline bump and `wasm_jit_ca_alloc_frame`. `compile_loop` / `compile_bridge` leak `build_home_gcmap` into `CaParams.home_gcmap_ptr`, and the fresh-entry path stores it after the home/input stores. Leftover item words are not traced; the bump stays O(1). The #1683 entry-home `memory.fill` on local 0 is unchanged.

## Tests

- `cargo test -p majit-backend-wasm --test codegen_test call_assembler_inlines` — CA bump emits no `memory.fill`
- `cargo test -p majit-backend-wasm --test codegen_test -- --ignored recursive_call_assembler` — `recursive_call_assembler_does_not_refill_zeroed_nursery_frames` ok (10.59s)

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection safety during JIT-compiled call transitions by publishing frame metadata only after required values and captures are initialized.
  * Ensured collection metadata accurately covers active frame homes and label captures across trace entry, resume, and chained-trace paths.
  * Improved handling of LABEL inputs and unresolved-value diagnostics.
  * Improved recovery of forwarded objects from interior garbage-collection roots and handling of invalid type identifiers.

* **Performance**
  * Reduced unnecessary initialization work when creating variable-sized call frames.

* **Diagnostics**
  * Added access to the most recent JIT compilation error in WASM runner statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->