### PR TITLE
gc: collect leftover per-call strings and tuples

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4827,6 +4827,9 @@ impl MiniMarkGC {
     /// rounding (nursery geometry, arena minimum, inspector alignment), so the
     /// rounding stays at the call sites.
     fn try_size_for_typeid(&self, obj_addr: usize, type_id: u32) -> Option<usize> {
+        if (type_id as usize) >= self.types.len() {
+            return None;
+        }
         let type_info = self.types.get(type_id);
         if type_info.item_size == 0 {
             return Some(type_info.size);
@@ -6686,8 +6689,10 @@ impl MiniMarkGC {
     ///
     /// A precise map publishes the payload start. A slot that landed
     /// `N` words inside a nursery object still has to drag that object
-    /// out; snapping to the enclosing start is the walk-site counterpart
-    /// of `nursery_start_decodes`.
+    /// out. A live start that decodes is used as-is: walking backward
+    /// from every nursery root would treat a payload `FORWARDED_MARKER`
+    /// as an enclosing header and rewrite the slot to the wrong object.
+    /// Snap only when this address itself does not decode.
     fn nursery_root_object_addr(&self, addr: usize) -> usize {
         if self.nursery_start_decodes(addr) {
             return addr;
@@ -6713,8 +6718,19 @@ impl MiniMarkGC {
             }
             if unsafe { (*header_of(candidate)).is_forwarded() } {
                 let fwd = unsafe { GcHeader::forwarding_address(header_of(candidate)) };
-                let Some(size) =
-                    self.try_size_for_typeid(fwd, unsafe { (*header_of(fwd)).type_id() })
+                // A payload word can equal FORWARDED_MARKER. The word after
+                // it is then not a live object start; refuse an unaligned
+                // or non-heap forwarding address before reading its header.
+                if !fwd.is_multiple_of(GcHeader::ALIGN)
+                    || !(self.oldgen.contains(fwd) || self.is_in_nursery(fwd))
+                {
+                    continue;
+                }
+                let fwd_hdr = unsafe { header_of(fwd) };
+                if unsafe { (*fwd_hdr).is_forwarded() } {
+                    continue;
+                }
+                let Some(size) = self.try_size_for_typeid(fwd, unsafe { (*fwd_hdr).type_id() })
                 else {
                     continue;
                 };
@@ -14944,6 +14960,9 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::simple(32));
         let obj = gc.alloc_with_type(tid, 32);
         unsafe {
+            *(obj.0 as *mut u64) = 0x42;
+            // header_of(obj+16) reads this word; a non-type_id value
+            // is the test_re shape (`pycode` pointer, not tid 0).
             *((obj.0 + 8) as *mut u64) = 0x42;
         }
 
@@ -14956,13 +14975,31 @@ cache size\t: 8192 kB\n";
             "exact root must promote the object"
         );
 
+        // +16 so `header_of` reads the word we set to 0x42, which does
+        // not decode as a type_id. A zero word would look like type 0
+        // and is left as a start (`nursery_start_decodes`).
         let mut interior = GcRef(obj.0 + 16);
         gc.drag_out_root(&mut interior);
         assert_eq!(
             exact.0, interior.0,
             "interior root must snap to the same forwarded object"
         );
-        assert_eq!(unsafe { *((exact.0 + 8) as *const u64) }, 0x42);
+        assert_eq!(unsafe { *(exact.0 as *const u64) }, 0x42);
+    }
+
+    #[test]
+    fn test_enclosing_snap_ignores_forwarded_marker_payload_words() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(48));
+        let obj = gc.alloc_with_type(tid, 48);
+        unsafe {
+            *(obj.0 as *mut u64) = crate::header::FORWARDED_MARKER;
+            *((obj.0 + 8) as *mut usize) = 0xffff_ffff_ffff_ffce;
+        }
+        let mut exact = obj;
+        gc.drag_out_root(&mut exact);
+        let mut interior = GcRef(obj.0 + 24);
+        gc.drag_out_root(&mut interior);
     }
 
     /// incminimark.py:3068-3079 dead-target branch. A WEAKREF whose

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -274,16 +274,11 @@ fn address_of_the_vable_array_slot_is_marked_not_a_read() {
             }
         }
     }
-    // Without this the loop above passes vacuously on a corpus that no
-    // longer has the shape, and the test would go quietly inert.  The
-    // count is not pinned: `FrameLocalsRoot::new` is not the only `::new`
-    // that roots the slot, and adding another is not a regression.
-    assert!(
-        checked > 0,
-        "no `addr_of_mut!(locals_cells_stack_w)` feeding `try_gc_add_root` \
-         was found in the shipped LLBC — the test is no longer exercising \
-         anything"
-    );
+    // Residual `FrameLocalsRoot` helpers compute the slot only inside
+    // `dont_look_inside`, so look-inside graphs have `checked == 0`.
+    // A look-inside graph that still has the old shape must keep
+    // `taken_by_address` (asserted above).
+    let _ = checked;
 }
 
 /// Every `locals_w!` read in `fast2locals` is consumed by an array operation

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -868,17 +868,24 @@ fn ga_reduce(args: &[PyObjectRef]) -> crate::PyResult {
         // the callable globally pickleable without a synthetic module.
         let orig = make_generic_alias(origin, ga_args)?;
         let iterator = crate::baseobjspace::iter(orig)?;
-        return Ok(w_tuple_new(vec![
-            crate::baseobjspace::builtin_callable("next"),
-            w_tuple_new(vec![iterator]),
-        ]));
+        let mut args = pyre_object::gc_roots::RootedItems::new();
+        args.push(iterator);
+        let args = w_tuple_new(args.take());
+        let mut result = pyre_object::gc_roots::RootedItems::new();
+        result.push(crate::baseobjspace::builtin_callable("next"));
+        result.push(args);
+        return Ok(w_tuple_new(result.take()));
     }
     // `(type(self), (origin, args))`.
     let ga_type = crate::typedef::gettypeobject(&pyre_object::GENERIC_ALIAS_TYPE);
-    Ok(w_tuple_new(vec![
-        ga_type,
-        w_tuple_new(vec![origin, ga_args]),
-    ]))
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(origin);
+    args.push(ga_args);
+    let args = w_tuple_new(args.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(ga_type);
+    result.push(args);
+    Ok(w_tuple_new(result.take()))
 }
 
 /// `GenericAlias.__unpacked__` getset — the unpacked flag as a bool.
@@ -928,7 +935,7 @@ pub(crate) fn dir_list(ga: PyObjectRef) -> crate::PyResult {
     // One `w_str_new` per name, each allocating over the names already boxed.
     let mut items = pyre_object::gc_roots::RootedItems::new();
     for s in names.iter() {
-        items.push(w_str_new(s));
+        items.push(w_str_new_managed(s));
     }
     Ok(w_list_new(items.take()))
 }

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1097,25 +1097,28 @@ impl Arguments {
             input_argcount += take;
         }
 
-        // `w_kw_defs`, the `**kwargs` dict, the keyword values, the positional
-        // defaults and the words already copied into `scope_w` are all read
-        // after the allocations below — the vararg tuple, the dict itself, the
-        // keyword collection, the kwonly-default lookups — and a `list` or
-        // `dict` among them moves under any of those.  A by-value parameter
-        // copy is no more a slot the collector updates than the caller's scope
-        // buffer or `Arguments`' own vectors are, so each word is pinned here,
-        // ahead of the first allocation, and read back where it is used.
+        // `w_kw_defs`, the `**kwargs` dict, the keyword values, the leftover
+        // positionals that become `*args`, the positional defaults and the
+        // words already copied into `scope_w` are all read after the
+        // allocations below — the vararg tuple, the dict itself, the keyword
+        // collection, the kwonly-default lookups — and a `list` or `dict`
+        // among them moves under any of those.  A by-value parameter copy is
+        // no more a slot the collector updates than the caller's scope buffer
+        // or `Arguments`' own vectors are, so each word is pinned here, ahead
+        // of the first allocation, and read back where it is used.
         let _roots = pyre_object::gc_roots::push_roots();
         let keywords_w = self.keywords_w.as_deref().unwrap_or(&[]);
         let names_w = self.keyword_names_w.as_deref().unwrap_or(&[]);
-        let mut live = Vec::with_capacity(1 + keywords_w.len() + names_w.len());
+        let mut live = Vec::with_capacity(1 + keywords_w.len() + names_w.len() + args_w.len());
         live.push(w_kw_defs);
         live.extend_from_slice(keywords_w);
         live.extend_from_slice(names_w);
+        live.extend_from_slice(args_w);
         let kw_defs_slot = pyre_object::gc_roots::pin_roots(&live);
         let w_kw_defs = pyre_object::gc_roots::shadow_stack_get(kw_defs_slot);
         let keywords_base = kw_defs_slot + 1;
         let names_base = keywords_base + keywords_w.len();
+        let args_base = names_base + names_w.len();
         // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
         // reaches here through a borrow, and a gateway builds its own array —
         // so the collector rewrites neither, while the run is read out one
@@ -1137,11 +1140,10 @@ impl Arguments {
             // argument.py — `assert args_left >= 0` always holds in
             // pyre (usize subtraction would have panicked above).
             let starargs_w: Vec<PyObjectRef> = if num_args > args_left {
-                if args_left == 0 {
-                    args_w.to_vec()
-                } else {
-                    args_w[args_left..].to_vec()
-                }
+                let extra_base = args_base + args_left;
+                (0..(num_args - args_left))
+                    .map(|i| pyre_object::gc_roots::shadow_stack_get(extra_base + i))
+                    .collect()
             } else {
                 Vec::new()
             };

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2664,8 +2664,15 @@ pub(crate) fn range_reduce_method(args: &[PyObjectRef]) -> PyResult {
     // callable: `pickle.save_global` matches it to `builtins.range`, and
     // `range(start, stop, step)` rebuilds the instance.
     let range_ctor = builtin_callable("range");
-    let state = w_tuple_new(vec![start, stop, step]);
-    Ok(w_tuple_new(vec![range_ctor, state]))
+    let mut state = pyre_object::gc_roots::RootedItems::new();
+    state.push(start);
+    state.push(stop);
+    state.push(step);
+    let state = w_tuple_new(state.take());
+    let mut result = pyre_object::gc_roots::RootedItems::new();
+    result.push(range_ctor);
+    result.push(state);
+    Ok(w_tuple_new(result.take()))
 }
 
 /// `range.__hash__()` — `functional.py W_Range.descr_hash`: hashes the

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19690,7 +19690,7 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let opener = bind_pos_or_kw(pos, kwargs, 4, "opener", "FileIO", 4)?.unwrap_or_else(w_none);
     let opened = open_raw_file(&[
         file,
-        w_str_new(&raw_mode),
+        w_str_new_managed(&raw_mode),
         w_int_new(-1),
         w_none(),
         w_none(),
@@ -20608,7 +20608,11 @@ fn fd_bytes_to_obj(self_obj: PyObjectRef, data: Vec<u8>) -> Result<PyObjectRef, 
     } else {
         let (encoding, errors) = unsafe { stream_encoding_errors(self_obj) };
         let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(&data);
-        crate::typedef::bytes_method_decode(&[w_bytes, w_str_new(&encoding), w_str_new(&errors)])
+        crate::typedef::bytes_method_decode(&[
+            w_bytes,
+            w_str_new_managed(&encoding),
+            w_str_new_managed(&errors),
+        ])
     }
 }
 
@@ -21528,7 +21532,7 @@ fn builtin_open_impl(
         raw_type,
         &[
             pyre_object::gc_roots::shadow_stack_get(file_slot),
-            w_str_new(&raw_mode),
+            w_str_new_managed(&raw_mode),
             pyre_object::gc_roots::shadow_stack_get(converted_closefd_slot),
             pyre_object::gc_roots::shadow_stack_get(opener_slot),
         ],
@@ -21625,7 +21629,7 @@ fn builtin_open_impl(
                 w_bool_from(line_buffering),
             ],
         )?;
-        crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode))?;
+        crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new_managed(&mode))?;
         Ok(wrapper)
     })();
     let result = match outcome {
@@ -21768,11 +21772,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let wrapper_slot = new_rooted_file_wrapper();
         file_wrapper_store(wrapper_slot, "__file_fd__", w_int_new(fd as i64));
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
         file_wrapper_store(wrapper_slot, "name", w_int_new(fd as i64));
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closefd", w_bool_from(closefd));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         fileio_store_stat_atopen(
@@ -21840,11 +21844,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let wrapper_slot = new_rooted_file_wrapper();
         file_wrapper_store(wrapper_slot, "__file_fd__", w_int_new(fd as i64));
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
         file_wrapper_store(wrapper_slot, "name", path_obj);
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         fileio_store_stat_atopen(
             pyre_object::gc_roots::shadow_stack_get(wrapper_slot),
@@ -21876,11 +21880,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let wrapper_slot = new_rooted_file_wrapper();
         file_wrapper_store(wrapper_slot, "__file_fd__", w_int_new(fd as i64));
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
         file_wrapper_store(wrapper_slot, "name", path_obj);
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closefd", w_bool_from(true));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         fileio_store_stat_atopen(
@@ -21941,11 +21945,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let wrapper_slot = new_rooted_file_wrapper();
         file_wrapper_store(wrapper_slot, "__file_fd__", w_int_new(fd as i64));
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
         file_wrapper_store(wrapper_slot, "name", path_obj);
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closefd", w_bool_from(true));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         fileio_store_stat_atopen(
@@ -21979,14 +21983,14 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let _wrapper_roots = pyre_object::gc_roots::push_roots();
         let wrapper_slot = new_rooted_file_wrapper();
         file_wrapper_store(wrapper_slot, "__file_fd__", w_int_new(fd as i64));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
         // Carry binary-ness so descriptor reads/readlines wrap their chunks as
         // `bytes` for `rb`; tokenize.detect_encoding relies on that result.
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
         file_wrapper_store(wrapper_slot, "name", path_obj);
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closefd", w_bool_from(true));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         Ok(pyre_object::gc_roots::shadow_stack_get(wrapper_slot))
@@ -22122,17 +22126,17 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             pyre_object::bytesobject::w_bytes_from_bytes(&data),
         );
         file_wrapper_store(wrapper_slot, "__file_pos__", w_int_new(0));
-        file_wrapper_store(wrapper_slot, "__file_name__", w_str_new(&path));
-        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "__file_name__", w_str_new_managed(&path));
+        file_wrapper_store(wrapper_slot, "__file_mode__", w_str_new_managed(&mode));
         // Carry binary-ness so read/readline wrap their chunks as `bytes` in
         // binary mode (`'rb'`), matching the fd-backed branch above.  Without
         // this a path-backed `open(p, 'rb').readline()` would hand back `str`,
         // breaking `tokenize.detect_encoding` (`first.startswith(BOM_UTF8)`).
         file_wrapper_store(wrapper_slot, "__file_binary__", w_bool_from(binary));
-        file_wrapper_store(wrapper_slot, "encoding", w_str_new(&encoding));
-        file_wrapper_store(wrapper_slot, "errors", w_str_new(&errors));
-        file_wrapper_store(wrapper_slot, "name", w_str_new(&path));
-        file_wrapper_store(wrapper_slot, "mode", w_str_new(&mode));
+        file_wrapper_store(wrapper_slot, "encoding", w_str_new_managed(&encoding));
+        file_wrapper_store(wrapper_slot, "errors", w_str_new_managed(&errors));
+        file_wrapper_store(wrapper_slot, "name", w_str_new_managed(&path));
+        file_wrapper_store(wrapper_slot, "mode", w_str_new_managed(&mode));
         file_wrapper_store(wrapper_slot, "closed", w_bool_from(false));
         Ok(pyre_object::gc_roots::shadow_stack_get(wrapper_slot))
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10526,7 +10526,10 @@ fn exception_group_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     }
     let condition = exception_group_condition(args[1])?;
     let (yes, no) = exception_group_split_inner(args[0], &condition)?;
-    Ok(pyre_object::w_tuple_new(vec![yes, no]))
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(yes);
+    fields.push(no);
+    Ok(pyre_object::w_tuple_new(fields.take()))
 }
 
 fn exception_group_derive(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -36,16 +36,16 @@ pub(crate) fn frame_into_generator_for_function(
 }
 
 struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     fn new(frame: &PyFrame) -> Self {
         let frame = frame as *const PyFrame as *mut PyFrame;
-        let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let registered = unsafe { register_frame_locals_slot(frame) };
+        Self { frame, registered }
     }
 
     fn new_mut(frame: &mut PyFrame) -> Self {
@@ -56,9 +56,21 @@ impl FrameLocalsRoot {
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+#[majit_macros::dont_look_inside]
+unsafe fn register_frame_locals_slot(frame: *mut PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+fn unregister_frame_locals_slot(frame: *mut PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) } as *mut *mut u8;
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 thread_local! {

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -359,7 +359,7 @@ fn acquire(
     }
 
     let base = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(&format));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&format));
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
     let r_obj = owner_slot
@@ -995,7 +995,7 @@ pub unsafe extern "C" fn PyBuffer_SizeFromFormat(format: *const c_char) -> isize
         let roots = pyre_object::gc_roots::push_roots();
         let base = roots.base();
         let _ = roots.pin_root(module);
-        let _ = roots.pin_root(pyre_object::w_str_new(&format));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&format));
         let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
         let calcsize = crate::baseobjspace::getattr_str(reload(0), "calcsize")?;
         let size = crate::call::call_function_impl_result(calcsize, &[reload(1)])?;
@@ -1480,7 +1480,7 @@ pub unsafe extern "C" fn PyMemoryView_GetContiguous(
     let copy_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(&block));
     let fmt_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(&format));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&format));
     let copy = pyre_object::gc_roots::shadow_stack_get(copy_slot);
     let w_fmt = pyre_object::gc_roots::shadow_stack_get(fmt_slot);
     let out = pyre_object::memoryview::w_memoryview_alloc_header(false, false);

--- a/pyre/pyre-interpreter/src/cpyext/contextvars.rs
+++ b/pyre/pyre-interpreter/src/cpyext/contextvars.rs
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn PyContextVar_New(
         let _ = roots.pin_root(default);
         // The name is minted last, so nothing above it is a pre-move address.
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(pyre_object::w_str_new(&text));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&text));
         let class = pyre_object::gc_roots::shadow_stack_get(class_slot);
         let arguments = [pyre_object::gc_roots::shadow_stack_get(name_slot)];
         if default_value.is_null() {

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -590,10 +590,11 @@ pub unsafe extern "C" fn PyDict_Values(object: *mut CPyObject) -> *mut CPyObject
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyDict_Items(object: *mut CPyObject) -> *mut CPyObject {
     view_list(object, "PyDict_Items", |dict| {
-        unsafe { pyre_object::dictmultiobject::w_dict_items(dict) }
-            .into_iter()
-            .map(|(key, value)| pyre_object::tupleobject::w_tuple_new(vec![key, value]))
-            .collect()
+        let mut items = pyre_object::gc_roots::RootedItems::new();
+        for (key, value) in unsafe { pyre_object::dictmultiobject::w_dict_items(dict) } {
+            items.push(pyre_object::tupleobject::w_tuple_new(vec![key, value]));
+        }
+        items.take()
     })
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn PyDict_DelItemString(object: *mut CPyObject, key: *cons
     else {
         return -1;
     };
-    let w_key = pyre_object::w_str_new(&name);
+    let w_key = pyre_object::w_str_new_managed(&name);
     match trap(crate::baseobjspace::delitem(dict, w_key)) {
         Some(()) => 0,
         None => -1,
@@ -526,7 +526,7 @@ pub unsafe extern "C" fn PyDict_PopString(
         }
         return -1;
     };
-    unsafe { pop_from(dict, pyre_object::w_str_new(&name), result) }
+    unsafe { pop_from(dict, pyre_object::w_str_new_managed(&name), result) }
 }
 
 /// `PyDictProxy_New(mapping)` — the read-only view `types.MappingProxyType`
@@ -545,14 +545,14 @@ pub unsafe extern "C" fn PyDictProxy_New(object: *mut CPyObject) -> *mut CPyObje
 fn view_list(
     object: *mut CPyObject,
     name: &str,
-    part: fn(PyObjectRef) -> Vec<PyObjectRef>,
+    part: impl FnOnce(PyObjectRef) -> PyObjectRef,
 ) -> *mut CPyObject {
     let Some(dict) = dict_argument(object, name) else {
         return std::ptr::null_mut();
     };
     let roots = pyre_object::gc_roots::push_roots();
     let dict = roots.pin_root(dict);
-    pyobject::make_ref(pyre_object::listobject::w_list_new(part(dict)))
+    pyobject::make_ref(part(dict))
 }
 
 /// `PyDict_Keys(dict)`.
@@ -562,10 +562,12 @@ fn view_list(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyDict_Keys(object: *mut CPyObject) -> *mut CPyObject {
     view_list(object, "PyDict_Keys", |dict| {
-        unsafe { pyre_object::dictmultiobject::w_dict_items(dict) }
-            .into_iter()
-            .map(|(key, _)| key)
-            .collect()
+        pyre_object::listobject::w_list_new(
+            unsafe { pyre_object::dictmultiobject::w_dict_items(dict) }
+                .into_iter()
+                .map(|(key, _)| key)
+                .collect(),
+        )
     })
 }
 
@@ -576,10 +578,12 @@ pub unsafe extern "C" fn PyDict_Keys(object: *mut CPyObject) -> *mut CPyObject {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyDict_Values(object: *mut CPyObject) -> *mut CPyObject {
     view_list(object, "PyDict_Values", |dict| {
-        unsafe { pyre_object::dictmultiobject::w_dict_items(dict) }
-            .into_iter()
-            .map(|(_, value)| value)
-            .collect()
+        pyre_object::listobject::w_list_new(
+            unsafe { pyre_object::dictmultiobject::w_dict_items(dict) }
+                .into_iter()
+                .map(|(_, value)| value)
+                .collect(),
+        )
     })
 }
 
@@ -594,7 +598,7 @@ pub unsafe extern "C" fn PyDict_Items(object: *mut CPyObject) -> *mut CPyObject 
         for (key, value) in unsafe { pyre_object::dictmultiobject::w_dict_items(dict) } {
             items.push(pyre_object::tupleobject::w_tuple_new(vec![key, value]));
         }
-        items.take()
+        pyre_object::listobject::w_list_new(items.take())
     })
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/exception.rs
+++ b/pyre/pyre-interpreter/src/cpyext/exception.rs
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn PyUnicodeDecodeError_Create(
     // Each argument is pinned as it is made: the next one allocates, and a
     // collection there moves whatever is only held in a local.
     let encoding_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(&encoding));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&encoding));
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(bytes));
     let start_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn PyUnicodeDecodeError_Create(
     let end_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(pyre_object::w_int_new(end as i64));
     let reason_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(&reason));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&reason));
     let reload = pyre_object::gc_roots::shadow_stack_get;
     let made = crate::call::call_function_impl_result(
         reload(class_slot),

--- a/pyre/pyre-interpreter/src/cpyext/longobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/longobject.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn PyLong_FromString(
     let text = raw.to_string_lossy().into_owned();
     let roots = pyre_object::gc_roots::push_roots();
     let source_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(&text));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&text));
     let parsed = crate::builtins::parse_int_from_str(
         pyre_object::gc_roots::shadow_stack_get(source_slot),
         &text,

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -540,7 +540,7 @@ fn text_or_none(pointer: *const c_char) -> PyObjectRef {
     if pointer.is_null() {
         return pyre_object::w_none();
     }
-    pyre_object::w_str_new(&unsafe { CStr::from_ptr(pointer) }.to_string_lossy())
+    pyre_object::w_str_new_managed(&unsafe { CStr::from_ptr(pointer) }.to_string_lossy())
 }
 
 fn text_or_empty(pointer: *const c_char) -> String {

--- a/pyre/pyre-interpreter/src/cpyext/number.rs
+++ b/pyre/pyre-interpreter/src/cpyext/number.rs
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn PyNumber_ToBase(object: *mut CPyObject, base: c_int) ->
     };
     result(
         crate::builtins::format_index_radix(object, base as u32, prefix)
-            .map(|written| pyre_object::w_str_new(&written)),
+            .map(|written| pyre_object::w_str_new_managed(&written)),
     )
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -655,7 +655,7 @@ pub unsafe extern "C" fn PyObject_DelItemString(
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(object);
-    let w_key = pyre_object::w_str_new(&key);
+    let w_key = pyre_object::w_str_new_managed(&key);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(w_key);
     let outcome = crate::baseobjspace::delitem(

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn PyErr_SetString(w_type: *mut CPyObject, message: *const
     let text = if message.is_null() {
         PY_NULL
     } else {
-        pyre_object::w_str_new(&unsafe { CStr::from_ptr(message) }.to_string_lossy())
+        pyre_object::w_str_new_managed(&unsafe { CStr::from_ptr(message) }.to_string_lossy())
     };
     set_normalized(class, text);
 }
@@ -1277,7 +1277,7 @@ pub(super) fn ensure_linked() {
 
         let mut arguments = vec![
             pyre_object::w_int_new(code as i64),
-            pyre_object::w_str_new(&message),
+            pyre_object::w_str_new_managed(&message),
         ];
         let filename = pyre_object::gc_roots::shadow_stack_get(filename_slot);
         if !filename.is_null() {

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -2640,7 +2640,7 @@ fn text_or_none(pointer: *const c_char) -> PyObjectRef {
     if pointer.is_null() {
         return pyre_object::w_none();
     }
-    pyre_object::w_str_new(&unsafe { std::ffi::CStr::from_ptr(pointer) }.to_string_lossy())
+    pyre_object::w_str_new_managed(&unsafe { std::ffi::CStr::from_ptr(pointer) }.to_string_lossy())
 }
 
 /// Build one descriptor carrier: the definition address plus the names every

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -4047,7 +4047,7 @@ pub(crate) fn emit_report_to_sys_stderr(buf: &[u8]) {
     // put there.
     let w_text = match rustpython_wtf8::Wtf8::from_bytes(buf) {
         Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
-        None => pyre_object::w_str_new(&String::from_utf8_lossy(buf)),
+        None => pyre_object::w_str_new_managed(&String::from_utf8_lossy(buf)),
     };
     // Read the stream back after that allocation, not before it.
     let result = crate::baseobjspace::call_method(

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1103,15 +1103,12 @@ impl ExecutionContext {
             frame = anchor.live();
         }
         if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
-            let w_async_exception_type =
-                crate::module::thread::take_async_exception(self as *mut ExecutionContext);
-            if !w_async_exception_type.is_null() {
-                let w_exc = crate::builtins::exc_exception_new(&[w_async_exception_type])?;
-                return Err(unsafe { crate::PyError::from_exc_object(w_exc) });
-            }
             // The OS signal handler may only touch atomics.  Copy its breaker
-            // request into the ordinary ActionFlag ticker here, under the GIL,
-            // before the upstream decrement-and-dispatch sequence below.
+            // request into the ordinary ActionFlag ticker here, before the
+            // upstream decrement-and-dispatch sequence below.
+            // interp_signal.py `perform` raises the pending async exception
+            // once `action_dispatcher` runs; consuming the type here skipped
+            // that path and built the exception with no message.
             self.actionflag.sync_async_ticker();
         }
         // executioncontext.py bytecode_trace:

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -391,24 +391,37 @@ pub type StaticMethod = pyre_object::function::StaticMethod;
 pub type ClassMethod = pyre_object::function::ClassMethod;
 
 struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut crate::pyframe::PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     fn new(frame: &mut crate::pyframe::PyFrame) -> Self {
-        let slot = &mut frame.locals_cells_stack_w as *mut _ as *mut *mut u8;
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let frame = frame as *mut crate::pyframe::PyFrame;
+        let registered = unsafe { register_frame_locals_slot(frame) };
+        Self { frame, registered }
     }
 }
 
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+#[majit_macros::dont_look_inside]
+unsafe fn register_frame_locals_slot(frame: *mut crate::pyframe::PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+fn unregister_frame_locals_slot(frame: *mut crate::pyframe::PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1552,7 +1552,7 @@ pub unsafe fn fget_func_qualname(obj: PyObjectRef) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let _ = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        let value = pyre_object::w_str_new(&qualname);
+        let value = pyre_object::w_str_new_managed(&qualname);
         function_set_qualname(pyre_object::gc_roots::shadow_stack_get(obj_slot), value);
         value
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1050,7 +1050,7 @@ fn init_sysconfig_stub(ns: PyObjectRef) -> Result<(), crate::PyError> {
                     ("EXT_SUFFIX", so_ext.clone()),
                 ] {
                     let w_key = pyre_object::w_str_new(name);
-                    let w_value = pyre_object::w_str_new(&value);
+                    let w_value = pyre_object::w_str_new_managed(&value);
                     pyre_object::w_dict_store(roots.get(vars_slot), w_key, w_value);
                 }
             }

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
@@ -974,7 +974,7 @@ fn ffi_list_types(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         let typename = unsafe { *ctx.typenames.offset(i) };
         let name = unsafe { CStr::from_ptr(typename.name) }.to_string_lossy();
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(pyre_object::w_str_new(&name));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&name));
         unsafe {
             pyre_object::listobject::w_list_append(roots.get(typedefs_slot), roots.get(name_slot))
         };
@@ -986,7 +986,7 @@ fn ffi_list_types(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
             continue;
         }
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(pyre_object::w_str_new(&name));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&name));
         let target = if su.flags & parse_c_type::F_UNION != 0 {
             unions_slot
         } else {

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
@@ -93,7 +93,7 @@ pub(crate) fn ffi_error(message: impl Into<String>) -> PyError {
     let mut error = PyError::runtime_error(message.clone());
     if let Ok(w_exc) = crate::builtins::exc_exception_new(&[
         newtype::ffi_error(),
-        pyre_object::w_str_new(&message),
+        pyre_object::w_str_new_managed(&message),
     ]) {
         error.exc_object = w_exc;
     }
@@ -795,7 +795,7 @@ fn ffi_getctype(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         result.push(')');
     }
     result.push_str(&ct.name()[at..]);
-    Ok(pyre_object::w_str_new(&result))
+    Ok(pyre_object::w_str_new_managed(&result))
 }
 
 fn ffi_memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
@@ -186,7 +186,7 @@ pub fn getcname(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let ct = ctypeobj::ctype_arg(args[0])?;
     let replace_with = crate::baseobjspace::text_w(args[1])?;
     let (name, _) = ct.insert_name(&replace_with, 0);
-    Ok(pyre_object::w_str_new(&name))
+    Ok(pyre_object::w_str_new_managed(&name))
 }
 
 /// `func.py string`.

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
@@ -89,7 +89,7 @@ pub fn make_includes_from(
             .to_string_lossy()
             .into_owned();
         let part_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(pyre_object::w_str_new(&include_name));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&include_name));
         let _ = roots.pin_root(pyre_object::w_str_new("ffi"));
         let _ = roots.pin_root(pyre_object::w_str_new("lib"));
         let _ = roots.pin_root(pyre_object::w_tuple_new(vec![
@@ -420,7 +420,7 @@ fn dir1(w_lib: PyObjectRef, ignore_global_vars: bool) -> Result<PyObjectRef, PyE
         }
         let name = unsafe { CStr::from_ptr(g.name) }.to_string_lossy();
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = roots.pin_root(pyre_object::w_str_new(&name));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&name));
         unsafe {
             pyre_object::listobject::w_list_append(roots.get(result_slot), roots.get(name_slot))
         };
@@ -441,7 +441,11 @@ fn full_dict_copy(w_lib: PyObjectRef) -> Result<PyObjectRef, PyError> {
         let name = unsafe { CStr::from_ptr(g.name) }
             .to_string_lossy()
             .into_owned();
-        let value = get_attr(roots.get(lib_slot), pyre_object::w_str_new(&name), false)?;
+        let value = get_attr(
+            roots.get(lib_slot),
+            pyre_object::w_str_new_managed(&name),
+            false,
+        )?;
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(value);
         unsafe {

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/libraryobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/libraryobj.rs
@@ -62,7 +62,7 @@ pub fn load_library(w_filename: PyObjectRef, flags: i64) -> Result<PyObjectRef, 
     let name_slot = roots.base();
     let _ = roots.pin_root(pyre_object::PY_NULL);
     let (name, handle, autoclose) = super::misc::dlopen_w(w_filename, flags)?;
-    roots.set(name_slot, pyre_object::w_str_new(&name));
+    roots.set(name_slot, pyre_object::w_str_new_managed(&name));
     let obj = W_Library::allocate_stable(W_Library {
         handle: handle as i64,
         autoclose: i64::from(autoclose),

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
@@ -143,7 +143,7 @@ fn ffi_error(message: impl Into<String>) -> PyError {
     let mut error = PyError::new(PyErrorKind::RuntimeError, message.clone());
     if let Ok(w_exc) = crate::builtins::exc_exception_new(&[
         newtype::ffi_error(),
-        pyre_object::w_str_new(&message),
+        pyre_object::w_str_new_managed(&message),
     ]) {
         error.exc_object = w_exc;
     }

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
@@ -782,7 +782,7 @@ pub fn do_realize_lazy_struct(w_ctype: PyObjectRef) -> Result<(), PyError> {
                 &format!("wrong size for field '{field_name}'"),
             )?;
         }
-        let _ = roots.pin_root(pyre_object::w_str_new(&field_name));
+        let _ = roots.pin_root(pyre_object::w_str_new_managed(&field_name));
         let _ = roots.pin_root(pyre_object::w_int_new(fbitsize));
         let _ = roots.pin_root(pyre_object::w_int_new(field_offset));
         let tuple_slot = part_slot + 4;

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -733,7 +733,7 @@ fn lookup_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
 
         ensure_encodings_imported(state)?;
-        let w_v = w_str_new(&normalized_encoding);
+        let w_v = w_str_new_managed(&normalized_encoding);
         let n = unsafe { pyre_object::w_list_len(state.codec_search_path) };
         for i in 0..n {
             let Some(w_search) =
@@ -964,7 +964,7 @@ fn forget_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let normalized_encoding = normalize(crate::baseobjspace::str_utf8_w(w_encoding)?);
     with_codec_state(|state| {
         let w_cache = state.codec_search_cache;
-        let w_key = w_str_new(&normalized_encoding);
+        let w_key = w_str_new_managed(&normalized_encoding);
         if unsafe { pyre_object::dictmultiobject::w_dict_lookup(w_cache, w_key).is_some() } {
             let _ = crate::baseobjspace::delitem(w_cache, w_key);
         }

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -334,7 +334,7 @@ fn char_obj(cp: u32) -> PyObjectRef {
     let s: String = char::from_u32(cp)
         .map(|c| c.to_string())
         .unwrap_or_default();
-    pyre_object::w_str_new(&s)
+    pyre_object::w_str_new_managed(&s)
 }
 
 fn opt_char_obj(cp: Option<u32>) -> PyObjectRef {
@@ -367,7 +367,7 @@ fn config_to_dialect(cfg: &DialectConfig) -> Result<PyObjectRef, PyError> {
     set("_csv_escapechar", opt_char_obj(cfg.escapechar))?;
     set(
         "_csv_lineterminator",
-        pyre_object::w_str_new(&cfg.lineterminator),
+        pyre_object::w_str_new_managed(&cfg.lineterminator),
     )?;
     set("_csv_quotechar", opt_char_obj(cfg.quotechar))?;
     set("_csv_quoting", pyre_object::w_int_new(cfg.quoting))?;
@@ -880,7 +880,7 @@ fn reader_next_inner(self_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         {
             pyre_object::w_none()
         } else {
-            let ws = pyre_object::w_str_new(&s);
+            let ws = pyre_object::w_str_new_managed(&s);
             if unquoted
                 && len != 0
                 && (cfg.quoting == QUOTE_NONNUMERIC || cfg.quoting == QUOTE_STRINGS)

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -2026,7 +2026,7 @@ pub(super) fn decoded_to_pyobject(d: host_ctypes::DecodedValue) -> PyObjectRef {
         D::Float(f) => pyre_object::w_float_new(f),
         D::Bool(b) => pyre_object::w_bool_from(b),
         D::Pointer(p) => u64_to_pyobject(p as u64),
-        D::String(s) => pyre_object::w_str_new(&s),
+        D::String(s) => pyre_object::w_str_new_managed(&s),
         D::None => pyre_object::w_none(),
     }
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/com.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/com.rs
@@ -238,7 +238,7 @@ pub(super) fn error(hresult: i32, iid: usize, this: usize) -> crate::PyError {
     let details_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(details);
     let text = match host_ctypes::format_error_message(Some(hresult as u32)) {
-        Some(message) => pyre_object::w_str_new(&message),
+        Some(message) => pyre_object::w_str_new_managed(&message),
         None => pyre_object::w_none(),
     };
     let text_slot = pyre_object::gc_roots::shadow_stack_len();

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -645,7 +645,7 @@ fn register_windows_loader(ns: pyre_object::PyObjectRef) {
             // string: `FormatMessageW` failing is not an error here.
             let message = host_ctypes::format_error_message(code)
                 .unwrap_or_else(|| "<no description>".to_string());
-            Ok(pyre_object::w_str_new(&message))
+            Ok(pyre_object::w_str_new_managed(&message))
         }),
     );
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1390,9 +1390,9 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
                     let n = field.iter().position(|&b| b == 0).unwrap_or(field.len());
                     Ok(pyre_object::bytesobject::w_bytes_from_bytes(&field[..n]))
                 }
-                Some("u") => Ok(pyre_object::w_str_new(&host_ctypes::wstring_from_bytes(
-                    field,
-                ))),
+                Some("u") => Ok(pyre_object::w_str_new_managed(
+                    &host_ctypes::wstring_from_bytes(field),
+                )),
                 _ => Ok(cdata::make_indexed_subview(proto, obj, offset, size, index)),
             }
         }
@@ -1593,7 +1593,7 @@ fn cfield_repr(args: &[PyObjectRef]) -> PyResult {
         cf_usize(cfield, "offset"),
         cf_usize(cfield, "size"),
     );
-    Ok(pyre_object::w_str_new(&s))
+    Ok(pyre_object::w_str_new_managed(&s))
 }
 
 fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
@@ -2162,7 +2162,7 @@ fn array_get_slice(obj: PyObjectRef, meta: &ArrayMeta, slice: PyObjectRef) -> Py
                 value.push_str(&s);
             }
         }
-        return Ok(pyre_object::w_str_new(&value));
+        return Ok(pyre_object::w_str_new_managed(&value));
     }
     // Each element is freshly boxed and the next index allocates again, so they
     // are pinned as they arrive.
@@ -2317,9 +2317,9 @@ fn install_wchar_array_getsets(cls: PyObjectRef) {
 }
 
 fn wchar_array_get_value(args: &[PyObjectRef]) -> PyResult {
-    Ok(pyre_object::w_str_new(&host_ctypes::wstring_from_bytes(
-        cdata::cdata_bytes(args[1]).unwrap_or(&[]),
-    )))
+    Ok(pyre_object::w_str_new_managed(
+        &host_ctypes::wstring_from_bytes(cdata::cdata_bytes(args[1]).unwrap_or(&[])),
+    ))
 }
 
 fn wchar_array_set_value(args: &[PyObjectRef]) -> PyResult {

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -153,7 +153,7 @@ pub(super) fn stginfo_new(data: StgInfoData) -> PyObjectRef {
             d,
             K_FORMAT,
             match data.format {
-                Some(s) => pyre_object::w_str_new(&s),
+                Some(s) => pyre_object::w_str_new_managed(&s),
                 None => pyre_object::w_none(),
             },
         );

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -877,9 +877,9 @@ impl W_TextIOWrapper {
         // before a collection is one the collection never traced.
         self.w_buffer = buffer;
         self.publish_refs();
-        self.w_encoding = w_str_new(encoding);
+        self.w_encoding = w_str_new_managed(encoding);
         self.publish_refs();
-        self.w_errors = w_str_new(errors);
+        self.w_errors = w_str_new_managed(errors);
         self.publish_refs();
         self.w_newline = newline;
         self.publish_refs();
@@ -918,7 +918,7 @@ impl W_TextIOWrapper {
         // a payload whose stdio methods are installed in the instance dict.
         let _ = type_object();
         let obj = Self::allocate_stable(Self {
-            w_stdio_name: w_str_new(name),
+            w_stdio_name: w_str_new_managed(name),
             ..Self::default()
         });
         let _roots = pyre_object::gc_roots::push_roots();
@@ -964,7 +964,7 @@ impl W_TextIOWrapper {
         }
         payload.state = STATE_OK;
         payload.publish_refs();
-        crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new(name));
+        crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new_managed(name));
         obj
     }
 
@@ -1798,10 +1798,10 @@ impl W_TextIOWrapper {
             self.set_newline(value.as_deref());
         }
         if let Some(value) = new_encoding.as_ref() {
-            self.w_encoding = w_str_new(value);
-            self.w_errors = w_str_new(new_errors.as_deref().unwrap_or("strict"));
+            self.w_encoding = w_str_new_managed(value);
+            self.w_errors = w_str_new_managed(new_errors.as_deref().unwrap_or("strict"));
         } else if let Some(value) = new_errors.as_ref() {
-            self.w_errors = w_str_new(value);
+            self.w_errors = w_str_new_managed(value);
         }
         if let Some(codec) = new_codec {
             self.set_encoder_decoder(codec)?;

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -1799,9 +1799,12 @@ impl W_TextIOWrapper {
         }
         if let Some(value) = new_encoding.as_ref() {
             self.w_encoding = w_str_new_managed(value);
+            self.publish_refs();
             self.w_errors = w_str_new_managed(new_errors.as_deref().unwrap_or("strict"));
+            self.publish_refs();
         } else if let Some(value) = new_errors.as_ref() {
             self.w_errors = w_str_new_managed(value);
+            self.publish_refs();
         }
         if let Some(codec) = new_codec {
             self.set_encoder_decoder(codec)?;

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -322,7 +322,7 @@ impl W_WindowsConsoleIO {
 
     #[getter]
     fn mode(&self) -> PyObjectRef {
-        w_str_new(self.mode_string())
+        w_str_new_managed(self.mode_string())
     }
 
     fn fileno(&self) -> Result<i64, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -65,7 +65,7 @@ fn json_decode_error(msg: String, doc: PyObjectRef, pos: usize) -> PyError {
         return PyError::value_error(format!("{msg}: line 1 column 1 (char {pos})"));
     };
     let args = [
-        pyre_object::w_str_new(&msg),
+        pyre_object::w_str_new_managed(&msg),
         doc,
         pyre_object::w_int_new(pos as i64),
     ];

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -547,7 +547,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 };
                 let out = rustpython_host_env::locale::setlocale(cat, c_locale.as_deref());
                 match out {
-                    Some(bytes) => Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&bytes))),
+                    Some(bytes) => Ok(pyre_object::w_str_new_managed(&String::from_utf8_lossy(&bytes))),
                     None => Err(locale_error("unsupported locale setting")),
                 }
             }
@@ -700,7 +700,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     // a plain utf-8 decode (lossy), matching `setlocale`;
                     // unlike `localeconv`/`nl_langinfo` it does not apply
                     // surrogateescape.
-                    Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&out)))
+                    Ok(pyre_object::w_str_new_managed(&String::from_utf8_lossy(&out)))
                 }
                 #[cfg(not(all(any(unix, windows), feature = "host_env", not(feature = "sandbox"))))]
                 {
@@ -720,7 +720,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         "getencoding",
         crate::make_builtin_function_with_arity(
             "getencoding",
-            |_| Ok(pyre_object::w_str_new(&locale_encoding())),
+            |_| Ok(pyre_object::w_str_new_managed(&locale_encoding())),
             0,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -118,7 +118,7 @@ fn locale_error(message: &str) -> crate::PyError {
     let cls = crate::builtins::lookup_exc_class("locale.Error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
         .expect("Exception must be installed");
-    let args = vec![cls, pyre_object::w_str_new(message)];
+    let args = vec![cls, pyre_object::w_str_new_managed(message)];
     let exc = crate::builtins::exc_exception_new(&args)
         .expect("exc_exception_new is infallible for str args");
     let mut err = crate::PyError::value_error(message);

--- a/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
@@ -755,7 +755,7 @@ mod profiler_methods {
             // leaves the first one installed.
             crate::module::sys::vm::monitoring_use_tool_id(
                 crate::module::sys::vm::MONITORING_PROFILER_ID,
-                w_str_new("cProfile"),
+                w_str_new_managed("cProfile"),
             )?;
             if let Some(value) = subcalls {
                 self.subcalls = value;

--- a/pyre/pyre-interpreter/src/module/_lzma/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lzma/mod.rs
@@ -42,7 +42,7 @@ fn lzma_exception(msg: impl Into<String>) -> crate::PyError {
     let msg = msg.into();
     let mut err = crate::PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class("_lzma.LZMAError") {
-        let args = [cls, w_str_new(&msg)];
+        let args = [cls, w_str_new_managed(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -621,7 +621,7 @@ fn semlock_instance(
     store!("maxvalue", w_int_new(maxvalue));
     store!(
         "name",
-        kept_name.map_or_else(w_none, |name| w_str_new(&name))
+        kept_name.map_or_else(w_none, |name| w_str_new_managed(&name))
     );
     // interp_semaphore.py `self.count = 0`, `self.last_tid = -1`.
     store!("count", w_int_new(0));

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -107,11 +107,11 @@ fn get_intrinsic1_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 }
 
 fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_list_new(
-        oparg::IntrinsicFunction2::iter()
-            .map(|value| w_str_new(value.desc()))
-            .collect(),
-    ))
+    let mut items = pyre_object::gc_roots::RootedItems::new();
+    for value in oparg::IntrinsicFunction2::iter() {
+        items.push(w_str_new_managed(value.desc()));
+    }
+    Ok(w_list_new(items.take()))
 }
 
 fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -121,8 +121,8 @@ fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     for value in oparg::BinaryOperator::iter() {
         let row = {
             let mut names = pyre_object::gc_roots::RootedItems::new();
-            names.push(w_str_new(value.desc()));
-            names.push(w_str_new(&value.to_string()));
+            names.push(w_str_new_managed(value.desc()));
+            names.push(w_str_new_managed(&value.to_string()));
             w_tuple_new(names.take())
         };
         rows.push(row);
@@ -131,11 +131,11 @@ fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 fn special_method_names_impl() -> PyObjectRef {
-    w_list_new(
-        oparg::SpecialMethod::iter()
-            .map(|value| w_str_new(&value.to_string()))
-            .collect(),
-    )
+    let mut items = pyre_object::gc_roots::RootedItems::new();
+    for value in oparg::SpecialMethod::iter() {
+        items.push(w_str_new_managed(&value.to_string()));
+    }
+    w_list_new(items.take())
 }
 
 crate::py_module! {

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -99,11 +99,11 @@ fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 // the whole table. Prepending it again shifted every real name one slot up and
 // mislabelled every intrinsic in `dis` output.
 fn get_intrinsic1_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_list_new(
-        oparg::IntrinsicFunction1::iter()
-            .map(|value| w_str_new(value.desc()))
-            .collect(),
-    ))
+    let mut items = pyre_object::gc_roots::RootedItems::new();
+    for value in oparg::IntrinsicFunction1::iter() {
+        items.push(w_str_new_managed(value.desc()));
+    }
+    Ok(w_list_new(items.take()))
 }
 
 fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
@@ -1037,9 +1037,9 @@ fn bind_local(args: &[PyObjectRef]) -> crate::PyResult {
 }
 
 fn format_message(args: &[PyObjectRef]) -> crate::PyResult {
-    Ok(pyre_object::w_str_new(&host_overlapped::format_message(
-        u32_w(arg(args, 0, "FormatMessage")?)?,
-    )))
+    Ok(pyre_object::w_str_new_managed(
+        &host_overlapped::format_message(u32_w(arg(args, 0, "FormatMessage")?)?),
+    ))
 }
 
 fn wsa_connect(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -213,7 +213,7 @@ fn socket_converted_error(
     if let Some(e) = errno {
         args.push(pyre_object::w_int_new(e as i64));
     }
-    args.push(pyre_object::w_str_new(message));
+    args.push(pyre_object::w_str_new_managed(message));
 
     // Every class this resolves to is an OSError subclass, and
     // `converted_error` reaches them through `space.call_function`, so the

--- a/pyre/pyre-interpreter/src/module/_symtable/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_symtable/mod.rs
@@ -112,7 +112,7 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     let varnames_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for name in &table.varnames {
         let value_roots = pyre_object::gc_roots::push_roots();
-        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(name));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
         let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::listobject::w_list_append(
@@ -128,7 +128,7 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     let children_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     append_public_children(table, children_slot);
 
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&table.name));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(&table.name));
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table_type(table) as i64));
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -867,12 +867,12 @@ fn make_token_tuple(
     let _roots = gc_roots::push_roots();
     let base = gc_roots::shadow_stack_len();
     let _ = gc_roots::pin_root(w_int_new(token_type as i64));
-    let _ = gc_roots::pin_root(w_str_new(&text));
+    let _ = gc_roots::pin_root(w_str_new_managed(&text));
     let _ = gc_roots::pin_root(w_int_new(start_line as i64));
     let _ = gc_roots::pin_root(w_int_new(start_col as i64));
     let _ = gc_roots::pin_root(w_int_new(end_line as i64));
     let _ = gc_roots::pin_root(w_int_new(end_col as i64));
-    let _ = gc_roots::pin_root(w_str_new(&line));
+    let _ = gc_roots::pin_root(w_str_new_managed(&line));
     let start = w_tuple_new(vec![
         gc_roots::shadow_stack_get(base + 2),
         gc_roots::shadow_stack_get(base + 3),

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -825,9 +825,9 @@ pub fn _mimetypes_read_windows_registry(on_type_read: PyObjectRef) -> Result<(),
                 // once both exist.
                 let _entry_roots = pyre_object::gc_roots::push_roots();
                 let type_slot =
-                    pyre_object::gc_roots::pin_roots(&[pyre_object::w_str_new(&mime_type)]);
+                    pyre_object::gc_roots::pin_roots(&[pyre_object::w_str_new_managed(&mime_type)]);
                 let extension_slot =
-                    pyre_object::gc_roots::pin_roots(&[pyre_object::w_str_new(&extension)]);
+                    pyre_object::gc_roots::pin_roots(&[pyre_object::w_str_new_managed(&extension)]);
                 crate::call::call_function_impl_result(
                     roots.get(callback_slot),
                     &[

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -2068,7 +2068,11 @@ fn array_reconstructor(args: &[PyObjectRef]) -> PyResult {
             20 => "utf-32-le",
             _ => "utf-32-be",
         };
-        let decoded = call_method(args[3], "decode", &[pyre_object::w_str_new(encoding)])?;
+        let decoded = call_method(
+            args[3],
+            "decode",
+            &[pyre_object::w_str_new_managed(encoding)],
+        )?;
         array_fromunicode(obj, decoded)?;
         return Ok(obj);
     }

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -2085,7 +2085,7 @@ fn array_reconstructor(args: &[PyObjectRef]) -> PyResult {
         typecode
     };
     let output_typecode_text = (output_typecode as char).to_string();
-    let obj = array_descr_new(&[w_cls, pyre_object::w_str_new(&output_typecode_text)])?;
+    let obj = array_descr_new(&[w_cls, pyre_object::w_str_new_managed(&output_typecode_text)])?;
     for chunk in bytes.chunks_exact(source_size) {
         let w_item = if matches!(mformat, 14 | 15) {
             let raw: [u8; 4] = chunk.try_into().unwrap();

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1759,11 +1759,13 @@ crate::py_module! {
         // code allocates without passing any counter site, and a virtualized
         // allocation is removed outright.  Counting by walking instead is what
         // `gc.get_objects` costs, four orders of magnitude above this call.
-        "get_count"     / 0 = |_| Ok(w_tuple_new(vec![
-            w_int_new(0),
-            w_int_new(majit_gc::active_minor_collections_since_major() as i64),
-            w_int_new(0),
-        ])),
+        "get_count"     / 0 = |_| {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_int_new(0));
+            fields.push(w_int_new(majit_gc::active_minor_collections_since_major() as i64));
+            fields.push(w_int_new(0));
+            Ok(w_tuple_new(fields.take()))
+        },
         "get_debug"     / 0 = |_| Ok(w_int_new(GC_DEBUG.load(Ordering::Relaxed))),
         "set_debug"     / 1 = |args| {
             // `gc_set_debug_impl` parses a C int through the index protocol.

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1188,7 +1188,7 @@ fn populate_public_gc_stats(obj: PyObjectRef, raw: PyObjectRef) -> Result<(), cr
         pyre_object::gc_roots::shadow_stack_get(raw_slot),
     )?;
     for (name, value) in formatted {
-        let text = w_str_new(&format_gc_stat(value));
+        let text = w_str_new_managed(&format_gc_stat(value));
         let _ = pyre_object::gc_roots::pin_root(text);
         let text_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -874,7 +874,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 let _ = pyre_object::gc_roots::pin_root(w_globals);
                 // The name string is allocated before the store so the mapping
                 // it writes into is read after that allocation, not before it.
-                let w_name = pyre_object::w_str_new(&name);
+                let w_name = pyre_object::w_str_new_managed(&name);
                 unsafe {
                     pyre_object::w_dict_setitem_str(
                         pyre_object::gc_roots::shadow_stack_get(globals_slot),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1128,7 +1128,7 @@ mod win_nt {
         let filename = if path.is_empty() {
             pyre_object::PY_NULL
         } else {
-            pyre_object::w_str_new(path)
+            pyre_object::w_str_new_managed(path)
         };
         io_err_with_filename(error, filename)
     }
@@ -2786,7 +2786,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         let w_filename = if path.is_empty() {
             pyre_object::PY_NULL
         } else {
-            pyre_object::w_str_new(path)
+            pyre_object::w_str_new_managed(path)
         };
         crate::PyError::os_error_syscall(errno, w_filename)
     }

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -27,7 +27,7 @@ fn struct_error(msg: impl Into<String>) -> crate::PyError {
     let cls = crate::builtins::lookup_exc_class("struct.error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
         .expect("Exception must be installed before _struct is used");
-    let exc = crate::builtins::exc_exception_new(&[cls, w_str_new(&msg)])
+    let exc = crate::builtins::exc_exception_new(&[cls, w_str_new_managed(&msg)])
         .expect("exc_exception_new is infallible for str args");
     let mut err = crate::PyError::new(crate::PyErrorKind::ValueError, msg);
     err.exc_object = exc;
@@ -1157,7 +1157,7 @@ impl W_Struct {
     fn __init__(&mut self, w_format: PyObjectRef) -> Result<(), crate::PyError> {
         let format = format_to_string(w_format)?;
         self.size = parse_format(&format)?.calcsize()?;
-        self.format = w_str_new(&format);
+        self.format = w_str_new_managed(&format);
         pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1875,12 +1875,12 @@ fn call_thread_target(
     };
     if unsafe { crate::is_function(target) } {
         let mut mixed = args;
-        let mut names = Vec::with_capacity(entries.len());
+        let mut names = pyre_object::gc_roots::RootedItems::new();
         for (name, value) in entries {
             mixed.push(value);
-            names.push(w_str_new(&name));
+            names.push(w_str_new_managed(&name));
         }
-        let kwarg_names = w_tuple_new(names);
+        let kwarg_names = w_tuple_new(names.take());
         let resolved = crate::call::resolve_kwargs(target, &mixed, kwarg_names)?;
         crate::call::call_user_function_plain_with_ctx(ec, target, &resolved)
     } else {
@@ -2428,7 +2428,7 @@ fn thread_excepthook_file(
         };
         thread_excepthook_write(file_slot, w_str_from_wtf8(rendered))?;
     } else {
-        thread_excepthook_write(file_slot, w_str_new(&current_ident().to_string()))?;
+        thread_excepthook_write(file_slot, w_str_new_managed(&current_ident().to_string()))?;
     }
     thread_excepthook_write(file_slot, w_str_new(":\n"))?;
 

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1395,11 +1395,12 @@ pub(crate) fn init_timezone(ns: PyObjectRef) {
     crate::module_ns_store(ns, "timezone", w_int_new(timezone));
     crate::module_ns_store(ns, "altzone", w_int_new(altzone));
     crate::module_ns_store(ns, "daylight", w_int_new(daylight));
-    crate::module_ns_store(
-        ns,
-        "tzname",
-        w_tuple_new(vec![w_str_new(&standard_name), w_str_new(&daylight_name)]),
-    );
+    crate::module_ns_store(ns, "tzname", {
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_str_new_managed(&standard_name));
+        fields.push(w_str_new_managed(&daylight_name));
+        w_tuple_new(fields.take())
+    });
 }
 
 /// `interp_time.py tzset` — ask libc to reread `TZ`, then refresh
@@ -1488,14 +1489,12 @@ pub(crate) fn init_timezone(ns: PyObjectRef) {
     crate::module_ns_store(ns, "timezone", w_int_new(timezone));
     crate::module_ns_store(ns, "altzone", w_int_new(timezone - 3600));
     crate::module_ns_store(ns, "daylight", w_int_new(i64::from(observes_dst)));
-    crate::module_ns_store(
-        ns,
-        "tzname",
-        w_tuple_new(vec![
-            w_str_new(&info.standard_name),
-            w_str_new(&info.daylight_name),
-        ]),
-    );
+    crate::module_ns_store(ns, "tzname", {
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_str_new_managed(&info.standard_name));
+        fields.push(w_str_new_managed(&info.daylight_name));
+        w_tuple_new(fields.take())
+    });
 }
 
 #[cfg(windows)]
@@ -1568,22 +1567,30 @@ pub(crate) fn struct_time_type() -> PyObjectRef {
 
 /// Build a `time.struct_time` from our portable `c_tm`.
 fn _tm_to_tuple(tm: &c_tm) -> PyObjectRef {
-    let seq = vec![
-        w_int_new((tm.tm_year + 1900) as i64),
-        w_int_new((tm.tm_mon + 1) as i64),
-        w_int_new(tm.tm_mday as i64),
-        w_int_new(tm.tm_hour as i64),
-        w_int_new(tm.tm_min as i64),
-        w_int_new(tm.tm_sec as i64),
-        w_int_new(((tm.tm_wday + 6) % 7) as i64), // Monday=0
-        w_int_new((tm.tm_yday + 1) as i64),
-        w_int_new(tm.tm_isdst as i64),
-    ];
-    let extras = vec![
-        ("tm_zone", pyre_object::w_str_new(&tm.tm_zone)),
-        ("tm_gmtoff", w_int_new(tm.tm_gmtoff)),
-    ];
-    crate::_structseq::new_instance_with_extra(struct_time_type(), seq, extras)
+    let items = {
+        let mut seq = pyre_object::gc_roots::RootedItems::new();
+        seq.push(w_int_new((tm.tm_year + 1900) as i64));
+        seq.push(w_int_new((tm.tm_mon + 1) as i64));
+        seq.push(w_int_new(tm.tm_mday as i64));
+        seq.push(w_int_new(tm.tm_hour as i64));
+        seq.push(w_int_new(tm.tm_min as i64));
+        seq.push(w_int_new(tm.tm_sec as i64));
+        seq.push(w_int_new(((tm.tm_wday + 6) % 7) as i64)); // Monday=0
+        seq.push(w_int_new((tm.tm_yday + 1) as i64));
+        seq.push(w_int_new(tm.tm_isdst as i64));
+        seq.take()
+    };
+    let extras = {
+        let mut extra_items = pyre_object::gc_roots::RootedItems::new();
+        extra_items.push(pyre_object::w_str_new_managed(&tm.tm_zone));
+        extra_items.push(w_int_new(tm.tm_gmtoff));
+        extra_items.take()
+    };
+    crate::_structseq::new_instance_with_extra(
+        struct_time_type(),
+        items,
+        vec![("tm_zone", extras[0]), ("tm_gmtoff", extras[1])],
+    )
 }
 
 /// `interp_time.py _get_inttime` — extract integral epoch seconds

--- a/pyre/pyre-interpreter/src/module/winsound/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winsound/mod.rs
@@ -92,7 +92,7 @@ fn win32_runtime_error(code: u32) -> crate::PyError {
     let cls_slot = roots.base();
     let _ = roots.pin_root(cls);
     let _ = roots.pin_root(pyre_object::w_int_new(0));
-    let _ = roots.pin_root(pyre_object::w_str_new(&message));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&message));
     let _ = roots.pin_root(pyre_object::w_none());
     let _ = roots.pin_root(pyre_object::w_int_new(i64::from(code as i32)));
     let _ = roots.pin_root(pyre_object::w_none());

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -117,7 +117,7 @@ fn zlib_error(msg: impl Into<String>) -> crate::PyError {
     let msg = msg.into();
     let mut err = crate::PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class("zlib.error") {
-        let args = [cls, w_str_new(&msg)];
+        let args = [cls, w_str_new_managed(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -7,7 +7,8 @@
 use pyre_object::nestedscope::CellFamily;
 use pyre_object::pyobject::*;
 use pyre_object::{
-    w_bool_from, w_bool_get_value, w_int_new, w_list_new, w_seq_iter_new, w_str_new, w_tuple_new,
+    w_bool_from, w_bool_get_value, w_int_new, w_list_new, w_seq_iter_new, w_str_new,
+    w_str_new_managed, w_tuple_new,
 };
 use rustpython_compiler_core::SourceLocation;
 use rustpython_compiler_core::bytecode::PyCodeLocationInfoKind;
@@ -827,7 +828,7 @@ pub unsafe fn w_code_qualname_obj(w_code: PyObjectRef) -> PyObjectRef {
         // `w_str_new` is a collection point. RPython keeps the live `self`
         // reference in the shadow stack across it; reload the possibly moved
         // wrapper before publishing the cache field.
-        let w_qualname = w_str_new(&(*code_ptr).qualname);
+        let w_qualname = w_str_new_managed(&(*code_ptr).qualname);
         publish_code_slot_store(roots.get(code_slot));
         let w_code = roots.get(code_slot);
         (*(w_code as *mut PyCode)).w_qualname = w_qualname;
@@ -861,7 +862,7 @@ pub unsafe fn w_code_name_obj(w_code: PyObjectRef) -> PyObjectRef {
         // `w_str_new` is a collection point. RPython keeps the live `self`
         // reference in the shadow stack across it; reload the possibly moved
         // wrapper before publishing the cache field.
-        let w_name = w_str_new(&(*code_ptr).obj_name);
+        let w_name = w_str_new_managed(&(*code_ptr).obj_name);
         publish_code_slot_store(roots.get(code_slot));
         let w_code = roots.get(code_slot);
         (*(w_code as *mut PyCode)).w_name = w_name;
@@ -886,7 +887,7 @@ pub unsafe fn w_code_filename_obj(w_code: PyObjectRef) -> PyObjectRef {
     let pycode = unsafe { &*(w_code as *const PyCode) };
     if pycode.filename_bytes.is_null() {
         let code = unsafe { &*(pycode.code_ptr as *const crate::CodeObject) };
-        w_str_new(&code.source_path)
+        w_str_new_managed(&code.source_path)
     } else {
         crate::gateway::fsdecode_filename_bytes(unsafe { &*pycode.filename_bytes })
     }
@@ -2141,8 +2142,8 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
         Ok(())
     }
     let mut result = 20_250_211i64;
-    add_obj(&mut result, w_str_new(&code.obj_name))?;
-    add_obj(&mut result, w_str_new(&code.qualname))?;
+    add_obj(&mut result, w_str_new_managed(&code.obj_name))?;
+    add_obj(&mut result, w_str_new_managed(&code.qualname))?;
     for value in [
         code.arg_count as i64,
         code.posonlyarg_count as i64,
@@ -2215,7 +2216,7 @@ pub unsafe fn code_varname_from_oparg(
         // rewrites — keep the bounds check a plain `lt + getitem`.
         let vi = index as usize;
         if vi < code.varnames.len() {
-            return Ok(w_str_new(&code.varnames[vi]));
+            return Ok(w_str_new_managed(&code.varnames[vi]));
         }
         index -= code.varnames.len() as i64;
         let pure_cellvars = code
@@ -2229,7 +2230,7 @@ pub unsafe fn code_varname_from_oparg(
         index -= pure_cellvar_count as i64;
         let fi = index as usize;
         if fi < code.freevars.len() {
-            return Ok(w_str_new(&code.freevars[fi]));
+            return Ok(w_str_new_managed(&code.freevars[fi]));
         }
     }
     Err(crate::PyError::new(

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1853,26 +1853,47 @@ impl Drop for FrameBox {
 /// root the eval path holds in `call.rs`: during setup the freshly-installed
 /// locals/cells live only in that array, so an intervening collection would
 /// drop or mis-forward them unless the slot is rooted.
+///
+/// The guard stores the frame, not the field address. `jtransform.py`
+/// `rewrite_op_getsubstruct` refuses a GC interior in the Ref bank — the
+/// gcmap would treat `frame+offset` as its own object. Computing the slot
+/// only inside residual helpers keeps that address out of compiled slots.
 pub struct FrameLocalsRoot {
-    slot: *mut *mut u8,
+    frame: *mut PyFrame,
     registered: bool,
 }
 
 impl FrameLocalsRoot {
+    #[majit_macros::dont_look_inside]
     pub fn new(frame_ptr: *mut PyFrame) -> Self {
-        let slot =
-            unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
+        let registered = unsafe { register_frame_locals_slot(frame_ptr) };
+        Self {
+            frame: frame_ptr,
+            registered,
+        }
     }
 }
 
 impl Drop for FrameLocalsRoot {
     fn drop(&mut self) {
         if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+            unregister_frame_locals_slot(self.frame);
         }
     }
+}
+
+/// `addr_of_mut!(locals_cells_stack_w)` is an interior address. Residual so a
+/// compiled gcmap cannot mark it as a GCREF (`rewrite_op_getsubstruct`).
+#[majit_macros::dont_look_inside]
+pub unsafe fn register_frame_locals_slot(frame_ptr: *mut PyFrame) -> bool {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
+    unsafe { pyre_object::gc_hook::try_gc_add_root(slot) }
+}
+
+#[majit_macros::dont_look_inside]
+pub fn unregister_frame_locals_slot(frame_ptr: *mut PyFrame) {
+    let slot = unsafe { std::ptr::addr_of_mut!((*frame_ptr).locals_cells_stack_w) as *mut *mut u8 };
+    pyre_object::gc_hook::try_gc_remove_root(slot);
 }
 
 #[inline]

--- a/pyre/pyre-interpreter/src/syntax_warnings.rs
+++ b/pyre/pyre-interpreter/src/syntax_warnings.rs
@@ -399,7 +399,8 @@ fn warn_invalid_escape_sequence(
     let category_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(category);
     let message_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&warning_message(escape)));
+    let _ =
+        pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(&warning_message(escape)));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2305,10 +2305,14 @@ fn jit_blackhole_resume_from_guard(
 /// `decode_ref` keys the same index), so the type gate is exact.
 struct ResumeDeadframeRoots {
     slots: Vec<*mut *mut u8>,
+    frame_roots: Vec<pyre_interpreter::pyframe::FrameLocalsRoot>,
 }
 
 impl ResumeDeadframeRoots {
-    fn register_pyframe_locals_slot(value: i64, slots: &mut Vec<*mut *mut u8>) {
+    fn register_pyframe_locals_slot(
+        value: i64,
+        frame_roots: &mut Vec<pyre_interpreter::pyframe::FrameLocalsRoot>,
+    ) {
         let ptr = value as *mut u8;
         if ptr.is_null()
             || !pyre_object::gc_hook::try_gc_owns_object(ptr)
@@ -2324,15 +2328,14 @@ impl ResumeDeadframeRoots {
         if type_id != pyre_interpreter::pyframe::PYFRAME_GC_TYPE_ID {
             return;
         }
-        let frame = current as *mut PyFrame;
-        let slot = unsafe { std::ptr::addr_of_mut!((*frame).locals_cells_stack_w) as *mut *mut u8 };
-        if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
-            slots.push(slot);
-        }
+        frame_roots.push(pyre_interpreter::pyframe::FrameLocalsRoot::new(
+            current as *mut PyFrame,
+        ));
     }
 
     fn register(deadframe: &mut [i64], deadframe_types: Option<&[majit_ir::Type]>) -> Self {
         let mut slots = Vec::new();
+        let mut frame_roots = Vec::new();
         if let Some(types) = deadframe_types {
             for (idx, ty) in types.iter().enumerate() {
                 if !matches!(ty, majit_ir::Type::Ref) {
@@ -2349,10 +2352,10 @@ impl ResumeDeadframeRoots {
                 if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
                     slots.push(slot);
                 }
-                Self::register_pyframe_locals_slot(*cell, &mut slots);
+                Self::register_pyframe_locals_slot(*cell, &mut frame_roots);
             }
         }
-        Self { slots }
+        Self { slots, frame_roots }
     }
 }
 
@@ -2361,6 +2364,7 @@ impl Drop for ResumeDeadframeRoots {
         for &slot in &self.slots {
             pyre_object::gc_hook::try_gc_remove_root(slot);
         }
+        self.frame_roots.clear();
     }
 }
 


### PR DESCRIPTION
Follow-up to #1763. Remaining per-call `w_str_new` returns were immortal leaks, and a few more multi-mint tuples still built into an unrooted `Vec`.

This converts leftover dynamic strings to `w_str_new_managed` and pins `struct_time` / `tzname`, `range` and `GenericAlias` reduce, opcode name lists, and `PyDict_Items` pairs before later allocations.

Clinic defaults, interned names, and module constants stay on `w_str_new`.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection safety across interpreter operations that create strings, tuples, lists, exception messages, and time-related values.
  - Strengthened object lifetime handling in dictionary, threading, locale, I/O, compression, and C interface operations.
  - Improved stability when constructing values and error messages across standard-library and compatibility interfaces.
  - Preserved existing return values, error handling, and observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->