### PR TITLE
wasm: drop CALL_ASSEMBLER bump-path jf_frame fill

### DIFF
--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -1,16 +1,10 @@
 # pyre-check: max-pypy-ratio=2.4
-# pyre-check: max-wasm-ratio=6.1
 #
 # Ceiling 6 derived floor. After `get_instantiate` became a word load of
 # the immutable OBJECT_VTABLE slot, ubuntu dynasm reads 0.5x and
 # cranelift 0.6x (run 34382609753). 2.4 puts the derived floor at 0.4x
 # under those and still covers the slower 1.4x cranelift host span from
 # before the slot folded.
-#
-# The walker stops unrolling `step` two frames past `FBW_MAX_INLINE_RECURSION`,
-# so each loop iteration is a residual recursive call. wasm compiles one
-# module per residual trace; ubuntu-24.04 measured 5.0x on main and 5.3x
-# here, so 6.1x is the higher reading plus WASM_RATIO_FIT_HEADROOM (15%).
 #
 # A recursion deeper than the inline unroll bound, driven from a loop body.
 #


### PR DESCRIPTION
`rewrite.py` `gen_malloc_frame` zeros the five GCREF fields and sets length. It does not fill `jf_frame`. The wasm CALL_ASSEMBLER nursery bump was `memory.fill`ing `ca_frame_bytes` on every recursive frame, which put `recursion_past_unroll_bound_from_loop` at 5.4x dynasm (gate 4x).

The callee entry's `emit_null_home_slots` is the first write that defines those slots, the way the assembler publishes `jf_gcmap` only at safepoints once the homes are live.

Also drops the `max-wasm-ratio=6.1` header that was fitted to those fill-tax readings. The default 4x wasm/dynasm gate stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Streamlined runtime frame initialization to avoid redundant memory clearing while preserving required initialization behavior.

- **Tests**
  - Updated code-generation checks to reflect the optimized frame initialization process and verify that unnecessary memory operations are not emitted.

- **Benchmarks**
  - Refined benchmark expectations and documentation for recursion performance across supported execution backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->