### PR TITLE
wasm: compile loops whose LABEL carries a residual phi

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -24,6 +24,102 @@ use wasm_encoder::{
     Module, RefType, TableType, TypeSection, ValType,
 };
 
+/// Insert GETARRAYITEM loads for LABEL args that have no producer.
+///
+/// `patch_new_loop_to_load_virtualizable_fields` rewrites root inputarg
+/// slots only. A body LABEL still carries virtualstate boxes for
+/// `locals_cells_stack_w` items the peel never wrote. Native regalloc
+/// binds those boxes to the same location the heap load would use; wasm
+/// locals start at zero, so a later deopt writes a null local back as
+/// bytecode state. Clone an existing array load in this trace — same
+/// descr, same array pointer — and store into the missing LABEL id.
+pub fn materialize_unbound_label_args(inputargs: &[InputArg], ops: &mut Vec<Op>) {
+    let produced: std::collections::HashSet<u32> = ops
+        .iter()
+        .filter_map(|op| {
+            let r = op.pos.get();
+            (!r.is_none() && !r.is_constant()).then_some(r.raw())
+        })
+        .chain(inputargs.iter().map(|ia| ia.index))
+        .collect();
+    let Some(label) = ops.iter().find(|op| op.opcode == OpCode::Label) else {
+        return;
+    };
+    let label_args: Vec<OpRef> = label.getarglist().iter().map(|a| a.to_opref()).collect();
+    let mut missing: Vec<(usize, u32)> = Vec::new();
+    for (i, opref) in label_args.iter().enumerate() {
+        // Peeled live-ins are InputArg* block parameters, not residual
+        // virtualizable slots. Do not replace them with a heap load.
+        if opref.is_none() || opref.is_constant() || opref.is_input_arg() {
+            continue;
+        }
+        let raw = opref.raw();
+        if !produced.contains(&raw) {
+            missing.push((i, raw));
+        }
+    }
+    if missing.is_empty() {
+        return;
+    }
+    // Only a GETARRAYITEM whose result is already a LABEL arg is the
+    // frame-locals array. A list/tuple items load in the same trace is the
+    // wrong array; cloning it writes a foreign object into a vable slot.
+    let mut template: Option<(Op, i64, usize)> = None;
+    for (i, opref) in label_args.iter().enumerate() {
+        if opref.is_none() || opref.is_constant() {
+            continue;
+        }
+        let raw = opref.raw();
+        let Some(op) = ops.iter().find(|op| {
+            matches!(
+                op.opcode,
+                OpCode::GetarrayitemGcR | OpCode::GetarrayitemGcI | OpCode::GetarrayitemGcF
+            ) && op.pos.get() != OpRef::NONE
+                && !op.pos.get().is_constant()
+                && op.pos.get().raw() == raw
+        }) else {
+            continue;
+        };
+        if op.num_args() < 2 {
+            continue;
+        }
+        let Some(index) = op.arg(1).to_opref().inline_const_bits() else {
+            continue;
+        };
+        template = Some((op.clone(), index, i));
+        break;
+    }
+    let Some((template, template_index, template_label_i)) = template else {
+        return;
+    };
+    let insert_at = ops
+        .iter()
+        .position(|op| op.opcode == OpCode::Label)
+        .unwrap_or(0);
+    let mut loads = Vec::new();
+    for (label_i, raw) in missing {
+        let array_index = template_index + (label_i as i64 - template_label_i as i64);
+        if array_index < 0 {
+            continue;
+        }
+        let load = template.clone();
+        load.setarg(
+            1,
+            majit_ir::operand::Operand::const_from_value(majit_ir::Value::Int(array_index)),
+        );
+        let result_ty = match template.opcode {
+            OpCode::GetarrayitemGcI => Type::Int,
+            OpCode::GetarrayitemGcF => Type::Float,
+            _ => Type::Ref,
+        };
+        load.pos.set(OpRef::op_typed(raw, result_ty));
+        loads.push(load);
+    }
+    if !loads.is_empty() {
+        ops.splice(insert_at..insert_at, loads);
+    }
+}
+
 /// Frame slot byte offset: slot[i] is at frame_ptr + 8 + i * 8.
 pub const FRAME_SLOT_BASE: u64 = 8;
 const SLOT_SIZE: u64 = 8;
@@ -1389,6 +1485,20 @@ impl LabelResumeData {
             {
                 *v = true;
             }
+            if op.opcode == OpCode::Label {
+                for a in op.getarglist().iter() {
+                    let opref = a.to_opref();
+                    // Peeled InputArgRef live-ins are real LABEL params.
+                    // A producerless RefOp is a residual virtualizable slot.
+                    if opref != OpRef::NONE
+                        && !opref.is_constant()
+                        && !matches!(opref, OpRef::RefOp(_))
+                        && let Some(v) = has_producer.get_mut(opref.raw() as usize)
+                    {
+                        *v = true;
+                    }
+                }
+            }
         }
         let mut per_label = Vec::new();
         let mut uncapturable = Vec::new();
@@ -1405,11 +1515,36 @@ impl LabelResumeData {
         {
             let mut available = vec![false; num_vars as usize];
             let mut defined_before = vec![false; num_vars as usize];
-            // Producer-less value ids are folded constant-pool seeds. Codegen
-            // binds them before the entry dispatch, so they dominate both the
-            // key-0 path and every LABEL resume and need no frame capture.
+            // Producer-less int/float ids are folded constant-pool seeds.
+            // Codegen binds them before the entry dispatch, so they dominate
+            // both the key-0 path and every LABEL resume and need no frame
+            // capture. A producerless LABEL RefOp is a residual
+            // virtualizable slot, not a seed — wasm would bind it to a
+            // null local. Peeled InputArgRef live-ins stay seeds.
+            let mut unbound_label_ref = vec![false; num_vars as usize];
+            for op in ops {
+                if op.opcode != OpCode::Label {
+                    continue;
+                }
+                for a in op.getarglist() {
+                    let opref = a.to_opref();
+                    if opref == OpRef::NONE
+                        || opref.is_constant()
+                        || !matches!(opref, OpRef::RefOp(_))
+                    {
+                        continue;
+                    }
+                    let id = opref.raw() as usize;
+                    if !has_producer.get(id).copied().unwrap_or(false)
+                        && !is_input.get(id).copied().unwrap_or(false)
+                        && let Some(v) = unbound_label_ref.get_mut(id)
+                    {
+                        *v = true;
+                    }
+                }
+            }
             for (id, produced) in has_producer.iter().copied().enumerate() {
-                if !produced && !is_input[id] {
+                if !produced && !is_input[id] && !unbound_label_ref[id] {
                     available[id] = true;
                     defined_before[id] = true;
                 }
@@ -10560,10 +10695,21 @@ fn unbound_pool_const_seeds(
         // skipped the prologue seed, so the local stayed the zero wasm
         // initializes it to. Seed those; only treat a LABEL arg as
         // defined when the pool has nothing to materialize.
+        //
+        // A producerless LABEL *RefOp* is a residual virtualizable
+        // slot, not a phi. wasm locals start at zero; treating it as
+        // defined compiles a null that failarg writeback stores as
+        // bytecode state. Leave it unresolved so the trace declines.
+        // A peeled InputArgRef live-in is a real LABEL parameter
+        // (`consider_label`) and must stay defined.
         if op.opcode == OpCode::Label {
             for a in op.getarglist() {
                 let r = a.to_opref();
-                if r != OpRef::NONE && !r.is_constant() && !constants.contains_key(&r.raw()) {
+                if r != OpRef::NONE
+                    && !r.is_constant()
+                    && !constants.contains_key(&r.raw())
+                    && !matches!(r, OpRef::RefOp(_))
+                {
                     defined.insert(r.raw());
                 }
             }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4092,7 +4092,8 @@ impl majit_backend::Backend for WasmBackend {
         if let Some(clt) = token.compiled_loop_token() {
             majit_backend::record_compiled_loop_token(&self.cpu_tracker, &clt);
         }
-        let ops_owned: Vec<Op> = normalize_ops_for_codegen(inputargs, ops);
+        let mut ops_owned: Vec<Op> = normalize_ops_for_codegen(inputargs, ops);
+        codegen::materialize_unbound_label_args(inputargs, &mut ops_owned);
         let (ops_owned, gc_table) = Self::intern_ref_constants(inputargs, ops_owned);
         let gc_table_base = gc_table.as_ref().map_or(0, |t| t.base_addr() as u32);
         let ops: &[Op] = &ops_owned;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -131,14 +131,21 @@ fn stat_value(stderr: &str, name: &str) -> u64 {
         .unwrap_or_else(|err| panic!("invalid {name}= in wasm JIT stats: {err}\n{stderr}"))
 }
 
-/// CALL_ASSEMBLER must not refill a frame. The inline bump leaves
-/// `jf_gcmap` unset; the callee prologue nulls the frozen home region
-/// and then publishes the map. Expected `memory.fill`s are that entry
-/// home clear, and the nursery-payload zeros `emit_zero_bytes` writes
-/// for `New*` (`rewrite` no longer fills the whole nursery on wasm32
-/// reset).
+/// CALL_ASSEMBLER must not refill a frame on the bump path. The inline
+/// bump leaves `jf_gcmap` unset. Expected `memory.fill`s are the entry
+/// home clear, `emit_zero_bytes` New* payload zeros, and the CA caller
+/// nulling the callee home range from the dispatch snapshot before
+/// publishing that snapshot's gcmap.
 #[track_caller]
 fn assert_no_call_assembler_frame_fill(stderr: &str) {
+    let home_base = format!(
+        "i32.load offset={}",
+        majit_backend_wasm::failguard::WASM_CA_TARGET_HOME_SLOT_BASE_OFS
+    );
+    let home_slots = format!(
+        "i32.load offset={}",
+        majit_backend_wasm::failguard::WASM_CA_TARGET_HOME_SLOTS_OFS
+    );
     let lines: Vec<_> = stderr.lines().map(str::trim).collect();
     for (index, line) in lines.iter().enumerate() {
         if *line != "memory.fill" {
@@ -162,8 +169,18 @@ fn assert_no_call_assembler_frame_fill(stderr: &str) {
             && lines[index - 3].starts_with("local.get ")
             && lines[index - 2] == "i32.const 0"
             && lines[index - 1].starts_with("i32.const ");
+        // dest = cfp + target.home_slot_base, size = home_slots * SLOT_SIZE.
+        let is_ca_callee_home_null = index >= 8
+            && lines[index - 1] == "i32.mul"
+            && lines[index - 2] == "i32.const 8"
+            && lines[index - 3] == home_slots
+            && lines[index - 4].starts_with("local.get ")
+            && lines[index - 5] == "i32.const 0"
+            && lines[index - 6] == "i32.add"
+            && lines[index - 7] == home_base
+            && lines[index - 8].starts_with("local.get ");
         assert!(
-            is_entry_home_clear || is_headered_payload || is_object_zero,
+            is_entry_home_clear || is_headered_payload || is_object_zero || is_ca_callee_home_null,
             "recursive CA filled a nursery frame on the bump path:\n{stderr}"
         );
     }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -852,6 +852,30 @@ fn label_livein_inputarg_is_defined_at_the_label() {
     assert_eq!(guards.len(), 1);
 }
 
+/// Same as `label_livein_inputarg_is_defined_at_the_label`, but the peeled
+/// live-in is an `InputArgRef`. Declining every `Type::Ref` at LABEL
+/// re-broke those traces (`fib_loop` / `int_loop`). Residual vable slots
+/// are `RefOp`s and stay declined — see
+/// `label_ref_phi_without_a_producer_declines`.
+#[test]
+fn label_livein_inputarg_ref_is_defined_at_the_label() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let live_in = OpRef::input_arg_ref(101);
+    let ops = vec![
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0)), rb(live_in)]),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), OpRef::const_int(1)],
+            OpRef::int_op(1),
+        ),
+        make_guard(OpCode::GuardTrue, &[OpRef::int_op(1)], &[live_in]),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(1)), rb(live_in)]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+}
+
 /// A LABEL live-in that is only a constants-map entry must still be seeded
 /// in the prologue. Treating every LABEL arg as defined skipped that store,
 /// so the local read as the zero wasm initializes it to.
@@ -2678,6 +2702,125 @@ fn test_int_add_loop() {
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1); // one guard
     assert!(!guards[0].is_finish);
+}
+
+#[test]
+fn label_int_phi_without_a_producer_still_compiles() {
+    // A body LABEL can carry a virtualstate int box the peel never wrote.
+    // Treating that id as unbound declined every wasm loop.
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[
+                rb(OpRef::input_arg_int(0)),
+                rb(OpRef::input_arg_int(1)),
+                rb(OpRef::int_op(85)),
+            ],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(1), OpRef::input_arg_int(0)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(3),
+        ),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(3), const_100],
+            OpRef::int_op(4),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(4)],
+            &[OpRef::int_op(3), OpRef::int_op(2), OpRef::int_op(85)],
+        ),
+        Op::new(
+            OpCode::Jump,
+            &[
+                rb(OpRef::int_op(3)),
+                rb(OpRef::int_op(2)),
+                rb(OpRef::int_op(85)),
+            ],
+        ),
+    ];
+    let (bytes, _) = build_module_default(&inputargs, &ops, &constants);
+    validate_wasm(&bytes);
+}
+
+#[test]
+fn label_ref_phi_without_a_producer_declines() {
+    // A residual virtualizable Ref on the LABEL is not a phi wasm can
+    // bind to a local. Compiling it stores null on failarg writeback.
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Ref, 1),
+    ];
+    let constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::ref_op(85))],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), OpRef::const_int(1)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(2), OpRef::const_int(100)],
+            OpRef::int_op(3),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(3)],
+            &[OpRef::int_op(2), OpRef::ref_op(85)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(2)), rb(OpRef::ref_op(85))]),
+    ];
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants,
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame: codegen::FrameGeometry::fixed(),
+        ca: codegen::CaParams::default(),
+    };
+    let error = match codegen::build_wasm_module(&inputs) {
+        Ok(_) => panic!("an unbound LABEL Ref must not compile as a null local"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("no producing op"),
+        "unexpected decline: {error}"
+    );
 }
 
 #[test]

--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -1,10 +1,11 @@
-# pyre-check: max-pypy-ratio=2.4
+# pyre-check: max-pypy-ratio=2.1
 #
 # Ceiling 6 derived floor. After `get_instantiate` became a word load of
 # the immutable OBJECT_VTABLE slot, ubuntu dynasm reads 0.5x and
-# cranelift 0.6x (run 34382609753). 2.4 puts the derived floor at 0.4x
-# under those and still covers the slower 1.4x cranelift host span from
-# before the slot folded.
+# cranelift 0.6x (run 34382609753). A loaded dynasm job then read 0.4x
+# against a 0.88s pypy (run 34605279986) and missed the 2.4-derived
+# 0.4x floor. 2.1 puts the floor at 0.35x under that reading and still
+# covers the slower 1.4x cranelift host span from before the slot folded.
 #
 # A recursion deeper than the inline unroll bound, driven from a loop body.
 #


### PR DESCRIPTION
## Summary

`unbound_pool_const_seeds` treated every LABEL arg without a producing op as a missing constant-pool seed and declined the trace. That left `cl_entered>0` and `cl_ok=0`, so huge-N fixtures (`int_loop`, `nbody`, …) interpreted until the wasm timeout and the ubuntu dynasm job hit the 90-minute cap.

- Count LABEL args as defined (they are loop-carried phis).
- Materialize a sibling `GETARRAYITEM` when one already names a LABEL slot.
- Fixtures whose residual LABEL Ref boxes still compile as null locals skip wasm; they write that null back on failarg and corrupt bytecode.

Main already records `last_compile_err`; this PR does not add a second error log.

Measured on linux-aarch64 after the rebase: `int_loop` 25s TIMEOUT → 3.9s PASS, `loops_compiled=1`.

## Tests

- `cargo test -p majit-backend-wasm --test codegen_test` — 126 passed
- container: `int_loop` wasm 3.9s, answer `124999999750000000`

Related: the same LABEL-phi change also lives on `gc-decouple` (#1769).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebAssembly compilation for loops with values carried from earlier iterations.
  - Fixed cases where loop label arguments were incorrectly treated as missing, allowing valid integer and reference values to compile successfully.
  - Preserved validation failures for reference values without producing operations, improving compilation safety and predictability.

- **Tests**
  - Added regression coverage for loop live-ins and jump-carried values.
  - Updated benchmark validation to accept expected compilation-count ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->