### PR TITLE
Drop redundant bitflags integer aliases

### DIFF
--- a/majit/majit-metainterp/src/heapcache.rs
+++ b/majit/majit-metainterp/src/heapcache.rs
@@ -7,6 +7,5 @@
 // path even when this crate itself does not.
 #[allow(unused_imports)]
 pub use majit_trace::heapcache::{
-    CacheEntry, FieldUpdater, HF_IS_UNESCAPED, HF_KNOWN_CLASS, HF_KNOWN_NULLITY, HF_LIKELY_VIRTUAL,
-    HF_NONSTD_VABLE, HF_SEEN_ALLOCATION, HF_VERSION_MAX, HeapCache, SameConstantOracle,
+    CacheEntry, FieldUpdater, HF_VERSION_MAX, HeapCache, HeapFlags, SameConstantOracle,
 };

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -95,19 +95,6 @@ bitflags::bitflags! {
     }
 }
 
-/// heapcache.py: HF_LIKELY_VIRTUAL
-pub const HF_LIKELY_VIRTUAL: u8 = HeapFlags::LIKELY_VIRTUAL.bits();
-/// heapcache.py: HF_KNOWN_CLASS
-pub const HF_KNOWN_CLASS: u8 = HeapFlags::KNOWN_CLASS.bits();
-/// heapcache.py: HF_KNOWN_NULLITY
-pub const HF_KNOWN_NULLITY: u8 = HeapFlags::KNOWN_NULLITY.bits();
-/// heapcache.py: HF_SEEN_ALLOCATION
-pub const HF_SEEN_ALLOCATION: u8 = HeapFlags::SEEN_ALLOCATION.bits();
-/// heapcache.py: HF_IS_UNESCAPED
-pub const HF_IS_UNESCAPED: u8 = HeapFlags::IS_UNESCAPED.bits();
-/// heapcache.py: HF_NONSTD_VABLE
-pub const HF_NONSTD_VABLE: u8 = HeapFlags::NONSTD_VABLE.bits();
-
 /// heapcache.py helper aliases.
 const HF_VERSION_INC: u32 = 0x40;
 pub const HF_VERSION_MAX: u32 = 0xffff_ffff - HF_VERSION_INC;
@@ -563,9 +550,9 @@ impl HeapCache {
         }
         let mut flags = self.head_version;
         if Self::versioned_or(old_flags, self.likely_virtual_version)
-            && (old_flags & u32::from(HF_LIKELY_VIRTUAL)) != 0
+            && (old_flags & u32::from(HeapFlags::LIKELY_VIRTUAL.bits())) != 0
         {
-            flags |= u32::from(HF_LIKELY_VIRTUAL);
+            flags |= u32::from(HeapFlags::LIKELY_VIRTUAL.bits());
         }
         self.set_flags_for_ref(opref, flags);
         // RPython: ref_frontend_op._heapc_deps = None
@@ -573,33 +560,33 @@ impl HeapCache {
     }
 
     /// RPython: _check_flag(box, flag)
-    pub fn _check_flag(&self, opref: OpRef, flag: u8) -> bool {
+    pub fn _check_flag(&self, opref: OpRef, flag: HeapFlags) -> bool {
         if !self.test_head_version(opref) {
             return false;
         }
-        (self.flags_for_ref(opref) & u32::from(flag)) != 0
+        (self.flags_for_ref(opref) & u32::from(flag.bits())) != 0
     }
 
     /// RPython: _set_flag(box, flag)
-    pub fn _set_flag(&mut self, opref: OpRef, flag: u8) {
+    pub fn _set_flag(&mut self, opref: OpRef, flag: HeapFlags) {
         if opref.is_constant() {
             return;
         }
         self.update_version(opref);
-        let flags = self.flags_for_ref(opref) | u32::from(flag);
+        let flags = self.flags_for_ref(opref) | u32::from(flag.bits());
         self.set_flags_for_ref(opref, flags);
         // Keep mirrors: boolean flags used by this Rust implementation.
         let i = opref.raw() as usize;
         match flag {
-            HF_SEEN_ALLOCATION => {
+            HeapFlags::SEEN_ALLOCATION => {
                 self.seen_allocation.insert(i);
             }
-            HF_KNOWN_CLASS => {
+            HeapFlags::KNOWN_CLASS => {
                 if i >= self.known_class.len() {
                     self.known_class.resize(i + 1, None);
                 }
             }
-            HF_KNOWN_NULLITY => {
+            HeapFlags::KNOWN_NULLITY => {
                 if i >= self.known_nullity.len() {
                     self.known_nullity.resize(i + 1, 0);
                 }
@@ -607,10 +594,10 @@ impl HeapCache {
                     self.known_nullity[i] = 1;
                 }
             }
-            HF_IS_UNESCAPED => {
+            HeapFlags::IS_UNESCAPED => {
                 self.is_unescaped.insert(i);
             }
-            HF_LIKELY_VIRTUAL => {
+            HeapFlags::LIKELY_VIRTUAL => {
                 self.likely_virtual.insert(i);
             }
             // HF_NONSTD_VABLE has no mirror — heapc_flags is the source of truth.
@@ -618,7 +605,7 @@ impl HeapCache {
         }
     }
 
-    fn _remove_flag(&mut self, opref: OpRef, flag: u8) {
+    fn _remove_flag(&mut self, opref: OpRef, flag: HeapFlags) {
         if opref.is_constant() {
             return;
         }
@@ -626,25 +613,25 @@ impl HeapCache {
         if flags == 0 {
             return;
         }
-        let updated = flags & !u32::from(flag);
+        let updated = flags & !u32::from(flag.bits());
         self.set_flags_for_ref(opref, updated);
         let i = opref.raw() as usize;
         match flag {
-            HF_IS_UNESCAPED => {
+            HeapFlags::IS_UNESCAPED => {
                 self.is_unescaped.remove(i);
             }
-            HF_LIKELY_VIRTUAL => {
+            HeapFlags::LIKELY_VIRTUAL => {
                 self.likely_virtual.remove(i);
             }
-            HF_SEEN_ALLOCATION => {
+            HeapFlags::SEEN_ALLOCATION => {
                 self.seen_allocation.remove(i);
             }
-            HF_KNOWN_NULLITY => {
+            HeapFlags::KNOWN_NULLITY => {
                 if i < self.known_nullity.len() {
                     self.known_nullity[i] = 0;
                 }
             }
-            HF_KNOWN_CLASS if i < self.known_class.len() => {
+            HeapFlags::KNOWN_CLASS if i < self.known_class.len() => {
                 self.known_class[i] = None;
             }
             _ => {}
@@ -738,8 +725,8 @@ impl HeapCache {
         // _remove_flag updates heapc_flags AND mirrors HF_IS_UNESCAPED /
         // HF_LIKELY_VIRTUAL Vec<bool> back out, so the version-gated
         // _check_flag query stays consistent.
-        self._remove_flag(opref, HF_LIKELY_VIRTUAL);
-        self._remove_flag(opref, HF_IS_UNESCAPED);
+        self._remove_flag(opref, HeapFlags::LIKELY_VIRTUAL);
+        self._remove_flag(opref, HeapFlags::IS_UNESCAPED);
         let i = opref.raw() as usize;
         let deps = self.heapc_deps.get_mut(i).and_then(Option::take);
         if let Some(deps) = deps
@@ -975,10 +962,10 @@ impl HeapCache {
         // RPython add_flags writes the bitwise OR of all four flags into the
         // versioned heapc_flags. We route through _set_flag so the Vec<bool>
         // mirrors stay in sync with heapc_flags.
-        self._set_flag(opref, HF_LIKELY_VIRTUAL);
-        self._set_flag(opref, HF_SEEN_ALLOCATION);
-        self._set_flag(opref, HF_IS_UNESCAPED);
-        self._set_flag(opref, HF_KNOWN_NULLITY);
+        self._set_flag(opref, HeapFlags::LIKELY_VIRTUAL);
+        self._set_flag(opref, HeapFlags::SEEN_ALLOCATION);
+        self._set_flag(opref, HeapFlags::IS_UNESCAPED);
+        self._set_flag(opref, HeapFlags::KNOWN_NULLITY);
     }
 
     /// heapcache.py new_array
@@ -1006,13 +993,13 @@ impl HeapCache {
         //     add_flags(box, flags)
         //     self.arraylen_now_known(box, lengthbox)
         self.update_version(opref);
-        self._set_flag(opref, HF_SEEN_ALLOCATION);
+        self._set_flag(opref, HeapFlags::SEEN_ALLOCATION);
         // RPython adds HF_KNOWN_NULLITY directly via add_flags. Route through
         // nullity_now_known so the Vec<u8> value mirror also captures non-null.
         self.nullity_now_known(opref, true);
         if length_is_const {
-            self._set_flag(opref, HF_LIKELY_VIRTUAL);
-            self._set_flag(opref, HF_IS_UNESCAPED);
+            self._set_flag(opref, HeapFlags::LIKELY_VIRTUAL);
+            self._set_flag(opref, HeapFlags::IS_UNESCAPED);
         }
         // heapcache.py: self.arraylen_now_known(box, lengthbox)
         self.arraylen_now_known(opref, lengthbox);
@@ -1025,7 +1012,8 @@ impl HeapCache {
     ///      return self._check_flag(box, HF_NONSTD_VABLE) or self._check_flag(box, HF_SEEN_ALLOCATION)
     /// ```
     pub fn is_known_nonstandard_virtualizable(&self, opref: OpRef) -> bool {
-        self._check_flag(opref, HF_NONSTD_VABLE) || self._check_flag(opref, HF_SEEN_ALLOCATION)
+        self._check_flag(opref, HeapFlags::NONSTD_VABLE)
+            || self._check_flag(opref, HeapFlags::SEEN_ALLOCATION)
     }
 
     /// heapcache.py:488-491
@@ -1040,7 +1028,7 @@ impl HeapCache {
         if opref.is_constant() {
             return;
         }
-        self._set_flag(opref, HF_NONSTD_VABLE);
+        self._set_flag(opref, HeapFlags::NONSTD_VABLE);
     }
 
     /// heapcache.py `replace_box(oldbox, newbox)`.
@@ -1090,7 +1078,7 @@ impl HeapCache {
             self.known_class[i] = Some(class);
         }
         // RPython _set_flag(box, HF_KNOWN_CLASS | HF_KNOWN_NULLITY).
-        self._set_flag(opref, HF_KNOWN_CLASS);
+        self._set_flag(opref, HeapFlags::KNOWN_CLASS);
         // RPython also writes HF_KNOWN_NULLITY in the same _set_flag call;
         // route through nullity_now_known so the Vec<u8> value mirror also
         // captures non-null.
@@ -1109,7 +1097,7 @@ impl HeapCache {
         if opref.is_constant() {
             return false;
         }
-        self._check_flag(opref, HF_KNOWN_CLASS)
+        self._check_flag(opref, HeapFlags::KNOWN_CLASS)
     }
 
     /// Get the known class of an object, if available.
@@ -1120,7 +1108,7 @@ impl HeapCache {
         if opref.is_constant() {
             return None;
         }
-        if !self._check_flag(opref, HF_KNOWN_CLASS) {
+        if !self._check_flag(opref, HeapFlags::KNOWN_CLASS) {
             return None;
         }
         // A stored class of 0 means the allocation's vtable address was unavailable at build
@@ -1186,7 +1174,7 @@ impl HeapCache {
     /// heapcache.py is_unescaped.
     ///   `return self._check_flag(box, HF_IS_UNESCAPED)`
     pub fn is_unescaped(&self, opref: OpRef) -> bool {
-        self._check_flag(opref, HF_IS_UNESCAPED)
+        self._check_flag(opref, HeapFlags::IS_UNESCAPED)
     }
 
     /// heapcache.py `CacheEntry._seen_alloc(box)`:
@@ -1197,7 +1185,7 @@ impl HeapCache {
     ///  return self.heapcache._check_flag(ref_box, HF_SEEN_ALLOCATION)
     /// ```
     pub fn saw_allocation(&self, opref: OpRef) -> bool {
-        self._check_flag(opref, HF_SEEN_ALLOCATION)
+        self._check_flag(opref, HeapFlags::SEEN_ALLOCATION)
     }
 
     /// Notify the cache about an operation, potentially invalidating entries.
@@ -1949,7 +1937,7 @@ impl HeapCache {
         }
         self.known_nullity[i] = if is_nonnull { 1 } else { 2 };
         // RPython _set_flag(box, HF_KNOWN_NULLITY).
-        self._set_flag(opref, HF_KNOWN_NULLITY);
+        self._set_flag(opref, HeapFlags::KNOWN_NULLITY);
     }
 
     /// Check if a value's nullity is known.
@@ -1972,7 +1960,7 @@ impl HeapCache {
         // heapcache.py: return self._check_flag(box, HF_KNOWN_NULLITY).
         // Version-gated so a stale `known_nullity` Vec entry from before
         // the last reset_keep_likely_virtuals does not leak through.
-        if !self._check_flag(opref, HF_KNOWN_NULLITY) {
+        if !self._check_flag(opref, HeapFlags::KNOWN_NULLITY) {
             return None;
         }
         self.known_nullity
@@ -2054,7 +2042,7 @@ impl HeapCache {
             return false;
         }
         let f = self.flags_for_ref(opref);
-        (f as u8) & HF_LIKELY_VIRTUAL != 0
+        (f as u8) & HeapFlags::LIKELY_VIRTUAL.bits() != 0
     }
 
     // ── Loop-invariant call result caching ──

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -3920,7 +3920,7 @@ mod tests {
     #[test]
     fn function_desc_buildgraph_surfaces_flow_error_from_objspace() {
         use crate::flowspace::bytecode::HostCode;
-        use crate::flowspace::objspace::CO_NEWLOCALS;
+        use crate::flowspace::objspace::CoFlags;
 
         let ann = crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
         let mut func = crate::flowspace::model::GraphFunc::new(
@@ -3935,7 +3935,7 @@ mod tests {
             co_nlocals: 0,
             co_argcount: 0,
             co_stacksize: 0,
-            co_flags: CO_NEWLOCALS,
+            co_flags: CoFlags::NEWLOCALS.bits(),
             co_code: rustpython_compiler_core::bytecode::CodeUnits::from(Vec::new()),
             co_varnames: Vec::new(),
             co_freevars: Vec::new(),

--- a/majit/majit-translate/src/flowspace/bytecode.rs
+++ b/majit/majit-translate/src/flowspace/bytecode.rs
@@ -54,24 +54,15 @@ impl core::fmt::Display for BytecodeCorruption {
 
 impl std::error::Error for BytecodeCorruption {}
 
-/// RPython: `bytecode.py:CO_NEWLOCALS` (0x0002).
-pub const CO_NEWLOCALS: u32 = 0x0002;
-/// RPython: `bytecode.py:CO_VARARGS` (0x0004).
-pub const CO_VARARGS: u32 = 0x0004;
-/// RPython: `bytecode.py:CO_VARKEYWORDS` (0x0008).
-pub const CO_VARKEYWORDS: u32 = 0x0008;
-/// RPython: `bytecode.py:CO_GENERATOR` (0x0020).
-pub const CO_GENERATOR: u32 = 0x0020;
-
 bitflags::bitflags! {
     /// RPython `bytecode.py` `CO_*` compile flags.
     #[repr(transparent)]
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     pub struct CoFlags: u32 {
-        const NEWLOCALS = CO_NEWLOCALS;
-        const VARARGS = CO_VARARGS;
-        const VARKEYWORDS = CO_VARKEYWORDS;
-        const GENERATOR = CO_GENERATOR;
+        const NEWLOCALS = 0x0002;
+        const VARARGS = 0x0004;
+        const VARKEYWORDS = 0x0008;
+        const GENERATOR = 0x0020;
     }
 }
 
@@ -81,14 +72,14 @@ bitflags::bitflags! {
 pub fn cpython_code_signature(code: &HostCode) -> Signature {
     let mut argcount = code.co_argcount as usize;
     let argnames: Vec<String> = code.co_varnames.iter().take(argcount).cloned().collect();
-    let varargname = if code.co_flags & CO_VARARGS != 0 {
+    let varargname = if code.co_flags & CoFlags::VARARGS.bits() != 0 {
         let name = code.co_varnames[argcount].clone();
         argcount += 1;
         Some(name)
     } else {
         None
     };
-    let kwargname = if code.co_flags & CO_VARKEYWORDS != 0 {
+    let kwargname = if code.co_flags & CoFlags::VARKEYWORDS.bits() != 0 {
         let name = code.co_varnames[argcount].clone();
         Some(name)
     } else {
@@ -252,7 +243,7 @@ impl HostCode {
 
     /// RPython: `HostCode.is_generator`.
     pub fn is_generator(&self) -> bool {
-        self.co_flags & CO_GENERATOR != 0
+        self.co_flags & CoFlags::GENERATOR.bits() != 0
     }
 
     /// Find the exception-table handler covering the given byte offset.

--- a/majit/majit-translate/src/flowspace/generator.rs
+++ b/majit/majit-translate/src/flowspace/generator.rs
@@ -616,7 +616,7 @@ mod tests {
             co_nlocals: 1,
             co_argcount: 1,
             co_stacksize: 0,
-            co_flags: super::super::objspace::CO_NEWLOCALS,
+            co_flags: super::super::objspace::CoFlags::NEWLOCALS.bits(),
             co_code: rustpython_compiler_core::bytecode::CodeUnits::from(Vec::new()),
             co_varnames: vec!["x".to_string()],
             co_freevars: Vec::new(),

--- a/majit/majit-translate/src/flowspace/objspace.rs
+++ b/majit/majit-translate/src/flowspace/objspace.rs
@@ -29,7 +29,7 @@ use super::pygraph::PyGraph;
 /// RPython `CO_NEWLOCALS` compile flag (0x0002). Used to verify that a
 /// code object allocates its own `f_locals` dict rather than sharing
 /// the caller's — RPython functions must always set this.
-pub const CO_NEWLOCALS: u32 = super::bytecode::CO_NEWLOCALS;
+pub use super::bytecode::CoFlags;
 
 /// RPython `objspace.py` — `_assert_rpythonic(func)`.
 ///
@@ -91,7 +91,7 @@ fn _assert_rpythonic(func: &GraphFunc) -> Result<(), FlowContextError> {
     }
 
     // upstream line 33-35: `if not (func.__code__.co_flags & CO_NEWLOCALS)`.
-    if code.co_flags & CO_NEWLOCALS == 0 {
+    if code.co_flags & CoFlags::NEWLOCALS.bits() == 0 {
         return Err(FlowContextError::Flowing(
             super::flowcontext::FlowingError::new(
                 "The code object for a RPython function should have \
@@ -145,7 +145,7 @@ pub fn build_flow(func: GraphFunc) -> Result<FunctionGraph, FlowContextError> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::bytecode::CO_GENERATOR;
+    use super::super::bytecode::CoFlags;
     use super::super::model::{ConstValue, Constant};
     use super::*;
 
@@ -172,7 +172,7 @@ mod tests {
         // attach a dummy HostCode with CO_NEWLOCALS set so co_cellvars
         // is the check that fires first.
         let mut code = make_empty_host_code();
-        code.co_flags = CO_NEWLOCALS;
+        code.co_flags = CoFlags::NEWLOCALS.bits();
         code.co_cellvars.push("x".to_string());
         func.code = Some(Box::new(code));
 
@@ -189,7 +189,7 @@ mod tests {
     fn assert_rpythonic_rejects_not_rpython_marker() {
         let mut func = GraphFunc::new("marked", empty_globals());
         let mut code = make_empty_host_code();
-        code.co_flags = CO_NEWLOCALS;
+        code.co_flags = CoFlags::NEWLOCALS.bits();
         func.code = Some(Box::new(code));
         func.not_rpython = true;
 
@@ -206,7 +206,7 @@ mod tests {
     fn assert_rpythonic_rejects_not_rpython_docstring() {
         let mut func = GraphFunc::new("doc", empty_globals());
         let mut code = make_empty_host_code();
-        code.co_flags = CO_NEWLOCALS;
+        code.co_flags = CoFlags::NEWLOCALS.bits();
         code.consts.push(ConstantData::Str {
             value: "NOT_RPYTHON: skip me".to_string().into(),
         });
@@ -241,7 +241,7 @@ mod tests {
     fn build_flow_bootstraps_generator_entry_graph() {
         let mut func = GraphFunc::new("gen", empty_globals());
         let mut code = make_empty_host_code();
-        code.co_flags = CO_NEWLOCALS | CO_GENERATOR;
+        code.co_flags = CoFlags::NEWLOCALS.bits() | CoFlags::GENERATOR.bits();
         func.code = Some(Box::new(code));
 
         let graph = build_flow(func).expect("generator bootstrap graph");

--- a/majit/majit-translate/src/tool/sourcetools.rs
+++ b/majit/majit-translate/src/tool/sourcetools.rs
@@ -66,16 +66,6 @@ pub const CO_VARARGS: u32 = 0x0004;
 /// RPython `CO_VARKEYWORDS` (`sourcetools.py`).
 pub const CO_VARKEYWORDS: u32 = 0x0008;
 
-bitflags::bitflags! {
-    /// RPython `sourcetools.py` `CO_*` compile flags.
-    #[repr(transparent)]
-    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-    pub struct CoFlags: u32 {
-        const VARARGS = CO_VARARGS;
-        const VARKEYWORDS = CO_VARKEYWORDS;
-    }
-}
-
 /// RPython `has_varargs(func)` for callers that already have
 /// `co_flags` (`sourcetools.py:250-252`).
 pub fn has_varargs_flags(co_flags: u32) -> bool {

--- a/majit/majit-translate/src/tool/sourcetools.rs
+++ b/majit/majit-translate/src/tool/sourcetools.rs
@@ -7,7 +7,7 @@
 //! helper surface onto `GraphFunc` / `HostObject` where the surrounding
 //! translator can carry equivalent metadata.
 
-use crate::flowspace::bytecode::HostCode;
+use crate::flowspace::bytecode::{CoFlags, HostCode};
 use crate::flowspace::model::{Constant, GraphFunc, HostObject};
 
 /// RPython `sourcetools.render_docstr(func, indent_str='',
@@ -61,21 +61,16 @@ pub fn valid_identifier(stuff: impl std::fmt::Display) -> String {
     stuff
 }
 
-/// RPython `CO_VARARGS` (`sourcetools.py`).
-pub const CO_VARARGS: u32 = 0x0004;
-/// RPython `CO_VARKEYWORDS` (`sourcetools.py`).
-pub const CO_VARKEYWORDS: u32 = 0x0008;
-
 /// RPython `has_varargs(func)` for callers that already have
 /// `co_flags` (`sourcetools.py:250-252`).
 pub fn has_varargs_flags(co_flags: u32) -> bool {
-    (co_flags & CO_VARARGS) != 0
+    (co_flags & CoFlags::VARARGS.bits()) != 0
 }
 
 /// RPython `has_varkeywords(func)` for callers that already have
 /// `co_flags` (`sourcetools.py:254-256`).
 pub fn has_varkeywords_flags(co_flags: u32) -> bool {
-    (co_flags & CO_VARKEYWORDS) != 0
+    (co_flags & CoFlags::VARKEYWORDS.bits()) != 0
 }
 
 /// RPython `has_varargs(func)` (`sourcetools.py`). Upstream
@@ -252,9 +247,9 @@ mod tests {
 
     #[test]
     fn vararg_flag_helpers_match_upstream_masks() {
-        assert!(has_varargs_flags(CO_VARARGS));
-        assert!(has_varkeywords_flags(CO_VARKEYWORDS));
-        assert!(!has_varargs_flags(CO_VARKEYWORDS));
+        assert!(has_varargs_flags(CoFlags::VARARGS.bits()));
+        assert!(has_varkeywords_flags(CoFlags::VARKEYWORDS.bits()));
+        assert!(!has_varargs_flags(CoFlags::VARKEYWORDS.bits()));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/translator.rs
+++ b/majit/majit-translate/src/translator/translator.rs
@@ -592,7 +592,7 @@ mod tests {
             co_nlocals: argnames.len() as u32,
             co_argcount: argnames.len() as u32,
             co_stacksize: 0,
-            co_flags: crate::flowspace::objspace::CO_NEWLOCALS,
+            co_flags: crate::flowspace::objspace::CoFlags::NEWLOCALS.bits(),
             co_code: rustpython_compiler_core::bytecode::CodeUnits::from(Vec::new()),
             co_varnames: argnames.iter().map(|arg| (*arg).to_string()).collect(),
             co_freevars: Vec::new(),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1237,7 +1237,9 @@ pub fn builtin_code_call_positional(
         // parameter also has HOPELESS fast arity; bypassing the binder let
         // excess positionals reach the typed wrapper, which consumes its
         // declared prefix and silently ignores the rest.
-        if unsafe { crate::builtin_code_get_fast_natural_arity(current_code) } == crate::HOPELESS {
+        if unsafe { crate::builtin_code_get_fast_natural_arity(current_code) }
+            == crate::BuiltinCodeFlags::HOPELESS.bits()
+        {
             // `descr_check` before the binder: binding reports a surplus
             // positional or an unknown keyword, and upstream reaches neither
             // until the receiver has answered for itself.

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -4360,14 +4360,14 @@ fn install_protocols(ns: PyObjectRef, tp: *mut CPyTypeObject) {
         publish(
             ns,
             "__pow__",
-            crate::gateway::HOPELESS,
+            crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
             power_slot,
             nb_pow_direct,
         );
         publish(
             ns,
             "__rpow__",
-            crate::gateway::HOPELESS,
+            crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
             power_slot,
             nb_pow_reflected,
         );
@@ -4377,7 +4377,7 @@ fn install_protocols(ns: PyObjectRef, tp: *mut CPyTypeObject) {
         publish(
             ns,
             "__ipow__",
-            crate::gateway::HOPELESS,
+            crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
             inplace_power,
             nb_ipow,
         );
@@ -4818,10 +4818,15 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
     // very name this would publish.
     let scalars: [(&'static str, u16, *const c_void, WrapperFn); 13] = unsafe {
         [
-            ("__new__", crate::gateway::HOPELESS, (*tp).tp_new, slot_new),
+            (
+                "__new__",
+                crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
+                (*tp).tp_new,
+                slot_new,
+            ),
             (
                 "__init__",
-                crate::gateway::HOPELESS,
+                crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
                 (*tp).tp_init,
                 slot_init,
             ),
@@ -4832,7 +4837,7 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
             ("__hash__", 1, (*tp).tp_hash, slot_hash),
             (
                 "__call__",
-                crate::gateway::HOPELESS,
+                crate::gateway::BuiltinCodeFlags::HOPELESS.bits(),
                 (*tp).tp_call,
                 slot_call,
             ),

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3837,8 +3837,8 @@ pub fn funccall_valuestack(
     // baseobjspace.py:1243 — skip when profiling (c_call/c_return events)
     if natural_arity_call && nargs <= 4 && !frame.get_is_being_profiled() {
         debug_assert!(
-            (fast_natural_arity & crate::FLATPYCALL as usize) == 0,
-            "FLATPYCALL bit set on arity {fast_natural_arity} — not a builtin code"
+            (fast_natural_arity & crate::BuiltinCodeFlags::FLATPYCALL.bits() as usize) == 0,
+            "BuiltinCodeFlags::FLATPYCALL.bits() bit set on arity {fast_natural_arity} — not a builtin code"
         );
         // function.py:154-184 — BuiltinCodeN.fastcall_N dispatch.
         // RPython translation keeps the BuiltinCode and each peeked argument
@@ -3901,12 +3901,16 @@ pub fn funccall_valuestack(
     }
 
     // function.py:185-187 — (nargs | FLATPYCALL) == fast_natural_arity
-    if !natural_arity_call && (nargs | crate::FLATPYCALL as usize) == fast_natural_arity {
+    if !natural_arity_call
+        && (nargs | crate::BuiltinCodeFlags::FLATPYCALL.bits() as usize) == fast_natural_arity
+    {
         return _flat_pycall(func, code, nargs, frame, dropvalues);
     }
 
     // function.py:188-193 — FLATPYCALL bit set + nargs within defaults range
-    if !natural_arity_call && (fast_natural_arity & crate::FLATPYCALL as usize) != 0 {
+    if !natural_arity_call
+        && (fast_natural_arity & crate::BuiltinCodeFlags::FLATPYCALL.bits() as usize) != 0
+    {
         let natural_arity = fast_natural_arity & 0xff;
         if nargs < natural_arity {
             let raw_defs = unsafe { crate::function_get_defaults(func) };
@@ -3937,7 +3941,10 @@ pub fn funccall_valuestack(
     // single BuiltinCodeFn signature already takes a flat slice, so the
     // peek/Arguments split is structural — the final closure invocation
     // sees `[w_obj, ...rest]` exactly as PyPy's post-merge args_w.
-    if !natural_arity_call && fast_natural_arity == crate::PASSTHROUGHARGS1 as usize && nargs >= 1 {
+    if !natural_arity_call
+        && fast_natural_arity == crate::BuiltinCodeFlags::PASSTHROUGHARGS1.bits() as usize
+        && nargs >= 1
+    {
         let w_obj = frame.peekvalue(nargs - 1);
         let rest = frame.make_arguments(nargs - 1, false, func);
         // Same live-variable set as the fixed-arity arm above, for the same

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -876,13 +876,6 @@ bitflags::bitflags! {
     }
 }
 
-/// eval.py:16 — `FLATPYCALL = 0x100`.
-pub const FLATPYCALL: u16 = BuiltinCodeFlags::FLATPYCALL.bits();
-/// eval.py — `PASSTHROUGHARGS1 = 0x200`.
-pub const PASSTHROUGHARGS1: u16 = BuiltinCodeFlags::PASSTHROUGHARGS1.bits();
-/// eval.py — `HOPELESS = 0x400`. Default for code that cannot fast-path.
-pub const HOPELESS: u16 = BuiltinCodeFlags::HOPELESS.bits();
-
 /// Allocate a new `BuiltinCode` with no docstring.
 /// `fast_natural_arity` defaults to HOPELESS (no fast path).
 pub fn builtin_code_new(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
@@ -913,7 +906,13 @@ pub fn builtin_code_new_with_doc(
     func: BuiltinCodeFn,
     docstring: Option<&'static str>,
 ) -> PyObjectRef {
-    builtin_code_new_full(name, func, docstring, HOPELESS, std::ptr::null())
+    builtin_code_new_full(
+        name,
+        func,
+        docstring,
+        BuiltinCodeFlags::HOPELESS.bits(),
+        std::ptr::null(),
+    )
 }
 
 /// Allocate a new `BuiltinCode` with `fast_natural_arity = PASSTHROUGHARGS1`.
@@ -926,7 +925,13 @@ pub fn builtin_code_new_with_doc(
 /// `function.rs:funccall_valuestack` peeks `args[0]` separately to mirror
 /// `function.py:194-199`, but the closure still receives `[w_obj, ...rest]`.
 pub fn builtin_code_new_passthrough_args1(name: &'static str, func: BuiltinCodeFn) -> PyObjectRef {
-    builtin_code_new_full(name, func, None, PASSTHROUGHARGS1, std::ptr::null())
+    builtin_code_new_full(
+        name,
+        func,
+        None,
+        BuiltinCodeFlags::PASSTHROUGHARGS1.bits(),
+        std::ptr::null(),
+    )
 }
 
 /// Full constructor for `BuiltinCode`.  `sig` is a `*const Signature`
@@ -1007,7 +1012,13 @@ pub fn builtin_code_new_with_signature(
     signature: Signature,
 ) -> PyObjectRef {
     let sig: *const Signature = Box::into_raw(Box::new(signature));
-    builtin_code_new_full(name, func, docstring, HOPELESS, sig)
+    builtin_code_new_full(
+        name,
+        func,
+        docstring,
+        BuiltinCodeFlags::HOPELESS.bits(),
+        sig,
+    )
 }
 
 /// Check if an object is a built-in function.
@@ -1197,7 +1208,7 @@ pub unsafe fn builtin_code_call(
     // count above the fast-path ceiling is rejected here too; only the
     // `FLATPYCALL` / `PASSTHROUGHARGS1` / `HOPELESS` markers, whose bodies read
     // the raw slice themselves, are left to do their own checking.
-    if arity < FLATPYCALL as usize
+    if arity < BuiltinCodeFlags::FLATPYCALL.bits() as usize
         && unsafe { (*code).sig.is_null() }
         && crate::builtins::has_real_kwargs(kwargs)
     {
@@ -1757,7 +1768,9 @@ pub fn make_builtin_function_with_arity_and_maybe_sig(
     signature: Option<Signature>,
 ) -> PyObjectRef {
     let arity = match &signature {
-        Some(s) if s.has_vararg() || s.has_kwarg() || s.num_kwonlyargnames() > 0 => HOPELESS,
+        Some(s) if s.has_vararg() || s.has_kwarg() || s.num_kwonlyargnames() > 0 => {
+            BuiltinCodeFlags::HOPELESS.bits()
+        }
         _ => arity,
     };
     let sig: *const Signature = match signature {
@@ -1972,7 +1985,7 @@ pub fn make_module_builtin_function_with_arity_and_sig(
 ) -> PyObjectRef {
     let arity =
         if signature.has_vararg() || signature.has_kwarg() || signature.num_kwonlyargnames() > 0 {
-            HOPELESS
+            BuiltinCodeFlags::HOPELESS.bits()
         } else {
             arity
         };
@@ -1998,7 +2011,9 @@ pub fn make_module_builtin_function_with_arity_and_maybe_sig(
     signature: Option<Signature>,
 ) -> PyObjectRef {
     let arity = match &signature {
-        Some(s) if s.has_vararg() || s.has_kwarg() || s.num_kwonlyargnames() > 0 => HOPELESS,
+        Some(s) if s.has_vararg() || s.has_kwarg() || s.num_kwonlyargnames() > 0 => {
+            BuiltinCodeFlags::HOPELESS.bits()
+        }
         _ => arity,
     };
     let sig: *const Signature = match signature {

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -907,10 +907,10 @@ pub use error::*;
 pub use executioncontext::*;
 pub use function::*;
 pub use gateway::{
-    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, FLATPYCALL, HOPELESS, MethodOwner,
-    PASSTHROUGHARGS1, Signature, SignatureBuilder, builtin_code_call, builtin_code_get,
-    builtin_code_get_fast_natural_arity, builtin_code_get_signature, builtin_code_name,
-    builtin_code_new, builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
+    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFlags, BuiltinCodeFn, MethodOwner, Signature,
+    SignatureBuilder, builtin_code_call, builtin_code_get, builtin_code_get_fast_natural_arity,
+    builtin_code_get_signature, builtin_code_name, builtin_code_new,
+    builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
     builtin_code_new_with_signature, builtin_code_no_keyword_arguments, is_builtin_code,
     make_builtin_function, make_builtin_function_as_builtin_with_signature,
     make_builtin_function_maybe_sig, make_builtin_function_passthrough_args1,

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ccallback.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ccallback.rs
@@ -156,7 +156,7 @@ pub fn make_callback(
     let fresult = ctypeobj::ctype_arg(functype.ctitem)?;
     let error_size = if fresult.size < 0 {
         0
-    } else if fresult.has(ctypeobj::F_PRIMITIVE_INTEGER)
+    } else if fresult.has(ctypeobj::CTypeFlags::PRIMITIVE_INTEGER)
         && (fresult.size as usize) < SIZE_OF_FFI_ARG
     {
         SIZE_OF_FFI_ARG
@@ -305,8 +305,8 @@ unsafe fn convert_from_object_fficallback(
         return Ok(());
     }
     let small_result = fresult.size >= 0 && (fresult.size as usize) < SIZE_OF_FFI_ARG;
-    if small_result && fresult.has(ctypeobj::F_PRIMITIVE_INTEGER) {
-        if fresult.kind == ctypeobj::KIND_PRIM_SIGNED && !fresult.has(ctypeobj::F_ENUM) {
+    if small_result && fresult.has(ctypeobj::CTypeFlags::PRIMITIVE_INTEGER) {
+        if fresult.kind == ctypeobj::KIND_PRIM_SIGNED && !fresult.has(ctypeobj::CTypeFlags::ENUM) {
             unsafe { ctypeobj::convert_from_object(fresult, ll_res as usize, w_res)? };
             let value = super::misc::as_long(w_res)?;
             return unsafe {

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cdataobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cdataobj.rs
@@ -1341,7 +1341,7 @@ fn cdata_sub(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let item_size = ctypeobj::ctype_at(other_ct.ctitem).map_or(-1, |it| it.size);
     if !std::ptr::eq(self_ct as *const W_CType, other_ct as *const W_CType)
         || other_ct.kind != ctypeobj::KIND_POINTER
-        || (item_size <= 0 && !other_ct.has(ctypeobj::F_VOID_PTR))
+        || (item_size <= 0 && !other_ct.has(ctypeobj::CTypeFlags::VOID_PTR))
     {
         return Err(PyError::type_error(format!(
             "cannot subtract cdata '{}' and cdata '{}'",
@@ -1383,7 +1383,7 @@ pub fn cdata_sizeof(w_cdata: PyObjectRef) -> Result<i64, PyError> {
 pub fn unpack(w_cdata: PyObjectRef, length: i64) -> Result<PyObjectRef, PyError> {
     let cdata = cdata_arg(w_cdata)?;
     let ct = cdata.ctype_ref()?;
-    if !ct.has(ctypeobj::F_NONFUNC_POINTER_OR_ARRAY) {
+    if !ct.has(ctypeobj::CTypeFlags::NONFUNC_POINTER_OR_ARRAY) {
         return Err(PyError::type_error(format!(
             "expected a pointer or array, got '{}'",
             ct.name()

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cdlopen.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cdlopen.rs
@@ -230,7 +230,11 @@ pub fn ffiobj_init(
             target.type_index = decoder.next_4bytes()?;
             target.flags = decoder.next_4bytes()?;
             target.name = decoder.next_name()?;
-            if target.flags & (parse_c_type::F_OPAQUE | parse_c_type::F_EXTERNAL) != 0 {
+            if target.flags
+                & (parse_c_type::CffiTypeFlags::OPAQUE | parse_c_type::CffiTypeFlags::EXTERNAL)
+                    .bits()
+                != 0
+            {
                 target.size = usize::MAX;
                 target.alignment = -1;
                 target.first_field_index = -1;

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeenum.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeenum.rs
@@ -2,7 +2,7 @@
 //!
 //! `_Mixin_Enum` mixes into `W_CTypePrimitiveSigned` and
 //! `W_CTypePrimitiveUnsigned`, so an enum ctype keeps their kind and adds
-//! only the two enumerator maps; [`ctypeobj::F_ENUM`] is what selects the
+//! only the two enumerator maps; [`ctypeobj::CTypeFlags::ENUM`] is what selects the
 //! mixin's overrides.
 
 use crate::PyError;

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypefunc.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypefunc.rs
@@ -410,7 +410,7 @@ pub(crate) mod cif {
             // out differently from the one the C compiler saw, and the calling
             // convention depends on the fields; so may an anonymous nested
             // struct, whose origin is no longer recorded here.
-            if ct.has(ctypeobj::F_CUSTOM_FIELD_POS) {
+            if ct.has(ctypeobj::CTypeFlags::CUSTOM_FIELD_POS) {
                 return Err(unsupported(
                     ct,
                     is_result,
@@ -419,7 +419,7 @@ pub(crate) mod cif {
                     "It is a struct declared with \"...;\", but the C calling convention may depend on the missing fields; or, it contains anonymous struct/unions".to_string(),
                 ));
             }
-            if ct.has(ctypeobj::F_WITH_PACKED_CHANGE) {
+            if ct.has(ctypeobj::CTypeFlags::WITH_PACKED_CHANGE) {
                 return Err(unsupported(
                     ct,
                     is_result,

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
@@ -71,42 +71,6 @@ bitflags::bitflags! {
     }
 }
 
-/// `W_CType.is_primitive_integer`.
-pub const F_PRIMITIVE_INTEGER: i64 = CTypeFlags::PRIMITIVE_INTEGER.bits();
-/// `W_CType.is_nonfunc_pointer_or_array`.
-pub const F_NONFUNC_POINTER_OR_ARRAY: i64 = CTypeFlags::NONFUNC_POINTER_OR_ARRAY.bits();
-/// `W_CTypePtrOrArray.accept_str`.
-pub const F_ACCEPT_STR: i64 = CTypeFlags::ACCEPT_STR.bits();
-/// `W_CTypePtrBase.is_void_ptr`.
-pub const F_VOID_PTR: i64 = CTypeFlags::VOID_PTR.bits();
-/// `W_CTypePtrBase.is_voidchar_ptr`.
-pub const F_VOIDCHAR_PTR: i64 = CTypeFlags::VOIDCHAR_PTR.bits();
-/// `W_CTypePtrBase.is_onebyte_ptr`.
-pub const F_ONEBYTE_PTR: i64 = CTypeFlags::ONEBYTE_PTR.bits();
-/// `W_CTypePointer.is_file`.
-pub const F_FILE_PTR: i64 = CTypeFlags::FILE_PTR.bits();
-/// `W_CTypePrimitiveSigned.value_fits_long` /
-/// `W_CTypePrimitiveUnsigned.value_fits_long`.
-pub const F_VALUE_FITS_LONG: i64 = CTypeFlags::VALUE_FITS_LONG.bits();
-/// `W_CTypePrimitiveSigned.value_smaller_than_long`.
-pub const F_VALUE_SMALLER_THAN_LONG: i64 = CTypeFlags::VALUE_SMALLER_THAN_LONG.bits();
-/// `W_CTypePrimitiveUnsigned.value_fits_ulong`.
-pub const F_VALUE_FITS_ULONG: i64 = CTypeFlags::VALUE_FITS_ULONG.bits();
-/// `W_CTypePrimitiveUniChar.is_signed_wchar`.
-pub const F_SIGNED_WCHAR: i64 = CTypeFlags::SIGNED_WCHAR.bits();
-/// `W_CTypeFunc.ellipsis`.
-pub const F_ELLIPSIS: i64 = CTypeFlags::ELLIPSIS.bits();
-/// The ctype is `ctypeenum.py W_CTypeEnumSigned` or `W_CTypeEnumUnsigned`.
-/// `_Mixin_Enum` mixes into the primitive signed and unsigned classes, so an
-/// enum keeps their kind and only adds the two enumerator maps.
-pub const F_ENUM: i64 = CTypeFlags::ENUM.bits();
-/// `W_CTypeStructOrUnion._custom_field_pos`.
-pub const F_CUSTOM_FIELD_POS: i64 = CTypeFlags::CUSTOM_FIELD_POS.bits();
-/// `W_CTypeStructOrUnion._with_var_array`.
-pub const F_WITH_VAR_ARRAY: i64 = CTypeFlags::WITH_VAR_ARRAY.bits();
-/// `W_CTypeStructOrUnion._with_packed_change`.
-pub const F_WITH_PACKED_CHANGE: i64 = CTypeFlags::WITH_PACKED_CHANGE.bits();
-
 /// `ctypeobj.py W_CType` and the RPython subclasses that share its typedef.
 ///
 /// `UniqueCache` keeps primitive/singleton ctypes strongly and reaches derived
@@ -151,7 +115,7 @@ pub struct W_CType {
     pub ctptr: PyObjectRef,
     /// `W_CTypeArray.length` — -1 for `int[]` and for anything not an array.
     pub length: i64,
-    /// The `F_*` class attributes above.
+    /// Packed [`CTypeFlags`].
     pub flags: i64,
     /// `W_CTypeFunc.fargs` — the argument ctypes, as a tuple.  `PY_NULL` on
     /// every other kind.
@@ -188,8 +152,8 @@ impl W_CType {
         self.name
     }
 
-    pub fn has(&self, flag: i64) -> bool {
-        self.flags & flag != 0
+    pub fn has(&self, flag: CTypeFlags) -> bool {
+        self.flags & flag.bits() != 0
     }
 
     /// The ctype as the object it is; every ctype is allocated non-moving, so
@@ -218,7 +182,7 @@ impl W_CType {
 
     /// `isinstance(ct, W_CTypePtrOrArray)`.  A function ctype answers yes:
     /// `W_CTypeFunc` is a `W_CTypePtrBase`, which is a `W_CTypePtrOrArray`.
-    /// The predicate that excludes it is `F_NONFUNC_POINTER_OR_ARRAY`.
+    /// The predicate that excludes it is `CTypeFlags::NONFUNC_POINTER_OR_ARRAY`.
     pub fn is_ptr_or_array(&self) -> bool {
         self.kind == KIND_POINTER || self.kind == KIND_ARRAY || self.kind == KIND_FUNC
     }
@@ -254,14 +218,14 @@ impl W_CType {
     /// `W_CTypePtrOrArray.is_unichar_ptr_or_array`, which `W_CTypeFunc`
     /// overrides to false.
     pub fn is_unichar_ptr_or_array(&self) -> bool {
-        self.has(F_NONFUNC_POINTER_OR_ARRAY)
+        self.has(CTypeFlags::NONFUNC_POINTER_OR_ARRAY)
             && ctype_at(self.ctitem).is_some_and(|it| it.kind == KIND_PRIM_UNICHAR)
     }
 
     /// `W_CTypePtrOrArray.is_char_or_unichar_ptr_or_array`, which
     /// `W_CTypeFunc` overrides to false.
     pub fn is_char_or_unichar_ptr_or_array(&self) -> bool {
-        self.has(F_NONFUNC_POINTER_OR_ARRAY)
+        self.has(CTypeFlags::NONFUNC_POINTER_OR_ARRAY)
             && ctype_at(self.ctitem).is_some_and(|it| it.is_char_or_unichar())
     }
 
@@ -345,7 +309,7 @@ impl W_CType {
         if self.kind == KIND_PRIM_LONGDOUBLE {
             return Ok(unsafe { super::misc::longdouble2str(cdata) });
         }
-        if self.has(F_ENUM) {
+        if self.has(CTypeFlags::ENUM) {
             return unsafe { super::ctypeenum::extra_repr(self, cdata) };
         }
         if self.is_primitive() {
@@ -659,7 +623,9 @@ pub fn string(w_cdata: PyObjectRef, maxlen: i64) -> Result<PyObjectRef, PyError>
     let ct = ctype_of(cdata).ok_or_else(|| PyError::type_error("expected a cdata object"))?;
     match ct.kind {
         KIND_POINTER | KIND_ARRAY => super::ctypeptr::string(w_cdata, maxlen),
-        _ if ct.has(F_ENUM) => unsafe { super::ctypeenum::string(ct, cdata.ptr as *const u8) },
+        _ if ct.has(CTypeFlags::ENUM) => unsafe {
+            super::ctypeenum::string(ct, cdata.ptr as *const u8)
+        },
         _ if ct.is_primitive() => super::ctypeprim::string(w_cdata, maxlen),
         _ => Err(unexpected_string_argument(ct)),
     }
@@ -887,12 +853,14 @@ fn fget(w_self: PyObjectRef, attrchar: char) -> Result<PyObjectRef, PyError> {
         // `W_CTypeFunc._fget`.
         'a' if ct.kind == KIND_FUNC => Ok(ct.fargs),
         'r' if ct.kind == KIND_FUNC => Ok(ct.ctitem),
-        'E' if ct.kind == KIND_FUNC => Ok(pyre_object::boolobject::w_bool_from(ct.has(F_ELLIPSIS))),
+        'E' if ct.kind == KIND_FUNC => Ok(pyre_object::boolobject::w_bool_from(
+            ct.has(CTypeFlags::ELLIPSIS),
+        )),
         'A' if ct.kind == KIND_FUNC => Ok(pyre_object::w_int_new(ct.abi)),
         // `_Mixin_Enum._fget` builds a fresh dict on each read, so the two
         // maps a ctype holds stay its own.
-        'e' if ct.has(F_ENUM) => super::ctypeenum::copy_map(ct.enumvalues2erators),
-        'R' if ct.has(F_ENUM) => super::ctypeenum::copy_map(ct.enumerators2values),
+        'e' if ct.has(CTypeFlags::ENUM) => super::ctypeenum::copy_map(ct.enumvalues2erators),
+        'R' if ct.has(CTypeFlags::ENUM) => super::ctypeenum::copy_map(ct.enumerators2values),
         _ => Err(PyError::attribute_error(format!(
             "ctype '{}' has no such attribute",
             ct.name()
@@ -909,7 +877,7 @@ pub fn kind_name(ct: &W_CType) -> &'static str {
         KIND_STRUCT => "struct",
         KIND_UNION => "union",
         KIND_FUNC => "function",
-        _ if ct.has(F_ENUM) => "enum",
+        _ if ct.has(CTypeFlags::ENUM) => "enum",
         _ => "primitive",
     }
 }

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeprim.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeprim.rs
@@ -103,7 +103,7 @@ pub unsafe fn convert_from_object(
                 let ob_slot = roots.base();
                 let _ = roots.pin_root(w_ob);
                 let value = misc::as_long(roots.get(ob_slot))?;
-                if ct.has(ctypeobj::F_VALUE_SMALLER_THAN_LONG)
+                if ct.has(ctypeobj::CTypeFlags::VALUE_SMALLER_THAN_LONG)
                     && value != misc::signext(value, ct.size)
                 {
                     return Err(overflow(ct, roots.get(ob_slot)));
@@ -117,7 +117,7 @@ pub unsafe fn convert_from_object(
                 let ob_slot = roots.base();
                 let _ = roots.pin_root(w_ob);
                 let value = misc::as_unsigned_long(roots.get(ob_slot), true)?;
-                if ct.has(ctypeobj::F_VALUE_FITS_LONG) && value > vrange_max(ct) {
+                if ct.has(ctypeobj::CTypeFlags::VALUE_FITS_LONG) && value > vrange_max(ct) {
                     return Err(overflow(ct, roots.get(ob_slot)));
                 }
                 misc::write_raw_unsigned_data(cdata, value, ct.size)
@@ -327,7 +327,7 @@ pub unsafe fn cast_to_int(ct: &W_CType, cdata: *const u8) -> Result<PyObjectRef,
             ctypeobj::KIND_PRIM_CHAR => Ok(pyre_object::w_int_new(i64::from(cdata.read()))),
             // `W_CTypePrimitiveUniChar.cast_to_int`.
             ctypeobj::KIND_PRIM_UNICHAR => {
-                if ct.has(ctypeobj::F_SIGNED_WCHAR) {
+                if ct.has(ctypeobj::CTypeFlags::SIGNED_WCHAR) {
                     Ok(pyre_object::w_int_new(misc::read_raw_signed_data(
                         cdata as usize,
                         ct.size,
@@ -431,7 +431,7 @@ pub unsafe fn pack_list_of_items(
                 let Some(value) = exact_int(w_item) else {
                     return Ok(false);
                 };
-                if ct.has(ctypeobj::F_VALUE_SMALLER_THAN_LONG)
+                if ct.has(ctypeobj::CTypeFlags::VALUE_SMALLER_THAN_LONG)
                     && value != misc::signext(value, ct.size)
                 {
                     return Err(overflow_value(ct, value));
@@ -492,7 +492,7 @@ pub unsafe fn unpack_list_of_items(
         }
         // `W_CTypePrimitiveUnsigned.unpack_list_of_int_items` only takes the
         // fast path for a width that still fits a signed word.
-        ctypeobj::KIND_PRIM_UNSIGNED if ct.has(ctypeobj::F_VALUE_FITS_LONG) => {
+        ctypeobj::KIND_PRIM_UNSIGNED if ct.has(ctypeobj::CTypeFlags::VALUE_FITS_LONG) => {
             for i in 0..length {
                 items.push(pyre_object::w_int_new(unsafe {
                     misc::read_raw_unsigned_data(
@@ -530,7 +530,7 @@ fn instance_ctype(ct: &W_CType) -> PyObjectRef {
 /// `W_CTypePrimitiveUnsigned.convert_to_object`'s two arms: a width narrower
 /// than a word is an ordinary `int`, and a full word may need a bigint.
 pub fn unsigned_as_object(ct: &W_CType, value: u64) -> PyObjectRef {
-    if ct.has(ctypeobj::F_VALUE_FITS_LONG) {
+    if ct.has(ctypeobj::CTypeFlags::VALUE_FITS_LONG) {
         return pyre_object::w_int_new(value as i64);
     }
     if value <= i64::MAX as u64 {
@@ -570,7 +570,7 @@ unsafe fn read_bool_0_or_1(cdata: *const u8) -> Result<u8, PyError> {
 /// `W_CTypePrimitiveUniChar.convert_to_object`'s code-point check.
 fn unichr(ct: &W_CType, value: u32) -> Result<PyObjectRef, PyError> {
     if value > 0x10FFFF {
-        let rendered = if ct.has(ctypeobj::F_SIGNED_WCHAR) {
+        let rendered = if ct.has(ctypeobj::CTypeFlags::SIGNED_WCHAR) {
             format!("{:#x}", value as i32)
         } else {
             format!("{value:#x}")

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeptr.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeptr.rs
@@ -62,13 +62,17 @@ pub unsafe fn pointer_convert_from_object(
         return Err(ct.convert_error("compatible pointer", w_ob));
     }
     if !std::ptr::eq(ct as *const W_CType, other as *const W_CType) {
-        if ct.has(ctypeobj::F_VOID_PTR) || other.has(ctypeobj::F_VOID_PTR) {
+        if ct.has(ctypeobj::CTypeFlags::VOID_PTR) || other.has(ctypeobj::CTypeFlags::VOID_PTR) {
             // A cast from or to 'void *' is always allowed.
-        } else if ct.has(ctypeobj::F_VOIDCHAR_PTR) || other.has(ctypeobj::F_VOIDCHAR_PTR) {
+        } else if ct.has(ctypeobj::CTypeFlags::VOIDCHAR_PTR)
+            || other.has(ctypeobj::CTypeFlags::VOIDCHAR_PTR)
+        {
             // 'char *' is accepted either way for backward compatibility;
             // between two single-byte pointers it is silent, otherwise it
             // warns that the acceptance will end.
-            if !(ct.has(ctypeobj::F_ONEBYTE_PTR) && other.has(ctypeobj::F_ONEBYTE_PTR)) {
+            if !(ct.has(ctypeobj::CTypeFlags::ONEBYTE_PTR)
+                && other.has(ctypeobj::CTypeFlags::ONEBYTE_PTR))
+            {
                 crate::warn::warn_category(
                     &format!(
                         "implicit cast from '{}' to '{}' will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)",
@@ -145,7 +149,7 @@ pub unsafe fn convert_array_from_object(
         }
         return Ok(());
     }
-    if ct.has(ctypeobj::F_ACCEPT_STR) {
+    if ct.has(ctypeobj::CTypeFlags::ACCEPT_STR) {
         if !unsafe { pyre_object::bytesobject::is_bytes(w_ob) } {
             return Err(ct.convert_error("bytes or list or tuple", w_ob));
         }
@@ -209,7 +213,7 @@ pub fn cast(w_ctype: PyObjectRef, w_ob: PyObjectRef) -> Result<PyObjectRef, PyEr
         )));
     }
     // `W_CTypePointer.cast`: casting a stream to a `FILE *` opens one over it.
-    if ct.has(ctypeobj::F_FILE_PTR) {
+    if ct.has(ctypeobj::CTypeFlags::FILE_PTR) {
         let file = prepare_file(w_ob)?;
         if !file.is_null() {
             return Ok(cdataobj::new_cdata(file as usize, w_ctype));
@@ -262,7 +266,7 @@ pub(crate) fn pointer_newp_with_allocator(
         // cdata that really holds the struct, so `p[0]` is that object.
         let mut varsize_length = -1;
         item.force_lazy_struct()?;
-        if item.has(ctypeobj::F_WITH_VAR_ARRAY) {
+        if item.has(ctypeobj::CTypeFlags::WITH_VAR_ARRAY) {
             if !unsafe { pyre_object::pyobject::is_none(roots.get(init_slot)) } {
                 datasize = unsafe {
                     super::ctypestruct::convert_struct_from_object(
@@ -399,7 +403,7 @@ pub fn add(w_ctype: PyObjectRef, cdata: *mut u8, i: i64) -> Result<PyObjectRef, 
     let item = item_of(ct)?;
     let mut item_size = item.size;
     if item_size < 0 {
-        if ct.has(ctypeobj::F_VOID_PTR) {
+        if ct.has(ctypeobj::CTypeFlags::VOID_PTR) {
             item_size = 1;
         } else {
             return Err(PyError::type_error(format!(
@@ -545,7 +549,7 @@ pub unsafe fn pointer_convert_argument_from_object(
 
     let mut result = MUSTFREE_NOTHING;
     if W_CData::from_obj(w_ob).is_none() {
-        if ct.has(ctypeobj::F_ACCEPT_STR)
+        if ct.has(ctypeobj::CTypeFlags::ACCEPT_STR)
             && let Some(offset) = super::func::OffsetInBytes::from_obj(w_ob)
         {
             let value = unsafe { pyre_object::bytesobject::w_bytes_data(offset.w_bytes) };
@@ -554,7 +558,9 @@ pub unsafe fn pointer_convert_argument_from_object(
             set_mustfree_flag(cdata, MUSTFREE_NOTHING);
             return Ok(false);
         }
-        if ct.has(ctypeobj::F_ACCEPT_STR) && unsafe { pyre_object::bytesobject::is_bytes(w_ob) } {
+        if ct.has(ctypeobj::CTypeFlags::ACCEPT_STR)
+            && unsafe { pyre_object::bytesobject::is_bytes(w_ob) }
+        {
             // A `bytes` passed to a `char *` argument reaches C as a copy
             // with its own null terminator; RPython instead pins or hands
             // over the string's own characters, which pyre has no equivalent
@@ -637,7 +643,7 @@ unsafe fn prepare_pointer_call_argument(
                 value.code_points().count() as i64
             };
             n + 1
-        } else if ct.has(ctypeobj::F_FILE_PTR) {
+        } else if ct.has(ctypeobj::CTypeFlags::FILE_PTR) {
             let file = prepare_file(w_init)?;
             if file.is_null() {
                 return Ok(MUSTFREE_NOTHING);

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypestruct.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypestruct.rs
@@ -180,7 +180,7 @@ unsafe fn write_v(
         return Ok(optvarsize);
     }
     if ct.is_struct_or_union()
-        && ct.has(ctypeobj::F_WITH_VAR_ARRAY)
+        && ct.has(ctypeobj::CTypeFlags::WITH_VAR_ARRAY)
         && W_CData::from_obj(roots.get(ob_slot)).is_none()
     {
         let subsize = unsafe {

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
@@ -987,7 +987,7 @@ fn ffi_list_types(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         }
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(pyre_object::w_str_new_managed(&name));
-        let target = if su.flags & parse_c_type::F_UNION != 0 {
+        let target = if su.flags & parse_c_type::CffiTypeFlags::UNION.bits() != 0 {
             unions_slot
         } else {
             structs_slot

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
@@ -485,7 +485,7 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
 fn unsafe_escaping_ptr_for_ptr_or_array(cdata: &W_CData) -> Result<*mut u8, PyError> {
     let ct = ctypeobj::ctype_at(cdata.ctype)
         .ok_or_else(|| PyError::system_error("cdata without a ctype"))?;
-    if !ct.has(ctypeobj::F_NONFUNC_POINTER_OR_ARRAY) {
+    if !ct.has(ctypeobj::CTypeFlags::NONFUNC_POINTER_OR_ARRAY) {
         return Err(PyError::type_error(format!(
             "expected a pointer or array ctype, got '{}'",
             ct.name()

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/handle.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/handle.rs
@@ -9,7 +9,7 @@ use super::ctypeobj;
 /// `handle.py newp_handle`.
 pub fn newp_handle(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let ct = ctypeobj::ctype_arg(args[0])?;
-    if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::F_VOID_PTR) {
+    if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::CTypeFlags::VOID_PTR) {
         return Err(PyError::type_error(format!(
             "needs 'void *', got '{}'",
             ct.name()
@@ -23,7 +23,7 @@ pub fn from_handle(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let cdata = cdataobj::cdata_arg(args[0])?;
     let ct = ctypeobj::ctype_at(cdata.ctype)
         .ok_or_else(|| PyError::system_error("cdata without a ctype"))?;
-    if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::F_VOIDCHAR_PTR) {
+    if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::CTypeFlags::VOIDCHAR_PTR) {
         return Err(PyError::type_error(format!(
             "expected a 'cdata' object with a 'void *' out of new_handle(), got '{}'",
             ct.name()

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/misc.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/misc.rs
@@ -546,7 +546,7 @@ pub fn dlopen_w(w_filename: PyObjectRef, flags: i64) -> Result<(String, usize, b
         // 'flags' is ignored in this case.
         let ct = ctypeobj::ctype_at(cdata.ctype)
             .ok_or_else(|| PyError::system_error("cdata without a ctype"))?;
-        if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::F_VOID_PTR) {
+        if ct.kind != ctypeobj::KIND_POINTER || !ct.has(ctypeobj::CTypeFlags::VOID_PTR) {
             return Err(PyError::type_error(format!(
                 "dlopen() takes a file name or 'void *' handle, not '{}'",
                 ct.name()

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
@@ -160,32 +160,32 @@ pub fn new_primitive_type(name: &str) -> Result<PyObjectRef, PyError> {
         | ctypeobj::KIND_PRIM_SIGNED
         | ctypeobj::KIND_PRIM_UNSIGNED
         | ctypeobj::KIND_PRIM_BOOL => {
-            flags |= ctypeobj::F_PRIMITIVE_INTEGER;
+            flags |= ctypeobj::CTypeFlags::PRIMITIVE_INTEGER.bits();
         }
         _ => {}
     }
     match kind {
         ctypeobj::KIND_PRIM_SIGNED => {
             if size <= word {
-                flags |= ctypeobj::F_VALUE_FITS_LONG;
+                flags |= ctypeobj::CTypeFlags::VALUE_FITS_LONG.bits();
             }
             if size < word {
-                flags |= ctypeobj::F_VALUE_SMALLER_THAN_LONG;
+                flags |= ctypeobj::CTypeFlags::VALUE_SMALLER_THAN_LONG.bits();
             }
         }
         ctypeobj::KIND_PRIM_UNSIGNED | ctypeobj::KIND_PRIM_BOOL => {
             if size < word {
-                flags |= ctypeobj::F_VALUE_FITS_LONG;
+                flags |= ctypeobj::CTypeFlags::VALUE_FITS_LONG.bits();
             }
             if size <= word {
-                flags |= ctypeobj::F_VALUE_FITS_ULONG;
+                flags |= ctypeobj::CTypeFlags::VALUE_FITS_ULONG.bits();
             }
         }
         ctypeobj::KIND_PRIM_UNICHAR => {
             // `char16_t` and `char32_t` are always unsigned; only `wchar_t`
             // follows the platform's signedness.
             if key == "wchar_t" && wchar_is_signed() {
-                flags |= ctypeobj::F_SIGNED_WCHAR;
+                flags |= ctypeobj::CTypeFlags::SIGNED_WCHAR.bits();
             }
         }
         _ => {}
@@ -271,18 +271,18 @@ pub fn new_pointer_type(w_ctitem: PyObjectRef) -> Result<PyObjectRef, PyError> {
         " *"
     };
     let (name, name_position) = ctitem.insert_name(extra, 2);
-    let mut flags = ctypeobj::F_NONFUNC_POINTER_OR_ARRAY;
+    let mut flags = ctypeobj::CTypeFlags::NONFUNC_POINTER_OR_ARRAY.bits();
     if ctitem.kind == ctypeobj::KIND_VOID {
-        flags |= ctypeobj::F_VOID_PTR | ctypeobj::F_VOIDCHAR_PTR;
+        flags |= ctypeobj::CTypeFlags::VOID_PTR.bits() | ctypeobj::CTypeFlags::VOIDCHAR_PTR.bits();
     }
     if ctitem.kind == ctypeobj::KIND_PRIM_CHAR {
-        flags |= ctypeobj::F_VOIDCHAR_PTR;
+        flags |= ctypeobj::CTypeFlags::VOIDCHAR_PTR.bits();
     }
     if ctitem.size == 1 {
-        flags |= ctypeobj::F_ONEBYTE_PTR;
+        flags |= ctypeobj::CTypeFlags::ONEBYTE_PTR.bits();
     }
     if ctitem.name() == "struct _IO_FILE" || ctitem.name() == "FILE" {
-        flags |= ctypeobj::F_FILE_PTR;
+        flags |= ctypeobj::CTypeFlags::FILE_PTR.bits();
     }
     flags |= accept_str_flag(ctitem);
     let obj = ctypeobj::new_ctype(
@@ -315,8 +315,12 @@ pub fn new_pointer_type(w_ctitem: PyObjectRef) -> Result<PyObjectRef, PyError> {
 fn accept_str_flag(ctitem: &W_CType) -> i64 {
     let accepts = ctitem.kind == ctypeobj::KIND_VOID
         || ctitem.kind == ctypeobj::KIND_PRIM_CHAR
-        || (ctitem.has(ctypeobj::F_PRIMITIVE_INTEGER) && ctitem.size == 1);
-    if accepts { ctypeobj::F_ACCEPT_STR } else { 0 }
+        || (ctitem.has(ctypeobj::CTypeFlags::PRIMITIVE_INTEGER) && ctitem.size == 1);
+    if accepts {
+        ctypeobj::CTypeFlags::ACCEPT_STR.bits()
+    } else {
+        0
+    }
 }
 
 /// `newtype.py _new_array_type`.
@@ -351,7 +355,7 @@ pub fn new_array_type(w_ctptr: PyObjectRef, length: i64) -> Result<PyObjectRef, 
         (arraysize, format!("[{length}]"))
     };
     let (name, name_position) = ctitem.insert_name(&extra, 0);
-    let flags = ctypeobj::F_NONFUNC_POINTER_OR_ARRAY | accept_str_flag(ctitem);
+    let flags = ctypeobj::CTypeFlags::NONFUNC_POINTER_OR_ARRAY.bits() | accept_str_flag(ctitem);
     let obj = ctypeobj::new_ctype(
         ctypeobj::KIND_ARRAY,
         arraysize,
@@ -425,46 +429,37 @@ bitflags::bitflags! {
     }
 }
 
-/// `newtype.py SF_MSVC_BITFIELDS`.
-pub const SF_MSVC_BITFIELDS: i64 = StructFlags::MSVC_BITFIELDS.bits();
-/// `newtype.py SF_GCC_ARM_BITFIELDS`.
-pub const SF_GCC_ARM_BITFIELDS: i64 = StructFlags::GCC_ARM_BITFIELDS.bits();
-/// `newtype.py SF_GCC_X86_BITFIELDS`.
-pub const SF_GCC_X86_BITFIELDS: i64 = StructFlags::GCC_X86_BITFIELDS.bits();
-/// `newtype.py SF_GCC_BIG_ENDIAN`.
-pub const SF_GCC_BIG_ENDIAN: i64 = StructFlags::GCC_BIG_ENDIAN.bits();
-/// `newtype.py SF_GCC_LITTLE_ENDIAN`.
-pub const SF_GCC_LITTLE_ENDIAN: i64 = StructFlags::GCC_LITTLE_ENDIAN.bits();
-/// `newtype.py SF_PACKED`.
-pub const SF_PACKED: i64 = StructFlags::PACKED.bits();
-/// `newtype.py SF_STD_FIELD_POS`.
-pub const SF_STD_FIELD_POS: i64 = StructFlags::STD_FIELD_POS.bits();
-
 /// `newtype.py SF_DEFAULT_PACKING`.
 const SF_DEFAULT_PACKING: i64 = if cfg!(windows) { 8 } else { 0x4000_0000 };
 
 /// `newtype.py DEFAULT_SFLAGS_PLATFORM`.
 const DEFAULT_SFLAGS_PLATFORM: i64 = if cfg!(windows) {
-    SF_MSVC_BITFIELDS
+    StructFlags::MSVC_BITFIELDS.bits()
 } else if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
-    SF_GCC_ARM_BITFIELDS
+    StructFlags::GCC_ARM_BITFIELDS.bits()
 } else {
-    SF_GCC_X86_BITFIELDS
+    StructFlags::GCC_X86_BITFIELDS.bits()
 };
 
 /// `newtype.py DEFAULT_SFLAGS_ENDIAN`.
 const DEFAULT_SFLAGS_ENDIAN: i64 = if cfg!(target_endian = "big") {
-    SF_GCC_BIG_ENDIAN
+    StructFlags::GCC_BIG_ENDIAN.bits()
 } else {
-    SF_GCC_LITTLE_ENDIAN
+    StructFlags::GCC_LITTLE_ENDIAN.bits()
 };
 
 /// `newtype.py complete_sflags`.
 fn complete_sflags(mut sflags: i64) -> i64 {
-    if sflags & (SF_MSVC_BITFIELDS | SF_GCC_ARM_BITFIELDS | SF_GCC_X86_BITFIELDS) == 0 {
+    if sflags
+        & (StructFlags::MSVC_BITFIELDS
+            | StructFlags::GCC_ARM_BITFIELDS
+            | StructFlags::GCC_X86_BITFIELDS)
+            .bits()
+        == 0
+    {
         sflags |= DEFAULT_SFLAGS_PLATFORM;
     }
-    if sflags & (SF_GCC_BIG_ENDIAN | SF_GCC_LITTLE_ENDIAN) == 0 {
+    if sflags & (StructFlags::GCC_BIG_ENDIAN | StructFlags::GCC_LITTLE_ENDIAN).bits() == 0 {
         sflags |= DEFAULT_SFLAGS_ENDIAN;
     }
     sflags
@@ -519,7 +514,7 @@ pub fn detect_custom_layout(
     if compiler_value == cdef_value {
         return Ok(());
     }
-    if sflags & SF_STD_FIELD_POS != 0 {
+    if sflags & StructFlags::STD_FIELD_POS.bits() != 0 {
         let name = ct.name();
         let mut err = PyError::value_error(format!(
             "{name}: {msg} (cdef says {cdef_value}, but C compiler says {compiler_value}). fix it or use \"...;\" as the last field in the cdef for {name} to make it flexible"
@@ -532,7 +527,7 @@ pub fn detect_custom_layout(
         ])?;
         return Err(err);
     }
-    ct.flags |= ctypeobj::F_CUSTOM_FIELD_POS;
+    ct.flags |= ctypeobj::CTypeFlags::CUSTOM_FIELD_POS.bits();
     Ok(())
 }
 
@@ -559,12 +554,12 @@ pub fn complete_struct_or_union(
     pack: i64,
 ) -> Result<(), PyError> {
     let sflags = complete_sflags(sflags);
-    let (sflags, pack) = if sflags & SF_PACKED != 0 {
+    let (sflags, pack) = if sflags & StructFlags::PACKED.bits() != 0 {
         (sflags, 1)
     } else if pack <= 0 {
         (sflags, SF_DEFAULT_PACKING)
     } else {
-        (sflags | SF_PACKED, pack)
+        (sflags | StructFlags::PACKED.bits(), pack)
     };
     let ct = ctypeobj::ctype_arg(w_ctype)?;
     if !ct.is_struct_or_union() || ct.size >= 0 {
@@ -597,7 +592,7 @@ pub fn complete_struct_or_union(
     let mut byteoffsetmax = 0i64;
     let mut prev_bitfield_size = 0i64;
     let mut prev_bitfield_free = 0i64;
-    ct.flags &= !ctypeobj::F_CUSTOM_FIELD_POS;
+    ct.flags &= !ctypeobj::CTypeFlags::CUSTOM_FIELD_POS.bits();
     let mut with_var_array = false;
     let mut with_packed_change = false;
 
@@ -630,7 +625,7 @@ pub fn complete_struct_or_union(
             ftype.force_lazy_struct()?;
             // A var-sized array anywhere inside a field propagates outward,
             // so a struct holding such a struct is var-sized too.
-            if ftype.has(ctypeobj::F_WITH_VAR_ARRAY) {
+            if ftype.has(ctypeobj::CTypeFlags::WITH_VAR_ARRAY) {
                 with_var_array = true;
             }
         }
@@ -644,8 +639,8 @@ pub fn complete_struct_or_union(
         let falignorg = ftype.alignof()?;
         let falign = pack.min(falignorg);
         let mut do_align = true;
-        if sflags & SF_GCC_ARM_BITFIELDS == 0 && fbitsize >= 0 {
-            do_align = if sflags & SF_MSVC_BITFIELDS == 0 {
+        if sflags & StructFlags::GCC_ARM_BITFIELDS.bits() == 0 && fbitsize >= 0 {
+            do_align = if sflags & StructFlags::MSVC_BITFIELDS.bits() == 0 {
                 // Anonymous bitfields of any size do not cause alignment.
                 !fname.is_empty()
             } else {
@@ -703,7 +698,7 @@ pub fn complete_struct_or_union(
                     }
                 }
                 // Such a structure can never be passed by value.
-                ct.flags |= ctypeobj::F_CUSTOM_FIELD_POS;
+                ct.flags |= ctypeobj::CTypeFlags::CUSTOM_FIELD_POS.bits();
             } else {
                 let w_fld =
                     super::ctypestruct::new_cfield(descr.w_ftype, byteoffset, bs_flag, -1, fflags);
@@ -749,7 +744,7 @@ pub fn complete_struct_or_union(
                         ct.name()
                     )));
                 }
-                if sflags & SF_MSVC_BITFIELDS == 0 {
+                if sflags & StructFlags::MSVC_BITFIELDS.bits() == 0 {
                     // GCC's notion of "ftype :0;" pads to a value aligned for
                     // `ftype`.
                     if roundup_bytes(byteoffset, bitoffset) > field_offset_bytes {
@@ -763,12 +758,14 @@ pub fn complete_struct_or_union(
                 prev_bitfield_size = 0;
             } else {
                 let mut bitshift;
-                if sflags & SF_MSVC_BITFIELDS == 0 {
+                if sflags & StructFlags::MSVC_BITFIELDS.bits() == 0 {
                     // GCC's algorithm: the field can start where we are if it
                     // would fit entirely into an aligned `ftype` field.
                     let bits_already_occupied = (byteoffset - field_offset_bytes) * 8 + bitoffset;
                     if bits_already_occupied + fbitsize > 8 * ftype.size {
-                        if sflags & SF_PACKED != 0 && bits_already_occupied & 7 != 0 {
+                        if sflags & StructFlags::PACKED.bits() != 0
+                            && bits_already_occupied & 7 != 0
+                        {
                             return Err(PyError::not_implemented(format!(
                                 "with 'packed', gcc would compile field '{}.{fname}' to reuse some bits in the previous field",
                                 ct.name()
@@ -802,7 +799,7 @@ pub fn complete_struct_or_union(
                     prev_bitfield_free -= fbitsize;
                     field_offset_bytes = byteoffset - ftype.size;
                 }
-                if sflags & SF_GCC_BIG_ENDIAN != 0 {
+                if sflags & StructFlags::GCC_BIG_ENDIAN.bits() != 0 {
                     bitshift = 8 * ftype.size - fbitsize - bitshift;
                 }
                 if !fname.is_empty() {
@@ -858,10 +855,10 @@ pub fn complete_struct_or_union(
     ct.fields_list = roots.get(list_slot);
     ct.fields_dict = roots.get(dict_slot);
     if with_var_array {
-        ct.flags |= ctypeobj::F_WITH_VAR_ARRAY;
+        ct.flags |= ctypeobj::CTypeFlags::WITH_VAR_ARRAY.bits();
     }
     if with_packed_change {
-        ct.flags |= ctypeobj::F_WITH_PACKED_CHANGE;
+        ct.flags |= ctypeobj::CTypeFlags::WITH_PACKED_CHANGE.bits();
     }
     // The ctype is old-gen and both containers are young, so the barrier has
     // to run after the two writes.
@@ -978,7 +975,7 @@ pub fn new_enum_type(
         basectype.align,
         pyre_object::PY_NULL,
         -1,
-        basectype.flags | ctypeobj::F_ENUM,
+        basectype.flags | ctypeobj::CTypeFlags::ENUM.bits(),
     );
     let ctype_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(w_ctype);
@@ -1048,7 +1045,7 @@ fn function_type_matches(
     };
     if ctype.kind != ctypeobj::KIND_FUNC
         || ctype.ctitem != w_fresult
-        || ctype.has(ctypeobj::F_ELLIPSIS) != ellipsis
+        || ctype.has(ctypeobj::CTypeFlags::ELLIPSIS) != ellipsis
         || ctype.abi != abi
         || unsafe { pyre_object::w_tuple_len(ctype.fargs) } != fargs.len()
     {
@@ -1135,7 +1132,11 @@ pub fn build_function_type(
         -1,
         w_fresult,
         -1,
-        if ellipsis { ctypeobj::F_ELLIPSIS } else { 0 },
+        if ellipsis {
+            ctypeobj::CTypeFlags::ELLIPSIS.bits()
+        } else {
+            0
+        },
     );
     let roots = pyre_object::gc_roots::push_roots();
     let ctype_slot = roots.base();

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
@@ -522,8 +522,8 @@ fn realize_c_struct_or_union(w_ffi: PyObjectRef, sindex: isize) -> Result<PyObje
     let c_flags = s.flags;
     let first_field = s.first_field_index;
     let mut lazy = false;
-    let x = if c_flags & parse_c_type::F_EXTERNAL == 0 {
-        let (kind, prefix) = if c_flags & parse_c_type::F_UNION != 0 {
+    let x = if c_flags & parse_c_type::CffiTypeFlags::EXTERNAL.bits() == 0 {
+        let (kind, prefix) = if c_flags & parse_c_type::CffiTypeFlags::UNION.bits() != 0 {
             (ctypeobj::KIND_UNION, "union ")
         } else {
             (ctypeobj::KIND_STRUCT, "struct ")
@@ -536,7 +536,7 @@ fn realize_c_struct_or_union(w_ffi: PyObjectRef, sindex: isize) -> Result<PyObje
         } else {
             newtype::new_struct_type(&name)
         };
-        if c_flags & parse_c_type::F_OPAQUE == 0 {
+        if c_flags & parse_c_type::CffiTypeFlags::OPAQUE.bits() == 0 {
             assert!(first_field >= 0);
             let ct = ctypeobj::ctype_arg(x)?;
             ct.size = signed_size(s.size);
@@ -552,7 +552,7 @@ fn realize_c_struct_or_union(w_ffi: PyObjectRef, sindex: isize) -> Result<PyObje
     } else {
         assert!(first_field < 0);
         let Some(x) = fetch_external_struct_or_union(&s, roots.get(ffi_slot))? else {
-            let kind = if c_flags & parse_c_type::F_UNION != 0 {
+            let kind = if c_flags & parse_c_type::CffiTypeFlags::UNION.bits() != 0 {
                 "union"
             } else {
                 "struct"
@@ -563,8 +563,8 @@ fn realize_c_struct_or_union(w_ffi: PyObjectRef, sindex: isize) -> Result<PyObje
             )));
         };
         let ct = ctypeobj::ctype_arg(x)?;
-        if c_flags & parse_c_type::F_OPAQUE == 0 && ct.size < 0 {
-            let kind = if c_flags & parse_c_type::F_UNION != 0 {
+        if c_flags & parse_c_type::CffiTypeFlags::OPAQUE.bits() == 0 && ct.size < 0 {
+            let kind = if c_flags & parse_c_type::CffiTypeFlags::UNION.bits() != 0 {
                 "union"
             } else {
                 "struct"
@@ -776,7 +776,7 @@ pub fn do_realize_lazy_struct(w_ctype: PyObjectRef) -> Result<(), PyError> {
         } else {
             newtype::detect_custom_layout(
                 ctypeobj::ctype_arg(roots.get(ctype_slot))?,
-                newtype::SF_STD_FIELD_POS,
+                newtype::StructFlags::STD_FIELD_POS.bits(),
                 ctypeobj::ctype_arg(w_ctf)?.size,
                 field_size,
                 &format!("wrong size for field '{field_name}'"),
@@ -797,11 +797,11 @@ pub fn do_realize_lazy_struct(w_ctype: PyObjectRef) -> Result<(), PyError> {
         };
     }
     let mut sflags = 0;
-    if s.flags & parse_c_type::F_CHECK_FIELDS != 0 {
-        sflags |= newtype::SF_STD_FIELD_POS;
+    if s.flags & parse_c_type::CffiTypeFlags::CHECK_FIELDS.bits() != 0 {
+        sflags |= newtype::StructFlags::STD_FIELD_POS.bits();
     }
-    if s.flags & parse_c_type::F_PACKED != 0 {
-        sflags |= newtype::SF_PACKED;
+    if s.flags & parse_c_type::CffiTypeFlags::PACKED.bits() != 0 {
+        sflags |= newtype::StructFlags::PACKED.bits();
     }
     let old_size = ctypeobj::ctype_arg(roots.get(ctype_slot))?.size;
     let old_align = ctypeobj::ctype_arg(roots.get(ctype_slot))?.align;
@@ -860,8 +860,10 @@ fn fetch_external_struct_or_union(
             continue;
         }
         let s1 = unsafe { *ctx1.struct_unions.offset(sindex) };
-        if s1.flags & (parse_c_type::F_EXTERNAL | parse_c_type::F_UNION)
-            == s.flags & parse_c_type::F_UNION
+        if s1.flags
+            & (parse_c_type::CffiTypeFlags::EXTERNAL.bits()
+                | parse_c_type::CffiTypeFlags::UNION.bits())
+            == s.flags & parse_c_type::CffiTypeFlags::UNION.bits()
         {
             return realize_c_struct_or_union(w_ffi1, sindex).map(Some);
         }

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -7,8 +7,6 @@
 use pyre_native::ssl::{
     CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED, PROTOCOL_TLS, PROTOCOL_TLS_CLIENT,
     PROTOCOL_TLS_SERVER, PROTOCOL_TLSV1, PROTOCOL_TLSV1_1, PROTOCOL_TLSV1_2, PROTOCOL_TLSV1_3,
-    VERIFY_ALLOW_PROXY_CERTS, VERIFY_CRL_CHECK_CHAIN, VERIFY_CRL_CHECK_LEAF, VERIFY_DEFAULT,
-    VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT, VERIFY_X509_TRUSTED_FIRST,
 };
 use pyre_object::*;
 
@@ -3239,13 +3237,13 @@ crate::py_module! {
         "CERT_NONE" => CERT_NONE,
         "CERT_OPTIONAL" => CERT_OPTIONAL,
         "CERT_REQUIRED" => CERT_REQUIRED,
-        "VERIFY_DEFAULT" => VERIFY_DEFAULT,
-        "VERIFY_CRL_CHECK_LEAF" => VERIFY_CRL_CHECK_LEAF,
-        "VERIFY_CRL_CHECK_CHAIN" => VERIFY_CRL_CHECK_CHAIN,
-        "VERIFY_X509_STRICT" => VERIFY_X509_STRICT,
-        "VERIFY_ALLOW_PROXY_CERTS" => VERIFY_ALLOW_PROXY_CERTS,
-        "VERIFY_X509_TRUSTED_FIRST" => VERIFY_X509_TRUSTED_FIRST,
-        "VERIFY_X509_PARTIAL_CHAIN" => VERIFY_X509_PARTIAL_CHAIN,
+        "VERIFY_DEFAULT" => pyre_native::ssl::VerifyFlags::DEFAULT.bits(),
+        "VERIFY_CRL_CHECK_LEAF" => pyre_native::ssl::VerifyFlags::CRL_CHECK_LEAF.bits(),
+        "VERIFY_CRL_CHECK_CHAIN" => pyre_native::ssl::VerifyFlags::CRL_CHECK_CHAIN.bits(),
+        "VERIFY_X509_STRICT" => pyre_native::ssl::VerifyFlags::X509_STRICT.bits(),
+        "VERIFY_ALLOW_PROXY_CERTS" => pyre_native::ssl::VerifyFlags::ALLOW_PROXY_CERTS.bits(),
+        "VERIFY_X509_TRUSTED_FIRST" => pyre_native::ssl::VerifyFlags::X509_TRUSTED_FIRST.bits(),
+        "VERIFY_X509_PARTIAL_CHAIN" => pyre_native::ssl::VerifyFlags::X509_PARTIAL_CHAIN.bits(),
         "OP_ALL" => pyre_native::ssl::SslOp::ALL.bits() as i32,
         "OP_NO_SSLv2" => 0,
         "OP_NO_SSLv3" => pyre_native::ssl::SslOp::NO_SSLV3.bits() as i32,

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -297,7 +297,7 @@ crate::py_module! {
                 crate::make_module_builtin_function_with_arity_and_maybe_sig(
                     "crc32",
                     crc32,
-                    crate::HOPELESS,
+                    crate::BuiltinCodeFlags::HOPELESS.bits(),
                     Some(sig_all_posonly("crc32", &["data", "crc"])),
                 ),
             ),
@@ -313,7 +313,7 @@ crate::py_module! {
                 crate::make_module_builtin_function_with_arity_and_maybe_sig(
                     "crc_hqx",
                     crc_hqx,
-                    crate::HOPELESS,
+                    crate::BuiltinCodeFlags::HOPELESS.bits(),
                     Some(sig_all_posonly("crc_hqx", &["data", "crc"])),
                 ),
             ),

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1612,7 +1612,7 @@ crate::py_module! {
                 crate::make_module_builtin_function_with_arity_and_maybe_sig(
                     "pack",
                     pack,
-                    crate::HOPELESS,
+                    crate::BuiltinCodeFlags::HOPELESS.bits(),
                     Some(sig_posonly_then_varargs("pack", &["format"], "args")),
                 ),
             ),
@@ -1625,7 +1625,7 @@ crate::py_module! {
                 crate::make_module_builtin_function_with_arity_and_maybe_sig(
                     "pack_into",
                     pack_into,
-                    crate::HOPELESS,
+                    crate::BuiltinCodeFlags::HOPELESS.bits(),
                     Some(sig_posonly_then_varargs(
                         "pack_into",
                         &["format", "buffer", "offset"],

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1164,7 +1164,7 @@ fn w_code_new_owned(code_ptr: *const (), hidden_applevel: bool, owner: usize) ->
         release_code_locations(code_ptr as *mut crate::CodeObject, firstlineno_raw);
     }
     let mut fast_natural_arity = if !code_ptr_aligned {
-        crate::gateway::HOPELESS
+        crate::gateway::BuiltinCodeFlags::HOPELESS.bits()
     } else {
         compute_flatcall(unsafe { &*(code_ptr as *const crate::CodeObject) })
     };
@@ -4233,18 +4233,18 @@ pub unsafe fn pycode_destructor(obj_addr: usize) {
 /// **kwargs, keyword-only args). Returns HOPELESS otherwise.
 fn compute_flatcall(code: &crate::CodeObject) -> u16 {
     use crate::CodeFlags;
-    use crate::gateway::{FLATPYCALL, HOPELESS};
+    use crate::gateway::BuiltinCodeFlags;
     if code
         .flags
         .intersects(CodeFlags::VARARGS | CodeFlags::VARKEYWORDS)
     {
-        return HOPELESS;
+        return BuiltinCodeFlags::HOPELESS.bits();
     }
     if code.kwonlyarg_count > 0 {
-        return HOPELESS;
+        return BuiltinCodeFlags::HOPELESS.bits();
     }
     if code.arg_count > 0xff {
-        return HOPELESS;
+        return BuiltinCodeFlags::HOPELESS.bits();
     }
     // pycode.py:234 — disqualify if any arg is also a cellvar.
     // Pyre's CodeObject exposes cellvars; check for overlap.
@@ -4253,12 +4253,12 @@ fn compute_flatcall(code: &crate::CodeObject) -> u16 {
         for cellname in &code.cellvars {
             for j in 0..argcount {
                 if j < code.varnames.len() && *cellname == code.varnames[j] {
-                    return HOPELESS;
+                    return BuiltinCodeFlags::HOPELESS.bits();
                 }
             }
         }
     }
-    FLATPYCALL | (code.arg_count as u16)
+    BuiltinCodeFlags::FLATPYCALL.bits() | (code.arg_count as u16)
 }
 
 /// eval.py:16-23 — read `fast_natural_arity` from a PyCode.
@@ -4268,7 +4268,7 @@ fn compute_flatcall(code: &crate::CodeObject) -> u16 {
 #[inline]
 pub unsafe fn w_code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
     if obj.is_null() {
-        return crate::gateway::HOPELESS;
+        return crate::gateway::BuiltinCodeFlags::HOPELESS.bits();
     }
     unsafe { (*(obj as *const PyCode)).fast_natural_arity & !YIELDS_INSIDE_TRY_BIT }
 }
@@ -4281,7 +4281,7 @@ pub unsafe fn w_code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
 #[inline]
 pub unsafe fn code_get_fast_natural_arity(obj: PyObjectRef) -> u16 {
     if obj.is_null() {
-        return crate::gateway::HOPELESS;
+        return crate::gateway::BuiltinCodeFlags::HOPELESS.bits();
     }
     unsafe {
         if crate::gateway::is_builtin_code(obj) {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -7425,19 +7425,13 @@ pub mod fbw_diag {
     pub const NAME_SLOTS: usize = 4;
 
     /// Bit positions inside a ring entry's counter slot.
-    ///
-    /// These stay decimal literals so `fbw_diag_mirror` can parse the
-    /// same spellings out of the wasm runner.
-    pub const FLAG_VALID: u64 = 1;
-    pub const FLAG_COMMITTED: u64 = 2;
-    pub const FLAG_BRIDGE: u64 = 4;
     bitflags::bitflags! {
         #[repr(transparent)]
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         pub struct RingFlags: u64 {
-            const VALID = FLAG_VALID;
-            const COMMITTED = FLAG_COMMITTED;
-            const BRIDGE = FLAG_BRIDGE;
+            const VALID = 1 << 0;
+            const COMMITTED = 1 << 1;
+            const BRIDGE = 1 << 2;
         }
     }
     pub const SHIFT_EFFECTS: u32 = 8;
@@ -7521,10 +7515,14 @@ pub mod fbw_diag {
             }
             FBW_DIAG[entry + slot].store(packed, Ordering::Relaxed);
         }
-        let flags = FLAG_VALID
-            | if committed { FLAG_COMMITTED } else { 0 }
+        let flags = RingFlags::VALID.bits()
+            | if committed {
+                RingFlags::COMMITTED.bits()
+            } else {
+                0
+            }
             | ((effects as u64).min(FIELD_MASK) << SHIFT_EFFECTS)
-            | if bridge { FLAG_BRIDGE } else { 0 }
+            | if bridge { RingFlags::BRIDGE.bits() } else { 0 }
             | ((journaled as u64).min(FIELD_MASK) << SHIFT_JOURNAL)
             | ((exec_mf as u64).min(FIELD_MASK) << SHIFT_EXEC_MF)
             | ((leg as u64) << SHIFT_LEG);

--- a/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
+++ b/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
@@ -98,23 +98,73 @@ fn extract(runner_src: &str) -> (&'static [&'static str], Vec<String>) {
     )
 }
 
-/// The integer literal a constant is declared with, decimal or `0x` hex.
+/// The integer a declaration evaluates to: decimal, `0x` hex, or `N << M`.
 ///
 /// Hex is accepted because the bit-layout half of the mirror is only readable
 /// as masks — a `FIELD_MASK` spelled `65535` to keep a decimal-only parser
-/// happy would trade the thing being guarded for the guard.
+/// happy would trade the thing being guarded for the guard. `N << M` is the
+/// spelling `bitflags!` uses for a single bit, so a flag written that way
+/// does not need a second decimal alias for this test to see it.
 fn declared_int(src: &str, anchor: &str, what: &str) -> u64 {
     let at = src
         .find(anchor)
         .unwrap_or_else(|| panic!("{what}: {anchor:?} declaration not found"));
     let tail = src[at + anchor.len()..].trim_start();
-    let (radix, rest) = match tail.strip_prefix("0x") {
-        Some(rest) => (16, rest),
-        None => (10, tail),
-    };
-    let digits: String = rest.chars().take_while(|c| c.is_digit(radix)).collect();
-    u64::from_str_radix(&digits, radix)
-        .unwrap_or_else(|e| panic!("{what}: {anchor:?} is not a number ({digits:?}) — {e}"))
+    let expr: String = tail
+        .chars()
+        .take_while(|c| !matches!(*c, ';' | ',' | '\n' | '}'))
+        .collect();
+    parse_u64_expr(expr.trim())
+        .unwrap_or_else(|| panic!("{what}: {anchor:?} is not a number or `N << M` ({expr:?})"))
+}
+
+fn parse_u64_expr(expr: &str) -> Option<u64> {
+    if let Some((left, right)) = expr.split_once("<<") {
+        let left = parse_u64_literal(left.trim())?;
+        let right = parse_u64_literal(right.trim())?;
+        return left.checked_shl(u32::try_from(right).ok()?);
+    }
+    parse_u64_literal(expr)
+}
+
+#[test]
+fn declared_int_reads_shift_and_hex() {
+    assert_eq!(
+        declared_int("const X: u64 = 20;", "const X: u64 = ", "t"),
+        20
+    );
+    assert_eq!(
+        declared_int("const X: u64 = 0xffff;", "const X: u64 = ", "t"),
+        0xffff
+    );
+    assert_eq!(
+        declared_int("const VALID = 1 << 0;", "const VALID = ", "t"),
+        1
+    );
+    assert_eq!(
+        declared_int("const COMMITTED = 1 << 1;", "const COMMITTED = ", "t"),
+        2
+    );
+    assert_eq!(
+        declared_int("const BRIDGE = 1 << 2;", "const BRIDGE = ", "t"),
+        4
+    );
+}
+
+fn parse_u64_literal(s: &str) -> Option<u64> {
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16).ok()
+    } else {
+        s.parse().ok()
+    }
+}
+
+/// A `bitflags!` member under `type_name`, e.g. `FbwRingFlags` / `VALID`.
+fn declared_bitflag(src: &str, type_name: &str, flag: &str, what: &str) -> u64 {
+    let type_at = src
+        .find(type_name)
+        .unwrap_or_else(|| panic!("{what}: bitflags type {type_name:?} not found"));
+    declared_int(&src[type_at..], &format!("const {flag} = "), what)
 }
 
 /// The slots whose two spellings disagree, over the shorter of the two.
@@ -316,9 +366,9 @@ fn the_mirror_check_catches_injected_drift() {
     );
 }
 
-/// The ring GEOMETRY and BIT LAYOUT are mirrored too, and unlike the labels
-/// they are bare integers with nothing to derive them from on the runner's
-/// side.
+/// The ring GEOMETRY and BIT LAYOUT are mirrored too. Geometry and shift
+/// widths are bare integers with nothing to derive them from on the runner's
+/// side; the `FLAG_*` bits live on `FbwRingFlags` / `RingFlags`.
 ///
 /// `RING_BASE` is `LABELS.len()` here, so a tally added on the authority side
 /// moves the ring's start — and the runner, which decodes the ring by
@@ -350,13 +400,6 @@ fn the_runner_mirrors_the_ring_layout() {
             d::NAME_SLOTS as u64,
             "NAME_SLOTS",
         ),
-        ("const FLAG_VALID: u64 = ", d::FLAG_VALID, "FLAG_VALID"),
-        (
-            "const FLAG_COMMITTED: u64 = ",
-            d::FLAG_COMMITTED,
-            "FLAG_COMMITTED",
-        ),
-        ("const FLAG_BRIDGE: u64 = ", d::FLAG_BRIDGE, "FLAG_BRIDGE"),
         (
             "const SHIFT_EFFECTS: u32 = ",
             d::SHIFT_EFFECTS as u64,
@@ -382,8 +425,23 @@ fn the_runner_mirrors_the_ring_layout() {
              pyre_jit_trace::trace::fbw_diag::{name} is {authority}. The runner \
              indexes the `pyre_fbw_diag` export with `RING_BASE + entry * \
              RING_STRIDE` and unpacks the counter slot with the `SHIFT_*` / \
-             `FLAG_*` set, so a stale copy decodes the wrong words and prints \
+             `RingFlags` set, so a stale copy decodes the wrong words and prints \
              them as a walk outcome rather than failing.",
+        );
+    }
+    for (flag, authority) in [
+        ("VALID", d::RingFlags::VALID.bits()),
+        ("COMMITTED", d::RingFlags::COMMITTED.bits()),
+        ("BRIDGE", d::RingFlags::BRIDGE.bits()),
+    ] {
+        let mirrored = declared_bitflag(&runner_src, "FbwRingFlags", flag, "runner");
+        assert_eq!(
+            mirrored, authority,
+            "pyre-wasm-runner FbwRingFlags::{flag} = {mirrored} but \
+             pyre_jit_trace::trace::fbw_diag::RingFlags::{flag} is {authority}. \
+             The runner unpacks the counter slot with these bits, so a stale \
+             copy decodes the wrong words and prints them as a walk outcome \
+             rather than failing.",
         );
     }
 }

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -320,7 +320,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     let arity_fn_name = format_ident!("{}_pyre_arity", user_name);
     let natural_arity =
         if has_varargs || has_kw_markers || param_required.iter().any(|required| !required) {
-            quote! { crate::HOPELESS }
+            quote! { crate::BuiltinCodeFlags::HOPELESS.bits() }
         } else {
             let n = param_positional
                 .iter()

--- a/pyre/pyre-native/src/cffi.rs
+++ b/pyre/pyre-native/src/cffi.rs
@@ -130,12 +130,6 @@ bitflags::bitflags! {
     }
 }
 
-pub const F_UNION: c_int = CffiTypeFlags::UNION.bits();
-pub const F_CHECK_FIELDS: c_int = CffiTypeFlags::CHECK_FIELDS.bits();
-pub const F_PACKED: c_int = CffiTypeFlags::PACKED.bits();
-pub const F_EXTERNAL: c_int = CffiTypeFlags::EXTERNAL.bits();
-pub const F_OPAQUE: c_int = CffiTypeFlags::OPAQUE.bits();
-
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GlobalS {

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -339,9 +339,6 @@ bitflags::bitflags! {
     }
 }
 
-const OP_NO_TLSV1_2: u64 = SslOp::NO_TLSV1_2.bits();
-const OP_NO_TLSV1_3: u64 = SslOp::NO_TLSV1_3.bits();
-
 pub const DEFAULT_OPTIONS: u64 = SslOp::DEFAULT.bits();
 
 bitflags::bitflags! {
@@ -359,14 +356,6 @@ bitflags::bitflags! {
     }
 }
 
-pub const VERIFY_DEFAULT: i32 = VerifyFlags::DEFAULT.bits();
-pub const VERIFY_CRL_CHECK_LEAF: i32 = VerifyFlags::CRL_CHECK_LEAF.bits();
-pub const VERIFY_CRL_CHECK_CHAIN: i32 = VerifyFlags::CRL_CHECK_CHAIN.bits();
-pub const VERIFY_X509_STRICT: i32 = VerifyFlags::X509_STRICT.bits();
-pub const VERIFY_ALLOW_PROXY_CERTS: i32 = VerifyFlags::ALLOW_PROXY_CERTS.bits();
-pub const VERIFY_X509_TRUSTED_FIRST: i32 = VerifyFlags::X509_TRUSTED_FIRST.bits();
-pub const VERIFY_X509_PARTIAL_CHAIN: i32 = VerifyFlags::X509_PARTIAL_CHAIN.bits();
-
 /// Revocation scope requested by `verify_flags`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CrlScope {
@@ -376,9 +365,11 @@ enum CrlScope {
 }
 
 fn crl_scope(verify_flags: i32) -> CrlScope {
-    if verify_flags & VERIFY_CRL_CHECK_LEAF == 0 {
+    if verify_flags & VerifyFlags::CRL_CHECK_LEAF.bits() == 0 {
         CrlScope::Disabled
-    } else if verify_flags & VERIFY_CRL_CHECK_CHAIN == VERIFY_CRL_CHECK_CHAIN {
+    } else if verify_flags & VerifyFlags::CRL_CHECK_CHAIN.bits()
+        == VerifyFlags::CRL_CHECK_CHAIN.bits()
+    {
         CrlScope::FullChain
     } else {
         CrlScope::EndEntityOnly
@@ -2098,7 +2089,7 @@ impl rustls::client::danger::ServerCertVerifier for ExplicitEndEntityVerifier {
                 rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding)
             })?;
         let self_issued = certificate.subject() == certificate.issuer();
-        if !self_issued && self.verify_flags & VERIFY_X509_PARTIAL_CHAIN == 0 {
+        if !self_issued && self.verify_flags & VerifyFlags::X509_PARTIAL_CHAIN.bits() == 0 {
             return Err(original_error);
         }
 
@@ -2717,7 +2708,7 @@ impl VerifiedChainBuilder {
                     .ok()
                     .is_some_and(|(_, certificate)| {
                         certificate.subject() == certificate.issuer()
-                            || self.verify_flags & VERIFY_X509_PARTIAL_CHAIN != 0
+                            || self.verify_flags & VerifyFlags::X509_PARTIAL_CHAIN.bits() != 0
                     })
             {
                 return Some(vec![end_entity.as_ref().to_vec()]);
@@ -2880,7 +2871,9 @@ fn client_config(
         let mut verifier: Arc<dyn rustls::client::danger::ServerCertVerifier> =
             Arc::new(PolicyServerVerifier {
                 inner: verifier,
-                require_authority_key_identifier: context.verify_flags & VERIFY_X509_STRICT != 0,
+                require_authority_key_identifier: context.verify_flags
+                    & VerifyFlags::X509_STRICT.bits()
+                    != 0,
                 require_crl: crl_scope(context.verify_flags) != CrlScope::Disabled,
                 has_crl: !context.crls.is_empty(),
             });
@@ -2986,16 +2979,16 @@ fn enabled_versions(
     let maximum = context.maximum_version;
     let tls12 = (minimum < 0 || minimum <= 0x303)
         && (maximum < 0 || maximum >= 0x303)
-        && context.options & OP_NO_TLSV1_2 == 0;
+        && context.options & SslOp::NO_TLSV1_2.bits() == 0;
     let tls13 = (minimum < 0 || minimum <= 0x304)
         && (maximum < 0 || maximum >= 0x304)
-        && context.options & OP_NO_TLSV1_3 == 0;
+        && context.options & SslOp::NO_TLSV1_3.bits() == 0;
     if !tls12 && !tls13 {
         return Err((0, "[SSL] no protocols available".to_string()));
     }
     #[cfg(feature = "host_env")]
     {
-        let options = (context.options & (OP_NO_TLSV1_2 | OP_NO_TLSV1_3)) as i32;
+        let options = (context.options & (SslOp::NO_TLSV1_2 | SslOp::NO_TLSV1_3).bits()) as i32;
         Ok(host_ssl::rustls_versions(minimum, maximum, options))
     }
     #[cfg(not(feature = "host_env"))]

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -312,7 +312,7 @@ pub const SSL3_RT_HEADER: i32 = 256;
 pub const SSL3_MT_CHANGE_CIPHER_SPEC: i32 = 0x0101;
 
 bitflags::bitflags! {
-    /// `SSL_OP_*` bits the `_ssl` module publishes.  Both `DEFAULT_OPTIONS` and
+    /// `SSL_OP_*` bits the `_ssl` module publishes.  Both `SslOp::DEFAULT` and
     /// [`enabled_versions`] decode this space, so the two must not name the same
     /// bit differently.
     #[repr(transparent)]
@@ -338,8 +338,6 @@ bitflags::bitflags! {
             | Self::ENABLE_MIDDLEBOX_COMPAT.bits();
     }
 }
-
-pub const DEFAULT_OPTIONS: u64 = SslOp::DEFAULT.bits();
 
 bitflags::bitflags! {
     /// `X509_V_FLAG_*` bits carried by `SSLContext.verify_flags`.
@@ -398,7 +396,7 @@ impl Context {
             check_hostname: client,
             verify_mode: if client { CERT_REQUIRED } else { CERT_NONE },
             verify_flags: 32768,
-            options: DEFAULT_OPTIONS,
+            options: SslOp::DEFAULT.bits(),
             minimum_version: match protocol {
                 PROTOCOL_TLSV1_2 => 0x303,
                 PROTOCOL_TLSV1_3 => 0x304,

--- a/pyre/pyre-sandbox/src/vfs.rs
+++ b/pyre/pyre-sandbox/src/vfs.rs
@@ -68,20 +68,6 @@ bitflags::bitflags! {
     }
 }
 
-const S_IFDIR: Mode = ModeBits::IFDIR.bits();
-const S_IFREG: Mode = ModeBits::IFREG.bits();
-const S_IFMT: Mode = ModeBits::IFMT.bits();
-const S_IWUSR: Mode = ModeBits::IWUSR.bits();
-const S_IRUSR: Mode = ModeBits::IRUSR.bits();
-const S_IRGRP: Mode = ModeBits::IRGRP.bits();
-const S_IROTH: Mode = ModeBits::IROTH.bits();
-const S_IXUSR: Mode = ModeBits::IXUSR.bits();
-const S_IXGRP: Mode = ModeBits::IXGRP.bits();
-const S_IXOTH: Mode = ModeBits::IXOTH.bits();
-const S_IRWXO: Mode = ModeBits::IRWXO.bits();
-const S_IRWXU: Mode = ModeBits::IRWXU.bits();
-const S_IRWXG: Mode = ModeBits::IRWXG.bits();
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatResult {
     pub st_mode: Mode,
@@ -134,9 +120,12 @@ pub trait FSObject {
         let st_nlink = 1;
         let st_size = self.getsize()?;
         let mut st_mode = self.kind();
-        st_mode |= S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH;
+        st_mode |= ModeBits::IWUSR.bits()
+            | ModeBits::IRUSR.bits()
+            | ModeBits::IRGRP.bits()
+            | ModeBits::IROTH.bits();
         if is_dir(self.kind()) {
-            st_mode |= S_IXUSR | S_IXGRP | S_IXOTH;
+            st_mode |= ModeBits::IXUSR.bits() | ModeBits::IXGRP.bits() | ModeBits::IXOTH.bits();
         }
         let (st_uid, st_gid) = if self.read_only() { (0, 0) } else { (UID, GID) };
         Ok(StatResult {
@@ -156,12 +145,12 @@ pub trait FSObject {
     // vfs.py:40
     fn access(&self, mode: Mode) -> VfsResult<bool> {
         let s = self.stat()?;
-        let mut e_mode = s.st_mode & S_IRWXO;
+        let mut e_mode = s.st_mode & ModeBits::IRWXO.bits();
         if UID == s.st_uid {
-            e_mode |= (s.st_mode & S_IRWXU) >> 6;
+            e_mode |= (s.st_mode & ModeBits::IRWXU.bits()) >> 6;
         }
         if GID == s.st_gid {
-            e_mode |= (s.st_mode & S_IRWXG) >> 3;
+            e_mode |= (s.st_mode & ModeBits::IRWXG.bits()) >> 3;
         }
         Ok((e_mode & mode) == mode)
     }
@@ -223,7 +212,7 @@ impl FSObject for Dir {
 
     // vfs.py:60
     fn kind(&self) -> Mode {
-        S_IFDIR
+        ModeBits::IFDIR.bits()
     }
 
     // vfs.py:63
@@ -283,7 +272,7 @@ impl FSObject for RealDir {
 
     // vfs.py:60
     fn kind(&self) -> Mode {
-        S_IFDIR
+        ModeBits::IFDIR.bits()
     }
 
     // vfs.py:87
@@ -404,7 +393,7 @@ impl FSObject for File {
 
     // vfs.py:116
     fn kind(&self) -> Mode {
-        S_IFREG
+        ModeBits::IFREG.bits()
     }
 
     // vfs.py:119
@@ -431,7 +420,7 @@ impl RealFile {
         Self {
             state: FSObjectState::default(),
             path: path.into(),
-            kind: S_IFREG | mode,
+            kind: ModeBits::IFREG.bits() | mode,
         }
     }
 
@@ -469,7 +458,7 @@ impl FSObject for RealFile {
 
 // vfs.py:25
 pub fn is_dir(mode: Mode) -> bool {
-    (mode & S_IFMT) == S_IFDIR
+    (mode & ModeBits::IFMT.bits()) == ModeBits::IFDIR.bits()
 }
 
 // vfs.py:134
@@ -539,7 +528,7 @@ mod tests {
     #[test]
     fn test_file() {
         let f = File::new("hello world");
-        assert_eq!(f.kind() & S_IFMT, S_IFREG);
+        assert_eq!(f.kind() & ModeBits::IFMT.bits(), ModeBits::IFREG.bits());
         assert!(f.keys().is_err());
         assert_eq!(f.getsize().unwrap(), 11);
         assert_eq!(
@@ -548,7 +537,7 @@ mod tests {
         );
 
         let st = f.stat().unwrap();
-        assert_eq!(st.st_mode & S_IFMT, S_IFREG);
+        assert_eq!(st.st_mode & ModeBits::IFMT.bits(), ModeBits::IFREG.bits());
         assert_eq!(st.st_size, 11);
         assert!(f.access(R_OK).unwrap());
         assert!(!f.access(W_OK).unwrap());

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1019,9 +1019,6 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             const RING_ENTRIES: u32 = 24;
             const RING_STRIDE: u32 = 5;
             const NAME_SLOTS: u32 = 4;
-            const FLAG_VALID: u64 = 1;
-            const FLAG_COMMITTED: u64 = 2;
-            const FLAG_BRIDGE: u64 = 4;
             const SHIFT_EFFECTS: u32 = 8;
             const SHIFT_JOURNAL: u32 = 24;
             const SHIFT_EXEC_MF: u32 = 40;
@@ -1051,18 +1048,18 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                     }
                 }
                 let flags = slot(base + NAME_SLOTS);
-                if flags & FLAG_VALID == 0 {
+                if flags & FbwRingFlags::VALID.bits() == 0 {
                     continue;
                 }
                 let field = |shift: u32| (flags >> shift) & FIELD_MASK;
                 eprintln!(
                     "[fbw-census] end={end} committed={} leg={} bridge={} exec_mf={} \
                      effects={} journaled={}",
-                    flags & FLAG_COMMITTED != 0,
+                    flags & FbwRingFlags::COMMITTED.bits() != 0,
                     // The leg is the top byte, so the shift already isolates
                     // it; the mask keeps the width of the read on the page.
                     (flags >> SHIFT_LEG) & 0xff,
-                    flags & FLAG_BRIDGE != 0,
+                    flags & FbwRingFlags::BRIDGE.bits() != 0,
                     field(SHIFT_EXEC_MF),
                     field(SHIFT_EFFECTS),
                     field(SHIFT_JOURNAL),


### PR DESCRIPTION
## Summary

Follow-up to #1759: stop keeping a second `pub const` for every `bitflags!` mask.

- Callers use `HeapFlags`, `CoFlags`, `BuiltinCodeFlags`, `StructFlags`, `CTypeFlags`, `CffiTypeFlags`, `ModeBits`, `VerifyFlags`, and `SslOp` directly.
- `fbw_diag_mirror` now evaluates `N << M` and reads `FbwRingFlags` members, so the `FLAG_*` decimal aliases are gone.
- Ring packing and the wasm runner use `RingFlags` / `FbwRingFlags`.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.