### PR TITLE
gc: collect leftover per-call strings and pin stat fields

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1739,9 +1739,9 @@ fn memoryview_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let mv = memoryview_getset_receiver(args);
     unsafe {
         memoryview_check_released(mv)?;
-        Ok(w_str_new(pyre_object::memoryview::w_memoryview_format_str(
-            mv,
-        )))
+        Ok(w_str_new_managed(
+            pyre_object::memoryview::w_memoryview_format_str(mv),
+        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19688,15 +19688,24 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         ));
     }
     let opener = bind_pos_or_kw(pos, kwargs, 4, "opener", "FileIO", 4)?.unwrap_or_else(w_none);
+    let _open_roots = pyre_object::gc_roots::push_roots();
+    let file_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(file);
+    let mode_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&raw_mode));
+    let closefd_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(closefd_obj);
+    let opener_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(opener);
     let opened = open_raw_file(&[
-        file,
-        w_str_new_managed(&raw_mode),
+        pyre_object::gc_roots::shadow_stack_get(file_slot),
+        pyre_object::gc_roots::shadow_stack_get(mode_slot),
         w_int_new(-1),
         w_none(),
         w_none(),
         w_none(),
-        closefd_obj,
-        opener,
+        pyre_object::gc_roots::shadow_stack_get(closefd_slot),
+        pyre_object::gc_roots::shadow_stack_get(opener_slot),
     ])?;
     let _roots = pyre_object::gc_roots::push_roots();
     let self_obj = pyre_object::gc_roots::pin_root(self_obj);
@@ -20607,11 +20616,18 @@ fn fd_bytes_to_obj(self_obj: PyObjectRef, data: Vec<u8>) -> Result<PyObjectRef, 
         Ok(pyre_object::bytesobject::w_bytes_from_bytes(&data))
     } else {
         let (encoding, errors) = unsafe { stream_encoding_errors(self_obj) };
-        let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(&data);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let bytes_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ =
+            pyre_object::gc_roots::pin_root(pyre_object::bytesobject::w_bytes_from_bytes(&data));
+        let enc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&encoding));
+        let err_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&errors));
         crate::typedef::bytes_method_decode(&[
-            w_bytes,
-            w_str_new_managed(&encoding),
-            w_str_new_managed(&errors),
+            pyre_object::gc_roots::shadow_stack_get(bytes_slot),
+            pyre_object::gc_roots::shadow_stack_get(enc_slot),
+            pyre_object::gc_roots::shadow_stack_get(err_slot),
         ])
     }
 }
@@ -21629,8 +21645,16 @@ fn builtin_open_impl(
                 w_bool_from(line_buffering),
             ],
         )?;
-        crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new_managed(&mode))?;
-        Ok(wrapper)
+        let wrapper_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(wrapper);
+        let mode_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&mode));
+        crate::baseobjspace::setattr_str(
+            pyre_object::gc_roots::shadow_stack_get(wrapper_slot),
+            "mode",
+            pyre_object::gc_roots::shadow_stack_get(mode_slot),
+        )?;
+        Ok(pyre_object::gc_roots::shadow_stack_get(wrapper_slot))
     })();
     let result = match outcome {
         Ok(object) => Ok(object),

--- a/pyre/pyre-interpreter/src/cpyext/mapping.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mapping.rs
@@ -44,7 +44,7 @@ fn key_of(pointer: *const c_char) -> Option<PyObjectRef> {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return None;
     }
-    Some(pyre_object::w_str_new(
+    Some(pyre_object::w_str_new_managed(
         &unsafe { CStr::from_ptr(pointer) }.to_string_lossy(),
     ))
 }

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -993,11 +993,12 @@ pub unsafe extern "C" fn PyModule_AddStringConstant(
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(module);
-    let value = pyre_object::w_str_new(&text);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&text));
     store(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
         &key,
-        value,
+        pyre_object::gc_roots::shadow_stack_get(value_slot),
     );
     0
 }
@@ -1036,7 +1037,7 @@ pub unsafe extern "C" fn PyModule_New(name: *const c_char) -> *mut CPyObject {
         return std::ptr::null_mut();
     }
     let name = text_or_empty(name);
-    pyobject::make_ref(new_module(pyre_object::w_str_new(&name)))
+    pyobject::make_ref(new_module(pyre_object::w_str_new_managed(&name)))
 }
 
 /// `modsupport.py:PyModule_NewObject`.
@@ -1178,11 +1179,12 @@ pub unsafe extern "C" fn PyModule_SetDocString(
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(module);
-    let value = pyre_object::w_str_new(&text);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(&text));
     store(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
         "__doc__",
-        value,
+        pyre_object::gc_roots::shadow_stack_get(value_slot),
     );
     0
 }

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -3189,7 +3189,9 @@ fn read_member(
             T_PYSSIZET => pyre_object::w_int_new(*(address as *const isize) as i64),
             T_FLOAT => pyre_object::w_float_new(*(address as *const f32) as f64),
             T_DOUBLE => pyre_object::w_float_new(*(address as *const f64)),
-            T_CHAR => pyre_object::w_str_new(&(*(address as *const u8) as char).to_string()),
+            T_CHAR => {
+                pyre_object::w_str_new_managed(&(*(address as *const u8) as char).to_string())
+            }
             T_STRING => {
                 let text = *(address as *const *const c_char);
                 text_or_none(text)
@@ -6847,7 +6849,7 @@ pub unsafe extern "C" fn PyType_GetFullyQualifiedName(tp: *mut CPyTypeObject) ->
         Some("builtins") | Some("__main__") | None => qualified,
         Some(module) => format!("{module}.{qualified}"),
     };
-    pyobject::make_ref(pyre_object::w_str_new(&name))
+    pyobject::make_ref(pyre_object::w_str_new_managed(&name))
 }
 
 /// The metaclass a type built from a spec is an instance of —

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -65,7 +65,7 @@ pub(super) fn utf8_text(bytes: &[u8]) -> Result<&str, crate::PyError> {
 
 fn from_utf8_bytes(bytes: &[u8]) -> *mut CPyObject {
     match utf8_text(bytes) {
-        Ok(text) => pyobject::make_ref(pyre_object::w_str_new(text)),
+        Ok(text) => pyobject::make_ref(pyre_object::w_str_new_managed(text)),
         Err(error) => {
             super::pyerrors::set_pending_error(error);
             std::ptr::null_mut()
@@ -973,7 +973,7 @@ pub unsafe extern "C" fn PyUnicode_DecodeLocaleAndSize(
         return std::ptr::null_mut();
     };
     let error = match std::str::from_utf8(bytes) {
-        Ok(text) => return pyobject::make_ref(pyre_object::w_str_new(text)),
+        Ok(text) => return pyobject::make_ref(pyre_object::w_str_new_managed(text)),
         Err(error) => error,
     };
     if escaping {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -4049,11 +4049,13 @@ pub(crate) fn emit_report_to_sys_stderr(buf: &[u8]) {
         Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
         None => pyre_object::w_str_new_managed(&String::from_utf8_lossy(buf)),
     };
-    // Read the stream back after that allocation, not before it.
+    let _ = pyre_object::gc_roots::pin_root(w_text);
+    let text_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    // Read the stream and text back after that allocation, not before it.
     let result = crate::baseobjspace::call_method(
         pyre_object::gc_roots::shadow_stack_get(sp),
         "write",
-        &[w_text],
+        &[pyre_object::gc_roots::shadow_stack_get(text_slot)],
     );
     if result.is_null() {
         let _ = crate::call::take_call_error();

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -732,7 +732,7 @@ impl PyError {
         name: &str,
     ) -> Self {
         let mut err = Self::new(PyErrorKind::AttributeError, msg);
-        err.w_name_context = pyre_object::w_str_new(name);
+        err.w_name_context = pyre_object::w_str_new_managed(name);
         err.w_obj_context = w_obj;
         err
     }
@@ -798,7 +798,7 @@ impl PyError {
         };
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(w_obj);
-        let w_name = pyre_object::w_str_new(name);
+        let w_name = pyre_object::w_str_new_managed(name);
         if let Some(slot) = exc_slot {
             self.exc_object = pyre_object::gc_roots::shadow_stack_get(slot);
         }
@@ -1042,7 +1042,7 @@ impl PyError {
     /// materialised (Python 3.10+).
     pub fn name_error_with_name(msg: impl Into<Wtf8Buf>, name: &str) -> Self {
         let mut err = Self::new(PyErrorKind::NameError, msg);
-        err.w_name_context = pyre_object::w_str_new(name);
+        err.w_name_context = pyre_object::w_str_new_managed(name);
         err
     }
 
@@ -1060,7 +1060,7 @@ impl PyError {
     /// `name` rides the shared `w_n` slot (ImportError / NameError /
     /// AttributeError), stamped by `to_exc_object`.
     pub fn module_not_found_with_name(msg: impl Into<Wtf8Buf>, name: &str) -> Self {
-        Self::module_not_found_with_name_obj(msg, pyre_object::w_str_new(name))
+        Self::module_not_found_with_name_obj(msg, pyre_object::w_str_new_managed(name))
     }
 
     /// `module_not_found_with_name` for a name with no `&str` spelling, so the

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -300,9 +300,20 @@ pub fn app_profile_call(
     // executioncontext.py — `frame = jit.hint(frame, access_directly=False)`:
     // from here on, frame is just a normal w_object.
     let frame = majit_metainterp::jit::hint_no_access_directly(frame);
-    let frame_obj = wrap_trace_frame(frame);
-    let w_event = pyre_object::w_str_new(event);
-    crate::call::call_function_impl_result(w_callable, &[frame_obj, w_event, w_arg]).map(|_| ())
+    let _roots = pyre_object::gc_roots::push_roots();
+    let frame_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(wrap_trace_frame(frame));
+    let arg_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_arg);
+    crate::call::call_function_impl_result(
+        w_callable,
+        &[
+            pyre_object::gc_roots::shadow_stack_get(frame_slot),
+            pyre_object::w_str_new(event),
+            pyre_object::gc_roots::shadow_stack_get(arg_slot),
+        ],
+    )
+    .map(|_| ())
 }
 
 /// pypy/interpreter/executioncontext.py:320 `self.profilefunc` — the
@@ -1650,7 +1661,11 @@ impl ExecutionContext {
                 // above put the same instance on the carrier, so the carrier
                 // reads it back.
                 let w_traceback = operr.get_w_traceback(space);
-                pyre_object::tupleobject::w_tuple_new(vec![w_type, w_value, w_traceback])
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(w_type);
+                fields.push(w_value);
+                fields.push(w_traceback);
+                pyre_object::tupleobject::w_tuple_new(fields.take())
             } else {
                 w_arg
             };
@@ -1690,11 +1705,18 @@ impl ExecutionContext {
                 // normal w_object.
                 let frame = majit_metainterp::jit::hint_no_access_directly(frame);
                 // executioncontext.py:382-385 space.call_function(w_callback, frame, w_event, w_arg)
-                let frame_obj = wrap_trace_frame(frame);
-                let w_event = pyre_object::w_str_new(event);
+                let _trace_roots = pyre_object::gc_roots::push_roots();
+                let frame_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(wrap_trace_frame(frame));
+                let arg_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_arg);
                 let call_result = crate::call::call_function_impl_result(
                     w_callback,
-                    &[frame_obj, w_event, w_arg],
+                    &[
+                        pyre_object::gc_roots::shadow_stack_get(frame_slot),
+                        pyre_object::w_str_new(event),
+                        pyre_object::gc_roots::shadow_stack_get(arg_slot),
+                    ],
                 );
                 // The callback received the live frame, so its
                 // `frame.f_trace = local` / `frame.f_lineno = N` setattrs

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1308,7 +1308,7 @@ pub unsafe fn descr_builtin_function_reduce(obj: PyObjectRef) -> crate::PyResult
     {
         let mut args = pyre_object::gc_roots::RootedItems::new();
         args.push(w_self);
-        args.push(pyre_object::w_str_new(unsafe {
+        args.push(pyre_object::w_str_new_managed(unsafe {
             crate::function_get_name(obj)
         }));
         let args = pyre_object::w_tuple_new(args.take());
@@ -1337,7 +1337,7 @@ pub unsafe fn descr_fixed_code_reduce(obj: PyObjectRef) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let owner_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(owner);
-    let name = pyre_object::w_str_new(unsafe { function_get_name(obj) });
+    let name = pyre_object::w_str_new_managed(unsafe { function_get_name(obj) });
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(name);
     let getattr = crate::baseobjspace::builtin_callable("getattr");
@@ -1598,7 +1598,7 @@ pub unsafe fn function_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
         let obj = pyre_object::gc_roots::pin_root(obj);
-        let w_qualname = pyre_object::w_str_new(function_get_name(obj));
+        let w_qualname = pyre_object::w_str_new_managed(function_get_name(obj));
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         function_write_barrier(obj);
         function_notify_quasi_immut(obj, QuasiImmutSlot::WQualname);
@@ -1663,7 +1663,7 @@ pub unsafe fn function_get_name_obj(obj: PyObjectRef) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
         let obj = pyre_object::gc_roots::pin_root(obj);
-        let w_name = pyre_object::w_str_new(function_get_name(obj));
+        let w_name = pyre_object::w_str_new_managed(function_get_name(obj));
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         function_set_name_obj(obj, w_name);
         w_name

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -215,12 +215,13 @@ pub type SeamResult<T> = Result<T, SeamError>;
 /// the `""` the fd call sites pass). Both real and trampoline-backed opens
 /// use this conversion so they expose the same Python exception shape.
 pub fn seam_os_err(e: SeamError, context: &str) -> crate::PyError {
-    let w_filename = if context.is_empty() {
-        pyre_object::PY_NULL
-    } else {
-        pyre_object::w_str_new(context)
-    };
-    seam_os_err_with_filename(e, w_filename)
+    if context.is_empty() {
+        return seam_os_err_with_filename(e, pyre_object::PY_NULL);
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let filename_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(context));
+    seam_os_err_with_filename(e, pyre_object::gc_roots::shadow_stack_get(filename_slot))
 }
 
 /// `wrap_oserror2(space, e, w_path)` in `interp_posix.py`: retain the exact

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeobj.rs
@@ -871,8 +871,8 @@ fn fget(w_self: PyObjectRef, attrchar: char) -> Result<PyObjectRef, PyError> {
     let ct = ctype_arg(w_self)?;
     match attrchar {
         // `W_CType._fget('k')` — a class attribute in PyPy.
-        'k' => Ok(pyre_object::w_str_new(kind_name(ct))),
-        'c' => Ok(pyre_object::w_str_new(ct.name)),
+        'k' => Ok(pyre_object::w_str_new_managed(kind_name(ct))),
+        'c' => Ok(pyre_object::w_str_new_managed(ct.name)),
         // `W_CTypePointer._fget('i')` and `W_CTypeArray._fget('i')`.  A
         // function type has none: `W_CTypeFunc` reaches `W_CType._fget`.
         'i' if ct.is_ptr_or_array() => Ok(ct.ctitem),

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -392,7 +392,10 @@ fn check_digest_name(name_obj: PyObjectRef) -> Result<(), crate::PyError> {
 fn unsupported_digestmod(msg: &str) -> crate::PyError {
     let mut err = crate::PyError::value_error(msg.to_string());
     if let Some(cls) = crate::builtins::lookup_exc_class("_hashlib.UnsupportedDigestmodError") {
-        let args = [cls, w_str_new(msg)];
+        let _roots = gc_roots::push_roots();
+        let msg_slot = gc_roots::shadow_stack_len();
+        let _ = gc_roots::pin_root(w_str_new_managed(msg));
+        let args = [cls, gc_roots::shadow_stack_get(msg_slot)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -964,7 +964,13 @@ impl W_TextIOWrapper {
         }
         payload.state = STATE_OK;
         payload.publish_refs();
-        crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new_managed(name));
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+        crate::baseobjspace::setdictvalue_native(
+            obj,
+            "name",
+            pyre_object::gc_roots::shadow_stack_get(name_slot),
+        );
         obj
     }
 

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -162,20 +162,41 @@ fn split_library_reason(message: &str) -> Option<(&str, &str)> {
 
 fn set_library_reason(exception: PyObjectRef, message: &str) {
     if let Some((library, reason)) = split_library_reason(message) {
-        let _ = crate::baseobjspace::setattr_str(exception, "library", w_str_new(library));
-        let _ = crate::baseobjspace::setattr_str(exception, "reason", w_str_new(reason));
+        let _roots = pyre_object::gc_roots::push_roots();
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(exception);
+        let library_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(library));
+        let _ = crate::baseobjspace::setattr_str(
+            pyre_object::gc_roots::shadow_stack_get(exc_slot),
+            "library",
+            pyre_object::gc_roots::shadow_stack_get(library_slot),
+        );
+        let reason_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(reason));
+        let _ = crate::baseobjspace::setattr_str(
+            pyre_object::gc_roots::shadow_stack_get(exc_slot),
+            "reason",
+            pyre_object::gc_roots::shadow_stack_get(reason_slot),
+        );
     }
 }
 
 fn ssl_error(message: impl Into<String>) -> crate::PyError {
     let message = message.into();
     let mut err = crate::PyError::os_error(message.clone());
-    if let Some(cls) = crate::builtins::lookup_exc_class("ssl.SSLError")
-        && let Ok(exc) =
-            crate::builtins::exc_exception_new(&[cls, w_int_new(0), w_str_new(&message)])
-    {
-        set_library_reason(exc, &message);
-        err.exc_object = exc;
+    if let Some(cls) = crate::builtins::lookup_exc_class("ssl.SSLError") {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let message_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&message));
+        if let Ok(exc) = crate::builtins::exc_exception_new(&[
+            cls,
+            w_int_new(0),
+            pyre_object::gc_roots::shadow_stack_get(message_slot),
+        ]) {
+            set_library_reason(exc, &message);
+            err.exc_object = exc;
+        }
     }
     err
 }
@@ -235,33 +256,46 @@ fn tls_error(code: i32, message: String) -> crate::PyError {
     } else {
         code
     };
-    if let Some(class) = crate::builtins::lookup_exc_class(class_name)
-        && let Ok(exception) = crate::builtins::exc_os_error_new(&[
+    if let Some(class) = crate::builtins::lookup_exc_class(class_name) {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let message_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&message));
+        if let Ok(exception) = crate::builtins::exc_os_error_new(&[
             class,
             w_int_new(public_errno as i64),
-            w_str_new(&message),
-        ])
-    {
-        set_library_reason(exception, &message);
-        if let Some(verify_code) = verify_code {
-            let _ = crate::baseobjspace::setattr_str(
-                exception,
-                "verify_code",
-                w_int_new(verify_code as i64),
-            );
-            let _ = crate::baseobjspace::setattr_str(
-                exception,
-                "verify_message",
-                w_str_new(pyre_native::ssl::certificate_verify_message(verify_code)),
-            );
-            let _ = crate::baseobjspace::setattr_str(exception, "library", w_str_new("SSL"));
-            let _ = crate::baseobjspace::setattr_str(
-                exception,
-                "reason",
-                w_str_new("CERTIFICATE_VERIFY_FAILED"),
-            );
+            pyre_object::gc_roots::shadow_stack_get(message_slot),
+        ]) {
+            let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(exception);
+            set_library_reason(pyre_object::gc_roots::shadow_stack_get(exc_slot), &message);
+            if let Some(verify_code) = verify_code {
+                let _ = crate::baseobjspace::setattr_str(
+                    pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                    "verify_code",
+                    w_int_new(verify_code as i64),
+                );
+                let verify_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(
+                    pyre_native::ssl::certificate_verify_message(verify_code),
+                ));
+                let _ = crate::baseobjspace::setattr_str(
+                    pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                    "verify_message",
+                    pyre_object::gc_roots::shadow_stack_get(verify_slot),
+                );
+                let _ = crate::baseobjspace::setattr_str(
+                    pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                    "library",
+                    w_str_new("SSL"),
+                );
+                let _ = crate::baseobjspace::setattr_str(
+                    pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                    "reason",
+                    w_str_new("CERTIFICATE_VERIFY_FAILED"),
+                );
+            }
+            error.exc_object = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         }
-        error.exc_object = exception;
     }
     error
 }
@@ -330,6 +364,18 @@ fn dict_from_pairs(items: &[(&str, PyObjectRef)]) -> PyObjectRef {
     dict
 }
 
+fn dict_put(dict_slot: usize, key: &str, value: PyObjectRef) {
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(value);
+    unsafe {
+        w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            key,
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
+        );
+    }
+}
+
 fn decoded_name(cert: *const pyre_native::ssl::DecodedCertificate, subject: bool) -> PyObjectRef {
     let rdn_count = unsafe { pyre_native::ssl::certificate_name_rdn_count(cert, subject) };
     // Every tuple here is freshly allocated and the next allocation can collect,
@@ -352,8 +398,8 @@ fn decoded_name(cert: *const pyre_native::ssl::DecodedCertificate, subject: bool
                 };
                 let attribute_tuple = {
                     let mut pair = pyre_object::gc_roots::RootedItems::new();
-                    pair.push(w_str_new(&key));
-                    pair.push(w_str_new(&value));
+                    pair.push(w_str_new_managed(&key));
+                    pair.push(w_str_new_managed(&value));
                     w_tuple_new(pair.take())
                 };
                 attributes.push(attribute_tuple);
@@ -391,8 +437,8 @@ fn decoded_directory_name(
                 };
                 let attribute_tuple = {
                     let mut pair = pyre_object::gc_roots::RootedItems::new();
-                    pair.push(w_str_new(&key));
-                    pair.push(w_str_new(&value));
+                    pair.push(w_str_new_managed(&key));
+                    pair.push(w_str_new_managed(&value));
                     w_tuple_new(pair.take())
                 };
                 attributes.push(attribute_tuple);
@@ -412,39 +458,44 @@ fn decoded_urls(
     if count == 0 {
         return None;
     }
-    Some(w_tuple_new(
-        (0..count)
-            .map(|index| {
-                w_str_new(&unsafe { pyre_native::ssl::certificate_url(cert, kind, index) })
-            })
-            .collect(),
-    ))
+    let mut urls = pyre_object::gc_roots::RootedItems::new();
+    for index in 0..count {
+        urls.push(w_str_new_managed(&unsafe {
+            pyre_native::ssl::certificate_url(cert, kind, index)
+        }));
+    }
+    Some(w_tuple_new(urls.take()))
 }
 
 fn decoded_certificate_dict(cert: *mut pyre_native::ssl::DecodedCertificate) -> PyObjectRef {
-    let dict = dict_from_pairs(&[
-        ("issuer", decoded_name(cert, false)),
-        (
-            "notAfter",
-            w_str_new(&unsafe { pyre_native::ssl::certificate_not_after(cert) }),
-        ),
-        (
-            "notBefore",
-            w_str_new(&unsafe { pyre_native::ssl::certificate_not_before(cert) }),
-        ),
-        (
-            "serialNumber",
-            w_str_new(&unsafe { pyre_native::ssl::certificate_serial_number(cert) }),
-        ),
-        ("subject", decoded_name(cert, true)),
-        (
-            "version",
-            w_int_new(unsafe { pyre_native::ssl::certificate_version(cert) } as i64),
-        ),
-    ]);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_dict_new());
+    dict_put(dict_slot, "issuer", decoded_name(cert, false));
+    dict_put(
+        dict_slot,
+        "notAfter",
+        w_str_new_managed(&unsafe { pyre_native::ssl::certificate_not_after(cert) }),
+    );
+    dict_put(
+        dict_slot,
+        "notBefore",
+        w_str_new_managed(&unsafe { pyre_native::ssl::certificate_not_before(cert) }),
+    );
+    dict_put(
+        dict_slot,
+        "serialNumber",
+        w_str_new_managed(&unsafe { pyre_native::ssl::certificate_serial_number(cert) }),
+    );
+    dict_put(dict_slot, "subject", decoded_name(cert, true));
+    dict_put(
+        dict_slot,
+        "version",
+        w_int_new(unsafe { pyre_native::ssl::certificate_version(cert) } as i64),
+    );
     for (name, kind) in [("OCSP", 0), ("caIssuers", 1), ("crlDistributionPoints", 2)] {
         if let Some(urls) = decoded_urls(cert, kind) {
-            unsafe { w_dict_setitem_str(dict, name, urls) };
+            dict_put(dict_slot, name, urls);
         }
     }
     let san_count = unsafe { pyre_native::ssl::certificate_san_count(cert) };
@@ -460,17 +511,19 @@ fn decoded_certificate_dict(cert: *mut pyre_native::ssl::DecodedCertificate) -> 
                 let value = if kind == "DirName" {
                     decoded_directory_name(cert, index)
                 } else {
-                    w_str_new(&unsafe { pyre_native::ssl::certificate_san_value(cert, index) })
+                    w_str_new_managed(&unsafe {
+                        pyre_native::ssl::certificate_san_value(cert, index)
+                    })
                 };
                 pair.push(value);
                 w_tuple_new(pair.take())
             };
             names.push(entry);
         }
-        unsafe { w_dict_setitem_str(dict, "subjectAltName", w_tuple_new(names.take())) };
+        dict_put(dict_slot, "subjectAltName", w_tuple_new(names.take()));
     }
     unsafe { pyre_native::ssl::certificate_free(cert) };
-    dict
+    pyre_object::gc_roots::shadow_stack_get(dict_slot)
 }
 
 fn parse_server_hostname(
@@ -500,7 +553,7 @@ fn parse_server_hostname(
             "server_hostname must contain ASCII only",
         ));
     }
-    Ok((Some(hostname.clone()), w_str_new(&hostname)))
+    Ok((Some(hostname.clone()), w_str_new_managed(&hostname)))
 }
 
 fn allocate_ssl_socket(
@@ -1129,25 +1182,52 @@ mod context_methods {
                 let name = pyre_native::ssl::cipher_name(index);
                 let bits = pyre_native::ssl::cipher_bits(index);
                 let description = pyre_native::ssl::cipher_description(index);
-                ciphers.push(dict_from_pairs(&[
-                    ("id", w_int_new(pyre_native::ssl::cipher_id(index))),
-                    ("name", w_str_new(name)),
-                    (
+                let cipher = {
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(w_dict_new());
+                    dict_put(
+                        dict_slot,
+                        "id",
+                        w_int_new(pyre_native::ssl::cipher_id(index)),
+                    );
+                    dict_put(dict_slot, "name", w_str_new_managed(name));
+                    dict_put(
+                        dict_slot,
                         "protocol",
-                        w_str_new(pyre_native::ssl::cipher_protocol(index)),
-                    ),
-                    ("description", w_str_new(&description)),
-                    ("strength_bits", w_int_new(bits as i64)),
-                    ("alg_bits", w_int_new(bits as i64)),
-                    ("aead", w_bool_from(pyre_native::ssl::cipher_aead(index))),
-                    (
+                        w_str_new_managed(pyre_native::ssl::cipher_protocol(index)),
+                    );
+                    dict_put(dict_slot, "description", w_str_new_managed(&description));
+                    dict_put(dict_slot, "strength_bits", w_int_new(bits as i64));
+                    dict_put(dict_slot, "alg_bits", w_int_new(bits as i64));
+                    dict_put(
+                        dict_slot,
+                        "aead",
+                        w_bool_from(pyre_native::ssl::cipher_aead(index)),
+                    );
+                    dict_put(
+                        dict_slot,
                         "symmetric",
-                        w_str_new(pyre_native::ssl::cipher_symmetric(index)),
-                    ),
-                    ("digest", w_str_new(pyre_native::ssl::cipher_digest(index))),
-                    ("kea", w_str_new(pyre_native::ssl::cipher_kea(index))),
-                    ("auth", w_str_new(pyre_native::ssl::cipher_auth(index))),
-                ]));
+                        w_str_new_managed(pyre_native::ssl::cipher_symmetric(index)),
+                    );
+                    dict_put(
+                        dict_slot,
+                        "digest",
+                        w_str_new_managed(pyre_native::ssl::cipher_digest(index)),
+                    );
+                    dict_put(
+                        dict_slot,
+                        "kea",
+                        w_str_new_managed(pyre_native::ssl::cipher_kea(index)),
+                    );
+                    dict_put(
+                        dict_slot,
+                        "auth",
+                        w_str_new_managed(pyre_native::ssl::cipher_auth(index)),
+                    );
+                    pyre_object::gc_roots::shadow_stack_get(dict_slot)
+                };
+                ciphers.push(cipher);
             }
             w_list_new(ciphers.take())
         }
@@ -1580,15 +1660,20 @@ mod ssl_socket_methods {
             return Ok(());
         }
         for event in events {
+            let _event_roots = pyre_object::gc_roots::push_roots();
+            let owner_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(owner);
+            let data_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&event.data));
             crate::call::call_function_impl_result(
                 context.msg_callback,
                 &[
-                    owner,
+                    pyre_object::gc_roots::shadow_stack_get(owner_slot),
                     w_str_new(if event.write { "write" } else { "read" }),
                     w_int_new(event.version as i64),
                     w_int_new(event.content_type as i64),
                     w_int_new(event.message_type as i64),
-                    w_bytes_from_bytes(&event.data),
+                    pyre_object::gc_roots::shadow_stack_get(data_slot),
                 ],
             )?;
         }
@@ -2005,14 +2090,24 @@ mod ssl_socket_methods {
                     "[SSL: PARSE_TLSEXT] SNI callback owner is no longer available".to_string(),
                 ));
             }
-            let server_name = unsafe {
+            let _sni_roots = pyre_object::gc_roots::push_roots();
+            let owner_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(owner);
+            let name_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(unsafe {
                 pyre_native::ssl::connection_server_name(backend)
-                    .map(|name| w_str_new(&name))
+                    .map(|name| w_str_new_managed(&name))
                     .unwrap_or_else(w_none)
-            };
+            });
+            let context_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(initial_context);
             let result = match crate::call::call_function_impl_result(
                 callback,
-                &[owner, server_name, initial_context],
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(owner_slot),
+                    pyre_object::gc_roots::shadow_stack_get(name_slot),
+                    pyre_object::gc_roots::shadow_stack_get(context_slot),
+                ],
             ) {
                 Ok(result) => result,
                 Err(mut error) => {
@@ -2382,7 +2477,7 @@ mod ssl_socket_methods {
                 return w_none();
             }
             unsafe { pyre_native::ssl::connection_alpn(self.backend) }
-                .map(|value| w_str_new(&String::from_utf8_lossy(&value)))
+                .map(|value| w_str_new_managed(&String::from_utf8_lossy(&value)))
                 .unwrap_or_else(w_none)
         }
 
@@ -2391,7 +2486,7 @@ mod ssl_socket_methods {
                 return w_none();
             }
             unsafe { pyre_native::ssl::connection_version(self.backend) }
-                .map(w_str_new)
+                .map(w_str_new_managed)
                 .unwrap_or_else(w_none)
         }
 
@@ -2695,7 +2790,7 @@ mod certificate_methods {
                 pem.push_str("-----END CERTIFICATE-----\n");
                 // Peer/path certificates carry no OpenSSL auxiliary trust
                 // data, so PEM_write_bio_X509_AUX has the same output as PEM.
-                return Ok(w_str_new(&pem));
+                return Ok(w_str_new_managed(&pem));
             }
             Err(crate::PyError::value_error("Unsupported format"))
         }
@@ -2910,7 +3005,7 @@ mod cert_store {
                     CertificateUses::Oids(oids) => {
                         let mut strings = RootedItems::new();
                         for oid in oids {
-                            strings.push(pyre_object::w_str_new(&oid));
+                            strings.push(pyre_object::w_str_new_managed(&oid));
                         }
                         pyre_object::w_frozenset_from_items(&strings.take())
                     }
@@ -2945,8 +3040,8 @@ mod cert_store {
 #[cfg(all(windows, not(feature = "host_env")))]
 mod cert_store {
     use pyre_object::{
-        PyObjectRef, w_bool_from, w_bytes_from_bytes, w_frozenset_from_items, w_int_new,
-        w_list_new, w_str_new, w_tuple_new,
+        PyObjectRef, gc_roots::RootedItems, w_bool_from, w_bytes_from_bytes,
+        w_frozenset_from_items, w_int_new, w_list_new, w_str_new, w_str_new_managed, w_tuple_new,
     };
     use windows_sys::Win32::Foundation::CRYPT_E_NOT_FOUND;
     use windows_sys::Win32::Security::Cryptography::{
@@ -3011,15 +3106,15 @@ mod cert_store {
             return key_usage_not_found();
         }
         let usage = &*usage;
-        let mut oids = Vec::with_capacity(usage.cUsageIdentifier as usize);
+        let mut oids = RootedItems::new();
         for i in 0..usage.cUsageIdentifier as usize {
             let oid = *usage.rgpszUsageIdentifier.add(i);
             if !oid.is_null() {
                 let oid = std::ffi::CStr::from_ptr(oid.cast());
-                oids.push(w_str_new(&oid.to_string_lossy()));
+                oids.push(w_str_new_managed(&oid.to_string_lossy()));
             }
         }
-        Ok(Some(w_frozenset_from_items(&oids)))
+        Ok(Some(w_frozenset_from_items(&oids.take())))
     }
 
     /// Walk one kind of store content: `next` is `CertEnumCertificatesInStore`

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -2062,6 +2062,9 @@ fn array_reconstructor(args: &[PyObjectRef]) -> PyResult {
 
     if matches!(mformat, 18..=21) {
         let obj = array_descr_new(&[w_cls, args[1]])?;
+        let _roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let encoding = match mformat {
             18 => "utf-16-le",
             19 => "utf-16-be",
@@ -2073,8 +2076,8 @@ fn array_reconstructor(args: &[PyObjectRef]) -> PyResult {
             "decode",
             &[pyre_object::w_str_new_managed(encoding)],
         )?;
-        array_fromunicode(obj, decoded)?;
-        return Ok(obj);
+        array_fromunicode(pyre_object::gc_roots::shadow_stack_get(obj_slot), decoded)?;
+        return Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot));
     }
 
     let (source_size, signed, big_endian) = reconstructor_descriptor(mformat);

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -5028,74 +5028,85 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         // The 10 sequence slots are the integer fields (integer-seconds
         // times at 7..10, named `_integer_*`); the float times, `st_*_ns`,
         // and the platform block/device extras are named-only fields.
-        let seq = vec![
-            pyre_object::w_int_new(st_mode),
-            w_ino(st_ino),
-            pyre_object::w_int_new(st_dev),
-            pyre_object::w_int_new(st_nlink),
-            pyre_object::w_int_new(st_uid),
-            pyre_object::w_int_new(st_gid),
-            pyre_object::w_int_new(st_size),
-            pyre_object::w_int_new(st_atime),
-            pyre_object::w_int_new(st_mtime),
-            pyre_object::w_int_new(st_ctime),
-        ];
         // `_ll_get_st_atime` — float times keep sub-second precision:
         // `float(seconds) + 1e-9 * nanosecond_fraction`, where the
         // fraction is recovered from the full-nanosecond field.
         let st_atime_f = st_atime as f64 + 1e-9 * (st_atime_ns - whole_ns(st_atime, 0)) as f64;
         let st_mtime_f = st_mtime as f64 + 1e-9 * (st_mtime_ns - whole_ns(st_mtime, 0)) as f64;
         let st_ctime_f = st_ctime as f64 + 1e-9 * (st_ctime_ns - whole_ns(st_ctime, 0)) as f64;
-        #[allow(unused_mut)]
-        let mut extras = vec![
-            ("st_atime", pyre_object::w_float_new(st_atime_f)),
-            ("st_mtime", pyre_object::w_float_new(st_mtime_f)),
-            ("st_ctime", pyre_object::w_float_new(st_ctime_f)),
-            ("st_atime_ns", w_time_ns(st_atime_ns)),
-            ("st_mtime_ns", w_time_ns(st_mtime_ns)),
-            ("st_ctime_ns", w_time_ns(st_ctime_ns)),
-            // `build_stat_result` (interp_posix.py): the
-            // sub-second remainder of each full-nanosecond timestamp,
-            // `value % 1_000_000_000` (non-negative for pre-1970 times).
-            (
-                "nsec_atime",
-                pyre_object::w_int_new(st_atime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-            (
-                "nsec_mtime",
-                pyre_object::w_int_new(st_mtime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-            (
-                "nsec_ctime",
-                pyre_object::w_int_new(st_ctime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-        ];
+        let _roots = pyre_object::gc_roots::push_roots();
+        let mut extra_slots: Vec<(&str, usize)> = Vec::new();
+        let mut put_extra = |name: &'static str, value: pyre_object::PyObjectRef| {
+            extra_slots.push((name, pyre_object::gc_roots::shadow_stack_len()));
+            let _ = pyre_object::gc_roots::pin_root(value);
+        };
+        put_extra("st_atime", pyre_object::w_float_new(st_atime_f));
+        put_extra("st_mtime", pyre_object::w_float_new(st_mtime_f));
+        put_extra("st_ctime", pyre_object::w_float_new(st_ctime_f));
+        put_extra("st_atime_ns", w_time_ns(st_atime_ns));
+        put_extra("st_mtime_ns", w_time_ns(st_mtime_ns));
+        put_extra("st_ctime_ns", w_time_ns(st_ctime_ns));
+        // `build_stat_result` (interp_posix.py): the
+        // sub-second remainder of each full-nanosecond timestamp,
+        // `value % 1_000_000_000` (non-negative for pre-1970 times).
+        put_extra(
+            "nsec_atime",
+            pyre_object::w_int_new(st_atime_ns.rem_euclid(1_000_000_000) as i64),
+        );
+        put_extra(
+            "nsec_mtime",
+            pyre_object::w_int_new(st_mtime_ns.rem_euclid(1_000_000_000) as i64),
+        );
+        put_extra(
+            "nsec_ctime",
+            pyre_object::w_int_new(st_ctime_ns.rem_euclid(1_000_000_000) as i64),
+        );
         #[cfg(unix)]
         {
-            extras.push(("st_blksize", pyre_object::w_int_new(st_blksize)));
-            extras.push(("st_blocks", pyre_object::w_int_new(st_blocks)));
-            extras.push(("st_rdev", pyre_object::w_int_new(st_rdev)));
+            put_extra("st_blksize", pyre_object::w_int_new(st_blksize));
+            put_extra("st_blocks", pyre_object::w_int_new(st_blocks));
+            put_extra("st_rdev", pyre_object::w_int_new(st_rdev));
         }
         #[cfg(target_os = "macos")]
-        extras.push(("st_flags", pyre_object::w_int_new(st_flags as i64)));
+        put_extra("st_flags", pyre_object::w_int_new(st_flags as i64));
         #[cfg(not(target_os = "macos"))]
         let _ = st_flags;
         #[cfg(windows)]
         {
             let birthtime_f =
                 f.birthtime as f64 + 1e-9 * (f.birthtime_ns - whole_ns(f.birthtime, 0)) as f64;
-            extras.push((
+            put_extra(
                 "st_file_attributes",
                 pyre_object::w_int_new(f.file_attributes as i64),
-            ));
-            extras.push((
+            );
+            put_extra(
                 "st_reparse_tag",
                 pyre_object::w_int_new(f.reparse_tag as i64),
-            ));
-            extras.push(("st_birthtime", pyre_object::w_float_new(birthtime_f)));
-            extras.push(("st_birthtime_ns", w_time_ns(f.birthtime_ns)));
+            );
+            put_extra("st_birthtime", pyre_object::w_float_new(birthtime_f));
+            put_extra("st_birthtime_ns", w_time_ns(f.birthtime_ns));
         }
-        crate::_structseq::new_instance_with_extra(super::stat_result_seq_type(), seq, extras)
+        drop(put_extra);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_int_new(st_mode));
+        fields.push(w_ino(st_ino));
+        fields.push(pyre_object::w_int_new(st_dev));
+        fields.push(pyre_object::w_int_new(st_nlink));
+        fields.push(pyre_object::w_int_new(st_uid));
+        fields.push(pyre_object::w_int_new(st_gid));
+        fields.push(pyre_object::w_int_new(st_size));
+        fields.push(pyre_object::w_int_new(st_atime));
+        fields.push(pyre_object::w_int_new(st_mtime));
+        fields.push(pyre_object::w_int_new(st_ctime));
+        let extras: Vec<_> = extra_slots
+            .into_iter()
+            .map(|(name, slot)| (name, pyre_object::gc_roots::shadow_stack_get(slot)))
+            .collect();
+        crate::_structseq::new_instance_with_extra(
+            super::stat_result_seq_type(),
+            fields.take(),
+            extras,
+        )
     }
     /// Build a `stat_result` from the sandbox wire `StatBuf` (sandbox build
     /// only, hence unix-only): the controller delivers the 10 protocol fields
@@ -5110,48 +5121,59 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         let st_atime_ns = whole_ns(st.atime, st.atime_nsec);
         let st_mtime_ns = whole_ns(st.mtime, st.mtime_nsec);
         let st_ctime_ns = whole_ns(st.ctime, st.ctime_nsec);
-        let seq = vec![
-            pyre_object::w_int_new(st.mode as i64),
-            pyre_object::w_int_new(st.ino as i64),
-            pyre_object::w_int_new(st.dev as i64),
-            pyre_object::w_int_new(st.nlink as i64),
-            pyre_object::w_int_new(st.uid as i64),
-            pyre_object::w_int_new(st.gid as i64),
-            pyre_object::w_int_new(st.size as i64),
-            pyre_object::w_int_new(st_atime),
-            pyre_object::w_int_new(st_mtime),
-            pyre_object::w_int_new(st_ctime),
-        ];
         let st_atime_f = st_atime as f64 + 1e-9 * (st_atime_ns - whole_ns(st_atime, 0)) as f64;
         let st_mtime_f = st_mtime as f64 + 1e-9 * (st_mtime_ns - whole_ns(st_mtime, 0)) as f64;
         let st_ctime_f = st_ctime as f64 + 1e-9 * (st_ctime_ns - whole_ns(st_ctime, 0)) as f64;
-        #[allow(unused_mut)]
-        let mut extras = vec![
-            ("st_atime", pyre_object::w_float_new(st_atime_f)),
-            ("st_mtime", pyre_object::w_float_new(st_mtime_f)),
-            ("st_ctime", pyre_object::w_float_new(st_ctime_f)),
-            ("st_atime_ns", w_time_ns(st_atime_ns)),
-            ("st_mtime_ns", w_time_ns(st_mtime_ns)),
-            ("st_ctime_ns", w_time_ns(st_ctime_ns)),
-            (
-                "nsec_atime",
-                pyre_object::w_int_new(st_atime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-            (
-                "nsec_mtime",
-                pyre_object::w_int_new(st_mtime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-            (
-                "nsec_ctime",
-                pyre_object::w_int_new(st_ctime_ns.rem_euclid(1_000_000_000) as i64),
-            ),
-            ("st_blksize", pyre_object::w_int_new(st.blksize as i64)),
-            ("st_blocks", pyre_object::w_int_new(st.blocks as i64)),
-            ("st_rdev", pyre_object::w_int_new(st.rdev as i64)),
-        ];
+        let _roots = pyre_object::gc_roots::push_roots();
+        let mut extra_slots: Vec<(&str, usize)> = Vec::new();
+        let mut put_extra = |name: &'static str, value: pyre_object::PyObjectRef| {
+            extra_slots.push((name, pyre_object::gc_roots::shadow_stack_len()));
+            let _ = pyre_object::gc_roots::pin_root(value);
+        };
+        put_extra("st_atime", pyre_object::w_float_new(st_atime_f));
+        put_extra("st_mtime", pyre_object::w_float_new(st_mtime_f));
+        put_extra("st_ctime", pyre_object::w_float_new(st_ctime_f));
+        put_extra("st_atime_ns", w_time_ns(st_atime_ns));
+        put_extra("st_mtime_ns", w_time_ns(st_mtime_ns));
+        put_extra("st_ctime_ns", w_time_ns(st_ctime_ns));
+        put_extra(
+            "nsec_atime",
+            pyre_object::w_int_new(st_atime_ns.rem_euclid(1_000_000_000) as i64),
+        );
+        put_extra(
+            "nsec_mtime",
+            pyre_object::w_int_new(st_mtime_ns.rem_euclid(1_000_000_000) as i64),
+        );
+        put_extra(
+            "nsec_ctime",
+            pyre_object::w_int_new(st_ctime_ns.rem_euclid(1_000_000_000) as i64),
+        );
+        put_extra("st_blksize", pyre_object::w_int_new(st.blksize as i64));
+        put_extra("st_blocks", pyre_object::w_int_new(st.blocks as i64));
+        put_extra("st_rdev", pyre_object::w_int_new(st.rdev as i64));
         #[cfg(target_os = "macos")]
-        extras.push(("st_flags", pyre_object::w_int_new(st.st_flags as i64)));
-        crate::_structseq::new_instance_with_extra(super::stat_result_seq_type(), seq, extras)
+        put_extra("st_flags", pyre_object::w_int_new(st.st_flags as i64));
+        drop(put_extra);
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_int_new(st.mode as i64));
+        fields.push(pyre_object::w_int_new(st.ino as i64));
+        fields.push(pyre_object::w_int_new(st.dev as i64));
+        fields.push(pyre_object::w_int_new(st.nlink as i64));
+        fields.push(pyre_object::w_int_new(st.uid as i64));
+        fields.push(pyre_object::w_int_new(st.gid as i64));
+        fields.push(pyre_object::w_int_new(st.size as i64));
+        fields.push(pyre_object::w_int_new(st_atime));
+        fields.push(pyre_object::w_int_new(st_mtime));
+        fields.push(pyre_object::w_int_new(st_ctime));
+        let extras: Vec<_> = extra_slots
+            .into_iter()
+            .map(|(name, slot)| (name, pyre_object::gc_roots::shadow_stack_get(slot)))
+            .collect();
+        crate::_structseq::new_instance_with_extra(
+            super::stat_result_seq_type(),
+            fields.take(),
+            extras,
+        )
     }
     /// `os.stat(path, *, dir_fd=None, follow_symlinks=True)` /
     /// `os.lstat(path, *, dir_fd=None)` — `follow_symlinks` is keyword-only,
@@ -9133,20 +9155,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         fn statvfs_to_obj(
             info: rustpython_host_env::posix::StatVfsInfo,
         ) -> pyre_object::PyObjectRef {
-            let seq = vec![
-                pyre_object::w_int_new(info.f_bsize as i64),
-                pyre_object::w_int_new(info.f_frsize as i64),
-                pyre_object::w_int_new(info.f_blocks as i64),
-                pyre_object::w_int_new(info.f_bfree as i64),
-                pyre_object::w_int_new(info.f_bavail as i64),
-                pyre_object::w_int_new(info.f_files as i64),
-                pyre_object::w_int_new(info.f_ffree as i64),
-                pyre_object::w_int_new(info.f_favail as i64),
-                pyre_object::w_int_new(info.f_flag as i64),
-                pyre_object::w_int_new(info.f_namemax as i64),
-            ];
-            let extras = vec![("f_fsid", pyre_object::w_int_new(info.f_fsid as i64))];
-            crate::_structseq::new_instance_with_extra(statvfs_result_seq_type(), seq, extras)
+            let _roots = pyre_object::gc_roots::push_roots();
+            let fsid_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(info.f_fsid as i64));
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_int_new(info.f_bsize as i64));
+            fields.push(pyre_object::w_int_new(info.f_frsize as i64));
+            fields.push(pyre_object::w_int_new(info.f_blocks as i64));
+            fields.push(pyre_object::w_int_new(info.f_bfree as i64));
+            fields.push(pyre_object::w_int_new(info.f_bavail as i64));
+            fields.push(pyre_object::w_int_new(info.f_files as i64));
+            fields.push(pyre_object::w_int_new(info.f_ffree as i64));
+            fields.push(pyre_object::w_int_new(info.f_favail as i64));
+            fields.push(pyre_object::w_int_new(info.f_flag as i64));
+            fields.push(pyre_object::w_int_new(info.f_namemax as i64));
+            crate::_structseq::new_instance_with_extra(
+                statvfs_result_seq_type(),
+                fields.take(),
+                vec![(
+                    "f_fsid",
+                    pyre_object::gc_roots::shadow_stack_get(fsid_slot),
+                )],
+            )
         }
         #[cfg(not(target_os = "redox"))]
         crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -218,30 +218,38 @@ fn seam_error(e: &std::io::Error, w_path: PyObjectRef) -> crate::PyError {
 /// block-device fields nor the Windows ones, leaving the float times, the
 /// sub-second remainders and the full nanosecond timestamps.
 fn make_stat_result(mode: i64, size: i64) -> PyObjectRef {
-    let seq = vec![
-        pyre_object::w_int_new(mode),
-        pyre_object::w_int_new(0), // st_ino
-        pyre_object::w_int_new(0), // st_dev
-        pyre_object::w_int_new(1), // st_nlink
-        pyre_object::w_int_new(0), // st_uid
-        pyre_object::w_int_new(0), // st_gid
-        pyre_object::w_int_new(size),
-        pyre_object::w_int_new(0), // _integer_atime
-        pyre_object::w_int_new(0), // _integer_mtime
-        pyre_object::w_int_new(0), // _integer_ctime
-    ];
-    let extras = vec![
-        ("st_atime", pyre_object::w_float_new(0.0)),
-        ("st_mtime", pyre_object::w_float_new(0.0)),
-        ("st_ctime", pyre_object::w_float_new(0.0)),
-        ("nsec_atime", pyre_object::w_int_new(0)),
-        ("nsec_mtime", pyre_object::w_int_new(0)),
-        ("nsec_ctime", pyre_object::w_int_new(0)),
-        ("st_atime_ns", pyre_object::w_int_new(0)),
-        ("st_mtime_ns", pyre_object::w_int_new(0)),
-        ("st_ctime_ns", pyre_object::w_int_new(0)),
-    ];
-    crate::_structseq::new_instance_with_extra(super::stat_result_seq_type(), seq, extras)
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut extra_slots: Vec<(&str, usize)> = Vec::new();
+    let mut put_extra = |name: &'static str, value: PyObjectRef| {
+        extra_slots.push((name, pyre_object::gc_roots::shadow_stack_len()));
+        let _ = pyre_object::gc_roots::pin_root(value);
+    };
+    put_extra("st_atime", pyre_object::w_float_new(0.0));
+    put_extra("st_mtime", pyre_object::w_float_new(0.0));
+    put_extra("st_ctime", pyre_object::w_float_new(0.0));
+    put_extra("nsec_atime", pyre_object::w_int_new(0));
+    put_extra("nsec_mtime", pyre_object::w_int_new(0));
+    put_extra("nsec_ctime", pyre_object::w_int_new(0));
+    put_extra("st_atime_ns", pyre_object::w_int_new(0));
+    put_extra("st_mtime_ns", pyre_object::w_int_new(0));
+    put_extra("st_ctime_ns", pyre_object::w_int_new(0));
+    drop(put_extra);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_int_new(mode));
+    fields.push(pyre_object::w_int_new(0)); // st_ino
+    fields.push(pyre_object::w_int_new(0)); // st_dev
+    fields.push(pyre_object::w_int_new(1)); // st_nlink
+    fields.push(pyre_object::w_int_new(0)); // st_uid
+    fields.push(pyre_object::w_int_new(0)); // st_gid
+    fields.push(pyre_object::w_int_new(size));
+    fields.push(pyre_object::w_int_new(0)); // _integer_atime
+    fields.push(pyre_object::w_int_new(0)); // _integer_mtime
+    fields.push(pyre_object::w_int_new(0)); // _integer_ctime
+    let extras: Vec<_> = extra_slots
+        .into_iter()
+        .map(|(name, slot)| (name, pyre_object::gc_roots::shadow_stack_get(slot)))
+        .collect();
+    crate::_structseq::new_instance_with_extra(super::stat_result_seq_type(), fields.take(), extras)
 }
 
 /// `os.terminal_size` structseq — `(columns, lines)`.

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -1266,16 +1266,15 @@ impl<'a> MiniXmlParser<'a> {
 
     fn intern_string(&self, value: &str) -> PyObjectRef {
         // Nothing holds the new string until the map takes it, and everything
-        // below can collect, so it gets one liveness pin at its mint; a `str`
-        // does not move, so the local stays current.
+        // below can collect, so it gets one liveness pin at its mint.
         let value_roots = pyre_object::gc_roots::push_roots();
-        let w_value = w_str_new(value);
-        let w_value = value_roots.pin_root(w_value);
+        let value_slot = value_roots.base();
+        let _ = value_roots.pin_root(w_str_new_managed(value));
         let Ok(intern) = crate::baseobjspace::getattr_str(self.parser, "intern") else {
-            return w_value;
+            return value_roots.get(value_slot);
         };
         if unsafe { is_none(intern) } {
-            return w_value;
+            return value_roots.get(value_slot);
         }
         // The intern map is a caller-supplied `dict`, whose header moves.  A
         // borrowed-str probe compares against whatever a colliding bucket
@@ -1289,8 +1288,8 @@ impl<'a> MiniXmlParser<'a> {
             if let Some(existing) = w_dict_getitem_str(roots.get(intern_slot), value) {
                 existing
             } else {
-                w_dict_setitem_str(roots.get(intern_slot), value, w_value);
-                w_value
+                w_dict_setitem_str(roots.get(intern_slot), value, value_roots.get(value_slot));
+                value_roots.get(value_slot)
             }
         }
     }
@@ -2049,7 +2048,7 @@ fn error_string(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(ERROR_TABLE
         .iter()
         .find(|(_, c)| *c == code)
-        .map(|(msg, _)| w_str_new(msg))
+        .map(|(msg, _)| w_str_new_managed(msg))
         .unwrap_or_else(w_none))
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -829,9 +829,9 @@ pub unsafe fn w_code_qualname_obj(w_code: PyObjectRef) -> PyObjectRef {
         // reference in the shadow stack across it; reload the possibly moved
         // wrapper before publishing the cache field.
         let w_qualname = w_str_new_managed(&(*code_ptr).qualname);
-        publish_code_slot_store(roots.get(code_slot));
-        let w_code = roots.get(code_slot);
-        (*(w_code as *mut PyCode)).w_qualname = w_qualname;
+        let published = publish_code_slot_store_rooting(roots.get(code_slot), &[w_qualname]);
+        let w_qualname = published.get(0);
+        (*(published.owner() as *mut PyCode)).w_qualname = w_qualname;
         w_qualname
     }
 }
@@ -863,9 +863,9 @@ pub unsafe fn w_code_name_obj(w_code: PyObjectRef) -> PyObjectRef {
         // reference in the shadow stack across it; reload the possibly moved
         // wrapper before publishing the cache field.
         let w_name = w_str_new_managed(&(*code_ptr).obj_name);
-        publish_code_slot_store(roots.get(code_slot));
-        let w_code = roots.get(code_slot);
-        (*(w_code as *mut PyCode)).w_name = w_name;
+        let published = publish_code_slot_store_rooting(roots.get(code_slot), &[w_name]);
+        let w_name = published.get(0);
+        (*(published.owner() as *mut PyCode)).w_name = w_name;
         w_name
     }
 }
@@ -2225,7 +2225,7 @@ pub unsafe fn code_varname_from_oparg(
             .filter(|cell| !code.varnames.iter().any(|var| var == *cell));
         let pure_cellvar_count = pure_cellvars.clone().count();
         if let Some(name) = pure_cellvars.skip(index as usize).next() {
-            return Ok(w_str_new(name));
+            return Ok(w_str_new_managed(name));
         }
         index -= pure_cellvar_count as i64;
         let fi = index as usize;

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2168,7 +2168,7 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     )?;
     for names in [&code.varnames, &code.freevars, &code.cellvars, &code.names] {
         for name in names.iter() {
-            add_obj(&mut result, w_str_new(name))?;
+            add_obj(&mut result, w_str_new_managed(name))?;
         }
     }
     for (index, constant) in crate::pyframe::code_constants(code).iter().enumerate() {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6424,7 +6424,13 @@ pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             fields.push(wtf8_slice_str(&s[i + sep.len()..]));
             Ok(w_tuple_new(fields.take()))
         }
-        None => Ok(w_tuple_new(vec![args[0], w_str_new(""), w_str_new("")])),
+        None => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(args[0]);
+            fields.push(w_str_new(""));
+            fields.push(w_str_new(""));
+            Ok(w_tuple_new(fields.take()))
+        }
     }
 }
 
@@ -6450,7 +6456,13 @@ pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
             fields.push(wtf8_slice_str(&s[i + sep.len()..]));
             Ok(w_tuple_new(fields.take()))
         }
-        None => Ok(w_tuple_new(vec![w_str_new(""), w_str_new(""), args[0]])),
+        None => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(w_str_new(""));
+            fields.push(w_str_new(""));
+            fields.push(args[0]);
+            Ok(w_tuple_new(fields.take()))
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15230,7 +15230,9 @@ unsafe fn descr_member_name(obj: PyObjectRef) -> crate::PyResult {
         }
         if pyre_object::is_member(obj) {
             // typedef.py interp_attrproperty('name')
-            return Ok(pyre_object::w_str_new(pyre_object::w_member_get_name(obj)));
+            return Ok(pyre_object::w_str_new_managed(
+                pyre_object::w_member_get_name(obj),
+            ));
         }
         if crate::function::is_function_carrier(obj) {
             return Ok(crate::function::fget_func_name(obj));
@@ -16012,7 +16014,7 @@ fn init_builtin_code_type(ns: PyObjectRef) {
                 return Ok(pyre_object::w_none());
             }
             let name = unsafe { crate::builtin_code_name(code) };
-            Ok(pyre_object::w_str_new(name))
+            Ok(pyre_object::w_str_new_managed(name))
         },
         2,
     );
@@ -16788,9 +16790,7 @@ fn init_classmethod_descriptor_type(ns: PyObjectRef) {
         ),
         ("__name__", |args: &[PyObjectRef]| {
             let function = classmethod_descriptor_function(args[1], "__name__")?;
-            Ok(pyre_object::w_str_new(unsafe {
-                crate::function::function_get_name(function)
-            }))
+            Ok(unsafe { crate::function::fget_func_name(function) })
         }),
         ("__qualname__", |args: &[PyObjectRef]| {
             let function = classmethod_descriptor_function(args[1], "__qualname__")?;
@@ -25194,11 +25194,18 @@ pub(crate) fn unicode_decode_error(
     end: usize,
     reason: &str,
 ) -> crate::PyError {
-    let w_encoding = pyre_object::w_str_new(encoding);
-    let w_object = pyre_object::w_bytes_from_bytes(data);
-    let w_start = pyre_object::w_int_new(start as i64);
-    let w_end = pyre_object::w_int_new(end as i64);
-    let w_reason = pyre_object::w_str_new(reason);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_str_new_managed(encoding));
+    fields.push(pyre_object::w_bytes_from_bytes(data));
+    fields.push(pyre_object::w_int_new(start as i64));
+    fields.push(pyre_object::w_int_new(end as i64));
+    fields.push(pyre_object::w_str_new_managed(reason));
+    let items = fields.take();
+    let w_encoding = items[0];
+    let w_object = items[1];
+    let w_start = items[2];
+    let w_end = items[3];
+    let w_reason = items[4];
     // Eager message for PyError.message; descr_str recomputes the same
     // text from the fields (display.rs unicode_decode_error_str).
     let msg = unicode_decode_error_msg(encoding, data, start, end, reason);
@@ -25213,9 +25220,7 @@ pub(crate) fn unicode_decode_error(
         pyre_object::interp_exceptions::w_exception_set_end(exc, w_end);
         pyre_object::interp_exceptions::w_exception_set_reason(exc, w_reason);
         // W_BaseException.descr_init: args_w = [encoding, object, start, end, reason]
-        let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            w_encoding, w_object, w_start, w_end, w_reason,
-        ]);
+        let args_list = pyre_object::interp_exceptions::w_exception_args_new(items);
         pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
         crate::PyError::from_exc_object(exc)
     }
@@ -25259,10 +25264,18 @@ pub(crate) fn unicode_encode_error(
     end: i64,
     reason: &str,
 ) -> crate::PyError {
-    let w_encoding = pyre_object::w_str_new(encoding);
-    let w_start = pyre_object::w_int_new(start);
-    let w_end = pyre_object::w_int_new(end);
-    let w_reason = pyre_object::w_str_new(reason);
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(pyre_object::w_str_new_managed(encoding));
+    fields.push(w_object);
+    fields.push(pyre_object::w_int_new(start));
+    fields.push(pyre_object::w_int_new(end));
+    fields.push(pyre_object::w_str_new_managed(reason));
+    let items = fields.take();
+    let w_encoding = items[0];
+    let w_object = items[1];
+    let w_start = items[2];
+    let w_end = items[3];
+    let w_reason = items[4];
     // PyPy stores the five fields/args here and formats them only from
     // `W_UnicodeEncodeError.descr_str`. `PyError::from_exc_object` follows
     // the same lazy display path, so do not precompute a parallel message.
@@ -25276,9 +25289,7 @@ pub(crate) fn unicode_encode_error(
         pyre_object::interp_exceptions::w_exception_set_end(exc, w_end);
         pyre_object::interp_exceptions::w_exception_set_reason(exc, w_reason);
         // W_BaseException.descr_init: args_w = [encoding, object, start, end, reason]
-        let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            w_encoding, w_object, w_start, w_end, w_reason,
-        ]);
+        let args_list = pyre_object::interp_exceptions::w_exception_args_new(items);
         pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
         crate::PyError::from_exc_object(exc)
     }
@@ -29410,7 +29421,7 @@ fn generator_name_value(obj: PyObjectRef, qualname: bool) -> crate::PyResult {
     if code_ptr.is_null() {
         return Ok(w_str_new("<finished>"));
     }
-    Ok(w_str_new(unsafe { &(*code_ptr).obj_name }))
+    Ok(w_str_new_managed(unsafe { &(*code_ptr).obj_name }))
 }
 
 fn generator_getter_for(args: &[PyObjectRef], field: usize, kind: u8) -> crate::PyResult {


### PR DESCRIPTION
Follow-up to #1767. Remaining per-call `w_str_new` returns were still immortal, and `os.stat` / `_ssl` still minted fields into an unrooted `Vec` (`WITHPREBUILTINT=false`, so `w_int_new` is collectable).

- Convert leftover dynamic strings to `w_str_new_managed`: `_ssl` cert/cipher/PEM/exception text, function/code/member names, C-API unicode/mapping/module strings, AttributeError/NameError/`OSError.filename`, UnicodeEncode/Decode fields.
- Pin `os.stat` extras first, then sequence fields, before `new_instance_with_extra`. Same shape for wasm `stat` and `statvfs`.
- Root profile/trace callback operands and partition miss-path tuples.

Clinic defaults, interned names, and module constants stay on `w_str_new`.

Local `python3 pyre/check.py`: dynasm 549/549, cranelift 549/549. wasm 436 failed with systematic `loops_aborted` SNAPDIFF/TIMEOUT; that pattern sits on current main after #1737/#1739, not this interpreter-only diff.

Assisted-by: Claude