### PR TITLE
llbc: skip extract when only the cargo closure moved

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -243,11 +243,13 @@ jobs:
     # any edit anywhere misses every crate. The fallback is what lets the
     # narrow digest decide instead: `extract-llbc.py` recomputes each crate's
     # stamp against the current tree, using the restored `.readfiles` to
-    # narrow `source=`, and compares it to the restored stamp as exact text.
-    # A crate whose own closure did not move skips; every other crate
-    # re-extracts. So the key only chooses what is OFFERED — a stale
-    # restore costs a download and is then re-extracted, it cannot survive
-    # into the artefact.
+    # narrow `source=`. Skip agrees with `check`: `source=` / `external=` /
+    # `artefacts=` (and the configuration fields) are gates; `closure=`
+    # alone only warns. A comment in a cargo-closure crate therefore
+    # re-extracts only the crates whose file table actually named that
+    # file. So the key only chooses what is OFFERED — a stale restore
+    # costs a download and is then re-extracted, it cannot survive into
+    # the artefact.
     - name: Cache LLBC (majit-rlib)
       id: llbc-cache-rlib
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1620,6 +1620,31 @@ def parse_stamp(text: str) -> dict[str, str]:
     return fields
 
 
+# `closure=` is a residual detector, not a skip/stale gate. `check` already
+# warns when it alone moves; `extract` used to require the whole stamp to
+# match, so a comment in a cargo-closure crate re-extracted every consumer
+# even when that crate was absent from the artefact's file table. Keep the
+# two verdicts on the same field set.
+STAMP_GATE_KEYS = tuple(key for key in STAMP_KEYS if key != "closure")
+
+
+def stamp_skip_ok(recorded_text: str, expected: str) -> tuple[bool, bool]:
+    """Whether extract may skip, and whether `closure=` alone moved.
+
+    `recorded_text` is the on-disk stamp (CRLF folded to LF). `expected` is
+    the string `stamp_for` just produced, without its trailing newline.
+    Missing any `STAMP_KEYS` field refuses the skip: a stamp that predates a
+    field cannot certify what that field now covers.
+    """
+    recorded = parse_stamp(recorded_text.replace("\r\n", "\n"))
+    want = parse_stamp(expected)
+    if any(key not in recorded for key in STAMP_KEYS):
+        return False, False
+    gates_match = all(recorded[key] == want.get(key) for key in STAMP_GATE_KEYS)
+    closure_moved = recorded.get("closure") != want.get("closure")
+    return gates_match, closure_moved
+
+
 def file_mtime(path: Path) -> str:
     return datetime.datetime.fromtimestamp(path.stat().st_mtime).isoformat(
         timespec="seconds"
@@ -2398,15 +2423,27 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         sidecars = [
             dest_dir / spec.layout_sidecar_name(t) for t in crate_layout_targets(eng, spec)
         ]
+        recorded_ok = False
+        closure_moved = False
+        if stamp_path.exists():
+            recorded_text = stamp_path.read_bytes().decode(
+                "utf-8", errors="replace"
+            )
+            recorded_ok, closure_moved = stamp_skip_ok(recorded_text, stamp)
         if (
             not args.force
             and dest.exists()
             and dest.stat().st_size > 0
             and all(s.exists() and s.stat().st_size > 0 for s in sidecars)
-            and stamp_path.exists()
-            and stamp_path.read_text() == stamp + "\n"
+            and recorded_ok
         ):
-            print(f"=== skipping {crate} -> {dest} (fingerprint unchanged) ===")
+            if closure_moved:
+                print(
+                    f"=== skipping {crate} -> {dest} "
+                    "(source unchanged; closure moved) ==="
+                )
+            else:
+                print(f"=== skipping {crate} -> {dest} (fingerprint unchanged) ===")
             # No provenance is written here on purpose. The sidecar describes
             # the artefact, and the artefact is the one the previous run built:
             # re-stamping it with the current HEAD would claim this checkout produced
@@ -2922,27 +2959,20 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             layout_flags=crate_layout_flags(spec, features, flags),
             artefacts=artefacts_fingerprint(eng, spec, dest_dir),
         )
-        if text == expected + "\n":
+        skip_ok, closure_moved = stamp_skip_ok(text, expected)
+        if skip_ok:
+            if closure_moved:
+                print(
+                    f"    WARNING: {crate}.ullbc's declared inputs are unchanged, "
+                    "but something else in its dependency closure moved; if a trait "
+                    "impl or proc macro changed, re-extract"
+                )
             print(f"    fingerprint matches the tree (source={recorded['source']})")
             verified.add(crate)
             continue
 
         want = parse_stamp(expected)
         differing = [key for key in STAMP_KEYS if recorded[key] != want.get(key)]
-        if "closure" in differing and "source" not in differing:
-            print(
-                f"    WARNING: {crate}.ullbc's declared inputs are unchanged, "
-                "but something else in its dependency closure moved; if a trait "
-                "impl or proc macro changed, re-extract"
-            )
-            differing.remove("closure")
-            expected_with_recorded_closure = "\n".join(
-                f"closure={recorded['closure']}" if line.startswith("closure=") else line
-                for line in expected.splitlines()
-            )
-            if not differing and text == expected_with_recorded_closure + "\n":
-                verified.add(crate)
-                continue
         if not differing:
             # The text differs while every modelled field agrees, so the stamp
             # carries content this engine does not write. Reporting nothing

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -225,9 +225,57 @@ def run_layout_sidecar(engine) -> int:
         shutil.rmtree(root, ignore_errors=True)
 
 
+def run_stamp_skip(engine) -> int:
+    """Skip extract when only `closure=` moved; refuse when `source=` moved."""
+    failures = 0
+
+    def expect(name, condition):
+        nonlocal failures
+        if condition:
+            print(f"ok   {name}")
+        else:
+            failures += 1
+            print(f"FAIL {name}")
+
+    keys = engine.STAMP_KEYS
+    base = {key: f"{key}-v1" for key in keys}
+    expected = "\n".join(f"{key}={base[key]}" for key in keys)
+
+    recorded = expected + "\n"
+    ok, closure_moved = engine.stamp_skip_ok(recorded, expected)
+    expect("identical stamp skips and reports closure still", ok and not closure_moved)
+
+    crlf = expected.replace("\n", "\r\n") + "\r\n"
+    ok, closure_moved = engine.stamp_skip_ok(crlf, expected)
+    expect("CRLF stamp folds to the same skip", ok and not closure_moved)
+
+    closure_only = "\n".join(
+        f"{key}={base[key] if key != 'closure' else 'closure-v2'}" for key in keys
+    )
+    ok, closure_moved = engine.stamp_skip_ok(closure_only + "\n", expected)
+    expect("closure-only move still skips", ok and closure_moved)
+
+    source_moved = "\n".join(
+        f"{key}={base[key] if key != 'source' else 'source-v2'}" for key in keys
+    )
+    ok, closure_moved = engine.stamp_skip_ok(source_moved + "\n", expected)
+    expect("source move refuses the skip", not ok and not closure_moved)
+
+    missing = "\n".join(f"{key}={base[key]}" for key in keys if key != "artefacts")
+    ok, _ = engine.stamp_skip_ok(missing + "\n", expected)
+    expect("stamp missing a gate field refuses the skip", not ok)
+
+    return failures
+
+
 def main() -> None:
     engine = load_engine()
-    failures = run(engine) + run_fingerprint(engine) + run_layout_sidecar(engine)
+    failures = (
+        run(engine)
+        + run_fingerprint(engine)
+        + run_layout_sidecar(engine)
+        + run_stamp_skip(engine)
+    )
     if failures:
         raise SystemExit(f"llbc_extract_selftest: {failures} failed")
     print("llbc_extract_selftest: all passed")


### PR DESCRIPTION
## Summary

- `extract()` used to require the whole stamp, including `closure=`, so a comment in a cargo-closure crate re-extracted every consumer even when that crate was absent from the artefact's file table.
- Skip now matches `check`: `source=` / `external=` / `artefacts=` (and the configuration fields) are gates; `closure=` alone only warns.
- CI cache keys stay the wide digest — they are computed before `.readfiles` exist, so they only choose what is offered. The restored artefacts then skip via the narrow stamp.
- Selftest covers identical / CRLF / closure-only skip, source refuse, and a stamp missing a gate field.

## PyPy parity

Cache invalidation only. No interpreter or JIT semantics change.

## Verification

- `python3 scripts/llbc_extract_selftest.py`: all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLBC cache validation so changes limited to closure metadata no longer incorrectly block extraction or verification.
  * Ensured stale restored cache data is re-extracted when required source, external, artifact, or configuration details have changed.
  * Added clearer warnings when only closure information has changed.

* **Tests**
  * Expanded validation coverage for unchanged stamps, line-ending differences, closure-only changes, source changes, and incomplete metadata.

* **Documentation**
  * Clarified cache and stamp comparison behavior in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->