### PR TITLE
gc: collect leftover names and pin remaining mint lists

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1797,7 +1797,7 @@ pub(crate) fn add_internal_exception_note(error: &mut PyError, text: &str) -> Re
     let exc = error.to_exc_object();
     let _ = pyre_object::gc_roots::pin_root(exc);
     let exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let note = w_str_new(text);
+    let note = w_str_new_managed(text);
     let _ = pyre_object::gc_roots::pin_root(note);
     let note_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
@@ -3428,8 +3428,15 @@ pub(crate) fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         );
         let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
-        let state = pyre_object::gc_roots::pin_root(state);
-        Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
+        let state_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(state);
+        let iter_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(builtin_callable("iter"));
+        Ok(w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(iter_slot),
+            pyre_object::gc_roots::shadow_stack_get(state_slot),
+            w_none(),
+        ]))
     }
 }
 
@@ -3468,8 +3475,15 @@ pub(crate) fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         );
         let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
-        let state = pyre_object::gc_roots::pin_root(state);
-        Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
+        let state_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(state);
+        let iter_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(builtin_callable("iter"));
+        Ok(w_tuple_new(vec![
+            pyre_object::gc_roots::shadow_stack_get(iter_slot),
+            pyre_object::gc_roots::shadow_stack_get(state_slot),
+            w_none(),
+        ]))
     }
 }
 
@@ -6456,7 +6470,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
         if pyre_object::typedef::is_member(obj) {
             match name {
                 "__name__" => {
-                    return Ok(pyre_object::w_str_new(pyre_object::w_member_get_name(obj)));
+                    return Ok(pyre_object::w_str_new_managed(
+                        pyre_object::w_member_get_name(obj),
+                    ));
                 }
                 "__objclass__" => return Ok(pyre_object::w_member_get_cls(obj)),
                 _ => {}
@@ -6481,8 +6497,15 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
             // The default result is memoized on the live, possibly retagged
             // type so ordinary modules retain the hot path.
             if call_getattr && let Some(slot) = module_getattribute_if_not_from_default(w_type) {
-                let name_obj = w_str_new(name);
-                match get_and_call_function(slot, obj, w_type, &[name_obj]) {
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                match get_and_call_function(
+                    slot,
+                    obj,
+                    w_type,
+                    &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                ) {
                     Ok(v) => return Ok(v),
                     // A replacement `__getattribute__` has taken over the
                     // whole lookup, so the PEP 562 module-dict tail no
@@ -6671,11 +6694,18 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
                     }
                     return object_getattr_miss(obj, name, call_getattr);
                 }
-                let name_obj = w_str_new(name);
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
                 // objspace.py:666 / descroperation.py:238
                 // `space.get_and_call_function(w_descr, w_obj, w_name)` —
                 // bind the `__getattribute__` slot through `__get__`.
-                match get_and_call_function(slot, obj, w_type, &[name_obj]) {
+                match get_and_call_function(
+                    slot,
+                    obj,
+                    w_type,
+                    &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                ) {
                     Ok(v) => return Ok(v),
                     Err(e) if e.kind == PyErrorKind::AttributeError => {
                         return instance_getattr_hook_or_err(w_type, obj, name, e);
@@ -6790,11 +6820,18 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
                 // not wrap and then unwrap an already validated name merely
                 // to re-enter that same canonical body.
                 if !is_type_getattribute_descr(slot) {
-                    let name_obj = w_str_new(name);
+                    let _name_roots = pyre_object::gc_roots::push_roots();
+                    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
                     // objspace.py:666 — bind the metaclass
                     // `__getattribute__` through `__get__` and call it with
                     // the attribute name.
-                    match get_and_call_function(slot, obj, w_metatype.as_ptr(), &[name_obj]) {
+                    match get_and_call_function(
+                        slot,
+                        obj,
+                        w_metatype.as_ptr(),
+                        &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                    ) {
                         Ok(v) => return Ok(v),
                         Err(e) if e.kind == PyErrorKind::AttributeError => {
                             return type_getattr_hook_or_err(
@@ -7691,7 +7728,13 @@ unsafe fn module_getattr_hook_or_err(
     if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")?
         && !mod_getattr.is_null()
     {
-        return crate::call::call_function_impl_result(mod_getattr, &[w_str_new(name)]);
+        let _name_roots = pyre_object::gc_roots::push_roots();
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+        return crate::call::call_function_impl_result(
+            mod_getattr,
+            &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+        );
     }
     // `module_getattro_impl` under `suppress`: the error is about to be
     // swallowed, so skip the `__spec__` diagnosis below (its `has_location`
@@ -7822,12 +7865,19 @@ unsafe fn instance_getattr_hook_or_err(
 ) -> PyResult {
     unsafe {
         if let Some(getattr_fn) = lookup_in_type_where(w_type, "__getattr__") {
-            let name_obj = w_str_new(name);
+            let _name_roots = pyre_object::gc_roots::push_roots();
+            let name_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
             // objspace.py `space.get_and_call_function(w_descr, w_obj,
             // w_name)` — bind `__getattr__` through `__get__` so a
             // staticmethod / classmethod / custom-descriptor hook receives the
             // arguments PyPy gives it.
-            return get_and_call_function(getattr_fn, obj, w_type, &[name_obj]);
+            return get_and_call_function(
+                getattr_fn,
+                obj,
+                w_type,
+                &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+            );
         }
     }
     Err(e)
@@ -7853,8 +7903,17 @@ unsafe fn type_getattr_hook_or_err(
                 && let Some(getattr_fn) =
                     unsafe { lookup_in_type_where(w_metaclass, "__getattr__") }
             {
-                let name_obj = w_str_new(name);
-                return unsafe { get_and_call_function(getattr_fn, obj, w_metaclass, &[name_obj]) };
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                return unsafe {
+                    get_and_call_function(
+                        getattr_fn,
+                        obj,
+                        w_metaclass,
+                        &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                    )
+                };
             }
         }
     }
@@ -12956,9 +13015,20 @@ pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult
             // `object.__setattr__` → `object_setattr` (wired from `typedef.rs`),
             // so skipping the descriptor call is equivalent).
             if let Some(sa) = setattr_if_not_from_object(w_type) {
-                let w_name = w_str_new(name);
-                return crate::call::call_function_impl_result(sa, &[obj, w_name, value])
-                    .map(|_| w_none());
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                let value_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(value);
+                return crate::call::call_function_impl_result(
+                    sa,
+                    &[
+                        obj,
+                        pyre_object::gc_roots::shadow_stack_get(name_slot),
+                        pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    ],
+                )
+                .map(|_| w_none());
             }
         } else if let Some(w_type) = crate::typedef::r#type(obj) {
             // descroperation.py:247 looks up __setattr__ on the receiver
@@ -12967,9 +13037,21 @@ pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult
             // __setattr__; only a real override (≠ object.__setattr__)
             // needs invoking — the default terminal path is object_setattr.
             if let Some(sa) = setattr_if_not_from_object(w_type.as_ptr()) {
-                let w_name = w_str_new(name);
-                return get_and_call_function(sa, obj, w_type.as_ptr(), &[w_name, value])
-                    .map(|_| w_none());
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                let value_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(value);
+                return get_and_call_function(
+                    sa,
+                    obj,
+                    w_type.as_ptr(),
+                    &[
+                        pyre_object::gc_roots::shadow_stack_get(name_slot),
+                        pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    ],
+                )
+                .map(|_| w_none());
             }
         }
     }
@@ -13617,7 +13699,16 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
         if is_module(obj) {
             let w_dict = pyre_object::w_module_get_w_dict(obj);
             if !w_dict.is_null() {
-                setitem(w_dict, w_str_new(name), value)?;
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                let value_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(value);
+                setitem(
+                    w_dict,
+                    pyre_object::gc_roots::shadow_stack_get(name_slot),
+                    pyre_object::gc_roots::shadow_stack_get(value_slot),
+                )?;
                 return Ok(w_none());
             }
         }
@@ -14139,8 +14230,16 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
                 let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
                     .is_some_and(|d| std::ptr::eq(da, d));
                 if !is_default {
-                    let w_name = w_str_new(name);
-                    return get_and_call_function(da, obj, w_type, &[w_name]).map(|_| w_none());
+                    let _name_roots = pyre_object::gc_roots::push_roots();
+                    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                    return get_and_call_function(
+                        da,
+                        obj,
+                        w_type,
+                        &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                    )
+                    .map(|_| w_none());
                 }
             }
         } else if let Some(w_type) = crate::typedef::r#type(obj) {
@@ -14152,9 +14251,16 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
                 let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
                     .is_some_and(|d| std::ptr::eq(da, d));
                 if !is_default {
-                    let w_name = w_str_new(name);
-                    return get_and_call_function(da, obj, w_type.as_ptr(), &[w_name])
-                        .map(|_| w_none());
+                    let _name_roots = pyre_object::gc_roots::push_roots();
+                    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                    return get_and_call_function(
+                        da,
+                        obj,
+                        w_type.as_ptr(),
+                        &[pyre_object::gc_roots::shadow_stack_get(name_slot)],
+                    )
+                    .map(|_| w_none());
                 }
             }
         }
@@ -14313,7 +14419,10 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
         if is_module(obj) {
             let w_dict = pyre_object::w_module_get_w_dict(obj);
             if !w_dict.is_null() {
-                match delitem(w_dict, w_str_new(name)) {
+                let _name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(name));
+                match delitem(w_dict, pyre_object::gc_roots::shadow_stack_get(name_slot)) {
                     Ok(()) => return Ok(w_none()),
                     Err(err) if err.kind == crate::PyErrorKind::KeyError => {
                         // descroperation.py descr__delattr__: deldictvalue

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19730,8 +19730,13 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     // descriptors.  Our generic instance layout stores the corresponding
     // fields under private mapdict names so descriptor writes cannot be
     // shadowed by user attributes.
-    if !crate::baseobjspace::setdictvalue(self_obj, "__file_public_mode__", w_str_new(binary_mode))?
-        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closefd__", w_bool_from(closefd))?
+    let public_mode_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(binary_mode));
+    if !crate::baseobjspace::setdictvalue(
+        self_obj,
+        "__file_public_mode__",
+        pyre_object::gc_roots::shadow_stack_get(public_mode_slot),
+    )? || !crate::baseobjspace::setdictvalue(self_obj, "__file_closefd__", w_bool_from(closefd))?
         || !crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(false))?
     {
         return Err(crate::PyError::runtime_error(

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -855,10 +855,10 @@ fn fill_user_function_args(
                 let slot = nparams + ki;
                 if roots.get(base + slot).is_null() {
                     let param_name = &code_ref.varnames[slot];
-                    let key = pyre_object::w_str_new(param_name);
-                    if let Some(val) =
-                        unsafe { pyre_object::w_dict_lookup(roots.get(kwdefaults_base), key) }
-                    {
+                    let key_slot = roots.pin_roots(&[pyre_object::w_str_new_managed(param_name)]);
+                    if let Some(val) = unsafe {
+                        pyre_object::w_dict_lookup(roots.get(kwdefaults_base), roots.get(key_slot))
+                    } {
                         roots.set(base + slot, val);
                     }
                 }
@@ -2698,8 +2698,15 @@ pub(crate) fn resolve_kwargs(
             let pi = n_pos_params + ki; // position in result
             if result[pi].is_null() {
                 let param_name = &code.varnames[skip_cls + pi];
-                let key = pyre_object::w_str_new(param_name);
-                if let Some(val) = unsafe { pyre_object::w_dict_lookup(kwdefaults, key) } {
+                let _key_roots = pyre_object::gc_roots::push_roots();
+                let key_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(param_name));
+                if let Some(val) = unsafe {
+                    pyre_object::w_dict_lookup(
+                        kwdefaults,
+                        pyre_object::gc_roots::shadow_stack_get(key_slot),
+                    )
+                } {
                     result[pi] = val;
                 }
             }
@@ -3580,9 +3587,17 @@ fn call_with_kwargs_in_ctx_impl(
                         let slot = n_pos_params + ki;
                         if slot < result.len() && result[slot].is_null() {
                             let param_name = &code.varnames[slot];
-                            let key = pyre_object::w_str_new(param_name);
-                            if let Some(v) = unsafe { pyre_object::w_dict_lookup(kwdefaults, key) }
-                            {
+                            let _key_roots = pyre_object::gc_roots::push_roots();
+                            let key_slot = pyre_object::gc_roots::shadow_stack_len();
+                            let _ = pyre_object::gc_roots::pin_root(
+                                pyre_object::w_str_new_managed(param_name),
+                            );
+                            if let Some(v) = unsafe {
+                                pyre_object::w_dict_lookup(
+                                    kwdefaults,
+                                    pyre_object::gc_roots::shadow_stack_get(key_slot),
+                                )
+                            } {
                                 result[slot] = v;
                             }
                         }
@@ -5246,12 +5261,26 @@ fn build_class_inner(
                     call_with_kwargs_in_ctx(
                         take_last_exec_ctx(),
                         prepare,
-                        &[pyre_object::w_str_new(name), bases()],
+                        &[
+                            {
+                                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                                let _ = pyre_object::gc_roots::pin_root(
+                                    pyre_object::w_str_new_managed(name),
+                                );
+                                pyre_object::gc_roots::shadow_stack_get(name_slot)
+                            },
+                            bases(),
+                        ],
                         &prepare_kwds,
                     )?
                 } else {
                     clear_call_error();
-                    let r = crate::call_function(prepare, &[pyre_object::w_str_new(name), bases()]);
+                    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
+                    let r = crate::call_function(
+                        prepare,
+                        &[pyre_object::gc_roots::shadow_stack_get(name_slot), bases()],
+                    );
                     if r.is_null() {
                         // __prepare__ was found but raised during execution —
                         // propagate that exception rather than silently using
@@ -5741,7 +5770,8 @@ fn build_class_inner(
         // Pass the ORIGINAL bases (not w_effective_bases) — the metaclass
         // expects the user-declared bases. Default (object,) is added by
         // type.__new__ internally if needed.
-        let name_obj = pyre_object::w_str_new(name);
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
         if let Some(root) = w_namespace_dict_root {
             w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(root);
         }
@@ -5750,12 +5780,32 @@ fn build_class_inner(
             // Only use kwargs path if there are actual extra kwargs
             let has_extra = unsafe { pyre_object::is_dict(kw) && pyre_object::w_dict_len(kw) > 0 };
             if has_extra {
-                call_metaclass_with_kwargs(w_metaclass, name_obj, bases(), w_namespace_dict, kw)
+                call_metaclass_with_kwargs(
+                    w_metaclass,
+                    pyre_object::gc_roots::shadow_stack_get(name_slot),
+                    bases(),
+                    w_namespace_dict,
+                    kw,
+                )
             } else {
-                crate::call_function(w_metaclass, &[name_obj, bases(), w_namespace_dict])
+                crate::call_function(
+                    w_metaclass,
+                    &[
+                        pyre_object::gc_roots::shadow_stack_get(name_slot),
+                        bases(),
+                        w_namespace_dict,
+                    ],
+                )
             }
         } else {
-            crate::call_function(w_metaclass, &[name_obj, bases(), w_namespace_dict])
+            crate::call_function(
+                w_metaclass,
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(name_slot),
+                    bases(),
+                    w_namespace_dict,
+                ],
+            )
         };
         // If the metaclass call raised, propagate the original error rather
         // than silently producing a NULL class object.

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -1275,10 +1275,9 @@ pub(super) fn ensure_linked() {
         let second_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(unsafe { pyobject::from_ref(second_filename) });
 
-        let mut arguments = vec![
-            pyre_object::w_int_new(code as i64),
-            pyre_object::w_str_new_managed(&message),
-        ];
+        let mut arguments = pyre_object::gc_roots::RootedItems::new();
+        arguments.push(pyre_object::w_int_new(code as i64));
+        arguments.push(pyre_object::w_str_new_managed(&message));
         let filename = pyre_object::gc_roots::shadow_stack_get(filename_slot);
         if !filename.is_null() {
             arguments.push(filename);
@@ -1290,7 +1289,7 @@ pub(super) fn ensure_linked() {
                 arguments.push(second);
             }
         }
-        let arguments = pyre_object::tupleobject::w_tuple_new(arguments);
+        let arguments = pyre_object::tupleobject::w_tuple_new(arguments.take());
         set_normalized(
             pyre_object::gc_roots::shadow_stack_get(class_slot),
             arguments,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -864,8 +864,9 @@ impl PyError {
         // young element (the filename or text string, or an uncached line/col
         // int), leaving its raw local pointing at the old address.
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ =
-            pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8(filename.to_wtf8_buf()));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(
+            filename.to_wtf8_buf(),
+        ));
         let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(lineno));
         let offset_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -876,7 +877,7 @@ impl PyError {
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(offset));
         let text_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(match text {
-            Some(t) => pyre_object::w_str_new(t),
+            Some(t) => pyre_object::w_str_new_managed(t),
             None => pyre_object::w_none(),
         });
         let end_lineno_slot = pyre_object::gc_roots::shadow_stack_len();

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4524,21 +4524,31 @@ impl OpcodeStepExecutor for PyFrame {
     ) -> Result<(), PyError> {
         // Stack: [value, expression, format_spec?] — format_spec present only
         // when the oparg low bit is set, else it defaults to the empty string.
-        let format_spec = if has_format_spec {
+        let _interp_roots = pyre_object::gc_roots::push_roots();
+        let format_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(if has_format_spec {
             self.pop()
         } else {
             pyre_object::w_str_new("")
-        };
-        let expression = self.pop();
-        let value = self.pop();
-        let conversion_obj = pyre_object::w_int_new(conversion as i64);
+        });
+        let expression_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(self.pop());
+        let value_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(self.pop());
+        let conversion_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(conversion as i64));
         let anchor = FrameAnchor::new(self);
         let module = self.import_module("_template")?;
         let func = getattr_str(module, "_build_interpolation")?;
         let result = call_callable(
             self,
             func,
-            &[value, expression, conversion_obj, format_spec],
+            &[
+                pyre_object::gc_roots::shadow_stack_get(value_slot),
+                pyre_object::gc_roots::shadow_stack_get(expression_slot),
+                pyre_object::gc_roots::shadow_stack_get(conversion_slot),
+                pyre_object::gc_roots::shadow_stack_get(format_slot),
+            ],
         )?;
         Self::push_anchored(&anchor, result)
     }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3027,10 +3027,26 @@ pub fn descr_function_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     if !w_name.is_null() && !unsafe { pyre_object::is_none(w_name) } {
         unsafe { function_set_name_obj(func, w_name) };
     }
-    let qualname = pyre_object::w_str_new(unsafe { (*code_ptr).qualname.as_ref() });
-    unsafe { function_set_qualname(func, qualname) };
+    let _qual_roots = pyre_object::gc_roots::push_roots();
+    let func_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(func);
+    let qualname_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(unsafe {
+        (*code_ptr).qualname.as_ref()
+    }));
+    unsafe {
+        function_set_qualname(
+            pyre_object::gc_roots::shadow_stack_get(func_slot),
+            pyre_object::gc_roots::shadow_stack_get(qualname_slot),
+        )
+    };
     if !w_argdefs.is_null() && !unsafe { pyre_object::is_none(w_argdefs) } {
-        unsafe { function_set_defaults(func, w_argdefs) };
+        unsafe {
+            function_set_defaults(
+                pyre_object::gc_roots::shadow_stack_get(func_slot),
+                w_argdefs,
+            )
+        };
     }
     if !w_kwdefaults.is_null() && !unsafe { pyre_object::is_none(w_kwdefaults) } {
         if !unsafe { pyre_object::is_dict(w_kwdefaults) } {
@@ -3038,9 +3054,14 @@ pub fn descr_function_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 "arg 6 (kwdefaults) must be None or dict",
             ));
         }
-        unsafe { function_set_kwdefaults(func, w_kwdefaults) };
+        unsafe {
+            function_set_kwdefaults(
+                pyre_object::gc_roots::shadow_stack_get(func_slot),
+                w_kwdefaults,
+            )
+        };
     }
-    Ok(func)
+    Ok(pyre_object::gc_roots::shadow_stack_get(func_slot))
 }
 
 /// PyPy-compatible static registry hook.

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -195,8 +195,21 @@ impl W_BufferedReader {
     }
 
     fn raw_seek(&mut self, pos: i64, whence: i64) -> Result<i64, crate::PyError> {
-        let result =
-            super::call_method_result(self.w_raw, "seek", &[w_int_new(pos), w_int_new(whence)])?;
+        let result = {
+            let _seek_roots = pyre_object::gc_roots::push_roots();
+            let pos_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(pos));
+            let whence_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(whence));
+            super::call_method_result(
+                self.w_raw,
+                "seek",
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(pos_slot),
+                    pyre_object::gc_roots::shadow_stack_get(whence_slot),
+                ],
+            )?
+        };
         let pos = crate::baseobjspace::int_w(result)?;
         if pos < 0 {
             return Err(crate::PyError::os_error(

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -146,8 +146,21 @@ impl W_BufferedRandom {
     }
 
     fn raw_seek(&mut self, pos: i64, whence: i64) -> Result<i64, crate::PyError> {
-        let result =
-            super::call_method_result(self.w_raw, "seek", &[w_int_new(pos), w_int_new(whence)])?;
+        let result = {
+            let _seek_roots = pyre_object::gc_roots::push_roots();
+            let pos_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(pos));
+            let whence_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(whence));
+            super::call_method_result(
+                self.w_raw,
+                "seek",
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(pos_slot),
+                    pyre_object::gc_roots::shadow_stack_get(whence_slot),
+                ],
+            )?
+        };
         let pos = crate::baseobjspace::int_w(result)?;
         if pos < 0 {
             return Err(crate::PyError::os_error(

--- a/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
@@ -159,8 +159,21 @@ impl W_BufferedWriter {
     }
 
     fn raw_seek(&mut self, pos: i64, whence: i64) -> Result<i64, crate::PyError> {
-        let result =
-            super::call_method_result(self.w_raw, "seek", &[w_int_new(pos), w_int_new(whence)])?;
+        let result = {
+            let _seek_roots = pyre_object::gc_roots::push_roots();
+            let pos_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(pos));
+            let whence_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(whence));
+            super::call_method_result(
+                self.w_raw,
+                "seek",
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(pos_slot),
+                    pyre_object::gc_roots::shadow_stack_get(whence_slot),
+                ],
+            )?
+        };
         let pos = crate::baseobjspace::int_w(result)?;
         if pos < 0 {
             return Err(crate::PyError::os_error(

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -320,7 +320,19 @@ fn iobase_tell(args: &[PyObjectRef]) -> crate::PyResult {
         .first()
         .copied()
         .ok_or_else(|| crate::PyError::type_error("tell() requires self"))?;
-    call_method_result(self_obj, "seek", &[w_int_new(0), w_int_new(1)])
+    let _seek_roots = pyre_object::gc_roots::push_roots();
+    let pos_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_int_new(0));
+    let whence_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_int_new(1));
+    call_method_result(
+        self_obj,
+        "seek",
+        &[
+            pyre_object::gc_roots::shadow_stack_get(pos_slot),
+            pyre_object::gc_roots::shadow_stack_get(whence_slot),
+        ],
+    )
 }
 
 fn iobase_enter(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -1631,7 +1631,17 @@ impl W_TextIOWrapper {
             if !self.w_decoder.is_null() {
                 super::call_method_result(self.w_decoder, "reset", &[])?;
             }
-            let result = self.call_buffer("seek", &[w_position, w_int_new(whence)])?;
+            let pos_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_position);
+            let whence_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(whence));
+            let result = self.call_buffer(
+                "seek",
+                &[
+                    pyre_object::gc_roots::shadow_stack_get(pos_slot),
+                    pyre_object::gc_roots::shadow_stack_get(whence_slot),
+                ],
+            )?;
             if !self.w_encoder.is_null() {
                 let at_start = crate::builtins::space_index_w(result)? == 0;
                 self.encoder_reset(at_start)?;

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -276,16 +276,26 @@ fn scan_scalar(
             if is_float { "parse_float" } else { "parse_int" },
         )?;
         let number = unsafe { core::str::from_utf8_unchecked(&rest[..end]) };
-        let parsed =
-            crate::call::call_function_impl_result(parser, &[pyre_object::w_str_new(number)])?;
+        let _token_roots = pyre_object::gc_roots::push_roots();
+        let token_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(number));
+        let parsed = crate::call::call_function_impl_result(
+            parser,
+            &[pyre_object::gc_roots::shadow_stack_get(token_slot)],
+        )?;
         return Ok((parsed, index + end, byte_index + end));
     }
 
     for (token, len) in [("NaN", 3usize), ("Infinity", 8), ("-Infinity", 9)] {
         if rest.starts_with(token.as_bytes()) {
             let parser = crate::baseobjspace::getattr_str(self_obj, "parse_constant")?;
-            let parsed =
-                crate::call::call_function_impl_result(parser, &[pyre_object::w_str_new(token)])?;
+            let _token_roots = pyre_object::gc_roots::push_roots();
+            let token_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(token));
+            let parsed = crate::call::call_function_impl_result(
+                parser,
+                &[pyre_object::gc_roots::shadow_stack_get(token_slot)],
+            )?;
             return Ok((parsed, index + len, byte_index + len));
         }
     }
@@ -1049,7 +1059,7 @@ fn coerce_key(self_obj: PyObjectRef, key: PyObjectRef) -> Result<Option<PyObject
             return Ok(Some(key));
         }
         if pyre_object::is_bool(key) {
-            return Ok(Some(pyre_object::w_str_new(
+            return Ok(Some(pyre_object::w_str_new_managed(
                 if pyre_object::w_bool_get_value(key) {
                     "true"
                 } else {
@@ -1058,7 +1068,7 @@ fn coerce_key(self_obj: PyObjectRef, key: PyObjectRef) -> Result<Option<PyObject
             )));
         }
         if pyre_object::is_none(key) {
-            return Ok(Some(pyre_object::w_str_new("null")));
+            return Ok(Some(pyre_object::w_str_new_managed("null")));
         }
         if is_instance(key, &pyre_object::INT_TYPE) {
             return Ok(Some(base_repr(key, &pyre_object::INT_TYPE)?));

--- a/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
@@ -978,12 +978,14 @@ fn get_queued_completion_status(args: &[PyObjectRef]) -> crate::PyResult {
     .map_err(win32_err)?
     {
         host_overlapped::WaitResult::Timeout => Ok(pyre_object::w_none()),
-        host_overlapped::WaitResult::Queued(status) => Ok(pyre_object::w_tuple_new(vec![
-            pyre_object::w_int_new(status.error as i64),
-            pyre_object::w_int_new(status.bytes_transferred as i64),
-            w_uintptr(status.completion_key),
-            w_uintptr(status.overlapped as usize),
-        ])),
+        host_overlapped::WaitResult::Queued(status) => {
+            let mut fields = pyre_object::gc_roots::RootedItems::new();
+            fields.push(pyre_object::w_int_new(status.error as i64));
+            fields.push(pyre_object::w_int_new(status.bytes_transferred as i64));
+            fields.push(w_uintptr(status.completion_key));
+            fields.push(w_uintptr(status.overlapped as usize));
+            Ok(pyre_object::w_tuple_new(fields.take()))
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -105,10 +105,10 @@ fn get_once_registry() -> Result<PyObjectRef, PyError> {
 
 fn create_filter(category: PyObjectRef, action: &str, module: Option<&str>) -> PyObjectRef {
     let mut fields = pyre_object::gc_roots::RootedItems::new();
-    fields.push(w_str_new(action));
+    fields.push(w_str_new_managed(action));
     fields.push(w_none());
     fields.push(category);
-    fields.push(module.map(w_str_new).unwrap_or_else(w_none));
+    fields.push(module.map(w_str_new_managed).unwrap_or_else(w_none));
     fields.push(w_int_new(0));
     w_tuple_new(fields.take())
 }
@@ -1024,13 +1024,40 @@ crate::py_module! {
         "_release_lock" / 0 = lock_noop,
     },
     extra_init: |ns| {
-        let filters = w_list_new(vec![
-            create_filter(warning_class("DeprecationWarning"), "default", Some("__main__")),
-            create_filter(warning_class("DeprecationWarning"), "ignore", None),
-            create_filter(warning_class("PendingDeprecationWarning"), "ignore", None),
-            create_filter(warning_class("ImportWarning"), "ignore", None),
-            create_filter(warning_class("ResourceWarning"), "ignore", None),
-        ]);
+        let _filter_roots = pyre_object::gc_roots::push_roots();
+        let mut filter_slots = Vec::new();
+        let mut put_filter = |filter: PyObjectRef| {
+            filter_slots.push(pyre_object::gc_roots::shadow_stack_len());
+            let _ = pyre_object::gc_roots::pin_root(filter);
+        };
+        put_filter(create_filter(
+            warning_class("DeprecationWarning"),
+            "default",
+            Some("__main__"),
+        ));
+        put_filter(create_filter(
+            warning_class("DeprecationWarning"),
+            "ignore",
+            None,
+        ));
+        put_filter(create_filter(
+            warning_class("PendingDeprecationWarning"),
+            "ignore",
+            None,
+        ));
+        put_filter(create_filter(warning_class("ImportWarning"), "ignore", None));
+        put_filter(create_filter(
+            warning_class("ResourceWarning"),
+            "ignore",
+            None,
+        ));
+        drop(put_filter);
+        let filters = w_list_new(
+            filter_slots
+                .into_iter()
+                .map(pyre_object::gc_roots::shadow_stack_get)
+                .collect(),
+        );
         // `moduledef.py:18-22 setup_after_space_initialization` publishes the
         // State fields into the module dict.  Capture the namespace only once
         // every field is in place, so `state_is_readable` never reports a

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4643,10 +4643,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     );
     // os.terminal_size — structseq (columns, lines).
     fn make_terminal_size(cols: i64, lines: i64) -> pyre_object::PyObjectRef {
-        crate::_structseq::new_instance(
-            terminal_size_seq_type(),
-            vec![pyre_object::w_int_new(cols), pyre_object::w_int_new(lines)],
-        )
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::w_int_new(cols));
+        fields.push(pyre_object::w_int_new(lines));
+        crate::_structseq::new_instance(terminal_size_seq_type(), fields.take())
     }
     crate::module_ns_store(ns, "terminal_size", terminal_size_seq_type());
     crate::module_ns_store(ns, "statvfs_result", statvfs_result_seq_type());
@@ -8507,15 +8507,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     if pid == 0 {
                         return Ok(pyre_object::w_none());
                     }
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_int_new(pid as i64));
+                    fields.push(pyre_object::w_int_new(uid as i64));
+                    fields.push(pyre_object::w_int_new(si.si_signo as i64));
+                    fields.push(pyre_object::w_int_new(status as i64));
+                    fields.push(pyre_object::w_int_new(si.si_code as i64));
                     Ok(crate::_structseq::new_instance(
                         waitid_result_seq_type(),
-                        vec![
-                            pyre_object::w_int_new(pid as i64),
-                            pyre_object::w_int_new(uid as i64),
-                            pyre_object::w_int_new(si.si_signo as i64),
-                            pyre_object::w_int_new(status as i64),
-                            pyre_object::w_int_new(si.si_code as i64),
-                        ],
+                        fields.take(),
                     ))
                 },
                 3,
@@ -9964,15 +9964,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 |_| {
                     let t =
                         rustpython_host_env::time::process_times().map_err(|e| io_err(e, ""))?;
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_float_new(t.user));
+                    fields.push(pyre_object::w_float_new(t.system));
+                    fields.push(pyre_object::w_float_new(t.children_user));
+                    fields.push(pyre_object::w_float_new(t.children_system));
+                    fields.push(pyre_object::w_float_new(t.elapsed));
                     Ok(crate::_structseq::new_instance(
                         times_result_seq_type(),
-                        vec![
-                            pyre_object::w_float_new(t.user),
-                            pyre_object::w_float_new(t.system),
-                            pyre_object::w_float_new(t.children_user),
-                            pyre_object::w_float_new(t.children_system),
-                            pyre_object::w_float_new(t.elapsed),
-                        ],
+                        fields.take(),
                     ))
                 },
                 0,

--- a/pyre/pyre-interpreter/src/module/resource/resource.rs
+++ b/pyre/pyre-interpreter/src/module/resource/resource.rs
@@ -51,27 +51,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     #[cfg(all(unix, feature = "host_env"))]
     fn make_struct_rusage(r: &rustpython_host_env::resource::RUsage) -> pyre_object::PyObjectRef {
         let tv_to_f = |tv: libc::timeval| tv.tv_sec as f64 + (tv.tv_usec as f64) * 1e-6;
-        crate::_structseq::new_instance(
-            struct_rusage_type(),
-            vec![
-                pyre_object::floatobject::w_float_new(tv_to_f(r.ru_utime)),
-                pyre_object::floatobject::w_float_new(tv_to_f(r.ru_stime)),
-                pyre_object::w_int_new(r.ru_maxrss),
-                pyre_object::w_int_new(r.ru_ixrss),
-                pyre_object::w_int_new(r.ru_idrss),
-                pyre_object::w_int_new(r.ru_isrss),
-                pyre_object::w_int_new(r.ru_minflt),
-                pyre_object::w_int_new(r.ru_majflt),
-                pyre_object::w_int_new(r.ru_nswap),
-                pyre_object::w_int_new(r.ru_inblock),
-                pyre_object::w_int_new(r.ru_oublock),
-                pyre_object::w_int_new(r.ru_msgsnd),
-                pyre_object::w_int_new(r.ru_msgrcv),
-                pyre_object::w_int_new(r.ru_nsignals),
-                pyre_object::w_int_new(r.ru_nvcsw),
-                pyre_object::w_int_new(r.ru_nivcsw),
-            ],
-        )
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(pyre_object::floatobject::w_float_new(tv_to_f(r.ru_utime)));
+        fields.push(pyre_object::floatobject::w_float_new(tv_to_f(r.ru_stime)));
+        fields.push(pyre_object::w_int_new(r.ru_maxrss));
+        fields.push(pyre_object::w_int_new(r.ru_ixrss));
+        fields.push(pyre_object::w_int_new(r.ru_idrss));
+        fields.push(pyre_object::w_int_new(r.ru_isrss));
+        fields.push(pyre_object::w_int_new(r.ru_minflt));
+        fields.push(pyre_object::w_int_new(r.ru_majflt));
+        fields.push(pyre_object::w_int_new(r.ru_nswap));
+        fields.push(pyre_object::w_int_new(r.ru_inblock));
+        fields.push(pyre_object::w_int_new(r.ru_oublock));
+        fields.push(pyre_object::w_int_new(r.ru_msgsnd));
+        fields.push(pyre_object::w_int_new(r.ru_msgrcv));
+        fields.push(pyre_object::w_int_new(r.ru_nsignals));
+        fields.push(pyre_object::w_int_new(r.ru_nvcsw));
+        fields.push(pyre_object::w_int_new(r.ru_nivcsw));
+        crate::_structseq::new_instance(struct_rusage_type(), fields.take())
     }
     crate::module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -588,7 +588,9 @@ impl AsyncActionOps for CheckSignalAction {
             let _roots = pyre_object::gc_roots::push_roots();
             let cls_slot = pyre_object::gc_roots::pin_roots(&[w_exc]);
             let w_msg =
-                pyre_object::w_str_new("asynchronous exception triggered from another thread");
+                pyre_object::w_str_new_managed(
+                    "asynchronous exception triggered from another thread",
+                );
             let msg_slot = pyre_object::gc_roots::pin_roots(&[w_msg]);
             let w_obj = crate::builtins::exc_exception_new(&[
                 pyre_object::gc_roots::shadow_stack_get(cls_slot),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1226,9 +1226,12 @@ fn sys_get_asyncgen_hooks_impl(_args: &[PyObjectRef]) -> crate::PyResult {
             )
         }
     };
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(firstiter);
+    fields.push(finalizer);
     Ok(crate::_structseq::new_instance(
         asyncgen_hooks_type(),
-        vec![firstiter, finalizer],
+        fields.take(),
     ))
 }
 
@@ -1894,16 +1897,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "sys.version_info",
                 &["major", "minor", "micro", "releaselevel", "serial"],
             ));
-        let vi = crate::_structseq::new_instance(
-            version_info_type,
-            vec![
-                w_int_new(3),
-                w_int_new(14),
-                w_int_new(6),
-                w_str_new("final"),
-                w_int_new(0),
-            ],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(3));
+        fields.push(w_int_new(14));
+        fields.push(w_int_new(6));
+        fields.push(w_str_new("final"));
+        fields.push(w_int_new(0));
+        let vi = crate::_structseq::new_instance(version_info_type, fields.take());
         module_ns_store(ns, "version_info", vi);
     }
     // PyPy exposes its implementation release independently from the Python
@@ -1916,16 +1916,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             &["major", "minor", "micro", "releaselevel", "serial"],
         );
         let parse_component = |value: &str| value.parse::<i64>().unwrap_or(0);
-        let vi = crate::_structseq::new_instance(
-            pyre_version_info_type,
-            vec![
-                w_int_new(parse_component(env!("CARGO_PKG_VERSION_MAJOR"))),
-                w_int_new(parse_component(env!("CARGO_PKG_VERSION_MINOR"))),
-                w_int_new(parse_component(env!("CARGO_PKG_VERSION_PATCH"))),
-                w_str_new("final"),
-                w_int_new(0),
-            ],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(parse_component(env!("CARGO_PKG_VERSION_MAJOR"))));
+        fields.push(w_int_new(parse_component(env!("CARGO_PKG_VERSION_MINOR"))));
+        fields.push(w_int_new(parse_component(env!("CARGO_PKG_VERSION_PATCH"))));
+        fields.push(w_str_new("final"));
+        fields.push(w_int_new(0));
+        let vi = crate::_structseq::new_instance(pyre_version_info_type, fields.take());
         module_ns_store(ns, "pyre_version_info", vi);
     }
     // sys.modules — live dict synced with the import cache.
@@ -2079,40 +2076,57 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 &["gil", "thread_inherit_context", "context_aware_warnings"],
             ),
         );
+        let _flag_roots = pyre_object::gc_roots::push_roots();
+        let gil_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(1));
+        let inherit_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(0));
+        let warn_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(0));
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        // `initconfig.c PYCONFIG_SPEC` declares `parser_debug` BOOL
+        // while `verbose` is UINT, so `-dd` reports 1 here and 2
+        // there.  Both count in the config; only this one saturates.
+        fields.push(w_int_new(i64::from(crate::importing::debug_flag() != 0)));
+        // `-i` sets both.
+        fields.push(w_int_new(i64::from(crate::importing::inspect_flag())));
+        fields.push(w_int_new(i64::from(crate::importing::interactive_flag())));
+        fields.push(w_int_new(crate::importing::optimize_level()));
+        fields.push(w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())));
+        fields.push(w_int_new(i64::from(crate::importing::no_user_site_flag())));
+        // `-S` (skip `import site`) is recorded by the launcher.
+        fields.push(w_int_new(i64::from(crate::importing::no_site_flag())));
+        fields.push(w_int_new(i64::from(crate::importing::ignore_environment_flag())));
+        fields.push(w_int_new(crate::importing::verbose_flag()));
+        fields.push(w_int_new(crate::importing::bytes_warning_flag()));
+        fields.push(w_int_new(i64::from(crate::importing::quiet_flag())));
+        fields.push(w_int_new(0)); // hash_randomization
+        fields.push(w_int_new(i64::from(crate::importing::isolated_flag())));
+        fields.push(w_bool_from(crate::importing::dev_mode_flag()));
+        fields.push(w_int_new(crate::importing::utf8_mode_flag()));
+        // sysmodule.c builds this one with `SetFlag` (PyLong_FromLong);
+        // only `dev_mode` and `safe_path` are PyBool_FromLong.
+        fields.push(w_int_new(i64::from(
+            crate::importing::warn_default_encoding_flag(),
+        )));
+        fields.push(w_bool_from(crate::importing::safe_path_flag()));
+        fields.push(w_int_new(
+            crate::module::sys::state::int_max_str_digits() as i64
+        ));
         let flags = crate::_structseq::new_instance_with_extra(
             flags_type,
-            vec![
-                // `initconfig.c PYCONFIG_SPEC` declares `parser_debug` BOOL
-                // while `verbose` is UINT, so `-dd` reports 1 here and 2
-                // there.  Both count in the config; only this one saturates.
-                w_int_new(i64::from(crate::importing::debug_flag() != 0)),
-                // `-i` sets both.
-                w_int_new(i64::from(crate::importing::inspect_flag())),
-                w_int_new(i64::from(crate::importing::interactive_flag())),
-                w_int_new(crate::importing::optimize_level()),
-                w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())),
-                w_int_new(i64::from(crate::importing::no_user_site_flag())),
-                // `-S` (skip `import site`) is recorded by the launcher.
-                w_int_new(i64::from(crate::importing::no_site_flag())),
-                w_int_new(i64::from(crate::importing::ignore_environment_flag())),
-                w_int_new(crate::importing::verbose_flag()),
-                w_int_new(crate::importing::bytes_warning_flag()),
-                w_int_new(i64::from(crate::importing::quiet_flag())),
-                w_int_new(0), // hash_randomization
-                w_int_new(i64::from(crate::importing::isolated_flag())),
-                w_bool_from(crate::importing::dev_mode_flag()),
-                w_int_new(crate::importing::utf8_mode_flag()),
-                // sysmodule.c builds this one with `SetFlag` (PyLong_FromLong);
-                // only `dev_mode` and `safe_path` are PyBool_FromLong.
-                w_int_new(i64::from(crate::importing::warn_default_encoding_flag())),
-                w_bool_from(crate::importing::safe_path_flag()),
-                w_int_new(crate::module::sys::state::int_max_str_digits() as i64),
-            ],
+            fields.take(),
             vec![
                 // The interpreter holds a GIL, so `-X gil=0` is not available.
-                ("gil", w_int_new(1)),
-                ("thread_inherit_context", w_int_new(0)),
-                ("context_aware_warnings", w_int_new(0)),
+                ("gil", pyre_object::gc_roots::shadow_stack_get(gil_slot)),
+                (
+                    "thread_inherit_context",
+                    pyre_object::gc_roots::shadow_stack_get(inherit_slot),
+                ),
+                (
+                    "context_aware_warnings",
+                    pyre_object::gc_roots::shadow_stack_get(warn_slot),
+                ),
             ],
         );
         module_ns_store(ns, "flags", flags);
@@ -2174,29 +2188,45 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 }) as PyObjectRef;
                 let (major, minor, build) =
                     version_ex_triple().unwrap_or((info.major, info.minor, info.build));
+                let _roots = pyre_object::gc_roots::push_roots();
+                let mut extra_slots: Vec<(&str, usize)> = Vec::new();
+                let mut put_extra = |name: &'static str, value: PyObjectRef| {
+                    extra_slots.push((name, pyre_object::gc_roots::shadow_stack_len()));
+                    let _ = pyre_object::gc_roots::pin_root(value);
+                };
+                put_extra(
+                    "service_pack_major",
+                    w_int_new(info.service_pack_major as i64),
+                );
+                put_extra(
+                    "service_pack_minor",
+                    w_int_new(info.service_pack_minor as i64),
+                );
+                put_extra("suite_mask", w_int_new(info.suite_mask as i64));
+                put_extra("product_type", w_int_new(info.product_type as i64));
+                let platform_version = {
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(w_int_new(info.major as i64));
+                    fields.push(w_int_new(info.minor as i64));
+                    fields.push(w_int_new(info.build as i64));
+                    pyre_object::w_tuple_new(fields.take())
+                };
+                put_extra("platform_version", platform_version);
+                drop(put_extra);
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(w_int_new(major as i64));
+                fields.push(w_int_new(minor as i64));
+                fields.push(w_int_new(build as i64));
+                fields.push(w_int_new(info.platform as i64));
+                fields.push(w_str_new_managed(&info.service_pack));
+                let extras: Vec<_> = extra_slots
+                    .into_iter()
+                    .map(|(name, slot)| (name, pyre_object::gc_roots::shadow_stack_get(slot)))
+                    .collect();
                 Ok(crate::_structseq::new_instance_with_extra(
                     cls,
-                    vec![
-                        w_int_new(major as i64),
-                        w_int_new(minor as i64),
-                        w_int_new(build as i64),
-                        w_int_new(info.platform as i64),
-                        w_str_new(&info.service_pack),
-                    ],
-                    vec![
-                        ("service_pack_major", w_int_new(info.service_pack_major as i64)),
-                        ("service_pack_minor", w_int_new(info.service_pack_minor as i64)),
-                        ("suite_mask", w_int_new(info.suite_mask as i64)),
-                        ("product_type", w_int_new(info.product_type as i64)),
-                        (
-                            "platform_version",
-                            pyre_object::w_tuple_new(vec![
-                                w_int_new(info.major as i64),
-                                w_int_new(info.minor as i64),
-                                w_int_new(info.build as i64),
-                            ]),
-                        ),
-                    ],
+                    fields.take(),
+                    extras,
                 ))
             },
             0,
@@ -2490,20 +2520,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "seed_bits", "cutoff",
             ],
         );
-        let value = crate::_structseq::new_instance(
-            ty,
-            vec![
-                w_int_new(64),
-                w_int_new((1i64 << 61) - 1),
-                w_int_new(314159),
-                w_int_new(0),
-                w_int_new(1000003),
-                w_str_new("siphash13"),
-                w_int_new(64),
-                w_int_new(128),
-                w_int_new(0),
-            ],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(64));
+        fields.push(w_int_new((1i64 << 61) - 1));
+        fields.push(w_int_new(314159));
+        fields.push(w_int_new(0));
+        fields.push(w_int_new(1000003));
+        fields.push(w_str_new("siphash13"));
+        fields.push(w_int_new(64));
+        fields.push(w_int_new(128));
+        fields.push(w_int_new(0));
+        let value = crate::_structseq::new_instance(ty, fields.take());
         module_ns_store(ns, "hash_info", value);
     }
     {
@@ -2514,22 +2541,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "mant_dig", "epsilon", "radix", "rounds",
             ],
         );
-        let value = crate::_structseq::new_instance(
-            ty,
-            vec![
-                w_float_new(f64::MAX),
-                w_int_new(1024),
-                w_int_new(308),
-                w_float_new(f64::MIN_POSITIVE),
-                w_int_new(-1021),
-                w_int_new(-307),
-                w_int_new(15),
-                w_int_new(53),
-                w_float_new(f64::EPSILON),
-                w_int_new(2),
-                w_int_new(1),
-            ],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_float_new(f64::MAX));
+        fields.push(w_int_new(1024));
+        fields.push(w_int_new(308));
+        fields.push(w_float_new(f64::MIN_POSITIVE));
+        fields.push(w_int_new(-1021));
+        fields.push(w_int_new(-307));
+        fields.push(w_int_new(15));
+        fields.push(w_int_new(53));
+        fields.push(w_float_new(f64::EPSILON));
+        fields.push(w_int_new(2));
+        fields.push(w_int_new(1));
+        let value = crate::_structseq::new_instance(ty, fields.take());
         module_ns_store(ns, "float_info", value);
     }
     // sysmodule.c — `sys.float_repr_style` is "short" wherever float repr
@@ -2540,14 +2564,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             "sys.thread_info",
             &["name", "lock", "version"],
         );
-        let value = crate::_structseq::new_instance(
-            ty,
-            vec![
-                w_str_new(if cfg!(windows) { "nt" } else { "pthread" }),
-                if cfg!(windows) { w_none() } else { w_str_new("semaphore") },
-                w_none(),
-            ],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_str_new(if cfg!(windows) { "nt" } else { "pthread" }));
+        fields.push(if cfg!(windows) {
+            w_none()
+        } else {
+            w_str_new("semaphore")
+        });
+        fields.push(w_none());
+        let value = crate::_structseq::new_instance(ty, fields.take());
         module_ns_store(ns, "thread_info", value);
     }
     {
@@ -2560,10 +2585,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "str_digits_check_threshold",
             ],
         );
-        let value = crate::_structseq::new_instance(
-            ty,
-            vec![w_int_new(30), w_int_new(4), w_int_new(4300), w_int_new(640)],
-        );
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(30));
+        fields.push(w_int_new(4));
+        fields.push(w_int_new(4300));
+        fields.push(w_int_new(640));
+        let value = crate::_structseq::new_instance(ty, fields.take());
         module_ns_store(ns, "int_info", value);
     }
     module_ns_store(ns, "hexversion", w_int_new(0x030e06f0));

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -70,34 +70,44 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     .map_err(|e| termios_converted_error(e.raw_os_error().unwrap_or(0)))?;
                 let ispeed = host_termios::cfgetispeed(&t);
                 let ospeed = host_termios::cfgetospeed(&t);
-                let cc_list = make_cc_bytes(&t.c_cc[..]);
+                let _roots = pyre_object::gc_roots::push_roots();
+                let cc_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(make_cc_bytes(&t.c_cc[..]));
                 // interp_termios.py:53 — in noncanonical mode VMIN/VTIME are
                 // single-byte counters, surfaced as ints rather than bytes.
                 if (t.c_lflag & libc::ICANON) == 0 {
                     let vmin = libc::VMIN;
                     let vtime = libc::VTIME;
+                    let vmin_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(
+                        t.c_cc[vmin] as i64,
+                    ));
+                    let vtime_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(
+                        t.c_cc[vtime] as i64,
+                    ));
                     unsafe {
                         pyre_object::w_list_setitem(
-                            cc_list,
+                            pyre_object::gc_roots::shadow_stack_get(cc_slot),
                             vmin as i64,
-                            pyre_object::w_int_new(t.c_cc[vmin] as i64),
+                            pyre_object::gc_roots::shadow_stack_get(vmin_slot),
                         );
                         pyre_object::w_list_setitem(
-                            cc_list,
+                            pyre_object::gc_roots::shadow_stack_get(cc_slot),
                             vtime as i64,
-                            pyre_object::w_int_new(t.c_cc[vtime] as i64),
+                            pyre_object::gc_roots::shadow_stack_get(vtime_slot),
                         );
                     }
                 }
-                Ok(pyre_object::w_list_new(vec![
-                    pyre_object::w_int_new(t.c_iflag as i64),
-                    pyre_object::w_int_new(t.c_oflag as i64),
-                    pyre_object::w_int_new(t.c_cflag as i64),
-                    pyre_object::w_int_new(t.c_lflag as i64),
-                    pyre_object::w_int_new(ispeed as i64),
-                    pyre_object::w_int_new(ospeed as i64),
-                    cc_list,
-                ]))
+                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                fields.push(pyre_object::w_int_new(t.c_iflag as i64));
+                fields.push(pyre_object::w_int_new(t.c_oflag as i64));
+                fields.push(pyre_object::w_int_new(t.c_cflag as i64));
+                fields.push(pyre_object::w_int_new(t.c_lflag as i64));
+                fields.push(pyre_object::w_int_new(ispeed as i64));
+                fields.push(pyre_object::w_int_new(ospeed as i64));
+                fields.push(pyre_object::gc_roots::shadow_stack_get(cc_slot));
+                Ok(pyre_object::w_list_new(fields.take()))
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -251,7 +251,7 @@ pub mod frame_locals_proxy {
             // the GC heap and so stays valid across those collections.
             let code = self.frame().code();
             let matches = |name: &str| -> Result<bool, crate::PyError> {
-                roots.set(candidate_slot, pyre_object::w_str_new(name));
+                roots.set(candidate_slot, pyre_object::w_str_new_managed(name));
                 // A name whose hash differs is never compared, so a key that
                 // claims equality with a name it does not hash like does not
                 // reach that name's slot.
@@ -383,7 +383,7 @@ pub mod frame_locals_proxy {
                     unsafe { pyre_object::w_str_get_wtf8(roots.get(key_slot)) }.as_bytes()
                         == name.as_bytes()
                 } else {
-                    roots.set(candidate_slot, pyre_object::w_str_new(name));
+                    roots.set(candidate_slot, pyre_object::w_str_new_managed(name));
                     // A name whose hash differs is never compared: a key that
                     // claims equality with a name it does not hash like reads
                     // as absent rather than as that name's slot.
@@ -473,7 +473,10 @@ pub mod frame_locals_proxy {
                 let key_slot = pyre_object::gc_roots::shadow_stack_len();
                 let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
                 let _ = pyre_object::gc_roots::pin_root(value);
-                pyre_object::gc_roots::shadow_stack_set(key_slot, pyre_object::w_str_new(name));
+                pyre_object::gc_roots::shadow_stack_set(
+                    key_slot,
+                    pyre_object::w_str_new_managed(name),
+                );
                 count += 1;
             }
             let extra = self.frame().get_extra_locals();
@@ -6574,7 +6577,7 @@ fn finditem_str_object(
     let object_slot = roots.base();
     let _ = roots.pin_root(w_obj);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new_managed(name) });
     match crate::baseobjspace::getitem(roots.get(object_slot), roots.get(key_slot)) {
         Ok(v) if !v.is_null() => Ok(Some(v)),
         Ok(_) => Ok(None),
@@ -6596,7 +6599,7 @@ fn setitem_str_object(
     let _ = roots.pin_root(w_obj);
     let _ = roots.pin_root(value);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new_managed(name) });
     crate::baseobjspace::setitem(
         roots.get(object_slot),
         roots.get(key_slot),
@@ -6612,7 +6615,7 @@ fn delitem_str_object(w_obj: PyObjectRef, name: &str) -> Result<(), crate::PyErr
     let object_slot = roots.base();
     let _ = roots.pin_root(w_obj);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new_managed(name) });
     match crate::baseobjspace::delitem(roots.get(object_slot), roots.get(key_slot)) {
         Ok(_) => Ok(()),
         Err(e) if e.kind == crate::PyErrorKind::KeyError => Ok(()),
@@ -6742,7 +6745,7 @@ pub extern "C" fn jit_locals_dict_delitem_local(dict: i64, code: i64, index: i64
     let code = unsafe { &*(code as usize as *const CodeObject) };
     let name: &str = &code.varnames[index as usize];
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_str_new_managed(name) });
     let deleted = unsafe {
         pyre_object::dictmultiobject::w_dict_delitem_checked(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -41,7 +41,11 @@ pub fn warn_category(
     category_name: &str,
     stacklevel: i64,
 ) -> Result<(), crate::PyError> {
-    warn_category_w(pyre_object::w_str_new(msg), category_name, stacklevel)
+    warn_category_w(
+        pyre_object::w_str_new_managed(msg),
+        category_name,
+        stacklevel,
+    )
 }
 
 /// `PyErr_ResourceWarning(source, stacklevel, format, ...)` -- the same warning
@@ -60,7 +64,7 @@ pub fn warn_category_source(
 ) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let source_slot = crate::module::_warnings::pin_root_slot(source);
-    let msg_slot = crate::module::_warnings::pin_root_slot(pyre_object::w_str_new(msg));
+    let msg_slot = crate::module::_warnings::pin_root_slot(pyre_object::w_str_new_managed(msg));
     warn_category_w_source(
         pyre_object::gc_roots::shadow_stack_get(msg_slot),
         category_name,


### PR DESCRIPTION
Follow-up to #1775. Remaining per-call `w_str_new` names and unrooted mint lists.

- Convert leftover attribute/warning/JSON/frame-local names to `w_str_new_managed` and pin them across later allocations.
- Root `_io` seek operands, `sys` structseqs (`flags`, `version_info`, `hash_info`, `float_info`, …), `termios.tcgetattr`, `resource.getrusage`, `os.times`/`waitid`, and range-iterator reduce.

Clinic defaults, interned names, and module constants stay on `w_str_new`.

Local `python3 pyre/check.py`: dynasm and cranelift have no FAILs. wasm still shows the systematic `loops_aborted` SNAPDIFF/TIMEOUT that sits on current main after #1737/#1739, not this interpreter-only diff.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interpreter stability during garbage collection across attribute access, function calls, I/O seeking, JSON parsing, warnings, and exception handling.
  - Improved reliability when creating structured results and system information objects.
  - Preserved existing behavior while preventing intermittent failures during object construction and callback execution.
  - Enhanced stability for frame-local operations, signal handling, terminal settings, and platform-specific functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->