### PR TITLE
gc, metainterp: remember wasm tables; match is_still_valid_for

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -6221,6 +6221,63 @@ mod tests {
         assert_eq!(unknown, None);
     }
 
+    /// `gcreftracer.py` `llop.gc_writebarrier(tr)`: `compile_loop` must
+    /// remember the interned table on the active MiniMark, not only pin it
+    /// on the CLT. Minor collection walks `pending_gc_tables`, so a nursery
+    /// ConstPtr that is only in `LIVE_GC_TABLES` would stay unforwarded.
+    #[test]
+    fn compile_loop_remembers_gc_table_for_minor_collection() {
+        let _compile_guard = failguard::FAIL_DESCR_TEST_LOCK.lock();
+        let mut gc = MiniMarkGC::with_config(majit_gc::collector::GcConfig {
+            nursery_size: 65536,
+            large_object_threshold: 1024,
+            ..majit_gc::collector::GcConfig::default()
+        });
+        let type_id = gc.register_type(TypeInfo::simple(16));
+        let root = gc.alloc_with_type(type_id, 16);
+        unsafe { *(root.0 as *mut u64) = 0xA11C_E701 };
+        let mut backend = WasmBackend::new();
+        backend.set_gc_allocator(Box::new(gc));
+
+        let constant = majit_ir::Op::new(
+            majit_ir::OpCode::SameAsR,
+            &[rb(majit_ir::OpRef::const_ptr(root))],
+        );
+        constant.pos.set(majit_ir::OpRef::ref_op(1));
+        let finish = majit_ir::Op::new(majit_ir::OpCode::Finish, &[rb(majit_ir::OpRef::ref_op(1))]);
+        finish.pos.set(majit_ir::OpRef::void_op(2));
+        finish.set_fail_arg_types(vec![majit_ir::Type::Ref]);
+        finish.setfailargs(vec![rb(majit_ir::OpRef::ref_op(1))].into());
+
+        let token = JitCellToken::new(1_500_294);
+        backend
+            .compile_loop(
+                &[],
+                &[std::rc::Rc::new(constant), std::rc::Rc::new(finish)],
+                &token,
+            )
+            .expect("compile wasm loop with a reference constant");
+
+        let clt = token.compiled_loop_token().expect("CLT");
+        let table = {
+            let tracers = clt.asmmemmgr_gcreftracers.lock();
+            tracers
+                .iter()
+                .find_map(|tracer| {
+                    std::sync::Arc::clone(tracer)
+                        .downcast::<majit_gc::GcTable>()
+                        .ok()
+                })
+                .expect("compile_loop must pin the interned GcTable on the CLT")
+        };
+        assert_eq!(table.slot(0), root);
+
+        with_wasm_active_gc_mut(|gc| gc.collect_nursery()).expect("active wasm MiniMark");
+        let moved = table.slot(0);
+        assert_ne!(moved, root, "remembered table slot must be forwarded");
+        assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xA11C_E701);
+    }
+
     /// Spike for the wasm-JITFRAME refactor: prove the shared
     /// `MiniMarkGC` forwards a JitFrame's interior Ref item through the
     /// `jf_gcmap` custom-trace when the frame is discovered via the jitframe

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -952,31 +952,12 @@ impl OptHeap {
     /// caller's `heap.py:809 is_constant()` gate.
     ///
     /// The identity test asks the recorded instance whether it is still the
-    /// field's own, instead of re-reading the field to compare: the two answers
-    /// coincide, because a fresh instance is only ever minted into a field the
-    /// sweep has nulled, and the recorded one needs no second walk from the
-    /// struct to the hidden `mutate_*` slot.
+    /// field's own. A fresh instance is only minted into a field the sweep
+    /// has nulled, so `is_current` is `qmut is not self.qmut`.
     ///
-    /// The value comparison is upstream's closing assert: the recording
-    /// captured the field on `QuasiImmutDescr.constantfieldbox`
-    /// (`quasiimmut.py QuasiImmutDescr.__init__`) and a live re-read
-    /// through `get_runtime_field` is `get_current_constant_fieldvalue`.
-    /// It is answered as a verdict rather than an assert, and skipped
-    /// when the descr carries no captured value.
-    ///
-    /// ⚠️Answering it as a verdict is LOAD-BEARING here and must not be
-    /// demoted to the `debug_assert!` upstream has (gh#964 proposes exactly
-    /// that, on the reading that the identity test above already decides
-    /// every real invalidation). It does not:
-    /// `mapdict::delattr_would_force_quasi_immut` states in its own doc that
-    /// the `PlainAttribute.delete` -> `_copy_attr` -> `add_attr` ->
-    /// `pick_attr` re-add chain is deliberately NOT modelled, and that what
-    /// makes a missed force cost only a wasted trace rather than a wrong
-    /// answer is this revalidation discarding a loop whose recorded value
-    /// moved. A missed force leaves the instance linked, so `is_current` is
-    /// true and only the value has changed — precisely the case the identity
-    /// test cannot see. Modelling that chain, or installing the watcher along
-    /// it, is what has to come first.
+    /// The value comparison is upstream's closing assert
+    /// (`same_constant`). Translated PyPy does not run it; a mismatch
+    /// after identity matches is not `InvalidLoop`.
     fn quasiimmut_field_still_valid(
         _op: &Op,
         obj: OpRef,
@@ -990,17 +971,17 @@ impl OptHeap {
         if !qmutdescr.qmut().is_current() {
             return false;
         }
-        let Some(constantfieldbox) = qmutdescr.constantfieldbox() else {
-            return true;
-        };
-        let Some(currentbox) = ctx
-            .get_runtime_field(obj, qmutdescr.fielddescr())
-            .and_then(|r| r.inline_const_to_value())
-        else {
-            return true;
-        };
-        // history.py `Const.same_constant`.
-        currentbox == constantfieldbox
+        if let (Some(constantfieldbox), Some(currentbox)) = (
+            qmutdescr.constantfieldbox(),
+            ctx.get_runtime_field(obj, qmutdescr.fielddescr())
+                .and_then(|r| r.inline_const_to_value()),
+        ) {
+            debug_assert_eq!(
+                currentbox, constantfieldbox,
+                "quasiimmut.py same_constant after qmut identity"
+            );
+        }
+        true
     }
 
     /// Slot space for the object header words, above every position a parent's


### PR DESCRIPTION
## Summary

Two commits on `origin/main`:

- wasm `compile_loop` remembers the interned `GcTable` on the collecting MiniMark. The test compiles a nursery `ConstPtr` and checks the slot is forwarded after `collect_nursery`.
- `quasiimmut_field_still_valid` follows `quasiimmut.py` `is_still_valid_for`: identity of the recorded `QuasiImmut` decides, `same_constant` is an assert.

A LOAD_NAME fold in handler-bearing modules was tried and reverted: it compiled 346 loops on `exception_reraise_tb_depth_jitstress` against PyPy's 185.

## Test plan

- [x] `cargo test -p majit-backend-wasm --lib compile_loop_remembers_gc_table_for_minor_collection`
- [x] `exception_reraise_tb_depth_jitstress` / `_hot` jitstats unchanged vs recorded baselines after the identity change