### PR TITLE
majit-translate: mixed Call.args and leftover rtyper follow-ups

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -4871,7 +4871,7 @@ mod tests {
                             crate::model::OpKind::Call {
                                 target: crate::model::CallTarget::FunctionPath { segments },
                                 ..
-                            } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                            } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
                         )
                 }),
             "the tuple writer must preserve the source PyObject class"

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1545,10 +1545,9 @@ fn ll_arraymove_intrinsic(
 /// same-bank `obj as *const RegisteredStruct` cast, so a field read on
 /// the pointee blocks on a classdef-less `SomeInstance` (unaryop.rs
 /// getattr arm).  The frontend instead lowers such a cast to
-/// `simple_call(__cast_instance_intrinsic, operand)`, stashing the target
-/// struct root in the `FunctionPath`; `flowspace_adapter` reconstructs
-/// the root as a trailing `ByteStr` constant arg (the `Vec<Variable>`
-/// arg carrier cannot hold a `Constant`).  The result is
+/// `simple_call(__cast_instance_intrinsic, operand, const(root))`.
+/// The frontend puts the target struct root in `Call.args[1]` as a
+/// `ByteStr` Constant.  The result is
 /// `SomeInstance(classdef)` for that root so the field read resolves;
 /// the rtyper lowers the call to a `cast_pointer` (rclass
 /// `pairtype(InstanceRepr, InstanceRepr).convert_from_to`,
@@ -1574,8 +1573,8 @@ fn cast_instance_intrinsic(
     args_s: &[Option<SomeValue>],
     kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
-    // The marker is `Call(["__cast_instance_intrinsic", <root>], [operand])`:
-    // exactly the pointer operand plus the constant-root string, no
+    // The marker is `Call(["__cast_instance_intrinsic"], [operand, const(root)])`:
+    // the pointer operand plus the constant-root string, no
     // keywords.  A different shape is a producer bug, surfaced here
     // rather than silently swallowed.
     if !kwds.is_empty() || args_s.len() != 2 {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5568,33 +5568,6 @@ impl Assembler {
     /// assembled. Pending inline-call descriptors are lowered here to the
     /// final `(jitcode_index, fnaddr, calldescr)` form that runtime
     /// consumers expect.
-    /// Publish every known field of a raw (non-GC) struct into the shared
-    /// descr pool. OBJECT_VTABLE-shaped storage keeps `instantiate` as a
-    /// pointer slot; the only source reader may be an atomic residual, so
-    /// no FieldRead is emitted unless the pool already names the slot.
-    pub(crate) fn publish_raw_struct_fields(
-        &mut self,
-        call_control: &crate::codewriter::call::CallControl,
-        owner: &str,
-    ) {
-        let Some(fields) = call_control.struct_field_entries(owner) else {
-            return;
-        };
-        for (name, type_str) in fields {
-            let (_, ir_type, _) = crate::codewriter::call::get_type_flag(type_str);
-            if ir_type == majit_ir::value::Type::Void {
-                continue;
-            }
-            let ty = match ir_type {
-                majit_ir::value::Type::Float => crate::model::ValueType::Float,
-                majit_ir::value::Type::Int => crate::model::ValueType::Int,
-                _ => crate::model::ValueType::Ref(None),
-            };
-            let field = crate::model::FieldDescriptor::new(name.clone(), Some(owner.to_string()));
-            self.emit_ready_descr(fielddescrof(&field, &ty, Some(call_control)));
-        }
-    }
-
     pub fn snapshot_descrs(&self) -> Vec<crate::jitcode::BhDescr> {
         self.descrs
             .iter()

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5342,7 +5342,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
             "bitxor" => "int_xor".into(),
             // RPython `jtransform.py:1243-1255` produces these opnames as-is —
             // do not prefix with `int_`.
-            "ptr_eq" | "ptr_ne" => op.clone(),
+            "ptr_eq" | "ptr_ne" | "instance_ptr_eq" | "instance_ptr_ne" => op.clone(),
             // jtransform-rewritten float operands carry the full RPython
             // opname (`float_add` / `float_lt` / etc.) — preserve as-is.
             s if s.starts_with("float_") => op.clone(),
@@ -6127,6 +6127,21 @@ mod tests {
         };
 
         assert_eq!(op_kind_to_opname_with_kinds(&identity, "rr"), "ptr_eq");
+    }
+
+    #[test]
+    fn instance_ptr_eq_is_not_prefixed_as_an_int_binop() {
+        let lhs = crate::flowspace::model::Variable::new();
+        let rhs = crate::flowspace::model::Variable::new();
+        for name in ["instance_ptr_eq", "instance_ptr_ne", "ptr_eq", "ptr_ne"] {
+            let kind = crate::model::OpKind::BinOp {
+                op: name.into(),
+                lhs: lhs.clone(),
+                rhs: rhs.clone(),
+                result_ty: crate::model::ValueType::Int,
+            };
+            assert_eq!(op_kind_to_opname(&kind), name);
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -601,11 +601,21 @@ impl CodeWriter {
         // `concretetype` cell, and `Variable::clone` Rc-shares that
         // cell so jtransform's internal `rewritten = graph.clone()`
         // carries it through.
+        //
+        // `cpu.rtyper.exceptiondata.fn_exception_match` is cloned out
+        // of the dual-gate session before the `&mut CallControl`
+        // borrow, matching `transform_graph(graph, cpu, ...)`.
+        let excmatch = self
+            .dual_gate_registry(callcontrol)
+            .session_if_started()
+            .and_then(|(_, rt)| rt.exceptiondata().ok())
+            .and_then(|ed| ed.fn_exception_match.borrow().clone());
         let mut rewritten =
             crate::codewriter::transform_profile::time_phase("step1_jtransform_transform", || {
                 let mut transformer = crate::jtransform::Transformer::new(config)
                     .with_callcontrol(callcontrol)
-                    .with_portal_jd(portal_jd_index);
+                    .with_portal_jd(portal_jd_index)
+                    .with_excmatch(excmatch.as_ref());
                 transformer.transform(graph)
             });
         // Transformer is dropped here, releasing the &mut CallControl borrow.
@@ -953,6 +963,16 @@ impl CodeWriter {
         verbose: bool,
         index: usize,
     ) {
+        // jtransform.py transform_graph starts with
+        // constant_fold_ll_issubclass(graph, cpu) on the flowspace
+        // graph. Spine B is the remaining entry that still holds
+        // `direct_call` Constants.
+        if let Some((_, rt)) = self.dual_gate_registry(callcontrol).session_if_started()
+            && let Ok(ed) = rt.exceptiondata()
+        {
+            let matcher = ed.fn_exception_match.borrow();
+            crate::jtransform::constant_fold_ll_issubclass_flowgraph(flow_graph, matcher.as_ref());
+        }
         let mut lowered = crate::codewriter::jtransform_opname::lower_graph(flow_graph);
         self.finalize_rewritten_graph_to_jitcode(
             &mut lowered,
@@ -1341,7 +1361,7 @@ mod stamp_classdef_hints_tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::method("push_value", Some("H".to_string())),
-                    args: vec![recv_var.clone()],
+                    args: crate::model::call_args(vec![recv_var.clone()]),
                     result_ty: ValueType::Unknown,
                 },
                 true,
@@ -1374,7 +1394,7 @@ mod stamp_classdef_hints_tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::method("push_value", Some("H".to_string())),
-                    args: vec![recv_var.clone()],
+                    args: crate::model::call_args(vec![recv_var.clone()]),
                     result_ty: ValueType::Unknown,
                 },
                 true,
@@ -1468,7 +1488,7 @@ mod stamp_classdef_hints_tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::method("push_value", Some("H".to_string())),
-                    args: vec![recv_var.clone()],
+                    args: crate::model::call_args(vec![recv_var.clone()]),
                     result_ty: ValueType::Unknown,
                 },
                 true,

--- a/majit/majit-translate/src/codewriter/getslice.rs
+++ b/majit/majit-translate/src/codewriter/getslice.rs
@@ -563,7 +563,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec![first.last_segment().unwrap().to_string()],
                 },
-                args: vec![Variable::new(), Variable::new()],
+                args: crate::model::call_args(vec![Variable::new(), Variable::new()]),
                 result_ty: ValueType::Ref(None),
             },
         };

--- a/majit/majit-translate/src/codewriter/iter_lower.rs
+++ b/majit/majit-translate/src/codewriter/iter_lower.rs
@@ -93,7 +93,7 @@ fn lower_site(graph: &mut FunctionGraph, d: usize, anchor_idx: usize) -> Result<
         let Some(result) = &op.result else {
             return Err("iter constructor has no result".into());
         };
-        (result.clone(), args[0].clone())
+        (result.clone(), args[0].clone().into_variable())
     };
     if !in_scope(graph, d, &x) {
         return Err("iterated container out of scope".into());
@@ -532,13 +532,15 @@ fn is_slice_iter_call(kind: &OpKind) -> bool {
         && segments.last().is_some_and(|s| s == "iter"))
 }
 
-fn is_marker_call<'op>(kind: &'op OpKind, name: &str, arity: usize) -> Option<&'op [Variable]> {
+fn is_marker_call(kind: &OpKind, name: &str, arity: usize) -> Option<Vec<Variable>> {
     match kind {
         OpKind::Call {
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if segments.len() == 1 && segments[0] == name && args.len() == arity => Some(args),
+        } if segments.len() == 1 && segments[0] == name && args.len() == arity => {
+            Some(crate::model::call_arg_vars(args))
+        }
         _ => None,
     }
 }
@@ -564,7 +566,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: segments.iter().map(|s| s.to_string()).collect(),
             },
-            args,
+            args: crate::model::call_args(args),
             result_ty: ValueType::Ref(None),
         }
     }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4870,8 +4870,7 @@ impl<'a> Transformer<'a> {
         // upstream `cast_pointer` op, see `cast_pointer_marker_op`)
         // folds back to the operand alias and emits no jitcode op.
         if let CallTarget::FunctionPath { segments } = target
-            && segments.len() == 2
-            && segments[0] == "__cast_pointer"
+            && segments.as_slice() == ["__cast_pointer"]
             && args.len() == 1
         {
             return RewriteResult::Identity(args[0].clone());
@@ -14659,15 +14658,11 @@ mod tests {
         let mut graph = FunctionGraph::new("cast_ptr_marker");
         let arg = graph.alloc_value_var_with_type(ConcreteType::GcRef);
         let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
-        let target = CallTarget::function_path(["__cast_pointer", "W_CastTarget"]);
+        let target = CallTarget::function_path(["__cast_pointer"]);
         let result_ty = ValueType::Ref(Some("W_CastTarget".into()));
         let op = SpaceOperation {
             result: Some(result_var),
-            kind: OpKind::Call {
-                target: target.clone(),
-                args: crate::model::call_args(vec![arg.clone()]),
-                result_ty: result_ty.clone(),
-            },
+            kind: crate::model::cast_pointer_call("W_CastTarget", arg.clone()),
         };
         let rewritten = transformer.rewrite_op_direct_call(
             &op,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -442,9 +442,7 @@ pub fn constant_fold_ll_issubclass_flowgraph(
     graph: &crate::flowspace::model::FunctionGraph,
     excmatch: Option<&crate::translator::rtyper::rtyper::LowLevelFunction>,
 ) {
-    use crate::flowspace::model::{
-        BlockRefExt, ConstValue, Constant, Hlvalue, SpaceOperation,
-    };
+    use crate::flowspace::model::{BlockRefExt, ConstValue, Constant, Hlvalue, SpaceOperation};
     use crate::translator::rtyper::lltypesystem::lltype::_ptr_obj;
     let Some(excmatch) = excmatch else {
         return;
@@ -8773,16 +8771,14 @@ fn remap_op(
             target,
             args,
             result_ty,
-        } => {
-            OpKind::Call {
-                target: target.clone(),
-                args: args
-                    .iter()
-                    .map(|arg| arg.map_value(|var| remap_value(var, aliases)))
-                    .collect(),
-                result_ty: result_ty.clone(),
-            }
-        }
+        } => OpKind::Call {
+            target: target.clone(),
+            args: args
+                .iter()
+                .map(|arg| arg.map_value(|var| remap_value(var, aliases)))
+                .collect(),
+            result_ty: result_ty.clone(),
+        },
         OpKind::GuardTrue { cond } => OpKind::GuardTrue {
             cond: remap_value(cond, aliases),
         },
@@ -18665,12 +18661,13 @@ mod tests {
                     )
                 })
                 .count();
-            assert_eq!(casts, 1, "the Ref operand must become a Signed address: {ops:?}");
+            assert_eq!(
+                casts, 1,
+                "the Ref operand must become a Signed address: {ops:?}"
+            );
             assert!(
-                ops.iter().any(|op| matches!(
-                    &op.kind,
-                    OpKind::CallResidual { .. }
-                )),
+                ops.iter()
+                    .any(|op| matches!(&op.kind, OpKind::CallResidual { .. })),
                 "mod over ints is the C-trunc residual, not ptr_mod: {ops:?}"
             );
         }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4876,9 +4876,8 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
-        // `__cast_instance_intrinsic/<Root>` — front::mir's pointer-downcast
-        // narrow (#298, `mir.rs` emits `Call(["__cast_instance_intrinsic",
-        // root], [v])` for a `Ref → *Struct` reinterpret).  The rtyper
+        // `__cast_instance_intrinsic` — front::mir's pointer-downcast
+        // narrow (`cast_instance_call`: operand + const(root)).  The rtyper
         // lowers it to `cast_pointer` (`rbuiltin.rs rtype_cast_instance_intrinsic`,
         // `exception_cannot_occur`), which jtransform folds to `same_as`;
         // the charon front-end skips the rtyper, so fold the marker to the
@@ -4890,10 +4889,10 @@ impl<'a> Transformer<'a> {
         // from its erasure than from its downcast, so it folds the same
         // way: the operand alias, no jitcode op.
         if let CallTarget::FunctionPath { segments } = target
-            && ((segments.len() == 2 && segments[0] == crate::runtime_names::shims::CAST_INSTANCE)
-                || (segments.len() == 1
-                    && segments[0] == crate::runtime_names::shims::CAST_ADDRESS))
-            && args.len() == 1
+            && ((segments.as_slice() == [crate::runtime_names::shims::CAST_INSTANCE]
+                && args.len() == 1)
+                || (segments.as_slice() == [crate::runtime_names::shims::CAST_ADDRESS]
+                    && args.len() == 1))
         {
             return RewriteResult::Identity(args[0].clone());
         }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -416,6 +416,122 @@ pub fn transform_graph(
     transformer.transform(graph)
 }
 
+/// RPython `jtransform.py constant_fold_ll_issubclass(graph, cpu)` on
+/// the codewriter model graph. `cpu is None` here: the flowspace
+/// counterpart [`constant_fold_ll_issubclass_flowgraph`] is the one
+/// that sees `direct_call` Constants.
+pub fn constant_fold_ll_issubclass(
+    _graph: &mut FunctionGraph,
+    excmatch: Option<&crate::translator::rtyper::rtyper::LowLevelFunction>,
+) {
+    let Some(_) = excmatch else {
+        return;
+    };
+}
+
+/// RPython `jtransform.py constant_fold_ll_issubclass(graph, cpu)` on
+/// a flowspace graph — the shape `direct_call` still has
+/// `args[0].value._obj`.
+///
+/// Identity is `funcobj.graph == excmatch.graph_key()`, not the helper
+/// name. Evaluation is `rclass.ll_issubclass` on the two constant
+/// vtables. A match becomes `same_as` of a Bool constant; if that
+/// result is the exitswitch, the block is reclosed onto the taken
+/// exit.
+pub fn constant_fold_ll_issubclass_flowgraph(
+    graph: &crate::flowspace::model::FunctionGraph,
+    excmatch: Option<&crate::translator::rtyper::rtyper::LowLevelFunction>,
+) {
+    use crate::flowspace::model::{
+        BlockRefExt, ConstValue, Constant, Hlvalue, SpaceOperation,
+    };
+    use crate::translator::rtyper::lltypesystem::lltype::_ptr_obj;
+    let Some(excmatch) = excmatch else {
+        return;
+    };
+    let Some(excmatch_id) = excmatch.graph_key() else {
+        return;
+    };
+    let blocks = graph.iterblocks();
+    for block in blocks {
+        let n = block.borrow().operations.len();
+        for i in 0..n {
+            let op = block.borrow().operations[i].clone();
+            if op.opname != "direct_call" {
+                continue;
+            }
+            if op.args.is_empty() || !op.args.iter().all(|a| matches!(a, Hlvalue::Constant(_))) {
+                continue;
+            }
+            let Hlvalue::Constant(func_c) = &op.args[0] else {
+                continue;
+            };
+            let ConstValue::LLPtr(func_ptr) = &func_c.value else {
+                continue;
+            };
+            let Ok(_ptr_obj::Func(funcobj)) = func_ptr._obj() else {
+                continue;
+            };
+            if funcobj.graph != Some(excmatch_id) {
+                continue;
+            }
+            let mut vtables = Vec::new();
+            let mut all_vtables = true;
+            for arg in op.args.iter().skip(1) {
+                let Hlvalue::Constant(c) = arg else {
+                    all_vtables = false;
+                    break;
+                };
+                let ConstValue::LLPtr(p) = &c.value else {
+                    all_vtables = false;
+                    break;
+                };
+                vtables.push(p.clone());
+            }
+            if !all_vtables || vtables.len() != 2 {
+                continue;
+            }
+            let Ok(constant_result) =
+                crate::translator::rtyper::rclass::ll_issubclass(&vtables[0], &vtables[1])
+            else {
+                continue;
+            };
+            let same_as = SpaceOperation::new(
+                "same_as",
+                vec![Hlvalue::Constant(Constant::with_concretetype(
+                    ConstValue::Bool(constant_result),
+                    crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Bool,
+                ))],
+                op.result.clone(),
+            );
+            block.borrow_mut().operations[i] = same_as;
+            let exitswitch_is_result = match &block.borrow().exitswitch {
+                Some(sw) => sw == &op.result,
+                None => false,
+            };
+            if exitswitch_is_result {
+                let kept: Vec<_> = block
+                    .borrow()
+                    .exits
+                    .iter()
+                    .filter(|link| {
+                        matches!(
+                            &link.borrow().exitcase,
+                            Some(Hlvalue::Constant(c))
+                                if c.value == ConstValue::Bool(constant_result)
+                        )
+                    })
+                    .cloned()
+                    .collect();
+                block.borrow_mut().exitswitch = None;
+                if !kept.is_empty() {
+                    block.recloseblock(kept);
+                }
+            }
+        }
+    }
+}
+
 /// `jtransform.py integer_bounds(size, unsigned)`.
 pub fn integer_bounds(size: usize, unsigned: bool) -> (i128, i128) {
     if unsigned {
@@ -485,6 +601,10 @@ pub struct Transformer<'a> {
     /// RPython: DependencyTracker — caches transitive analysis results.
     /// Shared across all getcalldescr() calls within this transform pass.
     analysis_cache: crate::call::AnalysisCache,
+    /// RPython `Transformer.cpu.rtyper.exceptiondata.fn_exception_match`.
+    /// Threaded for `constant_fold_ll_issubclass`; `None` is the
+    /// `cpu is None` no-op arm.
+    excmatch: Option<&'a crate::translator::rtyper::rtyper::LowLevelFunction>,
 }
 
 /// RPython: jtransform.py vable_flags values
@@ -1247,7 +1367,18 @@ impl<'a> Transformer<'a> {
             vable_rewrites: 0,
             calls_classified: 0,
             analysis_cache: crate::call::AnalysisCache::default(),
+            excmatch: None,
         }
+    }
+
+    /// RPython `Transformer.__init__(cpu=...)` — only
+    /// `cpu.rtyper.exceptiondata.fn_exception_match` is consulted.
+    pub fn with_excmatch(
+        mut self,
+        excmatch: Option<&'a crate::translator::rtyper::rtyper::LowLevelFunction>,
+    ) -> Self {
+        self.excmatch = excmatch;
+        self
     }
 
     /// Set the CallControl for call kind dispatch.
@@ -1290,16 +1421,12 @@ impl<'a> Transformer<'a> {
         let mut rewritten = graph.clone();
         join_blocks(&mut rewritten);
 
-        // PRE-EXISTING-ADAPTATION: jtransform.py transform_graph starts with
-        // constant_fold_ll_issubclass(graph, cpu), folding constant calls to
-        // exceptiondata.fn_exception_match. Its counterpart remains unported.
-        // Class helper bodies now use ordinary registration/translation; the
-        // old name-based body exclusions and high-level call rewrites are gone.
-        // Convergence still needs the actual exception-match callable identity
-        // and prebuilt vtable representation, plus inline.py's
-        // rewire_exceptblock_with_guard / generic_exception_matching path
-        // currently refused by Inliner::inline_once. Do not replace the fold
-        // with a name-based class-helper shortcut.
+        // jtransform.py transform_graph starts with
+        // constant_fold_ll_issubclass(graph, cpu). The model-graph
+        // walk is a no-op unless a matcher is threaded in; residual
+        // `direct_call` Constants live on the flowspace graph and
+        // are folded by `constant_fold_ll_issubclass_flowgraph`.
+        constant_fold_ll_issubclass(&mut rewritten, self.excmatch);
 
         // RPython `rtyper/rpbc.py::SingleFrozenPBCRepr` resolves
         // zero-arg unit-variant PBC ctors to a singleton
@@ -1993,14 +2120,16 @@ impl<'a> Transformer<'a> {
             OpKind::Call { target, args, .. } if classify_hint_target(target).is_some() => {
                 let kind = classify_hint_target(target).expect("guard checked Some");
                 let label = target.to_string();
-                self.rewrite_op_hint(op, kind, args, &label, graph_name)
+                let args = crate::model::call_arg_vars(args);
+                self.rewrite_op_hint(op, kind, &args, &label, graph_name)
             }
             // `jtransform.py rewrite_op_jit_force_virtualizable`: the
             // rtyper-injected op, not `hint(x, force_virtualizable=True)`.
             // The front lowers the stand-in helper as a Call; dispatch it
             // here so it never reaches residual `CallMayForce`.
             OpKind::Call { target, args, .. } if is_jit_force_virtualizable_target(target) => {
-                self.rewrite_op_jit_force_virtualizable(args, graph_name)
+                let args = crate::model::call_arg_vars(args);
+                self.rewrite_op_jit_force_virtualizable(&args, graph_name)
             }
             // RPython `Transformer.rewrite_op_cast_opaque_ptr` aliases
             // only the explicit low-level operation. A ptr/int roundtrip
@@ -2078,7 +2207,8 @@ impl<'a> Transformer<'a> {
                 args,
                 result_ty,
             } if self.config.classify_calls => {
-                self.rewrite_op_direct_call(op, target, args, result_ty, graph_name, graph)
+                let args = crate::model::call_arg_vars(args);
+                self.rewrite_op_direct_call(op, target, &args, result_ty, graph_name, graph)
             }
             // ── rewrite_op_indirect_call ──
             // RPython jtransform.py:410-412. Pyre's rtyper-equivalent
@@ -2399,13 +2529,10 @@ impl<'a> Transformer<'a> {
                 }])
             }
             // RPython `jtransform.py` `rewrite_op_ptr_eq`/`rewrite_op_ptr_ne`
-            // + `_rewrite_cmp_ptrs`: equality/inequality of two Ref operands is
-            // `ptr_eq`/`ptr_ne` (wired at `blackhole.py:585-590`), not `int_eq`/
-            // `int_ne`. Pyre's front-end emits a unified `BinOp { op: "eq"/"ne" }`
+            // + `_is_rclass_instance` → `instance_ptr_eq`/`instance_ptr_ne`.
+            // Pyre's front-end emits a unified `BinOp { op: "eq"/"ne" }`
             // because Rust's `==`/`!=` is one AST node regardless of operand type;
-            // the jtransform layer is where RPython branches on operand kind.
-            // Both operands Ref → rewrite to `ptr_eq`/`ptr_ne`. Mixed/Int operands
-            // stay as `int_eq`/`int_ne`.
+            // this arm is that rewrite. Mixed/Int operands stay as `int_eq`.
             OpKind::BinOp {
                 op: binop_name,
                 lhs,
@@ -2415,10 +2542,32 @@ impl<'a> Transformer<'a> {
                 && self.get_value_kind_var(lhs) == 'r'
                 && self.get_value_kind_var(rhs) == 'r' =>
             {
-                let new_op = if binop_name == "eq" {
-                    "ptr_eq"
+                let new_op = self.ptr_equality_opname(binop_name, lhs, rhs);
+                RewriteResult::Replace(vec![SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::BinOp {
+                        op: new_op.into(),
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                        result_ty: result_ty.clone(),
+                    },
+                }])
+            }
+            // Already-named `ptr_eq`/`ptr_ne` from rtyper `PtrRepr.rtype_eq`.
+            // `rewrite_op_ptr_eq` still promotes rclass instances.
+            OpKind::BinOp {
+                op: binop_name,
+                lhs,
+                rhs,
+                result_ty,
+            } if matches!(binop_name.as_str(), "ptr_eq" | "ptr_ne")
+                && self.is_rclass_instance(lhs)
+                && self.is_rclass_instance(rhs) =>
+            {
+                let new_op = if binop_name == "ptr_eq" {
+                    "instance_ptr_eq"
                 } else {
-                    "ptr_ne"
+                    "instance_ptr_ne"
                 };
                 RewriteResult::Replace(vec![SpaceOperation {
                     result: op.result.clone(),
@@ -2543,92 +2692,20 @@ impl<'a> Transformer<'a> {
                 });
                 RewriteResult::Replace(ops)
             }
-            // PRE-EXISTING-ADAPTATION (no direct RPython precedent): pyre-
-            // side recovery when integer comparisons reach jtransform with
-            // a Ref-typed operand because the rtyper-equivalent did not
-            // stamp the operand's `concretetype` (or an `lltype.
-            // cast_ptr_to_int` was elided from the SSA chain).  RPython's
-            // rtyper inserts the cast at the rtyper layer
-            // (`rpython/rtyper/rint.py`), so by the time `jtransform.py`
-            // observes the comparison the operands are uniformly `Signed`;
-            // pyre's lighter rtyper leaves the generic `BinOp` in place
-            // with one or both operands defaulting to `'r'` kind, so the
-            // unconditional `int_<op>` prefix at
-            // `assembler.rs`'s `op_kind_to_opname_with_kinds` would emit `int_eq/ir>i` /
-            // `int_le/ri>i` opnames that no RPython blackhole handler
-            // registers (see
-            // `default_bh_builder_unwired_set_matches_task_85_snapshot`).
-            //
-            // Coverage covers all six
-            // comparison ops (`eq`/`ne`/`lt`/`le`/`gt`/`ge`).  The
-            // earlier "eq/ne only" restriction surfaced `int_le/r*`
-            // as unwired blackhole opnames, breaking the expected-empty
-            // snapshot.  RPython has no `ptr_lt` family,
-            // but `cast_ptr_to_int` followed by `int_lt`/`int_le`
-            // matches what `rpython/rtyper/rint.py` emits for any
-            // comparison whose operands cross the ptr/int boundary —
-            // the cast is rtyper-orthodox, the resulting `int_<cmp>/ii>i`
-            // opname is wired by the blackhole.  Producer-side fix
-            // for the missing rtyper cast remains the canonical
-            // convergence path; this jtransform recovery is the
-            // bridge until that lands.
-            // eq/ne with BOTH operands ref-kind → emit ptr_eq / ptr_ne
-            // directly.  PyPy `rpython/rtyper/rptr.py:167-184
-            // pairtype(PtrRepr, Repr).rtype_eq/ne` calls
-            // `hop.inputargs(r_ptr, r_ptr)` (both already ptr-typed in
-            // this branch — no cast) and emits `ptr_eq` / `ptr_ne`.
-            // Pyre's blackhole has `bhimpl_ptr_eq` / `bhimpl_ptr_ne`
-            // wired at `bh_binop_r_to_i`, so the resulting
-            // `ptr_eq/rr>i` opname dispatches without going through
-            // `cast_ptr_to_int`.
+            // Ordered compare with a Ref operand. RPython has no `ptr_lt`
+            // family (`rptr.py` registers only eq/ne). The producer is
+            // `front::mir` `BinaryOp`: `p < q` lowers to
+            // `simple_call(lltype.cast_ptr_to_int)` then `int_lt`
+            // (`rbuiltin.py rtype_cast_ptr_to_int`). Graphs that still
+            // arrive bare (Skip arm, elided cast, hand-built fixtures)
+            // are coerced here so assembler does not emit the unwired
+            // `int_le/r*` blackhole names. Do not add `ptr_lt`.
             OpKind::BinOp {
                 op: binop_name,
                 lhs,
                 rhs,
                 result_ty,
-            } if matches!(binop_name.as_str(), "eq" | "ne")
-                && self.get_value_kind_var(lhs) == 'r'
-                && self.get_value_kind_var(rhs) == 'r' =>
-            {
-                self.stamp_value_kind(
-                    graph,
-                    op.result.clone(),
-                    crate::codewriter::type_state::ConcreteType::Signed,
-                );
-                let ptr_op = if binop_name == "eq" {
-                    "ptr_eq"
-                } else {
-                    "ptr_ne"
-                };
-                RewriteResult::Replace(vec![SpaceOperation {
-                    result: op.result.clone(),
-                    kind: OpKind::BinOp {
-                        op: ptr_op.into(),
-                        lhs: lhs.clone(),
-                        rhs: rhs.clone(),
-                        result_ty: result_ty.clone(),
-                    },
-                }])
-            }
-            // Mixed-kind eq/ne (one ref + one int) or any ordered
-            // ref-cmp (lt/le/gt/ge with a ref operand) — PRE-EXISTING
-            // ADAPTATION: pyre's frontend admits source patterns
-            // RPython does not (PyPy `rptr.py` only registers eq/ne for
-            // PtrRepr pairtype, never `<`/`<=`/`>`/`>=`; mixed
-            // ref+int eq/ne would surface as a TyperError at PyPy's
-            // `inputargs(r_ptr, r_ptr)` convertfromrepr step).  Pyre
-            // bridges by coercing every ref operand through
-            // `cast_ptr_to_int` and emitting `int_<op>`.  The canonical
-            // PyPy-orthodox close is fixing the source patterns
-            // upstream (use `is_null()` / explicit `as` cast) or
-            // moving the cast emission into pyre's rtyper rint
-            // compare-template; this is not yet implemented.
-            OpKind::BinOp {
-                op: binop_name,
-                lhs,
-                rhs,
-                result_ty,
-            } if matches!(binop_name.as_str(), "eq" | "ne" | "lt" | "le" | "gt" | "ge")
+            } if matches!(binop_name.as_str(), "lt" | "le" | "gt" | "ge")
                 && matches!(self.get_value_kind_var(lhs), 'i' | 'r')
                 && matches!(self.get_value_kind_var(rhs), 'i' | 'r')
                 && (self.get_value_kind_var(lhs) == 'r' || self.get_value_kind_var(rhs) == 'r') =>
@@ -2897,25 +2974,16 @@ impl<'a> Transformer<'a> {
                 } else {
                     "floordiv"
                 };
-                // TODO: no direct RPython precedent:
-                // pyre-side recovery when an explicit
-                // `lltype.cast_ptr_to_int` (`rbuiltin.py
-                // genop('cast_ptr_to_int', vlist, resulttype=Signed)`)
-                // emitted by the front-end is elided from the SSA chain
-                // before reaching jtransform.  The gate accepts a
-                // Ref-typed LHS/RHS and rebuilds the missing cast here
-                // so the residual call sees Signed operands.  RPython
-                // `rint.py rtype_mod` does NOT auto-cast
-                // arbitrary Ref operands; its `hop.inputargs(repr,
-                // repr)` assumes the rtyper has already inserted
-                // explicit casts at lltype / rbuiltin boundaries.  The
-                // wider tolerance here is therefore strictly broader
-                // than the RPython contract and exists only to keep the
-                // dispatch table closed while the upstream cast-
-                // elision is traced and fixed (the convergence path is
-                // to find which simplify / inline pass drops the cast
-                // and preserve it instead, then narrow this gate back
-                // to `'i' && 'i'`).
+                // The producer is `front::mir` `BinaryOp`: `%` / `/`
+                // over a Ref operand lowers to
+                // `simple_call(lltype.cast_ptr_to_int)` then the
+                // integer op (`rbuiltin.py rtype_cast_ptr_to_int`),
+                // with the result stamped Signed. An `Unknown`
+                // stamp used to make `get_value_kind_var` report
+                // `'r'` and look like the cast had been dropped.
+                // `rint.py rtype_mod` does not auto-cast Refs.
+                // Graphs that still arrive bare (Skip arm,
+                // hand-built fixtures) are coerced here.
                 let (lhs_var, lhs_pre_ops) = self.coerce_operand_to_int(graph, lhs);
                 let (rhs_var, rhs_pre_ops) = self.coerce_operand_to_int(graph, rhs);
                 let mut ops = Vec::with_capacity(lhs_pre_ops.len() + rhs_pre_ops.len() + 2);
@@ -3299,6 +3367,45 @@ impl<'a> Transformer<'a> {
         }
     }
 
+    /// RPython `Transformer._is_rclass_instance`
+    /// (`jtransform.py`): `lltype._castdepth(v.concretetype.TO, rclass.OBJECT) >= 0`.
+    fn is_rclass_instance(&self, var: &crate::flowspace::model::Variable) -> bool {
+        use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
+        use crate::translator::rtyper::rclass::OBJECT;
+        let Some(ct) = var.concretetype() else {
+            return false;
+        };
+        let LowLevelType::Ptr(ptr) = ct else {
+            return false;
+        };
+        let PtrTarget::Struct(outside) = &ptr.TO else {
+            return false;
+        };
+        let LowLevelType::Struct(object) = &*OBJECT else {
+            return false;
+        };
+        crate::translator::rtyper::lltypesystem::lltype::_castdepth(outside, object) >= 0
+    }
+
+    /// `rewrite_op_ptr_eq` / `rewrite_op_ptr_ne` opname after the
+    /// rclass-instance promotion.
+    fn ptr_equality_opname(
+        &self,
+        eq_or_ne: &str,
+        lhs: &crate::flowspace::model::Variable,
+        rhs: &crate::flowspace::model::Variable,
+    ) -> &'static str {
+        match (
+            eq_or_ne,
+            self.is_rclass_instance(lhs) && self.is_rclass_instance(rhs),
+        ) {
+            ("eq", true) => "instance_ptr_eq",
+            ("ne", true) => "instance_ptr_ne",
+            ("eq", false) => "ptr_eq",
+            _ => "ptr_ne",
+        }
+    }
+
     fn get_value_type(&self, var: &crate::flowspace::model::Variable) -> Option<ValueType> {
         // RPython `jit/codewriter/jtransform.py`: `getkind(v.concretetype)`
         // — read kind off the Variable.concretetype slot directly.
@@ -3424,18 +3531,13 @@ impl<'a> Transformer<'a> {
         )
     }
 
-    /// TODO: recovery helper — no direct RPython
-    /// precedent.  Inserts an explicit `cast_ptr_to_int` op for a
-    /// Ref-typed operand reaching an arithmetic site that requires
-    /// Int operands.  Upstream RPython does NOT auto-cast arbitrary
-    /// Ref to Signed at the rtyper boundary; ptr→int conversions come
-    /// from explicit `lltype.cast_ptr_to_int` builtins emitted at the
-    /// rbuiltin layer.  Pyre's analyzer/simplify chain may elide an
-    /// emitted cast before jtransform sees it, leaving a bare Ref at
-    /// the binop callsite; this helper rebuilds the missing cast so
-    /// the residual call sees Signed operands.  The convergence path
-    /// is to fix the cast elision upstream and retire this helper.
-    /// Non-Ref operands are returned unchanged.
+    /// Recovery helper — no direct RPython precedent. Inserts
+    /// `cast_ptr_to_int` for a Ref operand at an integer site.
+    /// The producer is `front::mir` `BinaryOp` (`simple_call` to
+    /// `lltype.cast_ptr_to_int`, `rbuiltin.py rtype_cast_ptr_to_int`).
+    /// This rebuilds a cast that was elided or never lowered (Skip
+    /// arm, hand-built fixtures). Retire once those graphs stop
+    /// arriving. Non-Ref operands are unchanged.
     fn coerce_operand_to_int(
         &mut self,
         graph: &mut FunctionGraph,
@@ -4394,7 +4496,7 @@ impl<'a> Transformer<'a> {
                     target: CallTarget::FunctionPath {
                         segments: path.segments.clone(),
                     },
-                    args: args.to_vec(),
+                    args: crate::model::call_args(args.iter().cloned()),
                     result_ty: result_ty.clone(),
                 },
             };
@@ -6582,7 +6684,7 @@ impl<'a> Transformer<'a> {
                     graph,
                     op,
                     target,
-                    &original_args,
+                    &crate::model::call_arg_vars(&original_args),
                     result_ty,
                     graph_name,
                     OopSpecIndex::NotInTrace,
@@ -6722,7 +6824,7 @@ impl<'a> Transformer<'a> {
             result: op.result.clone(),
             kind: OpKind::Call {
                 target: func_target.clone(),
-                args: func_args.to_vec(),
+                args: crate::model::call_args(func_args.iter().cloned()),
                 result_ty: result_ty.clone(),
             },
         };
@@ -8674,10 +8776,12 @@ fn remap_op(
             args,
             result_ty,
         } => {
-            let remap_var = |var: &crate::flowspace::model::Variable| remap_value(var, aliases);
             OpKind::Call {
                 target: target.clone(),
-                args: args.iter().map(remap_var).collect(),
+                args: args
+                    .iter()
+                    .map(|arg| arg.map_value(|var| remap_value(var, aliases)))
+                    .collect(),
                 result_ty: result_ty.clone(),
             }
         }
@@ -9003,7 +9107,7 @@ fn fold_we_are_jitted_calls(graph: &mut crate::model::FunctionGraph) {
             else {
                 continue;
             };
-            if !is_we_are_jitted_path(segments, args) {
+            if !is_we_are_jitted_path(segments, &crate::model::call_arg_vars(args)) {
                 continue;
             }
             op.kind = OpKind::ConstSymbolic {
@@ -11753,7 +11857,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_fresh_virtualizable"]),
-                args: vec![frame_var],
+                args: crate::model::call_args(vec![frame_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -11897,7 +12001,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_fresh_virtualizable"]),
-                args: vec![frame_var],
+                args: crate::model::call_args(vec![frame_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -12104,7 +12208,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_fresh_virtualizable"]),
-                args: vec![frame_var],
+                args: crate::model::call_args(vec![frame_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -12165,7 +12269,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_fresh_virtualizable"]),
-                args: vec![frame],
+                args: crate::model::call_args(vec![frame]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -12408,7 +12512,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::method("do_call", Some("Frame".into())),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -12442,7 +12546,7 @@ mod tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::function_path(["unknown_external_int"]),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Unknown,
                 },
                 true,
@@ -12813,7 +12917,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: target.clone(),
-                args: vec![arg_var],
+                args: crate::model::call_args(vec![arg_var]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -12862,7 +12966,7 @@ mod tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::function_path(["__builtin__", "float"]),
-                    args: vec![arg],
+                    args: crate::model::call_args(vec![arg]),
                     result_ty: ValueType::Float,
                 },
                 true,
@@ -12893,7 +12997,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["custom_reader"]),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -12945,7 +13049,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: target.clone(),
-                args: vec![arg],
+                args: crate::model::call_args(vec![arg]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -13011,7 +13115,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_access_directly"]),
-                args: vec![frame_var],
+                args: crate::model::call_args(vec![frame_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -13069,7 +13173,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_force_virtualizable"]),
-                args: vec![frame_var.clone()],
+                args: crate::model::call_args(vec![frame_var.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -13142,7 +13246,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["jit_force_virtualizable"]),
-                args: vec![frame_var.clone()],
+                args: crate::model::call_args(vec![frame_var.clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -13253,7 +13357,7 @@ mod tests {
             startblock,
             OpKind::Call {
                 target,
-                args: vec![x.clone(), y.clone()],
+                args: crate::model::call_args(vec![x.clone(), y.clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -13297,7 +13401,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote"]),
-                args: vec![v_var.clone()],
+                args: crate::model::call_args(vec![v_var.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -13364,7 +13468,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote"]),
-                args: vec![v_var.clone()],
+                args: crate::model::call_args(vec![v_var.clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -13621,7 +13725,7 @@ mod tests {
                         "jit_merge_point",
                         Some("UnpackIterableJitDriver".into()),
                     ),
-                    args: vec![receiver.clone(), green.clone()],
+                    args: crate::model::call_args(vec![receiver.clone(), green.clone()]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -13895,7 +13999,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::method("can_enter_jit", Some("PyPyJitDriver".into())),
-                    args: vec![receiver],
+                    args: crate::model::call_args(vec![receiver]),
                     result_ty: ValueType::Bool,
                 },
                 true,
@@ -14562,7 +14666,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -14665,7 +14769,7 @@ mod tests {
                 result: Some(result),
                 kind: OpKind::Call {
                     target: target.clone(),
-                    args: vec![operand.clone()],
+                    args: crate::model::call_args(vec![operand.clone()]),
                     result_ty: result_ty.clone(),
                 },
             };
@@ -14706,7 +14810,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -14752,7 +14856,7 @@ mod tests {
             result: Some(as_int.clone()),
             kind: OpKind::Call {
                 target: to_int.clone(),
-                args: vec![ptr.clone()],
+                args: crate::model::call_args(vec![ptr.clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -14768,7 +14872,7 @@ mod tests {
             result: Some(as_ptr),
             kind: OpKind::Call {
                 target: to_ptr.clone(),
-                args: vec![as_int.clone()],
+                args: crate::model::call_args(vec![as_int.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -14807,7 +14911,7 @@ mod tests {
                 result: Some(result_var),
                 kind: OpKind::Call {
                     target: target.clone(),
-                    args: vec![arg.clone()],
+                    args: crate::model::call_args(vec![arg.clone()]),
                     result_ty: result_ty.clone(),
                 },
             };
@@ -14861,7 +14965,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15046,7 +15150,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15111,7 +15215,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15167,7 +15271,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15205,7 +15309,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target,
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Bool,
                 },
                 true,
@@ -15239,7 +15343,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target,
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Bool,
                 },
                 true,
@@ -15278,7 +15382,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target,
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Bool,
                 },
                 true,
@@ -15325,7 +15429,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::function_path(path),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(None),
                     },
                     true,
@@ -15362,7 +15466,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15402,7 +15506,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15438,7 +15542,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15472,7 +15576,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: target.clone(),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: result_ty.clone(),
                 },
                 true,
@@ -15535,7 +15639,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15577,7 +15681,7 @@ mod tests {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: result_ty.clone(),
             },
         };
@@ -15738,7 +15842,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: target.clone(),
-                args: vec![value.clone()],
+                args: crate::model::call_args(vec![value.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -15794,7 +15898,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: target.clone(),
-                args: vec![value.clone()],
+                args: crate::model::call_args(vec![value.clone()]),
                 result_ty: ValueType::Float,
             },
             false,
@@ -15850,7 +15954,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: CallTarget::function_path(["libffi_call"]),
-                args: vec![cif, func, buffer],
+                args: crate::model::call_args(vec![cif, func, buffer]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -16097,7 +16201,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: args.clone(),
+                args: crate::model::call_args(args.clone()),
                 result_ty: result_ty.clone(),
             },
         };
@@ -16162,7 +16266,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: args.clone(),
+                args: crate::model::call_args(args.clone()),
                 result_ty: result_ty.clone(),
             },
         };
@@ -16230,7 +16334,7 @@ mod tests {
             result: Some(result_var),
             kind: OpKind::Call {
                 target: target.clone(),
-                args: args.clone(),
+                args: crate::model::call_args(args.clone()),
                 result_ty: result_ty.clone(),
             },
         };
@@ -16289,7 +16393,7 @@ mod tests {
             result: None,
             kind: OpKind::Call {
                 target: CallTarget::function_path(["ll_arraymove"]),
-                args: args.clone(),
+                args: crate::model::call_args(args.clone()),
                 result_ty: ValueType::Void,
             },
         };
@@ -16434,7 +16538,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::indirect("Handler", "run"),
-                args: vec![receiver_var],
+                args: crate::model::call_args(vec![receiver_var]),
                 result_ty: ValueType::Void,
             },
             true,
@@ -16528,7 +16632,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::indirect("Handler", "run"),
-                args: vec![receiver_var],
+                args: crate::model::call_args(vec![receiver_var]),
                 result_ty: ValueType::Void,
             },
             true,
@@ -16690,7 +16794,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::indirect("T", "m"),
-                args: args_vars,
+                args: crate::model::call_args(args_vars),
                 result_ty,
             },
             has_result,
@@ -16948,7 +17052,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::indirect("T", "m"),
-                args: args_vars,
+                args: crate::model::call_args(args_vars),
                 result_ty,
             },
             has_result,
@@ -17095,7 +17199,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote_or_string"]),
-                args: vec![v_var],
+                args: crate::model::call_args(vec![v_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -17126,7 +17230,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote_or_string"]),
-                args: vec![v_var.clone()],
+                args: crate::model::call_args(vec![v_var.clone()]),
                 result_ty: ValueType::Int,
             },
             false,
@@ -17166,7 +17270,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote_string"]),
-                args: vec![v_var],
+                args: crate::model::call_args(vec![v_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -17201,7 +17305,7 @@ mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["hint_promote_unicode"]),
-                args: vec![v_var],
+                args: crate::model::call_args(vec![v_var]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -17473,7 +17577,7 @@ mod tests {
             startblock,
             OpKind::Call {
                 target,
-                args: vec![count.clone()],
+                args: crate::model::call_args(vec![count.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -17530,7 +17634,7 @@ mod tests {
             startblock,
             OpKind::Call {
                 target,
-                args: vec![lhs.clone(), rhs.clone()],
+                args: crate::model::call_args(vec![lhs.clone(), rhs.clone()]),
                 result_ty: ValueType::Int,
             },
             false,
@@ -17594,7 +17698,7 @@ mod tests {
             startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["_ll_alloc_and_clear"]),
-                args: vec![count.clone()],
+                args: crate::model::call_args(vec![count.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -17652,7 +17756,7 @@ mod tests {
             startblock,
             OpKind::Call {
                 target: CallTarget::function_path(["_ll_fixed_alloc_and_clear"]),
-                args: vec![count.clone()],
+                args: crate::model::call_args(vec![count.clone()]),
                 result_ty: ValueType::Ref(None),
             },
             false,
@@ -18455,6 +18559,404 @@ mod tests {
                 "`x == 5` stays a binary compare: {ops:?}"
             );
         }
+
+        #[test]
+        fn an_ordered_compare_over_refs_inserts_cast_ptr_to_int() {
+            let mut graph = FunctionGraph::new("ordered_ref_lt");
+            let lhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "a".into(),
+                        ty: ValueType::Ref(None),
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let rhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "b".into(),
+                        ty: ValueType::Ref(None),
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let result = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: "lt".into(),
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                        result_ty: ValueType::Bool,
+                    },
+                    true,
+                )
+                .unwrap();
+            graph.set_return(graph.startblock, Some(result));
+            FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::GcRef);
+            FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::GcRef);
+            let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+            let ops = &transformed.graph.block(graph.startblock).operations;
+            let casts: Vec<_> = ops
+                .iter()
+                .filter_map(|op| match &op.kind {
+                    OpKind::UnaryOp { op, operand, .. } if op == "cast_ptr_to_int" => {
+                        Some(operand.clone())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                casts.len(),
+                2,
+                "each Ref operand must become a Signed address: {ops:?}"
+            );
+            let (op, _, _) = binary_op(ops).expect("the compare must survive");
+            assert_eq!(op, "lt", "do not invent ptr_lt: {ops:?}");
+        }
+
+        #[test]
+        fn a_mod_over_refs_inserts_cast_ptr_to_int() {
+            let mut graph = FunctionGraph::new("mod_ref");
+            let lhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "a".into(),
+                        ty: ValueType::Ref(None),
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let rhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "b".into(),
+                        ty: ValueType::Int,
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let result = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: "mod".into(),
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                        result_ty: ValueType::Int,
+                    },
+                    true,
+                )
+                .unwrap();
+            graph.set_return(graph.startblock, Some(result));
+            FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::GcRef);
+            FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::Signed);
+            let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+            let ops = &transformed.graph.block(graph.startblock).operations;
+            let casts = ops
+                .iter()
+                .filter(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::UnaryOp { op, .. } if op == "cast_ptr_to_int"
+                    )
+                })
+                .count();
+            assert_eq!(casts, 1, "the Ref operand must become a Signed address: {ops:?}");
+            assert!(
+                ops.iter().any(|op| matches!(
+                    &op.kind,
+                    OpKind::CallResidual { .. }
+                )),
+                "mod over ints is the C-trunc residual, not ptr_mod: {ops:?}"
+            );
+        }
+
+        #[test]
+        fn two_rclass_instance_refs_become_instance_ptr_eq() {
+            let mut graph = FunctionGraph::new("instance_ptr_eq");
+            let lhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "a".into(),
+                        ty: ValueType::Ref(None),
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let rhs = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::Input {
+                        name: "b".into(),
+                        ty: ValueType::Ref(None),
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            let result = graph
+                .push_op_var(
+                    graph.startblock,
+                    OpKind::BinOp {
+                        op: "eq".into(),
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                        result_ty: ValueType::Bool,
+                    },
+                    true,
+                )
+                .unwrap();
+            graph.set_return(graph.startblock, Some(result));
+            FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::GcRef);
+            FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::GcRef);
+            let transformed = Transformer::new(&GraphTransformConfig::default()).transform(&graph);
+            let ops = &transformed.graph.block(graph.startblock).operations;
+            let (op, _, _) = binary_op(ops).expect("the compare must survive");
+            assert_eq!(
+                op, "instance_ptr_eq",
+                "OBJECTPTR-stamped refs are rclass instances: {ops:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn constant_fold_ll_issubclass_is_a_noop_without_the_matcher() {
+        let mut graph = FunctionGraph::new("no_cpu");
+        let before = graph.clone();
+        super::constant_fold_ll_issubclass(&mut graph, None);
+        assert_eq!(
+            graph.blocks.len(),
+            before.blocks.len(),
+            "jtransform.py returns immediately when cpu is None"
+        );
+    }
+
+    /// Allocate a vtable and write `subclassrange_{min,max}`.
+    /// Mirrors `rtyper.rs` test helper `make_const_etype`.
+    fn make_const_etype(min: i64, max: i64) -> crate::flowspace::model::Hlvalue {
+        use crate::flowspace::model::{ConstValue, Constant, Hlvalue};
+        use crate::translator::rtyper::lltypesystem::lltype::{
+            LowLevelType, LowLevelValue, MallocFlavor, malloc,
+        };
+        let vtable_lltype = match crate::translator::rtyper::rclass::OBJECT_VTABLE.clone() {
+            LowLevelType::ForwardReference(fwd) => fwd
+                .resolved()
+                .expect("OBJECT_VTABLE forward-reference must be resolved"),
+            other => other,
+        };
+        let mut vtable_ptr =
+            malloc(vtable_lltype, None, MallocFlavor::Raw, true).expect("malloc OBJECT_VTABLE");
+        vtable_ptr
+            .setattr("subclassrange_min", LowLevelValue::Signed(min))
+            .expect("setattr subclassrange_min");
+        vtable_ptr
+            .setattr("subclassrange_max", LowLevelValue::Signed(max))
+            .expect("setattr subclassrange_max");
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::LLPtr(Box::new(vtable_ptr)),
+            crate::translator::rtyper::rclass::CLASSTYPE.clone(),
+        ))
+    }
+
+    fn fold_direct_call_to_matcher(
+        matcher: &crate::translator::rtyper::rtyper::LowLevelFunction,
+        func_ptr: crate::translator::rtyper::lltypesystem::lltype::_ptr,
+        sub: crate::flowspace::model::Hlvalue,
+        cls: crate::flowspace::model::Hlvalue,
+    ) -> crate::flowspace::model::SpaceOperation {
+        use crate::flowspace::model::{
+            Block, BlockRefExt, ConstValue, Constant, FunctionGraph as FlowGraph, Hlvalue, Link,
+            SpaceOperation, Variable,
+        };
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+        let result = Hlvalue::Variable(Variable::named("r"));
+        let start = Block::shared(vec![]);
+        let if_false = Block::shared(vec![]);
+        let if_true = Block::shared(vec![]);
+        if_false.borrow_mut().mark_final();
+        if_true.borrow_mut().mark_final();
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(Constant::with_concretetype(
+                    ConstValue::LLPtr(Box::new(func_ptr.clone())),
+                    LowLevelType::Ptr(Box::new(func_ptr._TYPE.clone())),
+                )),
+                sub,
+                cls,
+            ],
+            result.clone(),
+        ));
+        start.borrow_mut().exitswitch = Some(result.clone());
+        start.closeblock(vec![
+            Link::new(
+                vec![],
+                Some(if_false),
+                Some(Hlvalue::Constant(Constant::new(ConstValue::Bool(false)))),
+            )
+            .into_ref(),
+            Link::new(
+                vec![],
+                Some(if_true),
+                Some(Hlvalue::Constant(Constant::new(ConstValue::Bool(true)))),
+            )
+            .into_ref(),
+        ]);
+        let graph = FlowGraph::new("fold_ll_issubclass", start.clone());
+        super::constant_fold_ll_issubclass_flowgraph(&graph, Some(matcher));
+        let start_b = start.borrow();
+        assert!(
+            start_b.exitswitch.is_none(),
+            "jtransform.py clears exitswitch when the folded result is the switch"
+        );
+        assert_eq!(
+            start_b.exits.len(),
+            1,
+            "recloseblock keeps only the taken exit"
+        );
+        start_b.operations[0].clone()
+    }
+
+    #[test]
+    fn constant_fold_ll_issubclass_folds_constant_vtables() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{ConstValue, Hlvalue};
+        use crate::translator::rtyper::rtyper::RPythonTyper;
+        use std::rc::Rc;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata");
+        rtyper
+            .exceptiondata()
+            .expect("exceptiondata")
+            .make_helpers(&rtyper)
+            .expect("make_helpers");
+        let ed = rtyper.exceptiondata().expect("exceptiondata");
+        let matcher = ed
+            .fn_exception_match
+            .borrow()
+            .clone()
+            .expect("fn_exception_match after make_helpers");
+        let func_ptr = rtyper
+            .getcallable(matcher.graph.as_ref().expect("matcher graph"))
+            .expect("getcallable(fn_exception_match)");
+
+        // cls.min=0, cls.max=10, sub.min=1 → 0 <= 1 < 10
+        let folded = fold_direct_call_to_matcher(
+            &matcher,
+            func_ptr.clone(),
+            make_const_etype(1, 2),
+            make_const_etype(0, 10),
+        );
+        assert_eq!(folded.opname, "same_as");
+        match &folded.args[0] {
+            Hlvalue::Constant(c) => assert_eq!(c.value, ConstValue::Bool(true)),
+            other => panic!("expected Bool(true), got {other:?}"),
+        }
+
+        // cls.min=0, cls.max=10, sub.min=20 → 0 <= 20 < 10 is false
+        let folded = fold_direct_call_to_matcher(
+            &matcher,
+            func_ptr,
+            make_const_etype(20, 21),
+            make_const_etype(0, 10),
+        );
+        assert_eq!(folded.opname, "same_as");
+        match &folded.args[0] {
+            Hlvalue::Constant(c) => assert_eq!(c.value, ConstValue::Bool(false)),
+            other => panic!("expected Bool(false), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn constant_fold_ll_issubclass_ignores_a_different_funcptr() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{
+            Block, ConstValue, Constant, FunctionGraph as FlowGraph, Hlvalue, SpaceOperation,
+            Variable,
+        };
+        use crate::translator::rtyper::lltypesystem::lltype::{
+            FuncType, LowLevelType, functionptr_for_graph_with_type,
+        };
+        use crate::translator::rtyper::rtyper::RPythonTyper;
+        use std::rc::Rc;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata");
+        rtyper
+            .exceptiondata()
+            .expect("exceptiondata")
+            .make_helpers(&rtyper)
+            .expect("make_helpers");
+        let ed = rtyper.exceptiondata().expect("exceptiondata");
+        let matcher = ed
+            .fn_exception_match
+            .borrow()
+            .clone()
+            .expect("fn_exception_match after make_helpers");
+
+        // A different helper graph — identity is the graph key, not the
+        // string `ll_issubclass`.
+        let other = rtyper
+            .lowlevel_helper_function(
+                "ll_both_none",
+                vec![
+                    crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+                    crate::translator::rtyper::rclass::NONGCOBJECTPTR.clone(),
+                ],
+                LowLevelType::Bool,
+            )
+            .expect("ll_both_none helper");
+        let other_ptr = functionptr_for_graph_with_type(
+            &other.graph.as_ref().expect("other graph").graph,
+            FuncType {
+                args: vec![
+                    crate::translator::rtyper::rclass::OBJECTPTR.clone(),
+                    crate::translator::rtyper::rclass::NONGCOBJECTPTR.clone(),
+                ],
+                result: LowLevelType::Bool,
+            },
+        );
+
+        let result = Hlvalue::Variable(Variable::named("r"));
+        let start = Block::shared(vec![]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(Constant::with_concretetype(
+                    ConstValue::LLPtr(Box::new(other_ptr.clone())),
+                    LowLevelType::Ptr(Box::new(other_ptr._TYPE.clone())),
+                )),
+                make_const_etype(1, 2),
+                make_const_etype(0, 10),
+            ],
+            result,
+        ));
+        let graph = FlowGraph::new("not_excmatch", start.clone());
+        super::constant_fold_ll_issubclass_flowgraph(&graph, Some(&matcher));
+        assert_eq!(
+            start.borrow().operations[0].opname,
+            "direct_call",
+            "a funcptr whose graph is not fn_exception_match must stay"
+        );
     }
 
     /// `goto_if_not_fusable` names the RPython opnames (`int_lt`), but the

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4873,6 +4873,15 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
+        // Skip-path graphs never run `rtype_type`. Flatten's raise tail
+        // reads only evalue (`flatten.py make_return`), so fold
+        // `op.type(v)` to the operand and leave no residual call.
+        if let CallTarget::FunctionPath { segments } = target
+            && segments.as_slice() == ["type"]
+            && args.len() == 1
+        {
+            return RewriteResult::Identity(args[0].clone());
+        }
         // `__cast_instance_intrinsic` — front::mir's pointer-downcast
         // narrow (`cast_instance_call`: operand + const(root)).  The rtyper
         // lowers it to `cast_pointer` (`rbuiltin.rs rtype_cast_instance_intrinsic`,
@@ -14666,6 +14675,37 @@ mod tests {
             std::slice::from_ref(&arg),
             &result_ty,
             "cast_ptr_marker",
+            &mut graph,
+        );
+        match rewritten {
+            RewriteResult::Identity(alias) => assert_eq!(alias, arg),
+            _ => panic!("expected Identity alias to the operand"),
+        }
+    }
+
+    #[test]
+    fn type_op_elides_to_operand_on_the_skip_path() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("type_skip");
+        let arg = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let target = CallTarget::function_path(["type"]);
+        let result_ty = ValueType::Ref(None);
+        let op = SpaceOperation {
+            result: Some(result_var),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: crate::model::call_args(vec![arg.clone()]),
+                result_ty: result_ty.clone(),
+            },
+        };
+        let rewritten = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            std::slice::from_ref(&arg),
+            &result_ty,
+            "type_skip",
             &mut graph,
         );
         match rewritten {

--- a/majit/majit-translate/src/codewriter/jtransform_opname.rs
+++ b/majit/majit-translate/src/codewriter/jtransform_opname.rs
@@ -655,7 +655,7 @@ fn transduce_op(
                 block,
                 OpKind::Call {
                     target,
-                    args,
+                    args: crate::model::call_args(args),
                     result_ty,
                 },
                 result,
@@ -1643,7 +1643,7 @@ mod tests {
             result: None,
             kind: OpKind::Call {
                 target,
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Void,
             },
         };

--- a/majit/majit-translate/src/codewriter/support.rs
+++ b/majit/majit-translate/src/codewriter/support.rs
@@ -181,10 +181,11 @@ pub(crate) fn split_before_jit_merge_point(
         Some(JitMarkerKey::JitMergePoint),
         "split portal block must start with jit_merge_point"
     );
-    let marker_args = args
-        .get(1..)
-        .expect("jit_merge_point method call must carry its receiver");
-    let (greens, reds) = decode_hp_hint_args(marker_args, numgreens, numreds);
+    let marker_args = crate::model::call_arg_vars(
+        args.get(1..)
+            .expect("jit_merge_point method call must carry its receiver"),
+    );
+    let (greens, reds) = decode_hp_hint_args(&marker_args, numgreens, numreds);
     let mut linkargs = greens;
     linkargs.extend(reds);
     crate::unsimplify::split_block(graph, portalblock, 0, Some(&linkargs))
@@ -276,7 +277,8 @@ pub fn decode_builtin_call(
     match &op.kind {
         // `support.py:756-759`: op.opname == 'direct_call' → resolve via fnobj
         OpKind::Call { target, args, .. } => {
-            let args: &[crate::flowspace::model::Variable] = args.as_slice();
+            let args = crate::model::call_arg_vars(args);
+            let args: &[crate::flowspace::model::Variable] = &args;
             // `support.py decode_builtin_call fnobj = op.args[0].value._obj` →
             // `:759 get_call_oopspec_opargs(fnobj, opargs)` →
             // `:707 operation_name, args = ll_func.oopspec.split('(', 1)`.
@@ -1254,7 +1256,7 @@ mod tests {
             result: None,
             kind: OpKind::Call {
                 target,
-                args: arg_vars.clone(),
+                args: crate::model::call_args(arg_vars.clone()),
                 result_ty: crate::model::ValueType::Int,
             },
         };

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -200,7 +200,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     // args.
     let mut then_sources = carried.clone();
     if !then_sources.contains(&env) {
-        then_sources.push(env.clone());
+        then_sources.push(env.clone().into_variable());
     }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, else_inputs) = graph.create_block_with_arg_vars(carried.len());
@@ -229,7 +229,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
                 result: Some(payload.clone()),
                 kind: OpKind::Call {
                     target: CallTarget::method("call_once", Some(call_once_owner.clone())),
-                    args: vec![env_in_then, unit],
+                    args: crate::model::call_args(vec![env_in_then, unit]),
                     result_ty: site.payload_ty.clone(),
                 },
             });
@@ -287,7 +287,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     // construction ops before the call stay as A's tail.
     let a_id = graph.blocks[a].id;
     graph.blocks[a].operations.truncate(call_idx);
-    graph.set_branch(a_id, cond, then_bb, then_sources, else_bb, carried);
+    graph.set_branch(a_id, cond.into_variable(), then_bb, then_sources, else_bb, carried);
     Ok(())
 }
 

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -287,7 +287,14 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     // construction ops before the call stay as A's tail.
     let a_id = graph.blocks[a].id;
     graph.blocks[a].operations.truncate(call_idx);
-    graph.set_branch(a_id, cond.into_variable(), then_bb, then_sources, else_bb, carried);
+    graph.set_branch(
+        a_id,
+        cond.into_variable(),
+        then_bb,
+        then_sources,
+        else_bb,
+        carried,
+    );
     Ok(())
 }
 

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -254,7 +254,11 @@ fn rewire_one_checked_arith_site(
                 .ok_or_else(|| format!("{name}: checked_* call path is empty"))?;
             let ovf = checked_arith_ovf_opname(leaf)
                 .ok_or_else(|| format!("{name}: call leaf {leaf} is not a checked_* arith op"))?;
-            (args[0].clone(), args[1].clone(), ovf)
+            (
+                args[0].clone().into_variable(),
+                args[1].clone().into_variable(),
+                ovf,
+            )
         }
         other => {
             return Err(format!(
@@ -624,7 +628,7 @@ fn rewire_checked_arith_ok_or_else(
     let err_value = crate::front::option_closure_select::emit_call_once(
         graph,
         graph.blocks[c].id,
-        env,
+        env.into_variable(),
         None,
         &site.call_once_owner,
         site.err_payload_ty.clone(),
@@ -734,7 +738,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: checked_target(),
-                    args: vec![va.clone(), vb.clone()],
+                    args: crate::model::call_args(vec![va.clone(), vb.clone()]),
                     result_ty: ValueType::Ref(Some("core::option::Option".into())),
                 },
                 true,
@@ -853,7 +857,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: checked_target(),
-                    args: vec![lhs.clone(), rhs.clone()],
+                    args: crate::model::call_args(vec![lhs.clone(), rhs.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -881,7 +885,7 @@ mod tests {
                 c,
                 OpKind::Call {
                     target: CallTarget::method("ok_or_else", Some("Option".into())),
-                    args: vec![opt_c, env],
+                    args: crate::model::call_args(vec![opt_c, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -967,7 +971,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: checked_target(),
-                    args: vec![va, vb],
+                    args: crate::model::call_args(vec![va, vb]),
                     result_ty: ValueType::Ref(Some("core::option::Option".into())),
                 },
                 true,

--- a/majit/majit-translate/src/front/checked_arith_uint.rs
+++ b/majit/majit-translate/src/front/checked_arith_uint.rs
@@ -156,7 +156,11 @@ fn rewire_one_checked_arith_uint_site(
             let arith = UintArith::from_leaf(leaf).ok_or_else(|| {
                 format!("{name}: unsigned checked lowering does not handle {leaf}")
             })?;
-            (args[0].clone(), args[1].clone(), arith)
+            (
+                args[0].clone().into_variable(),
+                args[1].clone().into_variable(),
+                arith,
+            )
         }
         _ => {
             return Err(format!(
@@ -201,7 +205,7 @@ fn rewire_one_checked_arith_uint_site(
                 ValueType::Unsigned,
             );
             // Unsigned carry: the wrapped sum is strictly below an addend.
-            let ovf = push_binop(graph, a_id, "uint_lt", sum.clone(), lhs, ValueType::Int);
+            let ovf = push_binop(graph, a_id, "uint_lt", sum.clone(), lhs.clone(), ValueType::Int);
             let disc = push_no_overflow_disc(graph, a_id, ovf);
             (sum, disc)
         }
@@ -341,7 +345,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: checked_target(leaf),
-                    args: vec![x, y],
+                    args: crate::model::call_args(vec![x, y]),
                     result_ty: ValueType::Ref(Some("core::option::Option".into())),
                 },
                 true,

--- a/majit/majit-translate/src/front/checked_arith_uint.rs
+++ b/majit/majit-translate/src/front/checked_arith_uint.rs
@@ -205,7 +205,14 @@ fn rewire_one_checked_arith_uint_site(
                 ValueType::Unsigned,
             );
             // Unsigned carry: the wrapped sum is strictly below an addend.
-            let ovf = push_binop(graph, a_id, "uint_lt", sum.clone(), lhs.clone(), ValueType::Int);
+            let ovf = push_binop(
+                graph,
+                a_id,
+                "uint_lt",
+                sum.clone(),
+                lhs.clone(),
+                ValueType::Int,
+            );
             let disc = push_no_overflow_disc(graph, a_id, ovf);
             (sum, disc)
         }

--- a/majit/majit-translate/src/front/exc_from_raise.rs
+++ b/majit/majit-translate/src/front/exc_from_raise.rs
@@ -56,68 +56,18 @@
 //! synthesised `type(evalue)` call, which would be a residual with a dead
 //! result register on every raise tail.
 //!
-//! ### TODO: `Constant` SSA carrier shape
+//! ### Operand shape
 //!
-//! Upstream RPython encodes the exception class operand as a
-//! `Constant(class_obj)` SSA value living directly inside
-//! `SpaceOperation.args` — `flowspace/model.py` defines
-//! `Constant(value)`, `flowspace/model.py` makes `args` a mixed
-//! `Variable | Constant` list, and `flowspace/operation.py:666
-//! SimpleCall.eval` reads `w_callable, args_w = self.args[0],
-//! self.args[1:]` — that is, `args[0]` is *itself* the Constant
-//! carrier, with no producing op.
-//!
-//! Pyre's `FunctionGraph` represents every SSA value through a
-//! `Variable` produced by a `SpaceOperation`.  The op-args slot
-//! is currently `Vec<Variable>` and still carries no
-//! `LinkArg`-style mixed enum.  The properly orthodox fix is to
-//! migrate `OpKind::Call.args` to `Vec<LinkArg>` (RPython parity rule
-//! #1: structural equivalence) and update every consumer (~80 sites
-//! across 14 files spanning `front/`, `inline.rs`,
-//! `codewriter/{call,jtransform,liveness,regalloc,assembler,
-//! format,flatten,support}.rs`, `translator/rtyper/rpbc.rs`, plus
-//! tests).  That port is **deferred**.
-//!
-//! Until the `Vec<LinkArg>` migration lands, this helper carries the
-//! constant exception class as the *second segment* of the
-//! `simple_call` Call's `FunctionPath` target — `["simple_call",
-//! exc_class_name]` — instead of as `simple_call.args[0]`.  That
-//! preserves the per-segment string identity of the class without
-//! needing a real `Constant` SSA carrier, but is **not** RPython-
-//! orthodox at the operand level (`args[0]` should be a Constant,
-//! not a path segment).  Three earlier attempts to remove this
-//! adaptation each ran into a different blocker:
-//!
-//! 1. **`["const", X]` Call producer** — emitted a 0-arg Call to
-//!    materialise the class as a real `args[0]` Variable.  Reviewer
-//!    rejected it because RPython has no `const` op at all (Constants
-//!    are SSA values, not ops).
-//! 2. **`FunctionGraph.constants` side table + `alloc_const`** — gave
-//!    each constant a real `Variable` with no producer op, mirroring
-//!    upstream's "Constant has no producer".  Broke regalloc /
-//!    assembler `lookup_coloring_var` because the downstream pipeline
-//!    requires every `args` `Variable` to have a regalloc coloring,
-//!    which non-Variable Constants don't have.  Plumbing constants
-//!    through liveness / regalloc / assembler is deferred.
-//! 3. **`OpKind::Const { value, result_ty }`** — a typed parallel of
-//!    `OpKind::ConstInt(i64)`.  Reviewer would still reject because
-//!    `ConstInt` is itself a deviation
-//!    (RPython has no `const_int` op either), so adding more of the
-//!    same does not improve parity.  Also `ConstValue` lacks
-//!    `Serialize`/`Deserialize` derives, so wiring it into `OpKind`
-//!    bytes-stable serialisation is its own deep change.
-//!
-//! Once the `Vec<LinkArg>` migration is on the roadmap, the helper
-//! collapses to a `LinkArg::Const(ConstValue::HostObject(class))`
-//! at `args[0]` and this comment block goes away.
-//!
-//! ### Operand-position parity (the non-class args)
-//!
-//! `simple_call`'s *non-class* args (the message values) are real
-//! Variables and live at `args[1..]`, matching upstream
-//! `flowspace/operation.py SimpleCall.eval` reading
-//! `args_w = self.args[1:]`.  This part is already orthodox — only
-//! the operand-0 class slot is the deviation noted above.
+//! Upstream encodes the exception class as a `Constant(class_obj)`
+//! living in `SpaceOperation.args` — `flowspace/model.py` makes
+//! `args` a mixed `Variable | Constant` list, and
+//! `flowspace/operation.py SimpleCall.eval` reads
+//! `w_callable, args_w = self.args[0], self.args[1:]`.  The helper
+//! emits that list: `args[0]` is
+//! `LinkArg::Const(HostObject(exc_class))` from
+//! `HOST_ENV.lookup_builtin`, and the message Variables occupy
+//! `args[1..]`.  The Call's `FunctionPath` is the op name
+//! `["simple_call"]`; the adapter does not wrap a second callable.
 //!
 //! The Rust macro → RPython exception class mapping is an adapter
 //! decision (mirroring upstream's per-bytecode adapter at
@@ -136,8 +86,8 @@
 //!   opaque Call targets any more — that earlier deviation is removed
 //!   by the same change that introduced this module.
 
-use crate::flowspace::model::Variable;
-use crate::model::{BlockId, CallTarget, FunctionGraph, OpKind, ValueType};
+use crate::flowspace::model::{ConstValue, Variable, HOST_ENV};
+use crate::model::{BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
 
 /// Close `block` with an `(etype, evalue)` Link to `exceptblock`
 /// whose value comes from the canonical RPython `exc_from_raise` op
@@ -145,42 +95,38 @@ use crate::model::{BlockId, CallTarget, FunctionGraph, OpKind, ValueType};
 /// slot reuses `evalue` — see the module-level "etype link arg" note.
 ///
 /// `exc_class_name` is the Python-layer exception class name
-/// (`"AssertionError"`, `"PanicError"`, …) carried as the second
-/// segment of the `simple_call` target's `FunctionPath`.  See the
-/// module-level TODO block for why the class
-/// is not yet at `simple_call.args[0]` — the orthodox fix is the
-/// `Vec<Variable>` → `Vec<LinkArg>` migration tracked separately.
+/// (`"AssertionError"`, `"ValueError"`, …).  It is resolved through
+/// `HOST_ENV.lookup_builtin` and placed at `simple_call.args[0]` as
+/// a `Constant`, matching `flowcontext.py exc_from_raise`
+/// (`op.simple_call(w_arg1, …)` when `w_arg1` is a class Constant).
 ///
 /// `message_args` is the pre-evaluated list of message `Variable`s
 /// (side effects already on the graph from the caller's walk).
 /// Empty for bare `panic!()` / `assert!(cond)`; single element for
 /// `panic!(msg)` / `assert!(cond, msg)`; multiple for
-/// `panic!("fmt", a, b)`.  In every case they become the trailing
-/// positional arguments of the `simple_call` op — `simple_call`
-/// itself is variadic upstream (`flowspace/operation.py:663
-/// SimpleCall(SingleDispatchMixin, CallOp)`, `CallOp.args =
-/// [callable, *args]`), so the multi-arg shape is RPython-canonical.
-pub fn lower_exc_from_raise(
+/// `panic!("fmt", a, b)`.  They become `simple_call.args[1..]`.
+/// `simple_call` is variadic upstream (`flowspace/operation.py
+/// SimpleCall` / `CallOp.args = [callable, *args]`).
+#[allow(dead_code)] // exercised by tests; raise-class sites call this helper
+pub(crate) fn lower_exc_from_raise(
     graph: &mut FunctionGraph,
     block: BlockId,
     exc_class_name: &str,
     message_args: Vec<Variable>,
 ) {
-    // `op.simple_call(const(exc_class), *args)` — upstream
-    // `flowcontext.py:614/623`.  The class is carried as the second
-    // path segment so the single op still models
-    // `simple_call(const(exc_class), *args)`; downstream readers can
-    // reconstruct `(op, const_class, args…)` from `(path[0], path[1],
-    // op.args)`.  This is a documented deviation — see the module-level
-    // docstring for why it stands until the `Vec<Variable>` →
-    // `Vec<LinkArg>` migration lands.
-    let simple_call_target = CallTarget::function_path(["simple_call", exc_class_name]);
+    // `op.simple_call(const(exc_class), *args)` — `flowcontext.py`.
+    let exc_class = HOST_ENV.lookup_builtin(exc_class_name).unwrap_or_else(|| {
+        panic!("lower_exc_from_raise: {exc_class_name} is not a HOST_ENV builtin exception class")
+    });
+    let mut args = Vec::with_capacity(message_args.len() + 1);
+    args.push(LinkArg::from(ConstValue::HostObject(exc_class)));
+    args.extend(message_args.into_iter().map(LinkArg::from));
     let evalue_var = graph
         .push_op_var(
             block,
             OpKind::Call {
-                target: simple_call_target,
-                args: message_args,
+                target: CallTarget::function_path(["simple_call"]),
+                args,
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -195,12 +141,48 @@ pub fn lower_exc_from_raise(
     // `args[0]`, and `make_exception_link` drops both for a direct `reraise`.
     // So the `etype` link arg is write-only in every emitted jitcode. The
     // emitted drain tail is `-live-` + `raise <evalue>` and nothing else.
-    // Materialising it as a `type(evalue)` call — which pyre
-    // did, because `set_raise_values` takes `Variable`s and every pyre SSA
-    // value needs a producing op (see the `Constant` carrier TODO above) —
-    // left a residual whose result register is dead by construction on every
-    // raise tail in the corpus, and made the raise arm unwalkable in the
-    // blackhole (canonical `inline_call_*` on a callee with no runtime
-    // address). Reuse `evalue`: same ref kind, no new op.
+    // Materialising it as a `type(evalue)` call left a residual whose
+    // result register is dead by construction on every raise tail, and
+    // made the raise arm unwalkable in the blackhole (canonical
+    // `inline_call_*` on a callee with no runtime address). Reuse
+    // `evalue`: same ref kind, no new op.
     graph.set_raise_values(block, evalue_var.clone(), evalue_var);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{CallTarget, FunctionGraph, OpKind};
+
+    #[test]
+    fn lower_exc_from_raise_puts_class_constant_at_args_0() {
+        let mut graph = FunctionGraph::new("exc_from_raise_shape");
+        let start = graph.startblock;
+        let msg = graph.alloc_value_var();
+        lower_exc_from_raise(&mut graph, start, "ValueError", vec![msg.clone()]);
+        let op = graph.blocks[start.0]
+            .operations
+            .last()
+            .expect("simple_call must be emitted");
+        let OpKind::Call { target, args, .. } = &op.kind else {
+            panic!("expected Call, got {:?}", op.kind);
+        };
+        assert_eq!(
+            target,
+            &CallTarget::function_path(["simple_call"]),
+            "FunctionPath is the op name, not the class"
+        );
+        assert_eq!(args.len(), 2);
+        let LinkArg::Const(class) = &args[0] else {
+            panic!("args[0] must be the class Constant");
+        };
+        let expected = HOST_ENV
+            .lookup_builtin("ValueError")
+            .expect("ValueError is a builtin exception");
+        assert!(
+            matches!(&class.value, ConstValue::HostObject(h) if *h == expected),
+            "args[0] must be HOST_ENV ValueError"
+        );
+        assert_eq!(args[1], LinkArg::from(msg));
+    }
 }

--- a/majit/majit-translate/src/front/exc_from_raise.rs
+++ b/majit/majit-translate/src/front/exc_from_raise.rs
@@ -41,20 +41,18 @@
 //!
 //! ```text
 //! evalue = op.simple_call(const(exc_class), *message_args)
-//! graph.set_raise_values(block, evalue, evalue)
+//! etype  = op.type(evalue)
+//! graph.set_raise_values(block, etype, evalue)
 //! ```
 //!
 //! ### The `etype` link arg
 //!
-//! Upstream's tail line is `w_type = op.type(w_value)`, but that value never
-//! reaches a jitcode. `make_bytecode_block` hands the `exceptblock`'s
-//! `inputargs` to `make_return` (`flatten.py`), whose 2-arg arm emits
-//! `-live-` + `raise self.getcolor(args[1])` and never touches `args[0]`
-//! (`flatten.py:139-143`, mirrored at `flatten.rs`). So the slot the
-//! `etype` link arg feeds has no consumer in any emitted bytecode.
-//! `set_raise_values` therefore receives `evalue` for both slots instead of a
-//! synthesised `type(evalue)` call, which would be a residual with a dead
-//! result register on every raise tail.
+//! Flatten's 2-arg `make_return` reads only `args[1]` (`flatten.py`).
+//! The rtyper sees the link first: `setup_block_entry` forces
+//! exceptblock slot 0 to `ExceptionData.r_exception_type`
+//! (`RootClassRepr`).  `op.type(evalue)` is the upstream producer of
+//! that class/vtable value (`unaryop.py type_SomeObject` →
+//! `SomeTypeOf`; `InstanceRepr.rtype_type` → `__class__` / `ll_type`).
 //!
 //! ### Operand shape
 //!
@@ -89,10 +87,33 @@
 use crate::flowspace::model::{ConstValue, HOST_ENV, Variable};
 use crate::model::{BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
 
+/// `op.type(w_value)` (`flowcontext.py exc_from_raise`).  The result
+/// is class/vtable-shaped (`SomeTypeOf` / `RootClassRepr`), which
+/// `setup_block_entry` requires on exceptblock slot 0.
+pub(crate) fn push_type_of(graph: &mut FunctionGraph, block: BlockId, value: Variable) -> Variable {
+    graph
+        .push_op_var(
+            block,
+            OpKind::Call {
+                target: CallTarget::function_path(["type"]),
+                args: crate::model::call_args(vec![value]),
+                result_ty: ValueType::Ref(None),
+            },
+            true,
+        )
+        .expect("op.type(evalue) must produce a Ref type object")
+}
+
+/// Close `block` with `FSException(type(evalue), evalue)`.
+pub(crate) fn set_raise_from_instance(graph: &mut FunctionGraph, block: BlockId, evalue: Variable) {
+    let etype = push_type_of(graph, block, evalue.clone());
+    graph.set_raise_values(block, etype, evalue);
+}
+
 /// Close `block` with an `(etype, evalue)` Link to `exceptblock`
 /// whose value comes from the canonical RPython `exc_from_raise` op
-/// sequence (`op.simple_call(const(exc_class), *args)`).  The `etype`
-/// slot reuses `evalue` — see the module-level "etype link arg" note.
+/// sequence (`op.simple_call(const(exc_class), *args)` then
+/// `op.type(w_value)`).
 ///
 /// `exc_class_name` is the Python-layer exception class name
 /// (`"AssertionError"`, `"ValueError"`, …).  It is resolved through
@@ -132,21 +153,11 @@ pub(crate) fn lower_exc_from_raise(
             true,
         )
         .expect("op.simple_call(exc_class, ...) must produce a Ref exception instance");
-    // `flowspace/flowcontext.py Raise.nomoreblocks` — close the block
-    // with the `(etype, evalue)` Link to the graph's `exceptblock`.
-    //
-    // Upstream's `w_type = op.type(w_value)` (`flowcontext.py`) lives at
-    // flow-space level only — see the module-level "etype link arg" note: the
-    // 2-arg `make_return` arm emits `raise <args[1]>` and never reads
-    // `args[0]`, and `make_exception_link` drops both for a direct `reraise`.
-    // So the `etype` link arg is write-only in every emitted jitcode. The
-    // emitted drain tail is `-live-` + `raise <evalue>` and nothing else.
-    // Materialising it as a `type(evalue)` call left a residual whose
-    // result register is dead by construction on every raise tail, and
-    // made the raise arm unwalkable in the blackhole (canonical
-    // `inline_call_*` on a callee with no runtime address). Reuse
-    // `evalue`: same ref kind, no new op.
-    graph.set_raise_values(block, evalue_var.clone(), evalue_var);
+    // `w_type = op.type(w_value)` then `FSException(w_type, w_value)`
+    // (`flowcontext.py exc_from_raise`).  Slot 0 must be class-shaped
+    // so `_convert_link` / `setup_block_entry` can assign
+    // `ExceptionData.r_exception_type` (`RootClassRepr`).
+    set_raise_from_instance(graph, block, evalue_var);
 }
 
 #[cfg(test)]
@@ -162,16 +173,20 @@ mod tests {
         lower_exc_from_raise(&mut graph, start, "ValueError", vec![msg.clone()]);
         let op = graph.blocks[start.0]
             .operations
-            .last()
+            .iter()
+            .find(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.as_slice() == ["simple_call"]
+                )
+            })
             .expect("simple_call must be emitted");
-        let OpKind::Call { target, args, .. } = &op.kind else {
+        let OpKind::Call { args, .. } = &op.kind else {
             panic!("expected Call, got {:?}", op.kind);
         };
-        assert_eq!(
-            target,
-            &CallTarget::function_path(["simple_call"]),
-            "FunctionPath is the op name, not the class"
-        );
         assert_eq!(args.len(), 2);
         let LinkArg::Const(class) = &args[0] else {
             panic!("args[0] must be the class Constant");
@@ -184,5 +199,42 @@ mod tests {
             "args[0] must be HOST_ENV ValueError"
         );
         assert_eq!(args[1], LinkArg::from(msg));
+        let evalue = graph.blocks[start.0]
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.as_slice() == ["simple_call"] => op.result.clone(),
+                _ => None,
+            })
+            .expect("simple_call result");
+        let type_op = graph.blocks[start.0]
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                } if segments.as_slice() == ["type"] => Some((op.result.clone(), args.clone())),
+                _ => None,
+            })
+            .expect("op.type(evalue) must follow simple_call");
+        let (etype, type_args) = type_op;
+        assert_eq!(type_args.as_slice(), &[LinkArg::from(evalue.clone())]);
+        let raise_link = graph.blocks[start.0]
+            .exits
+            .iter()
+            .find(|l| l.target == graph.exceptblock)
+            .expect("raise link");
+        assert_eq!(raise_link.args.len(), 2);
+        assert_eq!(
+            raise_link.args[0].as_variable(),
+            etype.as_ref(),
+            "etype must be type(evalue), not the instance"
+        );
+        assert_eq!(raise_link.args[1].as_variable(), Some(&evalue));
     }
 }

--- a/majit/majit-translate/src/front/exc_from_raise.rs
+++ b/majit/majit-translate/src/front/exc_from_raise.rs
@@ -86,7 +86,7 @@
 //!   opaque Call targets any more — that earlier deviation is removed
 //!   by the same change that introduced this module.
 
-use crate::flowspace::model::{ConstValue, Variable, HOST_ENV};
+use crate::flowspace::model::{ConstValue, HOST_ENV, Variable};
 use crate::model::{BlockId, CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
 
 /// Close `block` with an `(etype, evalue)` Link to `exceptblock`

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -210,7 +210,10 @@ fn rewire_one_from_size_align_site(
                     ..
                 },
         } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
-            (args[0].clone(), args[1].clone())
+            (
+                args[0].clone().into_variable(),
+                args[1].clone().into_variable(),
+            )
         }
         _ => {
             return Err(format!(
@@ -402,7 +405,7 @@ fn rewire_one_from_size_align_expect_site(
             && receiver_root.as_deref() == Some("Result")
             && args.len() == 2 =>
         {
-            args[0].clone()
+            args[0].clone().into_variable()
         }
         _ => {
             return Err(format!(
@@ -433,7 +436,10 @@ fn rewire_one_from_size_align_expect_site(
                     ..
                 },
         } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
-            (args[0].clone(), args[1].clone())
+            (
+                args[0].clone().into_variable(),
+                args[1].clone().into_variable(),
+            )
         }
         _ => {
             return Err(format!(
@@ -648,7 +654,7 @@ mod tests {
                 p,
                 OpKind::Call {
                     target: fsa_target(),
-                    args: vec![size, align],
+                    args: crate::model::call_args(vec![size, align]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -661,7 +667,7 @@ mod tests {
                 q,
                 OpKind::Call {
                     target: ok_target(),
-                    args: vec![q_args[0].clone()],
+                    args: crate::model::call_args(vec![q_args[0].clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -794,7 +800,7 @@ mod tests {
                 p,
                 OpKind::Call {
                     target: fsa_target(),
-                    args: vec![size, align],
+                    args: crate::model::call_args(vec![size, align]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -806,7 +812,7 @@ mod tests {
                 q,
                 OpKind::Call {
                     target: ok_target(),
-                    args: vec![fsa.clone()],
+                    args: crate::model::call_args(vec![fsa.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -842,7 +848,7 @@ mod tests {
                 p,
                 OpKind::Call {
                     target: fsa_target(),
-                    args: vec![size, align],
+                    args: crate::model::call_args(vec![size, align]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -855,7 +861,7 @@ mod tests {
                 q,
                 OpKind::Call {
                     target: expect_target(),
-                    args: vec![fsa.clone(), msg],
+                    args: crate::model::call_args(vec![fsa.clone(), msg]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -965,7 +971,7 @@ mod tests {
                 p,
                 OpKind::Call {
                     target: fsa_target(),
-                    args: vec![size, align],
+                    args: crate::model::call_args(vec![size, align]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -978,7 +984,7 @@ mod tests {
                 q,
                 OpKind::Call {
                     target: expect_target(),
-                    args: vec![fsa.clone(), msg],
+                    args: crate::model::call_args(vec![fsa.clone(), msg]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -209,12 +209,10 @@ fn rewire_one_from_size_align_site(
                     args,
                     ..
                 },
-        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
-            (
-                args[0].clone().into_variable(),
-                args[1].clone().into_variable(),
-            )
-        }
+        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => (
+            args[0].clone().into_variable(),
+            args[1].clone().into_variable(),
+        ),
         _ => {
             return Err(format!(
                 "{name}: block {p} last op is not the 2-arg Layout::from_size_align call"
@@ -435,12 +433,10 @@ fn rewire_one_from_size_align_expect_site(
                     args,
                     ..
                 },
-        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
-            (
-                args[0].clone().into_variable(),
-                args[1].clone().into_variable(),
-            )
-        }
+        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => (
+            args[0].clone().into_variable(),
+            args[1].clone().into_variable(),
+        ),
         _ => {
             return Err(format!(
                 "{name}: block {p} last op is not the 2-arg Layout::from_size_align call"

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -133,7 +133,7 @@ fn iter_op_container(graph: &FunctionGraph, var: &Variable) -> Option<Variable> 
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if is_iter_op_segments(segments) => args.first().cloned(),
+        } if is_iter_op_segments(segments) => args.first().cloned().map(LinkArg::into_variable),
         _ => None,
     })
 }
@@ -518,7 +518,7 @@ fn rewire_one_next_site(
     // Capture the iterator operand (the `next` op's single argument) from
     // the raw call, before peeling any recast narrows off its result.
     let iter_arg = match &graph.blocks[a].operations[next_idx].kind {
-        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone().into_variable(),
         other => {
             return Err(format!(
                 "{name}: next() producer op is not a 1-arg call: {other:?}"
@@ -716,7 +716,7 @@ fn rewire_one_next_site(
                     ..
                 } if args.is_empty() && segments == &["core", "ptr", "null_mut"] => break,
                 OpKind::Call { args, .. } if is_recast_narrow(&op.kind) => {
-                    null_source = args[0].clone();
+                    null_source = args[0].clone().into_variable();
                 }
                 _ => {
                     return Err(format!(
@@ -935,7 +935,7 @@ fn rewire_one_next_site(
             target: CallTarget::FunctionPath {
                 segments: next_op_segments(),
             },
-            args: vec![iter_arg],
+            args: crate::model::call_args(vec![iter_arg]),
             result_ty: item_ty,
         },
     };
@@ -1017,7 +1017,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["core".to_string(), "slice".to_string(), "iter".to_string()],
                     },
-                    args: vec![container],
+                    args: crate::model::call_args(vec![container]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -405,14 +405,7 @@ pub(crate) fn rewire_next_call_sites(
 /// root.  It lowers to `cast_pointer` (a pure alias), so it carries no
 /// side effect and its result is bit-identical to its operand.
 fn is_recast_narrow(kind: &OpKind) -> bool {
-    matches!(
-        kind,
-        OpKind::Call {
-            target: CallTarget::FunctionPath { segments },
-            args,
-            ..
-        } if args.len() == 1 && segments.first().is_some_and(|s| s == crate::runtime_names::shims::CAST_INSTANCE)
-    )
+    crate::model::cast_instance_root(kind).is_some()
 }
 
 /// An unregistered `next()` returns an opaque `Ref`; the MIR immediately

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -44,6 +44,9 @@
 //!   - `BinaryOp` — `OpKind::BinOp` with a canonical snake_case label
 //!     (`add`, `eq`, `and`, …) so the assembler reaches the wired
 //!     `int_*` / `ptr_*` keys without inventing PascalCase shapes.
+//!     Integer ops with no pointer form (`lt`/`le`/`gt`/`ge`,
+//!     `mod`/`floordiv`/`div`) over a Ref operand first emit
+//!     `simple_call(lltype.cast_ptr_to_int)` — there is no `ptr_lt`.
 //!   - `UnaryOp` — `OpKind::UnaryOp` with a canonical label
 //!     (`neg`, `invert`, `cast_int_to_float`, …) per `binop_label` /
 //!     `unary_op_label`.
@@ -5197,7 +5200,7 @@ impl<'a> Lowering<'a> {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__deref_write".to_string()],
                         },
-                        args: vec![base, value_var(&value)],
+                        args: crate::model::call_args(vec![base, value_var(&value)]),
                         result_ty: ValueType::Void,
                     }
                 }
@@ -5336,7 +5339,7 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath {
                     segments: vec!["__cast_instance_intrinsic".to_string(), root.to_string()],
                 },
-                args: vec![value],
+                args: crate::model::call_args(vec![value]),
                 result_ty: ValueType::Ref(Some(root.to_string())),
             },
         });
@@ -5387,6 +5390,12 @@ impl<'a> Lowering<'a> {
                 Ok((None, v))
             }
             Rvalue::BinaryOp(op_json, lhs, rhs) => {
+                // Peek kinds before `resolve_operand` consumes the
+                // operands. Ordered pointer compares must emit
+                // `lltype.cast_ptr_to_int` first (`rbuiltin.py
+                // rtype_cast_ptr_to_int`); `rptr.py` has only eq/ne.
+                let lhs_kind = self.operand_value_kind(&lhs);
+                let rhs_kind = self.operand_value_kind(&rhs);
                 let lhs_v = self.resolve_operand(mir_bb, lhs)?;
                 let rhs_v = self.resolve_operand(mir_bb, rhs)?;
                 let mut op_label = binop_label(&op_json)?;
@@ -5433,6 +5442,37 @@ impl<'a> Lowering<'a> {
                 if result_ty == ValueType::Float && op_label == "floordiv" {
                     op_label = "truediv".to_string();
                 }
+                // Integer ops that have no pointer form (`rptr.py` is
+                // only eq/ne) must see Signed addresses:
+                // `cast_ptr_to_int(p) < cast_ptr_to_int(q)`, and the
+                // same for `%` / `/`. Equality stays a pointer compare
+                // (`ptr_eq` / `instance_ptr_eq` in jtransform).
+                let (lhs_v, rhs_v) = if int_binop_needs_ptr_to_int(
+                    &op_label,
+                    lhs_kind.as_ref(),
+                    rhs_kind.as_ref(),
+                ) {
+                    let bb_id = self.block_id[mir_bb];
+                    let lhs_v = if matches!(lhs_kind, Some(ValueType::Ref(_))) {
+                        let orig = lhs_v.clone();
+                        let v = push_cast_ptr_to_int(&mut self.graph, bb_id, lhs_v);
+                        self.cast_ptr_to_int_src.insert(v.clone(), orig);
+                        v
+                    } else {
+                        lhs_v
+                    };
+                    let rhs_v = if matches!(rhs_kind, Some(ValueType::Ref(_))) {
+                        let orig = rhs_v.clone();
+                        let v = push_cast_ptr_to_int(&mut self.graph, bb_id, rhs_v);
+                        self.cast_ptr_to_int_src.insert(v.clone(), orig);
+                        v
+                    } else {
+                        rhs_v
+                    };
+                    (lhs_v, rhs_v)
+                } else {
+                    (lhs_v, rhs_v)
+                };
                 Ok((
                     Some(OpKind::BinOp {
                         op: op_label,
@@ -5523,7 +5563,7 @@ impl<'a> Lowering<'a> {
                                         .map(str::to_string)
                                         .collect(),
                                 },
-                                args: vec![arg],
+                                args: crate::model::call_args(vec![arg]),
                                 result_ty: ValueType::Int,
                             }),
                             res,
@@ -5549,7 +5589,7 @@ impl<'a> Lowering<'a> {
                                         .map(str::to_string)
                                         .collect(),
                                 },
-                                args: vec![arg],
+                                args: crate::model::call_args(vec![arg]),
                                 result_ty: ValueType::Unsigned,
                             }),
                             res,
@@ -5603,7 +5643,7 @@ impl<'a> Lowering<'a> {
                                 (
                                     Some(OpKind::Call {
                                         target: CallTarget::FunctionPath { segments },
-                                        args: vec![arg],
+                                        args: crate::model::call_args(vec![arg]),
                                         result_ty: dst_kind,
                                     }),
                                     res,
@@ -5736,7 +5776,7 @@ impl<'a> Lowering<'a> {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__array_repeat".to_string()],
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Int,
                     }),
                     res,
@@ -5754,7 +5794,7 @@ impl<'a> Lowering<'a> {
                 Ok((
                     Some(OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("Box"),
-                        args: vec![arg],
+                        args: crate::model::call_args(vec![arg]),
                         result_ty: ValueType::Int,
                     }),
                     res,
@@ -5812,7 +5852,7 @@ impl<'a> Lowering<'a> {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__len".to_string()],
                         },
-                        args: vec![base],
+                        args: crate::model::call_args(vec![base]),
                         result_ty: ValueType::Int,
                     }),
                     res,
@@ -5839,7 +5879,7 @@ impl<'a> Lowering<'a> {
                         target: CallTarget::FunctionPath {
                             segments: vec![format!("__nullary_{op_name}")],
                         },
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Int,
                     }),
                     res,
@@ -6407,7 +6447,7 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath {
                     segments: vec![crate::runtime_names::shims::STRINGBUILDER_BUILD.to_string()],
                 },
-                args: vec![builder],
+                args: crate::model::call_args(vec![builder]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -6499,7 +6539,7 @@ impl<'a> Lowering<'a> {
         Some((
             OpKind::Call {
                 target: CallTarget::FunctionPath { segments },
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty,
             },
             res,
@@ -6545,7 +6585,7 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), s],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 // A `&str` / `&[u8]` literal lowers to `Ptr(STR)` (getkind
                 // `r`), so the synthetic call's result kind is a Ref, not an
                 // Int.  The `__str_const` path is never registered: on the
@@ -6587,7 +6627,7 @@ impl<'a> Lowering<'a> {
                     target: CallTarget::FunctionPath {
                         segments: synthetic,
                     },
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Int,
                 }
             }
@@ -6822,7 +6862,7 @@ impl<'a> Lowering<'a> {
                                         root.clone(),
                                     ],
                                 },
-                                args: vec![base],
+                                args: crate::model::call_args(vec![base]),
                                 result_ty: ValueType::Ref(Some(root)),
                             },
                         });
@@ -6905,7 +6945,7 @@ impl<'a> Lowering<'a> {
                             target: CallTarget::FunctionPath {
                                 segments: vec!["__string_byte_getitem".to_string()],
                             },
-                            args: vec![base, idx_var],
+                            args: crate::model::call_args(vec![base, idx_var]),
                             result_ty: ValueType::Int,
                         }
                     } else {
@@ -7049,7 +7089,7 @@ impl<'a> Lowering<'a> {
                                             owner.clone(),
                                         ],
                                     },
-                                    args: vec![base],
+                                    args: crate::model::call_args(vec![base]),
                                     result_ty: ValueType::Ref(Some(owner.clone())),
                                 },
                             });
@@ -7131,7 +7171,7 @@ impl<'a> Lowering<'a> {
                                     "PyObject".to_string(),
                                 ],
                             },
-                            args: vec![raw],
+                            args: crate::model::call_args(vec![raw]),
                             result_ty: ValueType::Ref(Some("PyObject".to_string())),
                         },
                     });
@@ -7200,7 +7240,7 @@ impl<'a> Lowering<'a> {
                                     root.clone(),
                                 ],
                             },
-                            args: vec![raw],
+                            args: crate::model::call_args(vec![raw]),
                             result_ty: ValueType::Ref(Some(root)),
                         },
                     });
@@ -7235,7 +7275,7 @@ impl<'a> Lowering<'a> {
                                     root.clone(),
                                 ],
                             },
-                            args: vec![raw],
+                            args: crate::model::call_args(vec![raw]),
                             result_ty: ValueType::Ref(Some(root)),
                         },
                     });
@@ -7286,7 +7326,7 @@ impl<'a> Lowering<'a> {
                     );
                     OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: tyref_to_value_type(&place_ty, self.llbc),
                     }
                 });
@@ -7828,7 +7868,7 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), s],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             }),
             _ => None,
@@ -8668,7 +8708,7 @@ impl<'a> Lowering<'a> {
                             .with_owner_id(Some(
                                 majit_ir::descr::StructId::from_canonical(store.owner_root),
                             )),
-                            value: LinkArg::Value(args[1].clone()),
+                            value: args[1].clone().into(),
                             ty: field_ty,
                         },
                     });
@@ -9114,7 +9154,7 @@ impl<'a> Lowering<'a> {
                             target: CallTarget::FunctionPath {
                                 segments: vec!["__string_byte_getitem".to_string()],
                             },
-                            args: vec![args[0].clone(), args[1].clone()],
+                            args: crate::model::call_args(vec![args[0].clone(), args[1].clone()]),
                             // `ord` returns RPython Signed. Rust's `u8`
                             // spelling is representation detail here.
                             result_ty: ValueType::Int,
@@ -9352,7 +9392,7 @@ impl<'a> Lowering<'a> {
                                         root.clone(),
                                     ],
                                 },
-                                args: vec![res],
+                                args: crate::model::call_args(vec![res]),
                                 result_ty: ValueType::Ref(Some(root)),
                             },
                         });
@@ -9465,7 +9505,7 @@ impl<'a> Lowering<'a> {
                                     crate::runtime_names::shims::LL_ARRAYMOVE.to_string(),
                                 ],
                             },
-                            args: vec![array, source_start, index, args[2].clone()],
+                            args: crate::model::call_args(vec![array, source_start, index, args[2].clone()]),
                             result_ty: ValueType::Void,
                         },
                     });
@@ -9525,7 +9565,7 @@ impl<'a> Lowering<'a> {
                     let base = self
                         .narrow_value_to_instance_root(
                             bb_id,
-                            LinkArg::Value(args[0].clone()),
+                            args[0].clone().into(),
                             &array_type_id,
                         )
                         .as_variable()
@@ -9618,7 +9658,7 @@ impl<'a> Lowering<'a> {
                     let base = self
                         .narrow_value_to_instance_root(
                             bb_id,
-                            LinkArg::Value(args[0].clone()),
+                            args[0].clone().into(),
                             &array_type_id,
                         )
                         .as_variable()
@@ -9680,7 +9720,7 @@ impl<'a> Lowering<'a> {
                     // to the same `cast_opaque_ptr` PyPy emits.
                     let value = self.narrow_value_to_instance_root(
                         bb_id,
-                        LinkArg::Value(args[2].clone()),
+                        args[2].clone().into(),
                         "PyObject",
                     );
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
@@ -9832,7 +9872,7 @@ impl<'a> Lowering<'a> {
                                 ],
                             },
                             args: if builder_ctor_leaf == Some("with_capacity") {
-                                args.clone()
+                                crate::model::call_args(args.clone())
                             } else {
                                 Vec::new()
                             },
@@ -9864,7 +9904,7 @@ impl<'a> Lowering<'a> {
                                 target: CallTarget::FunctionPath {
                                     segments: vec!["__majit_stringbuilder_append".to_string()],
                                 },
-                                args: vec![res.clone(), args[0].clone()],
+                                args: crate::model::call_args(vec![res.clone(), args[0].clone()]),
                                 result_ty: ValueType::Void,
                             },
                         });
@@ -9942,7 +9982,7 @@ impl<'a> Lowering<'a> {
                                             .to_string(),
                                     ],
                                 },
-                                args: vec![acc_val, piece_val],
+                                args: crate::model::call_args(vec![acc_val, piece_val]),
                                 result_ty: ValueType::Void,
                             },
                         });
@@ -9987,7 +10027,7 @@ impl<'a> Lowering<'a> {
                                         root.clone(),
                                     ],
                                 },
-                                args: vec![args[0].clone()],
+                                args: crate::model::call_args(vec![args[0].clone()]),
                                 result_ty: ValueType::Ref(Some(root)),
                             },
                         });
@@ -10123,8 +10163,8 @@ impl<'a> Lowering<'a> {
                     if let Some(referent) = referent {
                         let field_ty = clone_tyref(&referent.ty);
                         if let PlaceKind::Projection(inner, elem) = referent.kind {
-                            let value = LinkArg::Value(args[1].clone());
-                            self.emit_projection_write(mir_bb, *inner, elem, value, &field_ty)?;
+                            let value = args[1].clone();
+                            self.emit_projection_write(mir_bb, *inner, elem, value.into(), &field_ty)?;
                             // The store's result is an actual unit constant.
                             self.local_var[dest_local] = Some(self.emit_unit(bb_id));
                             let target_bb = self.block_id[target];
@@ -10178,7 +10218,7 @@ impl<'a> Lowering<'a> {
                 if args.len() == 2 && self.is_string_array_view_from_raw_parts(&reg) {
                     let view = self.narrow_value_to_instance_root(
                         bb_id,
-                        LinkArg::Value(args[0].clone()),
+                        args[0].clone().into(),
                         STRING_GCREF_GCARRAY_TYPE_ID,
                     );
                     self.local_var[dest_local] = Some(
@@ -10312,7 +10352,7 @@ impl<'a> Lowering<'a> {
                                     "longlong2float".to_string(),
                                 ],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Float,
                         },
                     });
@@ -10337,7 +10377,7 @@ impl<'a> Lowering<'a> {
                                     "float2longlong".to_string(),
                                 ],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Int,
                         },
                     });
@@ -10383,7 +10423,7 @@ impl<'a> Lowering<'a> {
                                     "float2longlong".to_string(),
                                 ],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Int,
                         },
                     });
@@ -10435,7 +10475,7 @@ impl<'a> Lowering<'a> {
                                     "iter".to_string(),
                                 ],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Ref(None),
                         },
                     });
@@ -10570,7 +10610,7 @@ impl<'a> Lowering<'a> {
                             target: CallTarget::FunctionPath {
                                 segments: vec!["__len".to_string()],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Int,
                         },
                     });
@@ -10896,7 +10936,7 @@ impl<'a> Lowering<'a> {
                                     "jit_bigint_from_i64".to_string(),
                                 ],
                             },
-                            args: vec![cst],
+                            args: crate::model::call_args(vec![cst]),
                             result_ty: ValueType::Ref(None),
                         },
                     });
@@ -11017,7 +11057,7 @@ impl<'a> Lowering<'a> {
                             target: CallTarget::FunctionPath {
                                 segments: vec!["__len".to_string()],
                             },
-                            args: vec![args[0].clone()],
+                            args: crate::model::call_args(vec![args[0].clone()]),
                             result_ty: ValueType::Int,
                         },
                     );
@@ -11192,7 +11232,7 @@ impl<'a> Lowering<'a> {
                     };
                     OpKind::Call {
                         target,
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: result_ty.clone(),
                     }
                 }
@@ -11262,7 +11302,7 @@ impl<'a> Lowering<'a> {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__dyn_call".to_string()],
                         },
-                        args: full_args,
+                        args: crate::model::call_args(full_args),
                         result_ty,
                     }
                 }
@@ -11305,7 +11345,7 @@ impl<'a> Lowering<'a> {
                 crate::hints::classify_hint_segments(segments.iter().map(String::as_str))
         {
             OpKind::Hint {
-                value: args[0].clone(),
+                value: args[0].clone().into_variable(),
                 kind,
             }
         } else {
@@ -11494,8 +11534,8 @@ impl<'a> Lowering<'a> {
         {
             OpKind::BinOp {
                 op: binop.to_string(),
-                lhs: args[0].clone(),
-                rhs: args[1].clone(),
+                lhs: args[0].clone().into_variable(),
+                rhs: args[1].clone().into_variable(),
                 result_ty: ValueType::Int,
             }
         } else {
@@ -11647,7 +11687,7 @@ impl<'a> Lowering<'a> {
                 _ => false,
             } {
             OpKind::FieldRead {
-                base: args[0].clone(),
+                base: args[0].clone().into_variable(),
                 field: FieldDescriptor::new("_digits", Some("RBigInt".to_string())).with_owner_id(
                     Some(majit_ir::descr::StructId::from_canonical(
                         "rbigint::RBigInt",
@@ -11696,12 +11736,12 @@ impl<'a> Lowering<'a> {
                             "RBigInt".to_string(),
                         ],
                     },
-                    args: vec![args[0].clone()],
+                    args: crate::model::call_args(vec![args[0].clone().into_variable()]),
                     result_ty: ValueType::Ref(Some("RBigInt".to_string())),
                 },
             });
             let mut narrowed_args = args.clone();
-            narrowed_args[0] = narrowed_receiver;
+            narrowed_args[0] = narrowed_receiver.into();
             OpKind::Call {
                 target: CallTarget::method(leaf.clone(), Some("RBigInt".to_string())),
                 args: narrowed_args,
@@ -12361,8 +12401,8 @@ impl<'a> Lowering<'a> {
             self.range_inclusive_new_sites.push(
                 crate::front::range_contains::RangeInclusiveNewSite {
                     result_var: result_var.clone(),
-                    lo: args[0].clone(),
-                    hi: args[1].clone(),
+                    lo: args[0].clone().into_variable(),
+                    hi: args[1].clone().into_variable(),
                 },
             );
         }
@@ -12583,7 +12623,7 @@ impl<'a> Lowering<'a> {
                             root.clone(),
                         ],
                     },
-                    args: vec![result_var.clone()],
+                    args: crate::model::call_args(vec![result_var.clone()]),
                     result_ty: ValueType::Ref(Some(root)),
                 },
             });
@@ -12941,7 +12981,7 @@ impl<'a> Lowering<'a> {
                         "Constants".to_string(),
                     ],
                 },
-                args: vec![base],
+                args: crate::model::call_args(vec![base]),
                 result_ty: ValueType::Ref(Some("Constants".to_string())),
             },
         });
@@ -16334,7 +16374,7 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath {
                     segments: vec![crate::runtime_names::shims::CAST_INSTANCE.to_string(), root],
                 },
-                args: vec![null],
+                args: crate::model::call_args(vec![null]),
                 result_ty,
             },
         });
@@ -16905,7 +16945,7 @@ impl<'a> Lowering<'a> {
                         "jit_bigint_to_i64_value_or_zero".to_string(),
                     ],
                 },
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty: ValueType::Int,
             },
         );
@@ -16919,7 +16959,7 @@ impl<'a> Lowering<'a> {
                         "jit_bigint_to_i64_fits".to_string(),
                     ],
                 },
-                args: vec![arg],
+                args: crate::model::call_args(vec![arg]),
                 result_ty: ValueType::Int,
             },
         );
@@ -17031,7 +17071,7 @@ impl<'a> Lowering<'a> {
                         "wtf8_key_is_utf8".to_string(),
                     ],
                 },
-                args: vec![arg.clone()],
+                args: crate::model::call_args(vec![arg.clone()]),
                 result_ty: ValueType::Bool,
             },
         );
@@ -17191,7 +17231,7 @@ impl<'a> Lowering<'a> {
                             .map(str::to_string)
                             .collect(),
                     },
-                    args: vec![arg],
+                    args: crate::model::call_args(vec![arg]),
                     result_ty: ValueType::Unsigned,
                 },
             );
@@ -17472,7 +17512,7 @@ impl<'a> Lowering<'a> {
                             .map(str::to_string)
                             .collect(),
                     },
-                    args: vec![arg],
+                    args: crate::model::call_args(vec![arg]),
                     result_ty: ValueType::Unsigned,
                 },
             });
@@ -17490,7 +17530,7 @@ impl<'a> Lowering<'a> {
                             .map(str::to_string)
                             .collect(),
                     },
-                    args: vec![arg],
+                    args: crate::model::call_args(vec![arg]),
                     result_ty: ValueType::Int,
                 },
             });
@@ -21336,21 +21376,32 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
     }
 }
 
-/// Emit RPython's pointer-to-Unsigned primitive cast sequence.
+/// `true` when an integer binop has a pointer operand and no pointer
+/// form of that op exists.
 ///
-/// `rbuiltin.py`'s `gen_cast` first produces a Signed address integer with
-/// `cast_ptr_to_int`, then applies `gen_cast(..., Unsigned)`.  The caller
-/// appends the returned `r_uint` operation after the Signed producer pushed
-/// here, preserving that ordering while fitting [`Lowering::build_rvalue`]'s
-/// one-returned-operation interface.
-fn push_ptr_to_unsigned_cast(
-    graph: &mut FunctionGraph,
-    bb_id: BlockId,
-    arg: Variable,
-) -> (OpKind, Variable) {
-    let signed = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+/// `rptr.py` registers only `rtype_eq` / `rtype_ne`. There is no
+/// `ptr_lt` / `ptr_mod` / `ptr_floordiv`. The RPython spelling is
+/// `lltype.cast_ptr_to_int` then the integer op (`rbuiltin.py
+/// rtype_cast_ptr_to_int`). Equality is excluded on purpose.
+fn int_binop_needs_ptr_to_int(
+    op: &str,
+    lhs: Option<&ValueType>,
+    rhs: Option<&ValueType>,
+) -> bool {
+    matches!(op, "lt" | "le" | "gt" | "ge" | "mod" | "floordiv" | "div")
+        && (matches!(lhs, Some(ValueType::Ref(_))) || matches!(rhs, Some(ValueType::Ref(_))))
+}
+
+/// Emit `simple_call(lltype.cast_ptr_to_int, p)` and return the Signed
+/// address integer. Shared by `p as usize` (`push_ptr_to_unsigned_cast`)
+/// and integer binops over a Ref. The result is stamped Signed —
+/// `rbuiltin.py rtype_cast_ptr_to_int` uses `resulttype=lltype.Signed`.
+/// Leaving it `Unknown` makes `get_value_kind_var` report `'r'` and
+/// jtransform re-inserts a second cast.
+fn push_cast_ptr_to_int(graph: &mut FunctionGraph, bb_id: BlockId, arg: Variable) -> Variable {
+    let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Signed);
     graph.block_mut(bb_id).operations.push(SpaceOperation {
-        result: Some(signed.clone()),
+        result: Some(result.clone()),
         kind: OpKind::Call {
             target: CallTarget::FunctionPath {
                 segments: [
@@ -21364,11 +21415,28 @@ fn push_ptr_to_unsigned_cast(
                 .map(str::to_string)
                 .collect(),
             },
-            args: vec![arg],
+            args: crate::model::call_args(vec![arg]),
             result_ty: ValueType::Int,
         },
     });
-    let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+    result
+}
+
+/// Emit RPython's pointer-to-Unsigned primitive cast sequence.
+///
+/// `rbuiltin.py`'s `gen_cast` first produces a Signed address integer with
+/// `cast_ptr_to_int`, then applies `gen_cast(..., Unsigned)`.  The caller
+/// appends the returned `r_uint` operation after the Signed producer pushed
+/// here, preserving that ordering while fitting [`Lowering::build_rvalue`]'s
+/// one-returned-operation interface.
+fn push_ptr_to_unsigned_cast(
+    graph: &mut FunctionGraph,
+    bb_id: BlockId,
+    arg: Variable,
+) -> (OpKind, Variable) {
+    let signed = push_cast_ptr_to_int(graph, bb_id, arg);
+    // `r_uint` is still the integer bank (`getkind(Unsigned) == 'int'`).
+    let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Signed);
     let retype = OpKind::Call {
         target: CallTarget::FunctionPath {
             segments: ["rpython", "rlib", "rarithmetic", "r_uint"]
@@ -21376,7 +21444,7 @@ fn push_ptr_to_unsigned_cast(
                 .map(str::to_string)
                 .collect(),
         },
-        args: vec![signed],
+        args: crate::model::call_args(vec![signed]),
         result_ty: ValueType::Unsigned,
     };
     (retype, result)
@@ -22708,19 +22776,17 @@ fn raw_ptr_typed_items_element(ty: &TyRef, llbc: &Llbc) -> Option<(ValueType, St
 
 /// The `__cast_pointer/<Root>` marker call — front::mir's carrier for
 /// the upstream `cast_pointer(PTRTYPE, ptr)` op (lltype.py).  The
-/// target class travels in the path (same `Vec<Variable>`-carrier
-/// constraint as the `simple_call(<exc class>)` raise marker,
-/// `front/exc_from_raise.rs`); the flowspace adapter rebuilds the
+/// target class travels in the path; the flowspace adapter rebuilds the
 /// 2-arg upstream shape, and jtransform re-aliases the call to its
 /// operand (`rewrite_op_cast_pointer` → `same_as`,
-/// jtransform.py:254-257) so the jitcode shape stays identical to the
+/// jtransform.py) so the jitcode shape stays identical to the
 /// plain alias lowering.
 fn cast_pointer_marker_op(root: String, arg: Variable) -> OpKind {
     OpKind::Call {
         target: CallTarget::FunctionPath {
             segments: vec!["__cast_pointer".to_string(), root.clone()],
         },
-        args: vec![arg],
+        args: crate::model::call_args(vec![arg]),
         result_ty: ValueType::Ref(Some(root)),
     }
 }
@@ -26589,7 +26655,7 @@ fn emit_str_const(graph: &mut FunctionGraph, bb_id: BlockId, text: &str) -> Vari
             target: CallTarget::FunctionPath {
                 segments: vec!["__str_const".to_string(), text.to_string()],
             },
-            args: vec![],
+            args: crate::model::call_args(vec![]),
             result_ty: ValueType::Ref(None),
         },
     });
@@ -26675,7 +26741,7 @@ fn emit_fmt_expansion_ops(
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), text.to_string()],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -26766,7 +26832,7 @@ fn emit_lower_hex_byte_02_ops(
             target: CallTarget::FunctionPath {
                 segments: vec!["__str_const".to_string(), "0123456789abcdef".to_string()],
             },
-            args: vec![],
+            args: crate::model::call_args(vec![]),
             result_ty: ValueType::Ref(None),
         },
     });
@@ -26854,7 +26920,7 @@ fn emit_lower_hex_byte_02_ops(
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), pieces[0].clone()],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -26870,7 +26936,7 @@ fn emit_lower_hex_byte_02_ops(
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), pieces[1].clone()],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -27008,7 +27074,10 @@ fn navigate_single_arg_fmt_chain(
             args,
             ..
         } if fmt_path_ends_with(segments, &["fmt", "format"]) => {
-            (args.first()?.clone(), format_op.result.as_ref()?.clone())
+            (
+                args.first()?.clone().into_variable(),
+                format_op.result.as_ref()?.clone(),
+            )
         }
         _ => return None,
     };
@@ -27427,7 +27496,7 @@ fn collapse_const_fmt(graph: &mut FunctionGraph) -> usize {
                 target: CallTarget::FunctionPath {
                     segments: vec!["__str_const".to_string(), text],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             };
         }
@@ -27502,7 +27571,7 @@ fn op_reads_var(op: &crate::model::SpaceOperation, var: &Variable) -> bool {
         OpKind::InteriorFieldWrite {
             base, index, value, ..
         } => is(base) || is(index) || is(value),
-        OpKind::Call { args, .. } => args.iter().any(is),
+        OpKind::Call { args, .. } => args.iter().any(|a| is(a)),
         OpKind::BinOp { lhs, rhs, .. } => is(lhs) || is(rhs),
         OpKind::UnaryOp { operand, .. } => is(operand),
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => is(cond),
@@ -27801,7 +27870,9 @@ fn collect_fmt_collapse_multi(
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if fmt_path_ends_with(segments, &["fmt", "format"]) => args.first()?.clone(),
+        } if fmt_path_ends_with(segments, &["fmt", "format"]) => {
+            args.first()?.clone().into_variable()
+        }
         _ => return None,
     };
     let chain = extract_fmt_chain(graph, &fmt_args)?;
@@ -27857,7 +27928,7 @@ fn collect_fmt_collapse_multi(
                 args,
                 ..
             } if fmt_argument_ctor_kind(segments) == Some(FmtArgKind::Display) => {
-                args.first()?.clone()
+                args.first()?.clone().into_variable()
             }
             _ => return None,
         };
@@ -28602,7 +28673,8 @@ mod tests {
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
         is_class_pytype_assoc_const, is_core_result_map_err_path, json_ty_is_thin_pointer_element,
-        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
+        json_ty_scalar_element_spelling, int_binop_needs_ptr_to_int, push_cast_ptr_to_int,
+        push_ptr_to_unsigned_cast, shaped_array_parts,
         simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
         tyref_positional_aggregate_root, tyref_to_value_type,
     };
@@ -29545,7 +29617,7 @@ mod tests {
             result: Some(arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -29610,7 +29682,7 @@ mod tests {
             result: Some(tuple.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Tuple".to_string())),
             },
         });
@@ -29645,7 +29717,7 @@ mod tests {
                         "new_display".to_string(),
                     ],
                 },
-                args: vec![arg_ref],
+                args: crate::model::call_args(vec![arg_ref]),
                 result_ty: ValueType::Ref(Some("Argument".to_string())),
             },
         });
@@ -29662,7 +29734,7 @@ mod tests {
             result: Some(args_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -29680,7 +29752,7 @@ mod tests {
             result: Some(pieces_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -29712,7 +29784,7 @@ mod tests {
                         "new".to_string(),
                     ],
                 },
-                args: vec![pieces_arr.clone(), args_arr],
+                args: crate::model::call_args(vec![pieces_arr.clone(), args_arr]),
                 result_ty: ValueType::Ref(Some("Arguments".to_string())),
             },
         });
@@ -29755,7 +29827,7 @@ mod tests {
             result: Some(tuple.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Tuple".to_string())),
             },
         });
@@ -29788,7 +29860,7 @@ mod tests {
                         .map(|s| s.to_string())
                         .collect(),
                 },
-                args: vec![arg_ref],
+                args: crate::model::call_args(vec![arg_ref]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -29803,7 +29875,7 @@ mod tests {
             result: Some(args_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -29821,7 +29893,7 @@ mod tests {
             result: Some(pieces_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -29851,7 +29923,7 @@ mod tests {
                         .map(|s| s.to_string())
                         .collect(),
                 },
-                args: vec![pieces_arr, args_arr],
+                args: crate::model::call_args(vec![pieces_arr, args_arr]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -29871,7 +29943,7 @@ mod tests {
                         .map(|s| s.to_string())
                         .collect(),
                 },
-                args: vec![fmt_args_in.clone()],
+                args: crate::model::call_args(vec![fmt_args_in.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -29966,7 +30038,7 @@ mod tests {
                 bf,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Arguments"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -29982,7 +30054,7 @@ mod tests {
                             .map(|s| s.to_string())
                             .collect(),
                     },
-                    args: vec![fmt_args],
+                    args: crate::model::call_args(vec![fmt_args]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -30159,7 +30231,7 @@ mod tests {
             result: Some(tuple.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Tuple".to_string())),
             },
         });
@@ -30189,7 +30261,7 @@ mod tests {
             result: Some(nd0.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "rt", "Argument", "new_display"]),
-                args: vec![ar0.clone()],
+                args: crate::model::call_args(vec![ar0.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30217,7 +30289,7 @@ mod tests {
             result: Some(nd1.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "rt", "Argument", "new_display"]),
-                args: vec![ar1.clone()],
+                args: crate::model::call_args(vec![ar1.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30233,7 +30305,7 @@ mod tests {
             result: Some(args_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -30253,7 +30325,7 @@ mod tests {
             result: Some(pieces_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -30279,7 +30351,7 @@ mod tests {
             result: Some(fmt_args.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "Arguments", "new"]),
-                args: vec![pieces_arr, args_arr],
+                args: crate::model::call_args(vec![pieces_arr, args_arr]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30294,7 +30366,7 @@ mod tests {
             result: Some(formatted.clone()),
             kind: OpKind::Call {
                 target: fpath(&["alloc", "fmt", "format"]),
-                args: vec![fmt_args_in.clone()],
+                args: crate::model::call_args(vec![fmt_args_in.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30440,7 +30512,7 @@ mod tests {
             result: Some(tuple.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Tuple".to_string())),
             },
         });
@@ -30470,7 +30542,7 @@ mod tests {
             result: Some(nd0.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "rt", "Argument", "new_display"]),
-                args: vec![ar0.clone()],
+                args: crate::model::call_args(vec![ar0.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30497,7 +30569,7 @@ mod tests {
             result: Some(nd1.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "rt", "Argument", "new_display"]),
-                args: vec![ar1.clone()],
+                args: crate::model::call_args(vec![ar1.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30513,7 +30585,7 @@ mod tests {
             result: Some(args_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -30533,7 +30605,7 @@ mod tests {
             result: Some(pieces_arr.clone()),
             kind: OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor("Array"),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
@@ -30558,7 +30630,7 @@ mod tests {
             result: Some(fmt_args.clone()),
             kind: OpKind::Call {
                 target: fpath(&["fmt", "Arguments", "new"]),
-                args: vec![pieces_arr, args_arr],
+                args: crate::model::call_args(vec![pieces_arr, args_arr]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -30573,7 +30645,7 @@ mod tests {
             result: Some(formatted.clone()),
             kind: OpKind::Call {
                 target: fpath(&["alloc", "fmt", "format"]),
-                args: vec![fmt_args_in.clone()],
+                args: crate::model::call_args(vec![fmt_args_in.clone()]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -32373,7 +32445,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor(owner),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some(owner.into())),
                 },
                 true,
@@ -33270,6 +33342,57 @@ mod tests {
         ));
         assert!(!cast_kind_is_raw_ptr(&serde_json::json!("Unsize")));
         assert!(!cast_kind_is_raw_ptr(&serde_json::json!({"Scalar": []})));
+    }
+
+    #[test]
+    fn int_binop_needs_ptr_to_int_only_for_int_ops_with_a_ref() {
+        let ptr = ValueType::Ref(None);
+        let int = ValueType::Int;
+        assert!(int_binop_needs_ptr_to_int("lt", Some(&ptr), Some(&ptr)));
+        assert!(int_binop_needs_ptr_to_int("le", Some(&ptr), Some(&int)));
+        assert!(int_binop_needs_ptr_to_int("gt", Some(&int), Some(&ptr)));
+        assert!(int_binop_needs_ptr_to_int("ge", Some(&ptr), None));
+        assert!(int_binop_needs_ptr_to_int("mod", Some(&ptr), Some(&int)));
+        assert!(int_binop_needs_ptr_to_int(
+            "floordiv",
+            Some(&int),
+            Some(&ptr)
+        ));
+        assert!(int_binop_needs_ptr_to_int("div", Some(&ptr), Some(&ptr)));
+        assert!(!int_binop_needs_ptr_to_int("eq", Some(&ptr), Some(&ptr)));
+        assert!(!int_binop_needs_ptr_to_int("ne", Some(&ptr), Some(&ptr)));
+        assert!(!int_binop_needs_ptr_to_int("lt", Some(&int), Some(&int)));
+        assert!(!int_binop_needs_ptr_to_int("mod", Some(&int), Some(&int)));
+        assert!(!int_binop_needs_ptr_to_int("add", Some(&ptr), Some(&ptr)));
+    }
+
+    #[test]
+    fn push_cast_ptr_to_int_emits_the_lltype_helper() {
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let ptr = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(0x1000), true)
+            .expect("pointer value");
+        let signed = push_cast_ptr_to_int(&mut graph, entry, ptr.clone());
+        assert_eq!(
+            FunctionGraph::concretetype_of(&signed),
+            crate::model::ConcreteType::Signed,
+            "rbuiltin.py rtype_cast_ptr_to_int resulttype is Signed"
+        );
+        match &graph.block(entry).operations.last().unwrap().kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                result_ty: ValueType::Int,
+            } if segments.last().map(String::as_str) == Some("cast_ptr_to_int") => {
+                assert_eq!(args, &vec![ptr]);
+            }
+            other => panic!("expected cast_ptr_to_int call, got {other:?}"),
+        }
+        assert_eq!(
+            graph.block(entry).operations.last().unwrap().result.as_ref(),
+            Some(&signed)
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -22675,21 +22675,14 @@ fn raw_ptr_typed_items_element(ty: &TyRef, llbc: &Llbc) -> Option<(ValueType, St
     Some((item_ty, format!("[{spelling}]")))
 }
 
-/// The `__cast_pointer/<Root>` marker call — front::mir's carrier for
+/// The `__cast_pointer` marker call — front::mir's carrier for
 /// the upstream `cast_pointer(PTRTYPE, ptr)` op (lltype.py).  The
-/// target class travels in the path; the flowspace adapter rebuilds the
-/// 2-arg upstream shape, and jtransform re-aliases the call to its
-/// operand (`rewrite_op_cast_pointer` → `same_as`,
-/// jtransform.py) so the jitcode shape stays identical to the
-/// plain alias lowering.
+/// target class is a trailing `ByteStr` Constant; the flowspace
+/// adapter interns it and rebuilds the 2-arg upstream shape.
+/// jtransform re-aliases the call to its operand
+/// (`rewrite_op_cast_pointer` → `same_as`).
 fn cast_pointer_marker_op(root: String, arg: Variable) -> OpKind {
-    OpKind::Call {
-        target: CallTarget::FunctionPath {
-            segments: vec!["__cast_pointer".to_string(), root.clone()],
-        },
-        args: crate::model::call_args(vec![arg]),
-        result_ty: ValueType::Ref(Some(root)),
-    }
+    crate::model::cast_pointer_call(root, arg)
 }
 
 /// Whether a Charon type node's top-level constructor is a MUTABLE reference,
@@ -31169,20 +31162,18 @@ mod tests {
         let op = cast_pointer_marker_op("W_CastTarget".to_string(), arg.clone());
         let OpKind::Call {
             target,
-            args,
             result_ty,
-        } = op
+            ..
+        } = &op
         else {
             panic!("marker must be an OpKind::Call");
         };
         assert_eq!(
             target,
-            CallTarget::FunctionPath {
-                segments: vec!["__cast_pointer".to_string(), "W_CastTarget".to_string()],
-            }
+            &CallTarget::function_path(["__cast_pointer"]),
         );
-        assert_eq!(args, vec![arg]);
-        assert_eq!(result_ty, ValueType::Ref(Some("W_CastTarget".to_string())));
+        assert_eq!(crate::model::cast_pointer_root(&op), Some("W_CastTarget"));
+        assert_eq!(result_ty, &ValueType::Ref(Some("W_CastTarget".to_string())));
     }
 
     /// Anchor [`Lowering::fold_size_const_global`] to the real lowered

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5335,13 +5335,7 @@ impl<'a> Lowering<'a> {
             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(narrowed.clone()),
-            kind: OpKind::Call {
-                target: CallTarget::FunctionPath {
-                    segments: vec!["__cast_instance_intrinsic".to_string(), root.to_string()],
-                },
-                args: crate::model::call_args(vec![value]),
-                result_ty: ValueType::Ref(Some(root.to_string())),
-            },
+            kind: crate::model::cast_instance_call(root, value),
         });
         LinkArg::Value(narrowed)
     }
@@ -6525,13 +6519,13 @@ impl<'a> Lowering<'a> {
                 )
             } else {
                 let root = tyref_class_root(dest_ty, self.llbc)?;
-                (
-                    vec![
-                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                        root.clone(),
-                    ],
-                    ValueType::Ref(Some(root)),
-                )
+                let res = self
+                    .graph
+                    .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                return Some((
+                    crate::model::cast_instance_call(root, arg.clone()),
+                    res,
+                ));
             };
         let res = self
             .graph
@@ -6855,16 +6849,7 @@ impl<'a> Lowering<'a> {
                             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                             result: Some(narrowed.clone()),
-                            kind: OpKind::Call {
-                                target: CallTarget::FunctionPath {
-                                    segments: vec![
-                                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                                        root.clone(),
-                                    ],
-                                },
-                                args: crate::model::call_args(vec![base]),
-                                result_ty: ValueType::Ref(Some(root)),
-                            },
+                            kind: crate::model::cast_instance_call(root, base),
                         });
                         narrowed
                     } else {
@@ -7082,16 +7067,7 @@ impl<'a> Lowering<'a> {
                                 .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                                 result: Some(narrowed.clone()),
-                                kind: OpKind::Call {
-                                    target: CallTarget::FunctionPath {
-                                        segments: vec![
-                                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                                            owner.clone(),
-                                        ],
-                                    },
-                                    args: crate::model::call_args(vec![base]),
-                                    result_ty: ValueType::Ref(Some(owner.clone())),
-                                },
+                                kind: crate::model::cast_instance_call(owner.clone(), base),
                             });
                             narrowed
                         } else {
@@ -7164,16 +7140,7 @@ impl<'a> Lowering<'a> {
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
-                        kind: OpKind::Call {
-                            target: CallTarget::FunctionPath {
-                                segments: vec![
-                                    "__cast_instance_intrinsic".to_string(),
-                                    "PyObject".to_string(),
-                                ],
-                            },
-                            args: crate::model::call_args(vec![raw]),
-                            result_ty: ValueType::Ref(Some("PyObject".to_string())),
-                        },
+                        kind: crate::model::cast_instance_call("PyObject", raw),
                     });
                     return Ok(res);
                 }
@@ -7233,16 +7200,7 @@ impl<'a> Lowering<'a> {
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
-                        kind: OpKind::Call {
-                            target: CallTarget::FunctionPath {
-                                segments: vec![
-                                    crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                                    root.clone(),
-                                ],
-                            },
-                            args: crate::model::call_args(vec![raw]),
-                            result_ty: ValueType::Ref(Some(root)),
-                        },
+                        kind: crate::model::cast_instance_call(root, raw),
                     });
                     return Ok(res);
                 }
@@ -7268,16 +7226,7 @@ impl<'a> Lowering<'a> {
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
-                        kind: OpKind::Call {
-                            target: CallTarget::FunctionPath {
-                                segments: vec![
-                                    crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                                    root.clone(),
-                                ],
-                            },
-                            args: crate::model::call_args(vec![raw]),
-                            result_ty: ValueType::Ref(Some(root)),
-                        },
+                        kind: crate::model::cast_instance_call(root, raw),
                     });
                     return Ok(res);
                 }
@@ -9385,16 +9334,7 @@ impl<'a> Lowering<'a> {
                             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                             result: Some(narrowed.clone()),
-                            kind: OpKind::Call {
-                                target: CallTarget::FunctionPath {
-                                    segments: vec![
-                                        "__cast_instance_intrinsic".to_string(),
-                                        root.clone(),
-                                    ],
-                                },
-                                args: crate::model::call_args(vec![res]),
-                                result_ty: ValueType::Ref(Some(root)),
-                            },
+                            kind: crate::model::cast_instance_call(root, res),
                         });
                         self.local_var[dest_local] = Some(narrowed);
                     } else {
@@ -10020,16 +9960,7 @@ impl<'a> Lowering<'a> {
                             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                             result: Some(res.clone()),
-                            kind: OpKind::Call {
-                                target: CallTarget::FunctionPath {
-                                    segments: vec![
-                                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                                        root.clone(),
-                                    ],
-                                },
-                                args: crate::model::call_args(vec![args[0].clone()]),
-                                result_ty: ValueType::Ref(Some(root)),
-                            },
+                            kind: crate::model::cast_instance_call(root, args[0].clone()),
                         });
                         self.local_var[dest_local] = Some(res);
                     } else {
@@ -11729,16 +11660,10 @@ impl<'a> Lowering<'a> {
                 .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: Some(narrowed_receiver.clone()),
-                kind: OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                            "RBigInt".to_string(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![args[0].clone().into_variable()]),
-                    result_ty: ValueType::Ref(Some("RBigInt".to_string())),
-                },
+                kind: crate::model::cast_instance_call(
+                    "RBigInt",
+                    args[0].clone().into_variable(),
+                ),
             });
             let mut narrowed_args = args.clone();
             narrowed_args[0] = narrowed_receiver.into();
@@ -12616,16 +12541,7 @@ impl<'a> Lowering<'a> {
                 .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: Some(narrowed.clone()),
-                kind: OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                            root.clone(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![result_var.clone()]),
-                    result_ty: ValueType::Ref(Some(root)),
-                },
+                kind: crate::model::cast_instance_call(root, result_var.clone()),
             });
             self.local_var[dest_local] = Some(narrowed);
         }
@@ -12974,16 +12890,7 @@ impl<'a> Lowering<'a> {
             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(narrowed.clone()),
-            kind: OpKind::Call {
-                target: CallTarget::FunctionPath {
-                    segments: vec![
-                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                        "Constants".to_string(),
-                    ],
-                },
-                args: crate::model::call_args(vec![base]),
-                result_ty: ValueType::Ref(Some("Constants".to_string())),
-            },
+            kind: crate::model::cast_instance_call("Constants", base),
         });
         let result = self
             .graph
@@ -16370,13 +16277,7 @@ impl<'a> Lowering<'a> {
             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(narrowed.clone()),
-            kind: OpKind::Call {
-                target: CallTarget::FunctionPath {
-                    segments: vec![crate::runtime_names::shims::CAST_INSTANCE.to_string(), root],
-                },
-                args: crate::model::call_args(vec![null]),
-                result_ty,
-            },
+            kind: crate::model::cast_instance_call_result(root, null, result_ty),
         });
         narrowed
     }
@@ -28989,7 +28890,7 @@ mod tests {
     #[test]
     #[ignore]
     fn random_wrapper_narrows_nullable_self_to_w_random() {
-        use crate::model::{CallTarget, OpKind, ValueType};
+        use crate::model::{CallTarget, OpKind};
 
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
@@ -29024,15 +28925,10 @@ mod tests {
             .find(|block| block.id == block_id)
             .expect("producer block")
             .operations[idx];
-        assert!(matches!(
-            &producer.kind,
-            OpKind::Call {
-                target: CallTarget::FunctionPath { segments },
-                result_ty: ValueType::Ref(Some(root)),
-                ..
-            } if segments == &[crate::runtime_names::shims::CAST_INSTANCE.to_string(), "W_Random".to_string()]
-                && root == "W_Random"
-        ));
+        assert_eq!(
+            crate::model::cast_instance_root(&producer.kind),
+            Some("W_Random")
+        );
     }
 
     #[test]
@@ -34211,22 +34107,20 @@ mod tests {
             .blocks
             .iter()
             .flat_map(|b| &b.operations)
-            .filter_map(|op| match &op.kind {
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                } if segments
-                    == &[
-                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                        "PyObject".to_string(),
-                    ]
-                    && args.len() == 1
-                    && null_results.contains(&args[0]) =>
+            .filter_map(|op| {
+                let OpKind::Call { args, .. } = &op.kind else {
+                    return None;
+                };
+                if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
+                    && args
+                        .first()
+                        .and_then(crate::model::LinkArg::as_variable)
+                        .is_some_and(|v| null_results.contains(v))
                 {
                     op.result.clone()
+                } else {
+                    None
                 }
-                _ => None,
             })
             .collect();
         assert!(
@@ -34436,16 +34330,7 @@ mod tests {
                 let Some(cast_result) = ops[0].result.as_ref() else {
                     return false;
                 };
-                matches!(
-                    &ops[0].kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if segments == &[
-                        "__cast_instance_intrinsic".to_string(),
-                        "PyObject".to_string(),
-                    ]
-                ) && matches!(
+                crate::model::cast_instance_root(&ops[0].kind) == Some("PyObject") && matches!(
                     &ops[1].kind,
                     OpKind::ArrayWrite {
                         value: crate::model::LinkArg::Value(value),
@@ -34468,7 +34353,7 @@ mod tests {
     #[test]
     #[ignore]
     fn popvalue_py_null_narrows_to_nullable_instance() {
-        use crate::model::{CallTarget, OpKind};
+        use crate::model::OpKind;
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
@@ -34484,17 +34369,7 @@ mod tests {
                 matches!(
                     &ops[0].kind,
                     OpKind::Call { target, .. } if target.to_string() == "core::ptr::null_mut"
-                ) && matches!(
-                    &ops[1].kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if segments.as_slice()
-                        == [
-                            "__cast_instance_intrinsic".to_string(),
-                            "PyObject".to_string(),
-                        ]
-                )
+                ) && crate::model::cast_instance_root(&ops[1].kind) == Some("PyObject")
             })
         });
         assert!(
@@ -34832,8 +34707,8 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
                     ..
-                } if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
-                    && segments.get(1).is_some_and(|root| root.ends_with("PyObject"))
+                } if crate::model::cast_instance_root(&op.kind)
+                    .is_some_and(|root| root.ends_with("PyObject"))
             )
         });
         assert!(
@@ -36294,13 +36169,7 @@ mod tests {
              representation (Some(ptr)=ptr, None=null), not an Option aggregate"
         );
         let is_instance_narrow = |op: &crate::model::SpaceOperation| {
-            matches!(
-                &op.kind,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    ..
-                } if segments == &["__cast_instance_intrinsic", "PyObject"]
-            )
+            crate::model::cast_instance_root(&op.kind) == Some("PyObject")
         };
         let join = graph.blocks.iter().find_map(|block| {
             let has_call_once = block.operations.iter().any(|op| {
@@ -36404,7 +36273,9 @@ mod tests {
                             target: CallTarget::FunctionPath { segments },
                             ..
                         },
-                    ) if segments == &["__cast_instance_intrinsic", owner] => Some(result),
+                    ) if crate::model::cast_instance_root(&op.kind) == Some(owner) => {
+                        Some(result)
+                    }
                     _ => None,
                 })
                 .expect("typed raw allocation destination");
@@ -36953,9 +36824,8 @@ mod tests {
                             OpKind::Call {
                                 target: CallTarget::FunctionPath { segments },
                                 ..
-                            } if segments.first().map(String::as_str)
-                                == Some("__cast_instance_intrinsic")
-                                && segments.get(1).is_some_and(|root| root.starts_with("Vec<"))
+                            } if crate::model::cast_instance_root(&op.kind)
+                                .is_some_and(|root| root.starts_with("Vec<"))
                         )
                 }),
             "index_storage null must narrow to the Vec/GcArray list repr"
@@ -37541,7 +37411,7 @@ mod tests {
     #[test]
     #[ignore]
     fn pyerror_new_narrows_null_object_fields() {
-        use crate::model::{CallTarget, LinkArg, OpKind};
+        use crate::model::{LinkArg, OpKind};
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
@@ -37567,13 +37437,7 @@ mod tests {
             assert!(
                 graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
                     op.result.as_ref() == Some(&value)
-                        && matches!(
-                            &op.kind,
-                            OpKind::Call {
-                                target: CallTarget::FunctionPath { segments },
-                                ..
-                            } if segments == &["__cast_instance_intrinsic", "PyObject"]
-                        )
+                        && crate::model::cast_instance_root(&op.kind) == Some("PyObject")
                 }),
                 "PyError::{field_name} null must retain the declared PyObject class"
             );
@@ -37625,7 +37489,8 @@ mod tests {
                                 OpKind::Call {
                                     target: CallTarget::FunctionPath { segments },
                                     ..
-                                } if segments == &["__cast_instance_intrinsic", "PyObject"]
+                                } if crate::model::cast_instance_root(&producer.kind)
+                                    == Some("PyObject")
                             )
                     }),
                 "PyError::{} projection write must retain the declared PyObject class",
@@ -37673,9 +37538,8 @@ mod tests {
                         OpKind::Call {
                             target: CallTarget::FunctionPath { segments },
                             ..
-                        } if segments.first().map(String::as_str)
-                            == Some("__cast_instance_intrinsic")
-                            && segments.last().is_some_and(|root| root.ends_with("DictStrategyRef"))
+                        } if crate::model::cast_instance_root(&op.kind)
+                            .is_some_and(|root| root.ends_with("DictStrategyRef"))
                     )
             }),
             "dstrategy assignment must retain the declared DictStrategyRef class"
@@ -38229,10 +38093,11 @@ mod tests {
                         target: CallTarget::FunctionPath { segments },
                         args,
                         result_ty: ValueType::Ref(Some(owner)),
-                    } if segments.first().map(String::as_str)
-                        == Some(crate::runtime_names::shims::CAST_INSTANCE)
+                    } if crate::model::cast_instance_root(&op.kind)
+                        == Some("dictmultiobject::DictStrategyRef")
                         && owner == "dictmultiobject::DictStrategyRef"
-                        && args.as_slice() == std::slice::from_ref(&raw))
+                        && args.first().and_then(crate::model::LinkArg::as_variable)
+                            == Some(&raw))
                 }),
             "a field-bearing prebuilt holder must enter annotation as its own instance"
         );

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6522,10 +6522,7 @@ impl<'a> Lowering<'a> {
                 let res = self
                     .graph
                     .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                return Some((
-                    crate::model::cast_instance_call(root, arg.clone()),
-                    res,
-                ));
+                return Some((crate::model::cast_instance_call(root, arg.clone()), res));
             };
         let res = self
             .graph
@@ -9445,7 +9442,12 @@ impl<'a> Lowering<'a> {
                                     crate::runtime_names::shims::LL_ARRAYMOVE.to_string(),
                                 ],
                             },
-                            args: crate::model::call_args(vec![array, source_start, index, args[2].clone()]),
+                            args: crate::model::call_args(vec![
+                                array,
+                                source_start,
+                                index,
+                                args[2].clone(),
+                            ]),
                             result_ty: ValueType::Void,
                         },
                     });
@@ -10095,7 +10097,13 @@ impl<'a> Lowering<'a> {
                         let field_ty = clone_tyref(&referent.ty);
                         if let PlaceKind::Projection(inner, elem) = referent.kind {
                             let value = args[1].clone();
-                            self.emit_projection_write(mir_bb, *inner, elem, value.into(), &field_ty)?;
+                            self.emit_projection_write(
+                                mir_bb,
+                                *inner,
+                                elem,
+                                value.into(),
+                                &field_ty,
+                            )?;
                             // The store's result is an actual unit constant.
                             self.local_var[dest_local] = Some(self.emit_unit(bb_id));
                             let target_bb = self.block_id[target];
@@ -11660,10 +11668,7 @@ impl<'a> Lowering<'a> {
                 .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: Some(narrowed_receiver.clone()),
-                kind: crate::model::cast_instance_call(
-                    "RBigInt",
-                    args[0].clone().into_variable(),
-                ),
+                kind: crate::model::cast_instance_call("RBigInt", args[0].clone().into_variable()),
             });
             let mut narrowed_args = args.clone();
             narrowed_args[0] = narrowed_receiver.into();
@@ -21284,11 +21289,7 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
 /// `ptr_lt` / `ptr_mod` / `ptr_floordiv`. The RPython spelling is
 /// `lltype.cast_ptr_to_int` then the integer op (`rbuiltin.py
 /// rtype_cast_ptr_to_int`). Equality is excluded on purpose.
-fn int_binop_needs_ptr_to_int(
-    op: &str,
-    lhs: Option<&ValueType>,
-    rhs: Option<&ValueType>,
-) -> bool {
+fn int_binop_needs_ptr_to_int(op: &str, lhs: Option<&ValueType>, rhs: Option<&ValueType>) -> bool {
     matches!(op, "lt" | "le" | "gt" | "ge" | "mod" | "floordiv" | "div")
         && (matches!(lhs, Some(ValueType::Ref(_))) || matches!(rhs, Some(ValueType::Ref(_))))
 }
@@ -23549,7 +23550,14 @@ fn tyref_to_field_layout_string(ty: &TyRef, llbc: &Llbc) -> String {
         // for it.
         let pointee = tyref_node(ty, llbc)
             .and_then(|node| strip_ty_wrappers(node, llbc))
-            .and_then(|node| node.get("Adt")?.get("generics")?.get("types")?.as_array()?.first().cloned())
+            .and_then(|node| {
+                node.get("Adt")?
+                    .get("generics")?
+                    .get("types")?
+                    .as_array()?
+                    .first()
+                    .cloned()
+            })
             .and_then(|arg| serde_json::from_value::<TyRef>(arg).ok())
             .map(|arg| tyref_to_ast_string(&arg, llbc));
         return match pointee {
@@ -26967,12 +26975,10 @@ fn navigate_single_arg_fmt_chain(
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if fmt_path_ends_with(segments, &["fmt", "format"]) => {
-            (
-                args.first()?.clone().into_variable(),
-                format_op.result.as_ref()?.clone(),
-            )
-        }
+        } if fmt_path_ends_with(segments, &["fmt", "format"]) => (
+            args.first()?.clone().into_variable(),
+            format_op.result.as_ref()?.clone(),
+        ),
         _ => return None,
     };
     let chain = extract_fmt_chain(graph, &fmt_args)?;
@@ -28566,11 +28572,10 @@ mod tests {
         DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
         cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
         checked_arith_uint_atom_is_word_sized, decode_literal, fn_ptr_family_for,
-        is_class_pytype_assoc_const, is_core_result_map_err_path, json_ty_is_thin_pointer_element,
-        json_ty_scalar_element_spelling, int_binop_needs_ptr_to_int, push_cast_ptr_to_int,
-        push_ptr_to_unsigned_cast, shaped_array_parts,
-        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
-        tyref_positional_aggregate_root, tyref_to_value_type,
+        int_binop_needs_ptr_to_int, is_class_pytype_assoc_const, is_core_result_map_err_path,
+        json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling, push_cast_ptr_to_int,
+        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
+        tyref_is_raw_byte_ptr, tyref_positional_aggregate_root, tyref_to_value_type,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -31161,17 +31166,12 @@ mod tests {
         let arg = crate::flowspace::model::Variable::new();
         let op = cast_pointer_marker_op("W_CastTarget".to_string(), arg.clone());
         let OpKind::Call {
-            target,
-            result_ty,
-            ..
+            target, result_ty, ..
         } = &op
         else {
             panic!("marker must be an OpKind::Call");
         };
-        assert_eq!(
-            target,
-            &CallTarget::function_path(["__cast_pointer"]),
-        );
+        assert_eq!(target, &CallTarget::function_path(["__cast_pointer"]),);
         assert_eq!(crate::model::cast_pointer_root(&op), Some("W_CastTarget"));
         assert_eq!(result_ty, &ValueType::Ref(Some("W_CastTarget".to_string())));
     }
@@ -33277,7 +33277,13 @@ mod tests {
             other => panic!("expected cast_ptr_to_int call, got {other:?}"),
         }
         assert_eq!(
-            graph.block(entry).operations.last().unwrap().result.as_ref(),
+            graph
+                .block(entry)
+                .operations
+                .last()
+                .unwrap()
+                .result
+                .as_ref(),
             Some(&signed)
         );
     }
@@ -36264,9 +36270,7 @@ mod tests {
                             target: CallTarget::FunctionPath { segments },
                             ..
                         },
-                    ) if crate::model::cast_instance_root(&op.kind) == Some(owner) => {
-                        Some(result)
-                    }
+                    ) if crate::model::cast_instance_root(&op.kind) == Some(owner) => Some(result),
                     _ => None,
                 })
                 .expect("typed raw allocation destination");

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -23583,7 +23583,19 @@ fn tyref_to_field_layout_string(ty: &TyRef, llbc: &Llbc) -> String {
         // leaves AtomicPtr out because the inner value is a pointer; the
         // field walk must still see a pointer spelling, or `is_known_struct`
         // treats `AtomicPtr<T>` as a by-value struct and drops `instantiate`.
-        return "*mut PyObject".to_string();
+        // Spell the actual pointee: `Function.mutate_slots` is an `AtomicPtr`
+        // over a raw (non-GC) struct, and an erased `*mut PyObject` would
+        // make the annotator's field projection answer `Instance(PyObject)`
+        // for it.
+        let pointee = tyref_node(ty, llbc)
+            .and_then(|node| strip_ty_wrappers(node, llbc))
+            .and_then(|node| node.get("Adt")?.get("generics")?.get("types")?.as_array()?.first().cloned())
+            .and_then(|arg| serde_json::from_value::<TyRef>(arg).ok())
+            .map(|arg| tyref_to_ast_string(&arg, llbc));
+        return match pointee {
+            Some(pointee) => format!("*mut {pointee}"),
+            None => "*mut PyObject".to_string(),
+        };
     }
     // `Option<E>` over a densely numbered fieldless E uses E's scalar tag
     // plus one reserved value for `None`.  Preserve that physical width in
@@ -32981,11 +32993,12 @@ mod tests {
             majit_ir::value::Type::Int
         );
 
-        // `AtomicPtr` is a pointer word. Spell it as one so fielddescrof
-        // does not treat the wrapper as a nested struct and drop it.
+        // `AtomicPtr<T>` is a pointer word. Spell it as a pointer to the
+        // actual `T` so fielddescrof does not treat the wrapper as a nested
+        // struct, and so a non-GC pointee is not erased to `PyObject`.
         let ptr_ty = adt_ty(2, serde_json::json!([{"Literal": {"UInt": "U8"}}]));
         let ptr_str = super::tyref_to_field_layout_string(&ptr_ty, &llbc);
-        assert_eq!(ptr_str, "*mut PyObject");
+        assert_eq!(ptr_str, "*mut u8");
         assert_eq!(
             crate::codewriter::call::get_type_flag(&ptr_str).1,
             majit_ir::value::Type::Ref

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -68,6 +68,7 @@ pub(crate) mod bigint_binop;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;
 pub(crate) mod checked_arith_uint;
+pub(crate) mod exc_from_raise;
 pub(crate) mod from_size_align;
 #[cfg(test)]
 pub(crate) mod graph_body;

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -259,14 +259,14 @@ fn rewire_one_closure_select_site(
     );
     let mut then_sources = carried.clone();
     if !then_sources.contains(&opt) {
-        then_sources.push(opt.clone());
+        then_sources.push(opt.clone().into_variable());
     }
     if closure_on_some && !then_sources.contains(&env) {
-        then_sources.push(env.clone());
+        then_sources.push(env.clone().into_variable());
     }
     let mut else_sources = carried.clone();
     if !closure_on_some && !else_sources.contains(&env) {
-        else_sources.push(env.clone());
+        else_sources.push(env.clone().into_variable());
     }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
@@ -457,7 +457,7 @@ fn rewire_one_closure_select_site(
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -470,7 +470,7 @@ fn rewire_one_closure_select_site(
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: none,
                 result_ty: ValueType::Int,
             },
@@ -479,7 +479,7 @@ fn rewire_one_closure_select_site(
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: opt.clone(),
+                base: opt.clone().into_variable(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
                     owner_root: Some(site.option_owner.clone()),
@@ -588,7 +588,7 @@ pub(crate) fn emit_call_once(
         result: Some(call_result.clone()),
         kind: OpKind::Call {
             target: CallTarget::method("call_once", Some(call_once_owner.to_string())),
-            args: vec![env, args_tuple],
+            args: crate::model::call_args(vec![env, args_tuple]),
             result_ty,
         },
     });
@@ -649,7 +649,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method(method, Some(RECV_OPTION.into())),
-                    args: vec![opt, env],
+                    args: crate::model::call_args(vec![opt, env]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -795,7 +795,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map", Some(RECV_OPTION.into())),
-                    args: vec![opt, env],
+                    args: crate::model::call_args(vec![opt, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -899,7 +899,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method(method, Some(RECV_OPTION.into())),
-                    args: vec![opt, env],
+                    args: crate::model::call_args(vec![opt, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -953,7 +953,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map", Some(RECV_OPTION.into())),
-                    args: vec![opt, env],
+                    args: crate::model::call_args(vec![opt, env]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -1123,7 +1123,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map", Some(RECV_OPTION.into())),
-                    args: vec![opt, env],
+                    args: crate::model::call_args(vec![opt, env]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -185,20 +185,12 @@ fn rewire_one_closure_select_site(
         (site.result_var.clone(), None, ci)
     } else if ci + 2 == ops_len {
         let cast = &graph.blocks[a].operations[ci + 1];
-        match (&cast.kind, cast.result.as_ref()) {
-            (
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                },
-                Some(narrowed),
-            ) if segments.len() == 2
-                && segments[0] == crate::runtime_names::shims::CAST_INSTANCE
-                && args.len() == 1
-                && args[0] == site.result_var =>
+        match cast.result.as_ref() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&cast.kind, &site.result_var) =>
             {
-                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+                (narrowed.clone(), Some(root.to_string()), ci + 1)
             }
             _ => {
                 return Err(format!(
@@ -748,7 +740,7 @@ mod tests {
                     OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         ..
-                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                    } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
                 )
         }));
     }

--- a/majit/majit-translate/src/front/option_expect.rs
+++ b/majit/majit-translate/src/front/option_expect.rs
@@ -154,7 +154,7 @@ fn rewire_one_expect_site(graph: &mut FunctionGraph, site: &ExpectSite) -> Resul
     // source-var lists double as the branch link args.
     let mut then_sources = carried.clone();
     if !then_sources.contains(&opt) {
-        then_sources.push(opt.clone());
+        then_sources.push(opt.clone().into_variable());
     }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
@@ -216,7 +216,7 @@ fn rewire_one_expect_site(graph: &mut FunctionGraph, site: &ExpectSite) -> Resul
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -225,7 +225,7 @@ fn rewire_one_expect_site(graph: &mut FunctionGraph, site: &ExpectSite) -> Resul
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: opt.clone(),
+                base: opt.clone().into_variable(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
                     owner_root: Some(site.option_owner.clone()),
@@ -266,7 +266,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: expect_target(),
-                    args: vec![opt.clone(), msg],
+                    args: crate::model::call_args(vec![opt.clone(), msg]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -336,7 +336,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: expect_target(),
-                    args: vec![opt],
+                    args: crate::model::call_args(vec![opt]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_is_none.rs
+++ b/majit/majit-translate/src/front/option_is_none.rs
@@ -94,7 +94,7 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
             result: Some(null.clone()),
             kind: OpKind::Call {
                 target: CallTarget::function_path(["core", "ptr", "null_mut"]),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         }];
@@ -109,7 +109,7 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
                             root.clone(),
                         ],
                     },
-                    args: vec![null],
+                    args: crate::model::call_args(vec![null]),
                     result_ty: result_ty.clone(),
                 },
             });
@@ -126,7 +126,7 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
             result: Some(is_none.clone()),
             kind: OpKind::BinOp {
                 op: "is_".to_string(),
-                lhs: opt,
+                lhs: opt.into_variable(),
                 rhs,
                 result_ty: ValueType::Int,
             },
@@ -156,7 +156,7 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
             SpaceOperation {
                 result: Some(disc.clone()),
                 kind: OpKind::FieldRead {
-                    base: opt,
+                    base: opt.into_variable(),
                     field: FieldDescriptor {
                         name: "__discriminant".to_string(),
                         owner_root: Some(site.option_owner.clone()),
@@ -219,7 +219,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: is_none_target(method),
-                    args: vec![opt.clone()],
+                    args: crate::model::call_args(vec![opt.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -293,7 +293,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: is_none_target("is_some"),
-                    args: vec![opt.clone()],
+                    args: crate::model::call_args(vec![opt.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -374,7 +374,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: is_none_target("is_none"),
-                    args: vec![opt, default],
+                    args: crate::model::call_args(vec![opt, default]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_is_none.rs
+++ b/majit/majit-translate/src/front/option_is_none.rs
@@ -102,16 +102,7 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
             let narrowed = graph.alloc_value_var();
             ops.push(SpaceOperation {
                 result: Some(narrowed.clone()),
-                kind: OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                            root.clone(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![null]),
-                    result_ty: result_ty.clone(),
-                },
+                kind: crate::model::cast_instance_call_result(root.clone(), null, result_ty.clone()),
             });
             narrowed
         } else {

--- a/majit/majit-translate/src/front/option_is_none.rs
+++ b/majit/majit-translate/src/front/option_is_none.rs
@@ -102,7 +102,11 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
             let narrowed = graph.alloc_value_var();
             ops.push(SpaceOperation {
                 result: Some(narrowed.clone()),
-                kind: crate::model::cast_instance_call_result(root.clone(), null, result_ty.clone()),
+                kind: crate::model::cast_instance_call_result(
+                    root.clone(),
+                    null,
+                    result_ty.clone(),
+                ),
             });
             narrowed
         } else {

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -154,20 +154,12 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
         (site.result_var.clone(), None, ci)
     } else if ci + 2 == ops_len {
         let cast = &graph.blocks[a].operations[ci + 1];
-        match (&cast.kind, cast.result.as_ref()) {
-            (
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                },
-                Some(narrowed),
-            ) if segments.len() == 2
-                && segments[0] == crate::runtime_names::shims::CAST_INSTANCE
-                && args.len() == 1
-                && args[0] == site.result_var =>
+        match cast.result.as_ref() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&cast.kind, &site.result_var) =>
             {
-                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+                (narrowed.clone(), Some(root.to_string()), ci + 1)
             }
             _ => {
                 return Err(format!(
@@ -409,16 +401,7 @@ pub(crate) fn emit_narrow(
     let narrowed = graph.alloc_value_var();
     graph.block_mut(block).operations.push(SpaceOperation {
         result: Some(narrowed.clone()),
-        kind: OpKind::Call {
-            target: CallTarget::FunctionPath {
-                segments: vec![
-                    crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                    root.clone(),
-                ],
-            },
-            args: crate::model::call_args(vec![value]),
-            result_ty: ValueType::Ref(Some(root.clone())),
-        },
+        kind: crate::model::cast_instance_call(root.clone(), value),
     });
     narrowed
 }
@@ -544,16 +527,7 @@ mod tests {
         let narrowed = g
             .push_op_var(
                 a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "PyObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![result.clone()]),
-                    result_ty: ValueType::Ref(Some("PyObject".into())),
-                },
+                crate::model::cast_instance_call("PyObject", result.clone()),
                 true,
             )
             .unwrap();
@@ -639,7 +613,7 @@ mod tests {
                     OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         ..
-                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                    } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
                 )
         }));
     }

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -230,14 +230,14 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     // source-var lists double as the branch link args.
     let mut then_sources = carried.clone();
     if !then_sources.contains(&opt) {
-        then_sources.push(opt.clone());
+        then_sources.push(opt.clone().into_variable());
     }
     if !then_sources.contains(&env) {
-        then_sources.push(env.clone());
+        then_sources.push(env.clone().into_variable());
     }
     let mut else_sources = carried.clone();
     if !else_sources.contains(&default) {
-        else_sources.push(default.clone());
+        else_sources.push(default.clone().into_variable());
     }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
@@ -310,7 +310,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
         result: Some(call_result.clone()),
         kind: OpKind::Call {
             target: CallTarget::method("call_once", Some(site.call_once_owner.clone())),
-            args: vec![env_in_then, args_tuple],
+            args: crate::model::call_args(vec![env_in_then, args_tuple]),
             result_ty: site.result_ty.clone(),
         },
     });
@@ -367,7 +367,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -376,7 +376,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: opt.clone(),
+                base: opt.clone().into_variable(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
                     owner_root: Some(site.option_owner.clone()),
@@ -416,7 +416,7 @@ pub(crate) fn emit_narrow(
                     root.clone(),
                 ],
             },
-            args: vec![value],
+            args: crate::model::call_args(vec![value]),
             result_ty: ValueType::Ref(Some(root.clone())),
         },
     });
@@ -458,7 +458,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map_or", Some("core::option::Option".into())),
-                    args: vec![opt.clone(), default.clone(), env.clone()],
+                    args: crate::model::call_args(vec![opt.clone(), default.clone(), env.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -534,7 +534,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map_or", Some("core::option::Option".into())),
-                    args: vec![opt.clone(), default.clone(), env.clone()],
+                    args: crate::model::call_args(vec![opt.clone(), default.clone(), env.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -551,7 +551,7 @@ mod tests {
                             "PyObject".into(),
                         ],
                     },
-                    args: vec![result.clone()],
+                    args: crate::model::call_args(vec![result.clone()]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -603,7 +603,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map_or", Some("core::option::Option".into())),
-                    args: vec![opt, default, env],
+                    args: crate::model::call_args(vec![opt, default, env]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -658,7 +658,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::method("map_or", Some("core::option::Option".into())),
-                    args: vec![opt, default, env],
+                    args: crate::model::call_args(vec![opt, default, env]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -606,16 +606,21 @@ mod tests {
                 _ => None,
             })
             .expect("closure Args tuple payload write");
-        assert!(g.blocks.iter().flat_map(|block| &block.operations).any(|op| {
-            op.result.as_ref() == Some(&written)
-                && matches!(
-                    &op.kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
-                )
-        }));
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    op.result.as_ref() == Some(&written)
+                        && matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
+                        )
+                })
+        );
     }
 
     /// A call block whose last op is not the recorded result declines

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -204,7 +204,7 @@ fn rewire_one_unwrap_site(
     // serves as the branch link args.
     let mut payload_sources = carried.clone();
     if !payload_sources.contains(&recv) {
-        payload_sources.push(recv.clone());
+        payload_sources.push(recv.clone().into_variable());
     }
     let (payload_bb, payload_inputs) = graph.create_block_with_arg_vars(payload_sources.len());
     let (failure_bb, _failure_inputs) = graph.create_block_with_arg_vars(0);
@@ -269,7 +269,7 @@ fn rewire_one_unwrap_site(
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: recv.clone(),
+                lhs: recv.clone().into_variable(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -278,7 +278,7 @@ fn rewire_one_unwrap_site(
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: recv.clone(),
+                base: recv.clone().into_variable(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
                     owner_root: Some(site.enum_owner.clone()),
@@ -336,7 +336,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_target(),
-                    args: vec![opt.clone()],
+                    args: crate::model::call_args(vec![opt.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -409,7 +409,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_target(),
-                    args: vec![opt],
+                    args: crate::model::call_args(vec![opt]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -425,7 +425,7 @@ mod tests {
                             "Tuple<f64,f64>".to_string(),
                         ],
                     },
-                    args: vec![result.clone()],
+                    args: crate::model::call_args(vec![result.clone()]),
                     result_ty: ValueType::Ref(Some("Tuple<f64,f64>".into())),
                 },
                 true,
@@ -489,7 +489,7 @@ mod tests {
                     } else {
                         unwrap_target()
                     },
-                    args,
+                    args: crate::model::call_args(args),
                     result_ty: ValueType::Unsigned,
                 },
                 true,
@@ -558,7 +558,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_target(),
-                    args: vec![opt, extra],
+                    args: crate::model::call_args(vec![opt, extra]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -130,23 +130,17 @@ fn rewire_one_unwrap_site(
         .position(|op| op.result.as_ref() == Some(&site.result_var))
         .expect("result var producer resolved to block A above");
     let last_idx = graph.blocks[a].operations.len() - 1;
-    let (cast, out_var): (Option<(Vec<String>, ValueType)>, Variable) = if call_idx == last_idx {
+    let (cast, out_var): (Option<(String, ValueType)>, Variable) = if call_idx == last_idx {
         (None, site.result_var.clone())
     } else if call_idx == last_idx - 1 {
         let tail = &graph.blocks[a].operations[last_idx];
-        match (&tail.kind, tail.result.clone()) {
-            (
-                OpKind::Call {
-                    target: crate::model::CallTarget::FunctionPath { segments },
-                    args,
-                    result_ty,
-                },
-                Some(narrowed),
-            ) if segments.first().map(String::as_str)
-                == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                && args.as_slice() == std::slice::from_ref(&site.result_var) =>
+        match tail.result.clone() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&tail.kind, &site.result_var)
+                    && let OpKind::Call { result_ty, .. } = &tail.kind =>
             {
-                (Some((segments.clone(), result_ty.clone())), narrowed)
+                (Some((root.to_string(), result_ty.clone())), narrowed)
             }
             _ => {
                 return Err(format!(
@@ -418,16 +412,7 @@ mod tests {
         let narrowed = g
             .push_op_var(
                 a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
-                            "Tuple<f64,f64>".to_string(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![result.clone()]),
-                    result_ty: ValueType::Ref(Some("Tuple<f64,f64>".into())),
-                },
+                crate::model::cast_instance_call("Tuple<f64,f64>", result.clone()),
                 true,
             )
             .unwrap();

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -47,9 +47,7 @@
 
 use crate::flowspace::model::Variable;
 use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
-use crate::model::{
-    FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
-};
+use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
 
 /// A recognized `Option::unwrap_or(opt, default)` / `Result::unwrap_or(res,
 /// default)` call site captured during body lowering (`front::mir`

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -215,11 +215,11 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     // below from `payload_on_disc_true`.
     let mut payload_sources = carried.clone();
     if !payload_sources.contains(&opt) {
-        payload_sources.push(opt.clone());
+        payload_sources.push(opt.clone().into_variable());
     }
     let mut default_sources = carried.clone();
     if !default_sources.contains(&default) {
-        default_sources.push(default.clone());
+        default_sources.push(default.clone().into_variable());
     }
     let (payload_bb, payload_inputs) = graph.create_block_with_arg_vars(payload_sources.len());
     let (default_bb, default_inputs) = graph.create_block_with_arg_vars(default_sources.len());
@@ -303,7 +303,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -316,7 +316,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: opt.clone().into_variable(),
                 rhs: none,
                 result_ty: ValueType::Int,
             },
@@ -325,7 +325,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: opt.clone(),
+                base: opt.clone().into_variable(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
                     owner_root: Some(site.enum_owner.clone()),
@@ -367,7 +367,7 @@ pub(crate) fn emit_narrow(
             target: CallTarget::FunctionPath {
                 segments: segments.clone(),
             },
-            args: vec![raw],
+            args: crate::model::call_args(vec![raw]),
             result_ty: result_ty.clone(),
         },
     });
@@ -440,7 +440,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_or_target(),
-                    args: vec![opt.clone(), default.clone()],
+                    args: crate::model::call_args(vec![opt.clone(), default.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -514,7 +514,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_or_target(),
-                    args: vec![opt.clone(), default.clone()],
+                    args: crate::model::call_args(vec![opt.clone(), default.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -532,7 +532,7 @@ mod tests {
                             "PyObject".into(),
                         ],
                     },
-                    args: vec![result.clone()],
+                    args: crate::model::call_args(vec![result.clone()]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -591,7 +591,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: result_target(),
-                    args: vec![res.clone(), default.clone()],
+                    args: crate::model::call_args(vec![res.clone(), default.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -640,7 +640,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_or_target(),
-                    args: vec![opt, default],
+                    args: crate::model::call_args(vec![opt, default]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -677,7 +677,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_or_target(),
-                    args: vec![opt.clone(), default.clone()],
+                    args: crate::model::call_args(vec![opt.clone(), default.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -747,7 +747,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: unwrap_or_target(),
-                    args: vec![opt, default],
+                    args: crate::model::call_args(vec![opt, default]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -48,7 +48,7 @@
 use crate::flowspace::model::Variable;
 use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
 use crate::model::{
-    CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+    FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
 };
 
 /// A recognized `Option::unwrap_or(opt, default)` / `Result::unwrap_or(res,
@@ -139,23 +139,17 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     // The cast is jitcode-identity (`cast_pointer` → `same_as`); carry it into
     // each arm so B keeps receiving a narrowed value.  `out_var` is the value
     // block B actually consumes for the select result.
-    let (cast, out_var): (Option<(Vec<String>, ValueType)>, Variable) = if call_idx == last_idx {
+    let (cast, out_var): (Option<(String, ValueType)>, Variable) = if call_idx == last_idx {
         (None, site.result_var.clone())
     } else if call_idx == last_idx - 1 {
         let tail = &graph.blocks[a].operations[last_idx];
-        match (&tail.kind, tail.result.clone()) {
-            (
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    result_ty,
-                },
-                Some(narrowed),
-            ) if segments.first().map(String::as_str)
-                == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                && args.as_slice() == std::slice::from_ref(&site.result_var) =>
+        match tail.result.clone() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&tail.kind, &site.result_var)
+                    && let OpKind::Call { result_ty, .. } = &tail.kind =>
             {
-                (Some((segments.clone(), result_ty.clone())), narrowed)
+                (Some((root.to_string(), result_ty.clone())), narrowed)
             }
             _ => {
                 return Err(format!(
@@ -354,22 +348,16 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
 pub(crate) fn emit_narrow(
     graph: &mut FunctionGraph,
     bb: crate::model::BlockId,
-    cast: &Option<(Vec<String>, ValueType)>,
+    cast: &Option<(String, ValueType)>,
     raw: Variable,
 ) -> Variable {
-    let Some((segments, result_ty)) = cast else {
+    let Some((root, result_ty)) = cast else {
         return raw;
     };
     let narrowed = graph.alloc_value_var();
     graph.block_mut(bb).operations.push(SpaceOperation {
         result: Some(narrowed.clone()),
-        kind: OpKind::Call {
-            target: CallTarget::FunctionPath {
-                segments: segments.clone(),
-            },
-            args: crate::model::call_args(vec![raw]),
-            result_ty: result_ty.clone(),
-        },
+        kind: crate::model::cast_instance_call_result(root.clone(), raw, result_ty.clone()),
     });
     narrowed
 }
@@ -525,16 +513,7 @@ mod tests {
         let narrowed = g
             .push_op_var(
                 a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "PyObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![result.clone()]),
-                    result_ty: ValueType::Ref(Some("PyObject".into())),
-                },
+                crate::model::cast_instance_call("PyObject", result.clone()),
                 true,
             )
             .unwrap();

--- a/majit/majit-translate/src/front/range_contains.rs
+++ b/majit/majit-translate/src/front/range_contains.rs
@@ -219,7 +219,7 @@ fn rewire_one_range_contains_site(
     let lo_le = graph.alloc_value_var();
     let hi_ge = graph.alloc_value_var();
     let inserts =
-        build_range_contains_compares(&site.result_var, lo_in_c, hi_in_c, x, lo_le, hi_ge);
+        build_range_contains_compares(&site.result_var, lo_in_c, hi_in_c, x.into_variable(), lo_le, hi_ge);
     let ops = &mut graph.blocks[c_idx].operations;
     ops.remove(call_idx);
     for (offset, op) in inserts.into_iter().enumerate() {
@@ -570,7 +570,7 @@ mod tests {
                 n,
                 OpKind::Call {
                     target: new_target(),
-                    args: vec![a.clone(), b.clone()],
+                    args: crate::model::call_args(vec![a.clone(), b.clone()]),
                     result_ty: ValueType::Ref(Some("RangeInclusive".into())),
                 },
                 true,
@@ -585,7 +585,7 @@ mod tests {
                 c,
                 OpKind::Call {
                     target: contains_target(),
-                    args: vec![range_in_c.clone(), x.clone()],
+                    args: crate::model::call_args(vec![range_in_c.clone(), x.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -640,7 +640,7 @@ mod tests {
                 n,
                 OpKind::Call {
                     target: new_target(),
-                    args: vec![a.clone(), b.clone()],
+                    args: crate::model::call_args(vec![a.clone(), b.clone()]),
                     result_ty: ValueType::Ref(Some("RangeInclusive".into())),
                 },
                 true,
@@ -664,7 +664,7 @@ mod tests {
                 c,
                 OpKind::Call {
                     target: contains_target(),
-                    args: vec![range_in_c.clone(), x.clone()],
+                    args: crate::model::call_args(vec![range_in_c.clone(), x.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -712,7 +712,7 @@ mod tests {
                 n,
                 OpKind::Call {
                     target: new_target(),
-                    args: vec![a.clone(), b.clone()],
+                    args: crate::model::call_args(vec![a.clone(), b.clone()]),
                     result_ty: ValueType::Ref(Some("RangeInclusive".into())),
                 },
                 true,
@@ -730,7 +730,7 @@ mod tests {
                 m,
                 OpKind::Call {
                     target: contains_target(),
-                    args: vec![range_in_m.clone(), x],
+                    args: crate::model::call_args(vec![range_in_m.clone(), x]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -790,7 +790,7 @@ mod tests {
                 n,
                 OpKind::Call {
                     target: new_target(),
-                    args: vec![a.clone(), b.clone()],
+                    args: crate::model::call_args(vec![a.clone(), b.clone()]),
                     result_ty: ValueType::Ref(Some("RangeInclusive".into())),
                 },
                 true,
@@ -804,7 +804,7 @@ mod tests {
                 c,
                 OpKind::Call {
                     target: contains_target(),
-                    args: vec![range_in_c.clone()],
+                    args: crate::model::call_args(vec![range_in_c.clone()]),
                     result_ty: ValueType::Int,
                 },
                 true,
@@ -851,7 +851,7 @@ mod tests {
                 n,
                 OpKind::Call {
                     target: new_target(),
-                    args: vec![a.clone(), b.clone()],
+                    args: crate::model::call_args(vec![a.clone(), b.clone()]),
                     result_ty: ValueType::Ref(Some("RangeInclusive".into())),
                 },
                 true,
@@ -867,7 +867,7 @@ mod tests {
                 c,
                 OpKind::Call {
                     target: contains_target(),
-                    args: vec![range_in_c.clone(), x],
+                    args: crate::model::call_args(vec![range_in_c.clone(), x]),
                     result_ty: ValueType::Int,
                 },
                 true,

--- a/majit/majit-translate/src/front/range_contains.rs
+++ b/majit/majit-translate/src/front/range_contains.rs
@@ -218,8 +218,14 @@ fn rewire_one_range_contains_site(
     //    place and reusing its result Variable for the final `bitand`.
     let lo_le = graph.alloc_value_var();
     let hi_ge = graph.alloc_value_var();
-    let inserts =
-        build_range_contains_compares(&site.result_var, lo_in_c, hi_in_c, x.into_variable(), lo_le, hi_ge);
+    let inserts = build_range_contains_compares(
+        &site.result_var,
+        lo_in_c,
+        hi_in_c,
+        x.into_variable(),
+        lo_le,
+        hi_ge,
+    );
     let ops = &mut graph.blocks[c_idx].operations;
     ops.remove(call_idx);
     for (offset, op) in inserts.into_iter().enumerate() {

--- a/majit/majit-translate/src/front/range_iter.rs
+++ b/majit/majit-translate/src/front/range_iter.rs
@@ -425,7 +425,7 @@ fn range_builtin_call(result: Variable, start: Variable, end: Variable) -> Space
             target: CallTarget::FunctionPath {
                 segments: vec![crate::runtime_names::shims::RANGE.to_string()],
             },
-            args: vec![start, end],
+            args: crate::model::call_args(vec![start, end]),
             result_ty: ValueType::Ref(None),
         },
     }
@@ -441,7 +441,7 @@ fn slice_iter_call(result: Variable, container: Variable) -> SpaceOperation {
             target: CallTarget::FunctionPath {
                 segments: vec!["core".to_string(), "slice".to_string(), "iter".to_string()],
             },
-            args: vec![container],
+            args: crate::model::call_args(vec![container]),
             result_ty: ValueType::Ref(None),
         },
     }
@@ -543,7 +543,7 @@ mod tests {
                 h,
                 OpKind::Call {
                     target: CallTarget::method("next", Some("Range".to_string())),
-                    args: vec![it.clone()],
+                    args: crate::model::call_args(vec![it.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -615,7 +615,7 @@ mod tests {
                 h,
                 OpKind::Call {
                     target: CallTarget::method("next", Some("Range".to_string())),
-                    args: vec![it.clone()],
+                    args: crate::model::call_args(vec![it.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -693,7 +693,7 @@ mod tests {
                 h,
                 OpKind::Call {
                     target: CallTarget::method("next", Some("Range".to_string())),
-                    args: vec![it.clone()],
+                    args: crate::model::call_args(vec![it.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/result_as_ref.rs
+++ b/majit/majit-translate/src/front/result_as_ref.rs
@@ -49,7 +49,7 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultAsRefSite) -> Result<(), S
         return Err("as_ref is not last".into());
     }
     let receiver = match &op.kind {
-        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone().into_variable(),
         _ => return Err("as_ref does not have one argument".into()),
     };
     let [exit] = graph.blocks[a].exits.as_slice() else {
@@ -119,7 +119,7 @@ fn rewire_one(graph: &mut FunctionGraph, site: &ResultAsRefSite) -> Result<(), S
         .push_op_var(
             a_id,
             OpKind::FieldRead {
-                base: receiver,
+                base: receiver.clone(),
                 field: FieldDescriptor::new("__discriminant", Some(site.receiver_owner.clone())),
                 ty: ValueType::Int,
                 pure: true,
@@ -148,7 +148,7 @@ mod tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::method("as_ref", Some("Result".into())),
-                    args: vec![receiver],
+                    args: crate::model::call_args(vec![receiver]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -3302,14 +3302,7 @@ pub(crate) fn assert_block_pure_besides(
 /// It lowers to `cast_pointer` (a pure alias), so it carries no side effect
 /// and its result is bit-identical to its operand.
 pub(crate) fn is_recast_narrow(kind: &OpKind) -> bool {
-    matches!(
-        kind,
-        OpKind::Call {
-            target: CallTarget::FunctionPath { segments },
-            args,
-            ..
-        } if args.len() == 1 && segments.first().is_some_and(|s| s == crate::runtime_names::shims::CAST_INSTANCE)
-    )
+    crate::model::cast_instance_root(kind).is_some()
 }
 
 /// Peel the trailing chain of pure `__cast_instance_intrinsic` recasts starting

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -830,7 +830,7 @@ pub(crate) fn materialize_error_to_exc_object(
                     target: CallTarget::FunctionPath {
                         segments: segments.iter().copied().map(str::to_string).collect(),
                     },
-                    args: vec![payload],
+                    args: crate::model::call_args(vec![payload]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1004,8 +1004,8 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
             value,
             ..
         } => vec![base.clone(), elem_index.clone(), value.clone()],
-        OpKind::Call { args, .. }
-        | OpKind::JitDebug { args }
+        OpKind::Call { args, .. } => crate::model::call_arg_vars(args),
+        OpKind::JitDebug { args }
         | OpKind::NewTuple { args }
         | OpKind::NewList { args }
         | OpKind::GetSlice { args }
@@ -1506,7 +1506,7 @@ fn rewire_one_option_ok_or_else_try_site(
     }
     let mut some_sources = carried.clone();
     if !some_sources.contains(&opt) {
-        some_sources.push(opt.clone());
+        some_sources.push(opt.clone().into_variable());
     }
     let (some_bb, some_inputs) = graph.create_block_with_arg_vars(some_sources.len());
     let (none_bb, none_inputs) = graph.create_block_with_arg_vars(1);
@@ -1572,7 +1572,7 @@ fn rewire_one_option_ok_or_else_try_site(
                 result: Some(disc.clone()),
                 kind: OpKind::BinOp {
                     op: "ne".to_string(),
-                    lhs: opt.clone(),
+                    lhs: opt.clone().into_variable(),
                     rhs: null,
                     result_ty: ValueType::Int,
                 },
@@ -1584,7 +1584,7 @@ fn rewire_one_option_ok_or_else_try_site(
             .push(crate::model::SpaceOperation {
                 result: Some(disc.clone()),
                 kind: OpKind::FieldRead {
-                    base: opt.clone(),
+                    base: opt.clone().into_variable(),
                     field: crate::model::FieldDescriptor {
                         name: "__discriminant".to_string(),
                         owner_root: Some(site.option_owner.clone()),
@@ -1597,7 +1597,7 @@ fn rewire_one_option_ok_or_else_try_site(
                 },
             });
     }
-    graph.set_branch(a_id, disc, some_bb, some_sources, none_bb, vec![env]);
+    graph.set_branch(a_id, disc, some_bb, some_sources, none_bb, vec![env.into_variable()]);
     Ok(())
 }
 
@@ -2039,7 +2039,7 @@ fn catch_and_rewrap(
                     e_id,
                     OpKind::Call {
                         target: CallTarget::method(method, Some(receiver_root.to_string())),
-                        args: vec![e_exc_value_in],
+                        args: crate::model::call_args(vec![e_exc_value_in]),
                         result_ty: ValueType::Ref(None),
                     },
                     true,
@@ -2722,11 +2722,12 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
             unreachable!("validated RootScope close is a call")
         };
         for arg in args {
-            if !close_vars_a.contains(arg) {
+            let arg = arg.clone().into_variable();
+            if !close_vars_a.contains(&arg) {
                 close_vars_a.push(arg.clone());
             }
-            if !forwarded.contains(arg) {
-                forwarded.push(arg.clone());
+            if !forwarded.contains(&arg) {
+                forwarded.push(arg);
             }
         }
     }
@@ -2761,7 +2762,7 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
                     "error",
                     "exception_object_matches_stop_iteration",
                 ]),
-                args: vec![h_vb.clone()],
+                args: crate::model::call_args(vec![h_vb.clone()]),
                 result_ty: ValueType::Int,
             },
             true,
@@ -2807,7 +2808,7 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
             r_id,
             OpKind::Call {
                 target,
-                args,
+                args: crate::model::call_args(args),
                 result_ty,
             },
             true,
@@ -2976,7 +2977,7 @@ fn remap_root_scope_close_through_links(
                 .position(|v| *v == current)
                 .ok_or_else(|| format!("{name}: close argument is not forwarded"))?;
             current = match link.args.get(pos) {
-                Some(LinkArg::Value(v)) => v.clone(),
+                Some(LinkArg::Value(v)) => v.clone().into(),
                 _ => return Err(format!("{name}: close argument is not a value")),
             };
         }
@@ -3338,7 +3339,7 @@ pub(crate) fn peel_recast_chain_from(
             let OpKind::Call { args, .. } = &op.kind else {
                 return None;
             };
-            if args.first() != Some(&cur) {
+            if args.first().and_then(|a| a.as_variable()) != Some(&cur) {
                 return None;
             }
             op.result.clone().map(|r| (i, r))

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -3589,9 +3589,25 @@ pub(crate) fn fuse_kind_ctor_raise(graph: &mut FunctionGraph) {
     let mut fusions: Vec<(usize, usize, &'static str, usize, usize)> = Vec::new();
     for si in 0..graph.blocks.len() {
         let succ = &graph.blocks[si];
-        // `succ` holds nothing but the materialisation, and raises its result.
-        let [op] = succ.operations.as_slice() else {
-            continue;
+        // `succ` holds the materialisation, optionally followed by
+        // `op.type(evalue)` (`exc_from_raise`), and raises.
+        let (op, type_result) = match succ.operations.as_slice() {
+            [op] => (op, None),
+            [op, type_op] => {
+                let OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args: type_args,
+                    ..
+                } = &type_op.kind
+                else {
+                    continue;
+                };
+                if segments.as_slice() != ["type"] {
+                    continue;
+                }
+                (op, Some((type_op.result.as_ref(), type_args.as_slice())))
+            }
+            _ => continue,
         };
         let OpKind::Call {
             target: CallTarget::FunctionPath { segments },
@@ -3607,15 +3623,25 @@ pub(crate) fn fuse_kind_ctor_raise(graph: &mut FunctionGraph) {
         let ([v_payload], Some(v_exc)) = (args.as_slice(), op.result.as_ref()) else {
             continue;
         };
+        match type_result {
+            None => {}
+            Some((Some(_), [type_arg])) if type_arg == v_exc => {}
+            _ => continue,
+        }
         let [exit] = succ.exits.as_slice() else {
             continue;
         };
-        if exit.target != graph.exceptblock
-            || !exit
-                .args
-                .iter()
-                .all(|a| matches!(a, LinkArg::Value(v) if v == v_exc))
-        {
+        let raise_ok = exit.target == graph.exceptblock
+            && match (type_result, exit.args.as_slice()) {
+                (Some((Some(etype), _)), [LinkArg::Value(t), LinkArg::Value(v)]) => {
+                    t == etype && v == v_exc
+                }
+                (None, args) => args
+                    .iter()
+                    .all(|a| matches!(a, LinkArg::Value(v) if v == v_exc)),
+                _ => false,
+            };
+        if !raise_ok {
             continue;
         }
         let Some(pos) = succ.inputargs.iter().position(|v| v == v_payload) else {
@@ -3677,12 +3703,12 @@ pub(crate) fn fuse_kind_ctor_raise(graph: &mut FunctionGraph) {
                     .to_vec(),
             };
         }
-        // The constructor's result variable now holds the exception object, so
-        // the value already forwarded into `succ` is what the raise link wants.
+        // The constructor's result variable now holds the exception object.
+        // Re-close with `op.type(payload)` so exceptblock slot 0 stays
+        // class-shaped (`flowcontext.py exc_from_raise`).
         let payload = graph.blocks[si].inputargs[pos].clone();
         graph.blocks[si].operations.clear();
-        let raise_arity = graph.blocks[si].exits[0].args.len();
-        graph.blocks[si].exits[0].args = vec![LinkArg::Value(payload); raise_arity];
+        crate::front::exc_from_raise::set_raise_from_instance(graph, graph.blocks[si].id, payload);
     }
 }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1597,7 +1597,14 @@ fn rewire_one_option_ok_or_else_try_site(
                 },
             });
     }
-    graph.set_branch(a_id, disc, some_bb, some_sources, none_bb, vec![env.into_variable()]);
+    graph.set_branch(
+        a_id,
+        disc,
+        some_bb,
+        some_sources,
+        none_bb,
+        vec![env.into_variable()],
+    );
     Ok(())
 }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -33,9 +33,8 @@
 //!   (`PyError::to_exc_object` — the trace-level exception value
 //!   domain is the `W_BaseException` ref, the same value
 //!   `BH_LAST_EXC_VALUE` carries) and closes the block towards
-//!   `exceptblock` with `(exc, exc)`, exactly the
-//!   `lower_exc_from_raise` tail shape (`flowcontext.py:600`) — whose
-//!   `etype` slot is write-only, see that module's "etype link arg" note.
+//!   `exceptblock` with `(type(exc), exc)`, the
+//!   `exc_from_raise` tail (`flowcontext.py`).
 //!
 //! - **Caller rule** ([`rewire_result_exc_call_sites`]): a `?` on a
 //!   call to a scoped callee lowers in MIR as a
@@ -766,12 +765,7 @@ fn lower_result_exc_returns_inner(
             for close in root_scope_closes {
                 graph.push_op_var(block_id, close, true);
             }
-            // `graph.set_raise_values(block, etype, evalue)`. The `etype`
-            // link arg is write-only: `make_return`'s 2-arg arm emits
-            // `raise <args[1]>` and never reads `args[0]`
-            // (`flatten.rs`, `flatten.py:139-143`). Pass the evalue
-            // for it — see `front::exc_from_raise`'s "etype link arg" note.
-            graph.set_raise_values(block_id, v_exc.clone(), v_exc);
+            crate::front::exc_from_raise::set_raise_from_instance(graph, block_id, v_exc);
         } else {
             // `return Ok(v)` → forward the payload itself.
             for link in &mut graph.blocks[bi].exits {
@@ -1559,7 +1553,7 @@ fn rewire_one_option_ok_or_else_try_site(
         "",
     );
     let exc = materialize_error_to_exc_object(graph, none_bb, error, spec);
-    graph.set_raise_values(none_bb, exc.clone(), exc);
+    crate::front::exc_from_raise::set_raise_from_instance(graph, none_bb, exc);
 
     graph.blocks[a].operations.truncate(call_idx);
     let disc = graph.alloc_value_var();
@@ -2821,7 +2815,7 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
             true,
         );
     }
-    graph.set_raise_values(r_id, r_vb.clone(), r_vb);
+    crate::front::exc_from_raise::set_raise_from_instance(graph, r_id, r_vb);
 
     // Break edge args in H scope (all forwarded Variables; the dead threads
     // were pruned, so no const rides the surviving edge).

--- a/majit/majit-translate/src/front/result_map_err.rs
+++ b/majit/majit-translate/src/front/result_map_err.rs
@@ -148,11 +148,11 @@ fn rewire_one(
 
     let mut ok_sources = carried.clone();
     if !ok_sources.contains(&receiver) {
-        ok_sources.push(receiver.clone());
+        ok_sources.push(receiver.clone().into_variable());
     }
     let mut err_sources = ok_sources.clone();
     if !err_sources.contains(&env) {
-        err_sources.push(env.clone());
+        err_sources.push(env.clone().into_variable());
     }
     // Validate the complete exception destination before adding any blocks.
     // Like ExceptionTransformer.transform_block / insert_matching, a rejected
@@ -350,7 +350,7 @@ fn rewire_one(
     graph.block_mut(a_id).operations.push(SpaceOperation {
         result: Some(disc.clone()),
         kind: OpKind::FieldRead {
-            base: receiver,
+            base: receiver.into_variable(),
             field: FieldDescriptor {
                 name: "__discriminant".to_string(),
                 owner_root: Some(site.receiver_owner.clone()),
@@ -495,7 +495,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::method("map_err", Some("Result".into())),
-                        args: vec![receiver, env],
+                        args: crate::model::call_args(vec![receiver, env]),
                         result_ty: ValueType::Ref(None),
                     },
                     true,
@@ -584,7 +584,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::method("map_err", Some("Result".into())),
-                    args: vec![receiver, env],
+                    args: crate::model::call_args(vec![receiver, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -658,7 +658,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::method("map_err", Some("Result".into())),
-                    args: vec![receiver, env],
+                    args: crate::model::call_args(vec![receiver, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -672,7 +672,7 @@ mod tests {
                 catch,
                 OpKind::Call {
                     target: CallTarget::method("from_exc_object", Some("Error".into())),
-                    args: vec![catch_inputs[2].clone()],
+                    args: crate::model::call_args(vec![catch_inputs[2].clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -775,7 +775,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::method("map_err", Some("Result".into())),
-                    args: vec![receiver, env],
+                    args: crate::model::call_args(vec![receiver, env]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/saturating_sub.rs
+++ b/majit/majit-translate/src/front/saturating_sub.rs
@@ -166,7 +166,7 @@ fn rewire_one_saturating_sub_site(
     let mut else_sources = carried.clone();
     for v in [&minuend, &subtrahend] {
         if !else_sources.contains(v) {
-            else_sources.push(v.clone());
+            else_sources.push(v.clone().into_variable());
         }
     }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(carried.len());
@@ -225,8 +225,8 @@ fn rewire_one_saturating_sub_site(
         result: Some(cond.clone()),
         kind: OpKind::BinOp {
             op: "lt".to_string(),
-            lhs: minuend,
-            rhs: subtrahend,
+            lhs: minuend.into_variable(),
+            rhs: subtrahend.into_variable(),
             result_ty: ValueType::Unsigned,
         },
     });
@@ -255,7 +255,7 @@ mod tests {
                         "saturating_sub".into(),
                     ],
                 },
-                args,
+                args: crate::model::call_args(args),
                 result_ty: ValueType::Unsigned,
             },
             true,

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -917,11 +917,12 @@ fn class_roots(func: &SemanticFunction) -> std::collections::HashMap<u64, String
                     CallTarget::SyntheticTransparentCtor {
                         name, is_struct, ..
                     } if *is_struct => Some(name.clone()),
-                    // `__cast_pointer/<Root>` and
-                    // `__cast_instance_intrinsic/<Root>` carry the target
-                    // class in the path.
+                    // `__cast_pointer` / `__cast_instance_intrinsic`
+                    // carry the target class as a trailing ByteStr.
                     CallTarget::FunctionPath { segments } if is_representation_cast(segments) => {
-                        segments.get(1).cloned()
+                        crate::model::cast_pointer_root(&op.kind)
+                            .or_else(|| crate::model::cast_instance_root(&op.kind))
+                            .map(str::to_string)
                     }
                     _ => leaf_root(result_ty).map(str::to_string),
                 },
@@ -1198,13 +1199,7 @@ mod tests {
             let cast = Variable::named("cast");
             f.graph.block_mut(start).operations.push(SpaceOperation {
                 result: Some(cast.clone()),
-                kind: OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec!["__cast_pointer".to_string(), receiver_root.to_string()],
-                    },
-                    args: crate::model::call_args(vec![hinted]),
-                    result_ty: ValueType::Ref(Some(receiver_root.to_string())),
-                },
+                kind: crate::model::cast_pointer_call(receiver_root, hinted),
             });
             cast
         } else {

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -1139,7 +1139,7 @@ mod tests {
         // shapes differ only in whether the value was hinted.
         let passed = if hint.is_some() { hinted } else { param };
         for (callee, arity) in calls {
-            let args = (0..*arity)
+            let args: Vec<Variable> = (0..*arity)
                 .map(|i| {
                     if i == 0 {
                         passed.clone()
@@ -1154,7 +1154,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec![(*callee).to_string()],
                     },
-                    args,
+                    args: crate::model::call_args(args),
                     result_ty: ValueType::Void,
                 },
             });
@@ -1202,7 +1202,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__cast_pointer".to_string(), receiver_root.to_string()],
                     },
-                    args: vec![hinted],
+                    args: crate::model::call_args(vec![hinted]),
                     result_ty: ValueType::Ref(Some(receiver_root.to_string())),
                 },
             });
@@ -1218,7 +1218,7 @@ mod tests {
                     receiver_root: Some(receiver_root.to_string()),
                     resolved_path: None,
                 },
-                args: vec![passed],
+                args: crate::model::call_args(vec![passed]),
                 result_ty: ValueType::Void,
             },
         });
@@ -1385,7 +1385,7 @@ mod tests {
                         receiver_root: Some("PyFrame".to_string()),
                         resolved_path: None,
                     },
-                    args: vec![carried],
+                    args: crate::model::call_args(vec![carried]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -1536,7 +1536,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["call_function".to_string()],
                     },
-                    args: vec![normal],
+                    args: crate::model::call_args(vec![normal]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -1603,7 +1603,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec!["init_cells".to_string()],
                 },
-                args: vec![hinted],
+                args: crate::model::call_args(vec![hinted]),
                 result_ty: ValueType::Void,
             },
         });
@@ -1658,7 +1658,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec!["call_function".to_string()],
                 },
-                args: vec![merged],
+                args: crate::model::call_args(vec![merged]),
                 result_ty: ValueType::Void,
             },
         });
@@ -1720,7 +1720,7 @@ mod tests {
                 _ => None,
             })
             .expect("the log call");
-        log_call[0] = crate::flowspace::model::Variable::named("unrelated");
+        log_call[0] = crate::flowspace::model::Variable::named("unrelated").into();
         propagate_access_directly(&mut fns, &Default::default(), &vable_roots());
         assert!(fns[1].graph.access_directly, "handle_bytecode is flagged");
         assert!(!fns[2].graph.access_directly, "log is not");

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -194,11 +194,13 @@ fn rewire_one_slice_first_site(
 
     // Capture the slice receiver and validate the recorded access operand.
     let slice = match (&graph.blocks[a].operations[ci].kind, &site.access) {
-        (OpKind::Call { args, .. }, SliceAccess::First) if args.len() == 1 => args[0].clone(),
+        (OpKind::Call { args, .. }, SliceAccess::First) if args.len() == 1 => {
+            args[0].clone().into_variable()
+        }
         (OpKind::Call { args, .. }, SliceAccess::RangeFrom { range, .. })
             if args.len() == 2 && args[1] == *range =>
         {
-            args[0].clone()
+            args[0].clone().into_variable()
         }
         other => {
             return Err(format!(
@@ -299,7 +301,7 @@ fn rewire_one_slice_first_site(
                     target: CallTarget::FunctionPath {
                         segments: vec!["__getslice_rangefrom".to_string()],
                     },
-                    args: vec![slice_in_then, start_in_then],
+                    args: crate::model::call_args(vec![slice_in_then, start_in_then]),
                     result_ty: site.payload_ty.clone(),
                 },
             });
@@ -363,7 +365,7 @@ fn rewire_one_slice_first_site(
             target: CallTarget::FunctionPath {
                 segments: vec!["__len".to_string()],
             },
-            args: vec![slice.clone()],
+            args: crate::model::call_args(vec![slice.clone()]),
             result_ty: ValueType::Int,
         },
     });
@@ -383,7 +385,7 @@ fn rewire_one_slice_first_site(
                         "r_uint".to_string(),
                     ],
                 },
-                args: vec![len],
+                args: crate::model::call_args(vec![len]),
                 result_ty: ValueType::Unsigned,
             },
         });
@@ -472,7 +474,7 @@ mod tests {
                             "first".into(),
                         ],
                     },
-                    args: vec![slice.clone()],
+                    args: crate::model::call_args(vec![slice.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -554,7 +556,7 @@ mod tests {
                             "first".into(),
                         ],
                     },
-                    args: vec![slice.clone()],
+                    args: crate::model::call_args(vec![slice.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -570,7 +572,7 @@ mod tests {
                             "PyObject".into(),
                         ],
                     },
-                    args: vec![opt.clone()],
+                    args: crate::model::call_args(vec![opt.clone()]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -630,7 +632,7 @@ mod tests {
                             "first".into(),
                         ],
                     },
-                    args: vec![slice],
+                    args: crate::model::call_args(vec![slice]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -165,20 +165,12 @@ fn rewire_one_slice_first_site(
         (site.result_var.clone(), None, ci)
     } else if ci + 2 == ops_len {
         let cast = &graph.blocks[a].operations[ci + 1];
-        match (&cast.kind, cast.result.as_ref()) {
-            (
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                },
-                Some(narrowed),
-            ) if segments.len() == 2
-                && segments[0] == crate::runtime_names::shims::CAST_INSTANCE
-                && args.len() == 1
-                && args[0] == site.result_var =>
+        match cast.result.as_ref() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&cast.kind, &site.result_var) =>
             {
-                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+                (narrowed.clone(), Some(root.to_string()), ci + 1)
             }
             _ => {
                 return Err(format!(
@@ -565,16 +557,7 @@ mod tests {
         let narrowed = g
             .push_op_var(
                 a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "PyObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![opt.clone()]),
-                    result_ty: ValueType::Ref(Some("PyObject".into())),
-                },
+                crate::model::cast_instance_call("PyObject", opt.clone()),
                 true,
             )
             .unwrap();

--- a/majit/majit-translate/src/front/slice_get.rs
+++ b/majit/majit-translate/src/front/slice_get.rs
@@ -203,7 +203,10 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
 
     // Capture the slice receiver and the index operand.
     let (slice, index) = match &graph.blocks[a].operations[ci].kind {
-        OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
+        OpKind::Call { args, .. } if args.len() == 2 => (
+            args[0].clone().into_variable(),
+            args[1].clone().into_variable(),
+        ),
         other => {
             return Err(format!(
                 "{name}: slice::get producer op is not a 2-arg call: {other:?}"
@@ -336,7 +339,7 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
             target: CallTarget::FunctionPath {
                 segments: vec!["__len".to_string()],
             },
-            args: vec![slice],
+            args: crate::model::call_args(vec![slice]),
             result_ty: ValueType::Int,
         },
     });
@@ -345,7 +348,7 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
         result: Some(cond.clone()),
         kind: OpKind::BinOp {
             op: "lt".to_string(),
-            lhs: index,
+            lhs: index.clone(),
             rhs: len,
             result_ty: ValueType::Int,
         },
@@ -384,7 +387,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec!["core".into(), "slice".into(), "<Impl>".into(), "get".into()],
                 },
-                args,
+                args: crate::model::call_args(args),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -617,7 +620,7 @@ mod tests {
                             "PyObject".into(),
                         ],
                     },
-                    args: vec![opt.clone()],
+                    args: crate::model::call_args(vec![opt.clone()]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,

--- a/majit/majit-translate/src/front/slice_get.rs
+++ b/majit/majit-translate/src/front/slice_get.rs
@@ -174,20 +174,12 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
         (site.result_var.clone(), None, ci)
     } else if ci + 2 == ops_len {
         let cast = &graph.blocks[a].operations[ci + 1];
-        match (&cast.kind, cast.result.as_ref()) {
-            (
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                },
-                Some(narrowed),
-            ) if segments.len() == 2
-                && segments[0] == crate::runtime_names::shims::CAST_INSTANCE
-                && args.len() == 1
-                && args[0] == site.result_var =>
+        match cast.result.as_ref() {
+            Some(narrowed)
+                if let Some(root) =
+                    crate::model::cast_instance_of(&cast.kind, &site.result_var) =>
             {
-                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+                (narrowed.clone(), Some(root.to_string()), ci + 1)
             }
             _ => {
                 return Err(format!(
@@ -548,7 +540,7 @@ mod tests {
                     OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
                         ..
-                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                    } if crate::model::cast_instance_root(&op.kind) == Some("PyObject")
                 )
             })
             .count();
@@ -613,16 +605,7 @@ mod tests {
         let narrowed = g
             .push_op_var(
                 a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "PyObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![opt.clone()]),
-                    result_ty: ValueType::Ref(Some("PyObject".into())),
-                },
+                crate::model::cast_instance_call("PyObject", opt.clone()),
                 true,
             )
             .unwrap();

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -220,7 +220,7 @@ fn rewire_one_slice_index_rangeto_site(
                 return None;
             };
             (is_slice_range_index_call(&op.kind) && args.len() == 2 && args[1] == *range)
-                .then(|| args[0].clone())
+                .then(|| args[0].clone().into_variable())
         })
         .ok_or_else(|| format!("{}: no RangeTo index consumer", graph.name))?;
     let bounds = if minus_one_end_matches(graph, &site.end, &slice) {
@@ -261,7 +261,11 @@ fn rewire_one_slice_index_site(
                 let OpKind::Call { result_ty, .. } = &op.kind else {
                     unreachable!()
                 };
-                Some((args[0].clone(), result.clone(), result_ty.clone()))
+                Some((
+                    args[0].clone().into_variable(),
+                    result.clone(),
+                    result_ty.clone(),
+                ))
             })
         })
         .ok_or_else(|| format!("{name}: no slice::index call consumes the RangeFrom value"))?;
@@ -378,7 +382,7 @@ fn rewire_one_slice_index_site(
                     target: CallTarget::FunctionPath {
                         segments: vec!["__getslice_range".to_string()],
                     },
-                    args: vec![slice, start.clone(), end.clone()],
+                    args: crate::model::call_args(vec![slice, start.clone(), end.clone()]),
                     result_ty: index_result_ty,
                 },
             };
@@ -399,7 +403,7 @@ fn rewire_one_slice_index_site(
                 result: Some(index_result),
                 kind: OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
-                    args,
+                    args: crate::model::call_args(args),
                     result_ty: index_result_ty,
                 },
             };
@@ -411,7 +415,7 @@ fn rewire_one_slice_index_site(
                     target: CallTarget::FunctionPath {
                         segments: vec!["__getslice_rangefrom".to_string()],
                     },
-                    args: vec![slice, start.clone()],
+                    args: crate::model::call_args(vec![slice, start.clone()]),
                     result_ty: index_result_ty,
                 },
             };
@@ -826,7 +830,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: repeat_args,
+                    args: crate::model::call_args(repeat_args),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -888,7 +892,7 @@ mod tests {
                 site_block,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![receiver, range.clone()],
+                    args: crate::model::call_args(vec![receiver, range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -957,7 +961,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice, range.clone()],
+                    args: crate::model::call_args(vec![slice, range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -988,7 +992,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill.clone(), count.clone()],
+                    args: crate::model::call_args(vec![fill.clone(), count.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1001,7 +1005,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill.clone(), count.clone()],
+                    args: crate::model::call_args(vec![fill.clone(), count.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1051,7 +1055,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["vec".into(), "Vec".into(), "push".into()],
                     },
-                    args: vec![site_args[0].clone(), fill],
+                    args: crate::model::call_args(vec![site_args[0].clone(), fill]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -1088,7 +1092,7 @@ mod tests {
                 site_block,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![site_args[0].clone(), range.clone()],
+                    args: crate::model::call_args(vec![site_args[0].clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1130,7 +1134,7 @@ mod tests {
         else {
             unreachable!()
         };
-        let expected_args = vec![args[0].clone(), site.end.clone()];
+        let expected_args = vec![args[0].clone(), site.end.clone().into()];
         assert_eq!(rewire_slice_index_rangeto_sites(g, &[site]), 1);
         assert!(!has_residual_slice_index(g));
         let rewritten = g
@@ -1163,7 +1167,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: vec!["vec".into(), "Vec".into(), "push".into()],
             },
-            args: vec![base.clone()],
+            args: crate::model::call_args(vec![base.clone()]),
             result_ty: ValueType::Void,
         }
     }
@@ -1228,7 +1232,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["util".into(), "get".into()],
                     },
-                    args: vec![receiver.clone(), receiver],
+                    args: crate::model::call_args(vec![receiver.clone(), receiver]),
                     result_ty: ValueType::Unsigned,
                 },
             },
@@ -1303,7 +1307,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill.clone(), count.clone()],
+                    args: crate::model::call_args(vec![fill.clone(), count.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1316,7 +1320,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill, count],
+                    args: crate::model::call_args(vec![fill, count]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1378,7 +1382,7 @@ mod tests {
                 site,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![site_args[0].clone(), range.clone()],
+                    args: crate::model::call_args(vec![site_args[0].clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1484,7 +1488,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill, count],
+                    args: crate::model::call_args(vec![fill, count]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1531,7 +1535,7 @@ mod tests {
                 site,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![receiver, range.clone()],
+                    args: crate::model::call_args(vec![receiver, range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1667,7 +1671,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["some".into(), "opaque".into(), "mutator".into()],
                     },
-                    args: vec![owner],
+                    args: crate::model::call_args(vec![owner]),
                     result_ty: ValueType::Void,
                 },
             },
@@ -1892,7 +1896,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice.clone(), range.clone()],
+                    args: crate::model::call_args(vec![slice.clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -2073,7 +2077,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice, range.clone()],
+                    args: crate::model::call_args(vec![slice, range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -2179,7 +2183,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice.clone(), range.clone()],
+                    args: crate::model::call_args(vec![slice.clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -2245,7 +2249,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice, range.clone()],
+                    args: crate::model::call_args(vec![slice, range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -2334,7 +2338,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice.clone(), range.clone()],
+                    args: crate::model::call_args(vec![slice.clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -2396,7 +2400,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: slice_index_call_target(),
-                    args: vec![slice.clone(), range.clone()],
+                    args: crate::model::call_args(vec![slice.clone(), range.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/front/str_find.rs
+++ b/majit/majit-translate/src/front/str_find.rs
@@ -38,7 +38,7 @@ pub(crate) fn emit_rpython_str_find_char(
         result: Some(result.clone()),
         kind: OpKind::Call {
             target: CallTarget::method("find", None),
-            args: args.to_vec(),
+            args: crate::model::call_args(args.iter().cloned()),
             result_ty: ValueType::Int,
         },
     });

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -311,7 +311,10 @@ fn inline_call_site(graph: &mut FunctionGraph, site: InlineSite) {
     // inputargs.
     let inputarg_count = callee_entry_block.inputargs.len();
     let entry_arg_vars: Vec<crate::flowspace::model::Variable> =
-        call_args.iter().take(inputarg_count).cloned().collect();
+        crate::model::call_arg_vars(&call_args)
+            .into_iter()
+            .take(inputarg_count)
+            .collect();
     graph.set_goto(block_id, callee_entry, entry_arg_vars);
 }
 
@@ -597,7 +600,10 @@ pub(crate) fn remap_op_kind(
             result_ty,
         } => OpKind::Call {
             target: target.clone(),
-            args: args.iter().map(&remap_var).collect(),
+            args: args
+                .iter()
+                .map(|arg| arg.map_value(|var| remap_var(var)))
+                .collect(),
             result_ty: result_ty.clone(),
         },
         OpKind::GuardTrue { cond } => OpKind::GuardTrue {
@@ -1041,7 +1047,10 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         OpKind::InteriorFieldWrite {
             base, index, value, ..
         } => vec![clone_var(base), clone_var(index), clone_var(value)],
-        OpKind::Call { args, .. } => args.iter().map(&clone_var).collect(),
+        OpKind::Call { args, .. } => args
+            .iter()
+            .filter_map(|arg| arg.as_variable().map(&clone_var))
+            .collect(),
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![clone_var(cond)],
         OpKind::GuardValue { value, .. } => vec![clone_var(value)],
         OpKind::AssertGreen { value, .. }
@@ -1732,7 +1741,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: CallTarget::function_path(["callee"]),
-                args: vec![base_var],
+                args: crate::model::call_args(vec![base_var]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -1776,7 +1785,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: CallTarget::function_path(["unknown_fn"]),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -1819,7 +1828,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: CallTarget::function_path(["callee"]),
-                args: vec![base_var],
+                args: crate::model::call_args(vec![base_var]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -1844,7 +1853,7 @@ mod tests {
             centry,
             OpKind::Call {
                 target: CallTarget::function_path(["outer"]),
-                args: vec![x_var],
+                args: crate::model::call_args(vec![x_var]),
                 result_ty: ValueType::Ref(None),
             },
             true,
@@ -1899,7 +1908,7 @@ mod tests {
             entry,
             OpKind::Call {
                 target: CallTarget::function_path(["callee"]),
-                args: vec![base_var],
+                args: crate::model::call_args(vec![base_var]),
                 result_ty: ValueType::Ref(None),
             },
             true,

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -274,7 +274,7 @@ fn inline_call_site(graph: &mut FunctionGraph, site: InlineSite) {
     // Map call args to callee input values
     for (i, callee_input_var) in input_vars.iter().enumerate() {
         let remapped_input_var = value_map[callee_input_var].clone();
-        if let Some(call_arg_var) = call_args.get(i) {
+        if let Some(crate::model::LinkArg::Value(call_arg_var)) = call_args.get(i) {
             // Add alias: remapped callee input = call argument
             // We do this by prepending a "move" in the callee entry block
             // Actually, we set the entry block's inputargs and jump with call args
@@ -310,12 +310,12 @@ fn inline_call_site(graph: &mut FunctionGraph, site: InlineSite) {
     // behaviour is preserved bit-for-bit when the callee has no
     // inputargs.
     let inputarg_count = callee_entry_block.inputargs.len();
-    let entry_arg_vars: Vec<crate::flowspace::model::Variable> =
-        crate::model::call_arg_vars(&call_args)
-            .into_iter()
-            .take(inputarg_count)
-            .collect();
-    graph.set_goto(block_id, callee_entry, entry_arg_vars);
+    // RPython `get_new_name` keeps Constants on the entry Link
+    // (`backendopt/inline.py`).  `call_arg_vars` would drop them and
+    // shift later arguments.
+    let entry_args: Vec<crate::model::LinkArg> =
+        call_args.into_iter().take(inputarg_count).collect();
+    graph.set_goto_mixed(block_id, callee_entry, entry_args);
 }
 
 /// Allocate fresh caller-graph Variables for every callee-graph
@@ -1775,6 +1775,50 @@ mod tests {
             .flat_map(|b| &b.operations)
             .any(|op| matches!(&op.kind, OpKind::Call { .. }));
         assert!(!has_call, "Call op should be replaced by inlined body");
+    }
+
+    #[test]
+    fn inline_keeps_constant_call_args_on_the_entry_link() {
+        use crate::flowspace::model::{ConstValue, Variable};
+        use crate::model::LinkArg;
+
+        let mut callee = FunctionGraph::new("const_callee");
+        let param = Variable::new();
+        callee.blocks[callee.startblock.0].inputargs = vec![param.clone()];
+        callee.set_return(callee.startblock, Some(param));
+
+        let mut caller = FunctionGraph::new("caller");
+        let entry = caller.startblock;
+        let result = caller
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::function_path(["const_callee"]),
+                    args: vec![LinkArg::from(ConstValue::Int(7))],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        caller.set_return(entry, Some(result));
+
+        let mut cc = CallControl::new();
+        cc.register_function_graph(CallPath::from_segments(["const_callee"]), callee);
+        cc.find_all_graphs_for_tests();
+        assert_eq!(inline_graph(&mut caller, &cc, 1), 1);
+
+        let entry_link = caller.blocks[caller.startblock.0]
+            .exits
+            .first()
+            .expect("caller jumps to inlined entry");
+        assert_eq!(entry_link.args.len(), 1);
+        assert!(
+            matches!(
+                &entry_link.args[0],
+                LinkArg::Const(c) if c.value == ConstValue::Int(7)
+            ),
+            "constant positional arg must stay on the entry Link"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2489,7 +2489,7 @@ fn register_configured_jitdrivers(
                         .iter()
                         .skip(1)
                         .take(spec.greens.len())
-                        .cloned()
+                        .filter_map(|a| a.as_variable().cloned())
                         .collect::<Vec<_>>(),
                     _ => panic!("jit_merge_point must be a call"),
                 };
@@ -2501,7 +2501,9 @@ fn register_configured_jitdrivers(
                 // support.py autodetect_jit_markers_redvars: `op.args.extend(reds_v)`
                 // so `decode_hp_hint_args` can split greens/reds off the marker.
                 match &mut portal.block_mut(marker_block).operations[marker_index].kind {
-                    crate::model::OpKind::Call { args, .. } => args.extend(reds.iter().cloned()),
+                    crate::model::OpKind::Call { args, .. } => {
+                        args.extend(reds.iter().cloned().map(crate::model::LinkArg::from));
+                    }
                     _ => panic!("jit_merge_point must be a call"),
                 }
                 reds.len()
@@ -2924,7 +2926,7 @@ mod portal_driver_tests {
                 result: None,
                 kind: OpKind::Call {
                     target: CallTarget::method("jit_merge_point", Some("PyPyJitDriver".into())),
-                    args: vec![receiver],
+                    args: crate::model::call_args(vec![receiver]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -2992,14 +2994,14 @@ mod portal_driver_tests {
                 result: None,
                 kind: OpKind::Call {
                     target: CallTarget::method("jit_merge_point", Some("PyPyJitDriver".into())),
-                    args: vec![
+                    args: crate::model::call_args(vec![
                         frame.clone(),
                         next_instr,
                         is_being_profiled,
                         pycode,
                         frame.clone(),
                         ec.clone(),
-                    ],
+                    ]),
                     result_ty: ValueType::Void,
                 },
             });
@@ -3121,7 +3123,7 @@ mod portal_driver_tests {
                         "jit_merge_point",
                         Some("UnpackIterableJitDriver".into()),
                     ),
-                    args: vec![receiver, green.clone()],
+                    args: crate::model::call_args(vec![receiver, green.clone()]),
                     result_ty: ValueType::Void,
                 },
             });

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2641,20 +2641,6 @@ fn make_jitcodes(
         .indirectcalltargets
         .extend(builtin_wrapper_targets);
 
-    // Raw OBJECT_VTABLE-shaped structs publish every Charon-known field
-    // through fielddescrof. AtomicPtr/AtomicI64 are layout-transparent
-    // leaves, so `instantiate` names the same bytes `offset_of!` does
-    // even when the source reader stays an Acquire residual.
-    for descriptor in &pipeline_config.transform.struct_storage {
-        if descriptor.is_gc_managed {
-            continue;
-        }
-        let owner = majit_ir::descr::canonical_struct_name(&descriptor.owner);
-        codewriter
-            .assembler
-            .publish_raw_struct_fields(call_control, &owner);
-    }
-
     // RPython codewriter.py:85: self.assembler.finished(callinfocollection).
     codewriter
         .assembler

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -8739,11 +8739,7 @@ mod tests {
         graph.set_goto(right, join, vec![right_args[0].clone()]);
         let raw = graph.push_op_var(join, OpKind::ConstRefNull, true).unwrap();
         let destination = graph
-            .push_op_var(
-                join,
-                crate::model::cast_instance_call("Payload", raw),
-                true,
-            )
+            .push_op_var(join, crate::model::cast_instance_call("Payload", raw), true)
             .unwrap();
         graph.push_op_var(
             join,
@@ -11267,7 +11263,9 @@ mod tests {
             "the cross-block dead header ctor must be swept: {kinds:#?}"
         );
         assert!(
-            !kinds.iter().any(|k| cast_instance_root(k) == Some("PyType")),
+            !kinds
+                .iter()
+                .any(|k| cast_instance_root(k) == Some("PyType")),
             "the dead PyType cast threaded across the block boundary must be swept"
         );
         assert!(
@@ -11277,7 +11275,9 @@ mod tests {
             "the live NewWithVtable must survive"
         );
         assert!(
-            kinds.iter().any(|k| cast_instance_root(k) == Some("PyObject")),
+            kinds
+                .iter()
+                .any(|k| cast_instance_root(k) == Some("PyObject")),
             "the live return cast must survive"
         );
         assert!(

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1869,6 +1869,66 @@ pub fn call_arg_vars(args: &[LinkArg]) -> Vec<crate::flowspace::model::Variable>
         .collect()
 }
 
+/// `simple_call(__cast_instance_intrinsic, operand, const(root))`.
+///
+/// The root is a trailing `ByteStr` Constant —
+/// `annotator/builtin.rs cast_instance_intrinsic` reads `args[1]`.
+pub fn cast_instance_call(
+    root: impl Into<String>,
+    operand: crate::flowspace::model::Variable,
+) -> OpKind {
+    let root = root.into();
+    cast_instance_call_result(root.clone(), operand, ValueType::Ref(Some(root)))
+}
+
+/// Same as [`cast_instance_call`] with an explicit result type.
+/// Niche-null string payloads use `ValueType::Str` rather than `Ref`.
+pub fn cast_instance_call_result(
+    root: impl Into<String>,
+    operand: crate::flowspace::model::Variable,
+    result_ty: ValueType,
+) -> OpKind {
+    OpKind::Call {
+        target: CallTarget::function_path([crate::runtime_names::shims::CAST_INSTANCE]),
+        args: vec![
+            LinkArg::from(operand),
+            LinkArg::from(ConstValue::byte_str(root.into())),
+        ],
+        result_ty,
+    }
+}
+
+/// The target-struct root of a [`cast_instance_call`], if `kind` is one.
+pub fn cast_instance_root(kind: &OpKind) -> Option<&str> {
+    let OpKind::Call {
+        target: CallTarget::FunctionPath { segments },
+        args,
+        ..
+    } = kind
+    else {
+        return None;
+    };
+    if segments.as_slice() != [crate::runtime_names::shims::CAST_INSTANCE] {
+        return None;
+    }
+    match args.get(1) {
+        Some(LinkArg::Const(c)) => c.value.as_pystr(),
+        _ => None,
+    }
+}
+
+/// [`cast_instance_root`] when `args[0]` is `operand`.
+pub fn cast_instance_of<'a>(
+    kind: &'a OpKind,
+    operand: &crate::flowspace::model::Variable,
+) -> Option<&'a str> {
+    let root = cast_instance_root(kind)?;
+    let OpKind::Call { args, .. } = kind else {
+        return None;
+    };
+    (args.first().and_then(LinkArg::as_variable) == Some(operand)).then_some(root)
+}
+
 /// A basic block in the control flow graph.
 ///
 /// RPython equivalent: `flowspace/model.py Block` — slots
@@ -3476,22 +3536,8 @@ pub fn lower_struct_ptr_writes(
                 continue;
             };
             let destination_owner = block.operations[..oi].iter().find_map(|candidate| {
-                match (&candidate.result, &candidate.kind) {
-                    (
-                        Some(result),
-                        OpKind::Call {
-                            target: CallTarget::FunctionPath { segments },
-                            args,
-                            ..
-                        },
-                    ) if result == destination
-                        && args.len() == 1
-                        && segments.first().map(String::as_str)
-                            == Some("__cast_instance_intrinsic")
-                        && segments.len() == 2 =>
-                    {
-                        Some(segments[1].as_str())
-                    }
+                match candidate.result.as_ref() {
+                    Some(result) if result == destination => cast_instance_root(&candidate.kind),
                     _ => None,
                 }
             });
@@ -4024,9 +4070,9 @@ pub fn fuse_boxing_alloc(
         } = &producer.kind
             && segments.first().map(String::as_str)
                 == Some(crate::runtime_names::shims::CAST_INSTANCE)
-            && args.len() == 1
+            && let Some(operand) = args.first().and_then(LinkArg::as_variable)
         {
-            return resolve_addr(graph, &args[0], depth - 1, terminal);
+            return resolve_addr(graph, operand, depth - 1, terminal);
         }
         terminal(graph, &producer.kind, depth)
     }
@@ -4900,13 +4946,13 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) -> usize {
             args,
             ..
         } => {
-            // `__cast_instance_intrinsic[<root>]` — the front-end pointer-downcast
-            // narrow (`front::mir`), always a single-operand reinterpret.
+            // `__cast_instance_intrinsic` — the front-end pointer-downcast
+            // narrow (`cast_instance_call`: operand + const(root)).
             // Pin the arity so an unrelated multi-arg path that happens to
             // share the synthetic marker leaf is never swept as a cast.
             let is_cast = segments.first().map(String::as_str)
                 == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                && args.len() == 1;
+                && args.len() == 2;
             // The same single-argument runtime helper recognized by
             // `get_instantiate_arg_addr`; its result feeds only the class word
             // removed with the dead header. Restrict the owner so an unrelated
@@ -8567,13 +8613,7 @@ mod tests {
         let destination = graph
             .push_op_var(
                 write_block,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
-                    },
-                    args: crate::model::call_args(vec![raw]),
-                    result_ty: ValueType::Ref(Some("Payload".into())),
-                },
+                crate::model::cast_instance_call("Payload", raw),
                 true,
             )
             .unwrap();
@@ -8664,13 +8704,7 @@ mod tests {
         let destination = graph
             .push_op_var(
                 join,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
-                    },
-                    args: crate::model::call_args(vec![raw]),
-                    result_ty: ValueType::Ref(Some("Payload".into())),
-                },
+                crate::model::cast_instance_call("Payload", raw),
                 true,
             )
             .unwrap();
@@ -9487,12 +9521,9 @@ mod tests {
             let ty = graph
                 .push_op_var(entry, OpKind::ConstRefAddr(FLOAT_TYPE_ADDR), true)
                 .unwrap();
-            call(
-                graph,
-                entry,
-                &[crate::runtime_names::shims::CAST_INSTANCE, "PyType"],
-                vec![ty],
-            )
+            graph
+                .push_op_var(entry, cast_instance_call("PyType", ty), true)
+                .unwrap()
         };
         let ob_type = cast(&mut graph);
         let w_class_cast = cast(&mut graph);
@@ -9759,12 +9790,9 @@ mod tests {
                 let ty = graph
                     .push_op_var(entry, OpKind::ConstRefAddr(addr), true)
                     .unwrap();
-                call(
-                    graph,
-                    entry,
-                    &[crate::runtime_names::shims::CAST_INSTANCE, "PyType"],
-                    vec![ty],
-                )
+                graph
+                    .push_op_var(entry, cast_instance_call("PyType", ty), true)
+                    .unwrap()
             };
             let ob_type = cast(&mut graph, FLOAT_TYPE_ADDR);
             let w_class_cast = cast(&mut graph, FLOAT_TYPE_ADDR);
@@ -9882,12 +9910,9 @@ mod tests {
             let other = graph
                 .push_op_var(blk, OpKind::ConstRefAddr(OTHER_TYPE_ADDR), true)
                 .unwrap();
-            let cast = call(
-                graph,
-                blk,
-                &[crate::runtime_names::shims::CAST_INSTANCE, "PyType"],
-                vec![other],
-            );
+            let cast = graph
+                .push_op_var(blk, cast_instance_call("PyType", other), true)
+                .unwrap();
             graph.push_op_var(blk, field(header, "ob_type", "PyObject", &cast), false);
         };
 
@@ -10019,12 +10044,9 @@ mod tests {
                 let ty = graph
                     .push_op_var(blk, OpKind::ConstRefAddr(addr), true)
                     .unwrap();
-                call(
-                    graph,
-                    blk,
-                    &[crate::runtime_names::shims::CAST_INSTANCE, "PyType"],
-                    vec![ty],
-                )
+                graph
+                    .push_op_var(blk, cast_instance_call("PyType", ty), true)
+                    .unwrap()
             };
             let ob_type = cast(graph);
             let w_class_cast = cast(graph);
@@ -10176,13 +10198,7 @@ mod tests {
         // constants; the dual-gate seeds them from the constant table, so they
         // do not diverge.)
         type Var = crate::flowspace::model::Variable;
-        let cast_instance = |to: &str, arg: &Var| OpKind::Call {
-            target: CallTarget::FunctionPath {
-                segments: vec![crate::runtime_names::shims::CAST_INSTANCE.into(), to.into()],
-            },
-            args: crate::model::call_args(vec![arg.clone()]),
-            result_ty: ValueType::Ref(Some(to.into())),
-        };
+        let cast_instance = |to: &str, arg: &Var| crate::model::cast_instance_call(to, arg.clone());
         let field = |base: &Var, name: &str, owner: &str, value: &Var| OpKind::FieldWrite {
             base: base.clone(),
             field: FieldDescriptor {
@@ -10320,12 +10336,8 @@ mod tests {
             ops.iter().map(|o| &o.kind).collect::<Vec<_>>()
         );
         assert!(
-            !ops.iter().any(|op| matches!(
-                &op.kind,
-                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                        && segments.get(1).map(String::as_str) == Some("PyType")
-            )),
+            !ops.iter()
+                .any(|op| cast_instance_root(&op.kind) == Some("PyType")),
             "the dead ob_type/w_class header casts must be swept"
         );
         assert!(
@@ -10349,12 +10361,8 @@ mod tests {
             "NewWithVtable must survive carrying the captured type pointer"
         );
         assert!(
-            ops.iter().any(|op| matches!(
-                &op.kind,
-                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                        && segments.get(1).map(String::as_str) == Some("PyObject")
-            )),
+            ops.iter()
+                .any(|op| cast_instance_root(&op.kind) == Some("PyObject")),
             "the live return cast must survive"
         );
         let _ = ret;
@@ -11038,16 +11046,7 @@ mod tests {
         let p = graph
             .push_op_var(
                 entry,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "W_FloatObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![obj.clone()]),
-                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
-                },
+                crate::model::cast_instance_call("W_FloatObject", obj.clone()),
                 true,
             )
             .unwrap();
@@ -11100,16 +11099,7 @@ mod tests {
         // target inputarg is itself unread, then `prune_dead_phis` reclaims
         // the dangling inputarg / link arg / address constant.
         type Var = crate::flowspace::model::Variable;
-        let cast_pytype = |arg: &Var| OpKind::Call {
-            target: CallTarget::FunctionPath {
-                segments: vec![
-                    crate::runtime_names::shims::CAST_INSTANCE.into(),
-                    "PyType".into(),
-                ],
-            },
-            args: crate::model::call_args(vec![arg.clone()]),
-            result_ty: ValueType::Ref(Some("PyType".into())),
-        };
+        let cast_pytype = |arg: &Var| crate::model::cast_instance_call("PyType", arg.clone());
         let field = |base: &Var, name: &str, value: &Var| OpKind::FieldWrite {
             base: base.clone(),
             field: FieldDescriptor {
@@ -11214,16 +11204,7 @@ mod tests {
         let ret = graph
             .push_op_var(
                 blk,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            crate::runtime_names::shims::CAST_INSTANCE.into(),
-                            "PyObject".into(),
-                        ],
-                    },
-                    args: crate::model::call_args(vec![boxed.clone()]),
-                    result_ty: ValueType::Ref(Some("PyObject".into())),
-                },
+                crate::model::cast_instance_call("PyObject", boxed.clone()),
                 true,
             )
             .unwrap();
@@ -11249,12 +11230,7 @@ mod tests {
             "the cross-block dead header ctor must be swept: {kinds:#?}"
         );
         assert!(
-            !kinds.iter().any(|k| matches!(
-                k,
-                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some(crate::runtime_names::shims::CAST_INSTANCE)
-                        && segments.get(1).map(String::as_str) == Some("PyType")
-            )),
+            !kinds.iter().any(|k| cast_instance_root(k) == Some("PyType")),
             "the dead PyType cast threaded across the block boundary must be swept"
         );
         assert!(
@@ -11264,11 +11240,7 @@ mod tests {
             "the live NewWithVtable must survive"
         );
         assert!(
-            kinds.iter().any(|k| matches!(
-                k,
-                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.get(1).map(String::as_str) == Some("PyObject")
-            )),
+            kinds.iter().any(|k| cast_instance_root(k) == Some("PyObject")),
             "the live return cast must survive"
         );
         assert!(

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1917,6 +1917,43 @@ pub fn cast_instance_root(kind: &OpKind) -> Option<&str> {
     }
 }
 
+/// `cast_pointer(PTRTYPE, ptr)` marker (`lltype.py cast_pointer`).
+/// The target class is a trailing `ByteStr` Constant; the adapter
+/// interns it through the bookkeeper.
+pub fn cast_pointer_call(
+    root: impl Into<String>,
+    operand: crate::flowspace::model::Variable,
+) -> OpKind {
+    let root = root.into();
+    OpKind::Call {
+        target: CallTarget::function_path(["__cast_pointer"]),
+        args: vec![
+            LinkArg::from(operand),
+            LinkArg::from(ConstValue::byte_str(&root)),
+        ],
+        result_ty: ValueType::Ref(Some(root)),
+    }
+}
+
+/// The target-struct root of a [`cast_pointer_call`], if `kind` is one.
+pub fn cast_pointer_root(kind: &OpKind) -> Option<&str> {
+    let OpKind::Call {
+        target: CallTarget::FunctionPath { segments },
+        args,
+        ..
+    } = kind
+    else {
+        return None;
+    };
+    if segments.as_slice() != ["__cast_pointer"] {
+        return None;
+    }
+    match args.get(1) {
+        Some(LinkArg::Const(c)) => c.value.as_pystr(),
+        _ => None,
+    }
+}
+
 /// [`cast_instance_root`] when `args[0]` is `operand`.
 pub fn cast_instance_of<'a>(
     kind: &'a OpKind,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1071,7 +1071,9 @@ pub enum OpKind {
     },
     Call {
         target: CallTarget,
-        args: Vec<crate::flowspace::model::Variable>,
+        /// Mixed Variable | Constant, matching
+        /// `flowspace/model.py SpaceOperation.args`.
+        args: Vec<LinkArg>,
         result_ty: ValueType,
     },
     GuardTrue {
@@ -1776,6 +1778,22 @@ impl LinkArg {
         }
     }
 
+    /// The Variable arm. Constants panic — call sites that have not
+    /// yet grown a Constant case use this while `Call.args` migrates
+    /// to the mixed `SpaceOperation.args` shape.
+    pub fn expect_variable(&self) -> &crate::flowspace::model::Variable {
+        self.as_variable()
+            .expect("Call.args entry is a Constant; handle LinkArg::Const")
+    }
+
+    /// Owned Variable arm.
+    pub fn into_variable(self) -> crate::flowspace::model::Variable {
+        match self {
+            Self::Value(var) => var,
+            Self::Const(_) => panic!("Call.args entry is a Constant; handle LinkArg::Const"),
+        }
+    }
+
     /// Remap the backing `Variable` of a `LinkArg::Value` through
     /// `remap`, leaving a `LinkArg::Const` literal untouched.  Mirrors
     /// the `remap_link_arg` closure in
@@ -1806,6 +1824,49 @@ impl From<crate::flowspace::model::Constant> for LinkArg {
     fn from(c: crate::flowspace::model::Constant) -> Self {
         Self::Const(c)
     }
+}
+
+impl std::ops::Deref for LinkArg {
+    type Target = crate::flowspace::model::Variable;
+    fn deref(&self) -> &Self::Target {
+        self.expect_variable()
+    }
+}
+
+impl PartialEq<crate::flowspace::model::Variable> for LinkArg {
+    fn eq(&self, other: &crate::flowspace::model::Variable) -> bool {
+        self.as_variable() == Some(other)
+    }
+}
+
+impl PartialEq<LinkArg> for crate::flowspace::model::Variable {
+    fn eq(&self, other: &LinkArg) -> bool {
+        other == self
+    }
+}
+
+impl From<crate::flowspace::model::Variable> for LinkArg {
+    /// RPython `SpaceOperation.args` is a mixed list of Variable /
+    /// Constant (`flowspace/model.py SpaceOperation.__init__`).
+    fn from(v: crate::flowspace::model::Variable) -> Self {
+        Self::Value(v)
+    }
+}
+
+/// Collect call operands into the mixed `SpaceOperation.args` shape.
+pub fn call_args(
+    vars: impl IntoIterator<Item = crate::flowspace::model::Variable>,
+) -> Vec<LinkArg> {
+    vars.into_iter().map(LinkArg::from).collect()
+}
+
+/// Project Variable operands out of mixed call args.
+/// Constants are skipped — RPython `isinstance(a, Variable)` filter.
+pub fn call_arg_vars(args: &[LinkArg]) -> Vec<crate::flowspace::model::Variable> {
+    args.iter()
+        .filter_map(LinkArg::as_variable)
+        .cloned()
+        .collect()
 }
 
 /// A basic block in the control flow graph.
@@ -3538,7 +3599,7 @@ pub fn lower_struct_ptr_writes(
             rewrites.push(Rewrite {
                 block: bi,
                 op: oi,
-                destination: destination.clone(),
+                destination: destination.clone().into_variable(),
                 stores: ordered_stores,
                 result: op.result.clone(),
             });
@@ -4648,7 +4709,7 @@ fn sink_fused_boxing_aggregates_at_raw_writes(
 
         let block = &mut graph.blocks[bi];
         if let OpKind::Call { args, .. } = &mut block.operations[oi].kind {
-            args[1] = remap(&aggregate);
+            args[1] = remap(&aggregate).into();
         }
         moved += cloned.len();
         block.operations.splice(oi..oi, cloned);
@@ -6574,7 +6635,7 @@ impl FunctionGraph {
             result: Some(res.clone()),
             kind: OpKind::Call {
                 target: CallTarget::function_path(["core", "ptr", "null_mut"]),
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         });
@@ -8366,7 +8427,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Tuple".into())),
                 },
                 true,
@@ -8424,7 +8485,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Tuple"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Tuple".into())),
                 },
                 true,
@@ -8476,7 +8537,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Payload"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Payload".into())),
                 },
                 true,
@@ -8510,7 +8571,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
                     },
-                    args: vec![raw],
+                    args: crate::model::call_args(vec![raw]),
                     result_ty: ValueType::Ref(Some("Payload".into())),
                 },
                 true,
@@ -8522,7 +8583,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec!["core".into(), "ptr".into(), "write".into()],
                 },
-                args: vec![destination, carried[0].clone()],
+                args: crate::model::call_args(vec![destination, carried[0].clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -8556,7 +8617,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Payload"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Payload".into())),
                 },
                 true,
@@ -8607,7 +8668,7 @@ mod tests {
                     target: CallTarget::FunctionPath {
                         segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
                     },
-                    args: vec![raw],
+                    args: crate::model::call_args(vec![raw]),
                     result_ty: ValueType::Ref(Some("Payload".into())),
                 },
                 true,
@@ -8619,7 +8680,7 @@ mod tests {
                 target: CallTarget::FunctionPath {
                     segments: vec!["core".into(), "ptr".into(), "write".into()],
                 },
-                args: vec![destination, joined[0].clone()],
+                args: crate::model::call_args(vec![destination, joined[0].clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -8776,7 +8837,7 @@ mod tests {
                             "get_instantiate".into(),
                         ],
                     },
-                    args: vec![instantiate_arg],
+                    args: crate::model::call_args(vec![instantiate_arg]),
                     result_ty: ValueType::Ref(Some("object".into())),
                 },
                 true,
@@ -8787,7 +8848,7 @@ mod tests {
                 blk,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("PyObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -8828,7 +8889,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("W_FloatObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                 },
                 true,
@@ -8877,7 +8938,7 @@ mod tests {
                             "malloc_typed".into(),
                         ],
                     },
-                    args: vec![agg.clone()],
+                    args: crate::model::call_args(vec![agg.clone()]),
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                 },
                 true,
@@ -9007,7 +9068,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("W_ComplexObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("W_ComplexObject".into())),
                 },
                 true,
@@ -9058,7 +9119,7 @@ mod tests {
                             "malloc_typed".into(),
                         ],
                     },
-                    args: vec![agg.clone()],
+                    args: crate::model::call_args(vec![agg.clone()]),
                     result_ty: ValueType::Ref(Some("W_ComplexObject".into())),
                 },
                 true,
@@ -9108,7 +9169,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("SomeOtherStruct"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("SomeOtherStruct".into())),
                 },
                 true,
@@ -9125,7 +9186,7 @@ mod tests {
                             "malloc_typed".into(),
                         ],
                     },
-                    args: vec![agg.clone()],
+                    args: crate::model::call_args(vec![agg.clone()]),
                     result_ty: ValueType::Ref(Some("SomeOtherStruct".into())),
                 },
                 true,
@@ -9170,7 +9231,7 @@ mod tests {
                         target: CallTarget::FunctionPath {
                             segments: path.iter().map(|s| (*s).to_string()).collect(),
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Ref(Some("object".into())),
                     },
                     true,
@@ -9217,7 +9278,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("PyObject"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("PyObject".into())),
                     },
                     true,
@@ -9238,7 +9299,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("W_FloatObject"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                     },
                     true,
@@ -9383,7 +9444,7 @@ mod tests {
                         target: CallTarget::FunctionPath {
                             segments: path.iter().map(|s| (*s).to_string()).collect(),
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Ref(Some("object".into())),
                     },
                     true,
@@ -9410,7 +9471,7 @@ mod tests {
                     blk,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor(name),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some(name.into())),
                     },
                     true,
@@ -9513,7 +9574,7 @@ mod tests {
                         .map(|s| s.to_string())
                         .collect(),
                 },
-                args: vec![gc_args[1].clone(), gc_args[0].clone()],
+                args: crate::model::call_args(vec![gc_args[1].clone(), gc_args[0].clone()]),
                 result_ty: ValueType::Void,
             },
             false,
@@ -9576,7 +9637,7 @@ mod tests {
                     .map(String::as_str)
                     .eq(["core", "ptr", "write"]) =>
                 {
-                    Some(args[1].clone())
+                    Some(args[1].clone().into_variable())
                 }
                 _ => None,
             })
@@ -9652,7 +9713,7 @@ mod tests {
                         target: CallTarget::FunctionPath {
                             segments: path.iter().map(|s| (*s).to_string()).collect(),
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Ref(Some("object".into())),
                     },
                     true,
@@ -9679,7 +9740,7 @@ mod tests {
                     blk,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor(name),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some(name.into())),
                     },
                     true,
@@ -9918,7 +9979,7 @@ mod tests {
                         target: CallTarget::FunctionPath {
                             segments: path.iter().map(|s| (*s).to_string()).collect(),
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Ref(Some("object".into())),
                     },
                     true,
@@ -9945,7 +10006,7 @@ mod tests {
                     blk,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor(name),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some(name.into())),
                     },
                     true,
@@ -10119,7 +10180,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: vec![crate::runtime_names::shims::CAST_INSTANCE.into(), to.into()],
             },
-            args: vec![arg.clone()],
+            args: crate::model::call_args(vec![arg.clone()]),
             result_ty: ValueType::Ref(Some(to.into())),
         };
         let field = |base: &Var, name: &str, owner: &str, value: &Var| OpKind::FieldWrite {
@@ -10165,7 +10226,7 @@ mod tests {
                             "get_instantiate".into(),
                         ],
                     },
-                    args: vec![w_class_cast],
+                    args: crate::model::call_args(vec![w_class_cast]),
                     result_ty: ValueType::Ref(Some("object".into())),
                 },
                 true,
@@ -10177,7 +10238,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("PyObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -10199,7 +10260,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("W_FloatObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                 },
                 true,
@@ -10226,7 +10287,7 @@ mod tests {
                             "malloc_typed".into(),
                         ],
                     },
-                    args: vec![agg.clone()],
+                    args: crate::model::call_args(vec![agg.clone()]),
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                 },
                 true,
@@ -10322,7 +10383,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("W_SetObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("W_SetObject".into())),
                 },
                 true,
@@ -10377,7 +10438,7 @@ mod tests {
                             "malloc".into(),
                         ],
                     },
-                    args: vec![agg.clone()],
+                    args: crate::model::call_args(vec![agg.clone()]),
                     result_ty: ValueType::Ref(Some("W_SetObject".into())),
                 },
                 true,
@@ -10486,7 +10547,7 @@ mod tests {
                         target: CallTarget::FunctionPath {
                             segments: path.iter().map(|s| (*s).to_string()).collect(),
                         },
-                        args,
+                        args: crate::model::call_args(args),
                         result_ty: ValueType::Ref(Some("object".into())),
                     },
                     true,
@@ -10519,7 +10580,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor(header_owner),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some(header_owner.into())),
                     },
                     true,
@@ -10569,7 +10630,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("W_IntObject"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("W_IntObject".into())),
                     },
                     true,
@@ -10745,7 +10806,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("TypeOnlyHeader"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("TypeOnlyHeader".into())),
                     },
                     true,
@@ -10775,7 +10836,7 @@ mod tests {
                                         .map(|s| (*s).to_string())
                                         .collect(),
                                     },
-                                    args: vec![base],
+                                    args: crate::model::call_args(vec![base]),
                                     result_ty: ValueType::Ref(Some("object".into())),
                                 },
                                 true,
@@ -10796,7 +10857,7 @@ mod tests {
                     entry,
                     OpKind::Call {
                         target: CallTarget::synthetic_transparent_ctor("W_IntObject"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("W_IntObject".into())),
                     },
                     true,
@@ -10818,7 +10879,7 @@ mod tests {
                                 .map(|s| (*s).to_string())
                                 .collect(),
                         },
-                        args: vec![agg],
+                        args: crate::model::call_args(vec![agg]),
                         result_ty: ValueType::Ref(Some("W_IntObject".into())),
                     },
                     true,
@@ -10984,7 +11045,7 @@ mod tests {
                             "W_FloatObject".into(),
                         ],
                     },
-                    args: vec![obj.clone()],
+                    args: crate::model::call_args(vec![obj.clone()]),
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
                 },
                 true,
@@ -10997,7 +11058,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("PyObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -11046,7 +11107,7 @@ mod tests {
                     "PyType".into(),
                 ],
             },
-            args: vec![arg.clone()],
+            args: crate::model::call_args(vec![arg.clone()]),
             result_ty: ValueType::Ref(Some("PyType".into())),
         };
         let field = |base: &Var, name: &str, value: &Var| OpKind::FieldWrite {
@@ -11083,7 +11144,7 @@ mod tests {
                     "get_instantiate".into(),
                 ],
             },
-            args: vec![arg.clone()],
+            args: crate::model::call_args(vec![arg.clone()]),
             result_ty: ValueType::Ref(Some("object".into())),
         };
         let ty_addr1 = graph
@@ -11141,7 +11202,7 @@ mod tests {
                 blk,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("PyObject"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -11160,7 +11221,7 @@ mod tests {
                             "PyObject".into(),
                         ],
                     },
-                    args: vec![boxed.clone()],
+                    args: crate::model::call_args(vec![boxed.clone()]),
                     result_ty: ValueType::Ref(Some("PyObject".into())),
                 },
                 true,
@@ -11258,7 +11319,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: vec!["boxed".into(), "Box".into(), "new_uninit".into()],
             },
-            args: vec![],
+            args: crate::model::call_args(vec![]),
             result_ty: ValueType::Ref(Some("Box".into())),
         };
         let mut graph = FunctionGraph::new("test");
@@ -11275,7 +11336,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Array"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Array".into())),
                 },
                 true,
@@ -12045,7 +12106,7 @@ mod tests {
                 join,
                 OpKind::Call {
                     target: CallTarget::synthetic_transparent_ctor("Box"),
-                    args: vec![],
+                    args: crate::model::call_args(vec![]),
                     result_ty: ValueType::Ref(Some("Box".into())),
                 },
                 true,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -6992,6 +6992,25 @@ impl FunctionGraph {
         self.set_control_flow_metadata(block, None, vec![link]);
     }
 
+    /// Close `block` with a single Goto whose `Link.args` keep mixed
+    /// Variable|Constant operands — `flowspace/model.py Link`.
+    pub fn set_goto_mixed(&mut self, block: BlockId, target: BlockId, args: Vec<LinkArg>) {
+        let target_inputarg_count = self.block(target).inputargs.len();
+        assert_eq!(
+            args.len(),
+            target_inputarg_count,
+            "set_goto_mixed: args.len() ({}) != target.inputargs.len() ({}) — \
+             block {:?} → target {:?} on graph {:?}",
+            args.len(),
+            target_inputarg_count,
+            block,
+            target,
+            self.name,
+        );
+        let link = Link::new_mixed(args, target, None);
+        self.set_control_flow_metadata(block, None, vec![link]);
+    }
+
     /// Close `block` with a single-exit Link into `target_block` whose
     /// `args` are derived from `pred_state.getoutputargs(target_state,
     /// self)`.  Direct port of `flowcontext.py:438`:

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -1418,7 +1418,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::function_path(["scope_from_frame"]),
-                    args: vec![frame.clone()],
+                    args: crate::model::call_args(vec![frame.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,

--- a/majit/majit-translate/src/translator/rtyper/box_str_const_fold.rs
+++ b/majit/majit-translate/src/translator/rtyper/box_str_const_fold.rs
@@ -147,7 +147,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: vec!["__str_const".to_string(), payload.to_string()],
             },
-            args: vec![],
+            args: crate::model::call_args(vec![]),
             result_ty: ValueType::Ref(None),
         }
     }
@@ -157,7 +157,7 @@ mod tests {
             target: CallTarget::FunctionPath {
                 segments: BOX_STR_CONSTANT_PATH.map(str::to_string).to_vec(),
             },
-            args: vec![arg],
+            args: crate::model::call_args(vec![arg]),
             result_ty: ValueType::Ref(None),
         }
     }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -5692,7 +5692,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["side_effect".into()],
                     },
-                    args: vec![base.clone(), index.clone()],
+                    args: crate::model::call_args(vec![base.clone(), index.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
             }],
@@ -5968,7 +5968,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["consume".into()],
                     },
-                    args: vec![pay.clone()],
+                    args: crate::model::call_args(vec![pay.clone()]),
                     result_ty: ValueType::Int,
                 },
             }
@@ -6045,7 +6045,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["consume_carrier".into()],
                 },
-                args: vec![consumed_carrier.clone()],
+                args: crate::model::call_args(vec![consumed_carrier.clone()]),
                 result_ty: ValueType::Void,
             },
         });
@@ -6193,7 +6193,7 @@ mod tests {
                         target: crate::model::CallTarget::FunctionPath {
                             segments: vec!["consume".into()],
                         },
-                        args: vec![threaded.clone()],
+                        args: crate::model::call_args(vec![threaded.clone()]),
                         result_ty: ValueType::Int,
                     },
                 }]
@@ -6500,7 +6500,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![fill.clone(), count.clone()],
+                    args: crate::model::call_args(vec![fill.clone(), count.clone()]),
                     result_ty: ValueType::Int,
                 },
             }],
@@ -6748,7 +6748,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["foo".into()],
                     },
-                    args: vec![v1_var.clone(), v2_var.clone()],
+                    args: crate::model::call_args(vec![v1_var.clone(), v2_var.clone()]),
                     result_ty: ValueType::Unknown,
                 },
             }],
@@ -6795,7 +6795,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["__array_repeat".into()],
                     },
-                    args: vec![foo_v10_var.clone(), foo_v11_var.clone()],
+                    args: crate::model::call_args(vec![foo_v10_var.clone(), foo_v11_var.clone()]),
                     result_ty: ValueType::Ref(None),
                 },
             }],

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1932,6 +1932,16 @@ pub fn translate_op(
                     // that mixed list directly (`const(exc_class)` at
                     // args[0]).  The path names the op, not a second
                     // callable — do not wrap it again.
+                    if segments.as_slice() == ["type"] {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(
+                                "translate_op: FunctionPath [\"type\"] requires \
+                                 one operand (flowspace/operation.py Type)"
+                                    .to_string(),
+                            ));
+                        }
+                        return Ok(vec![FlowspaceOp::new("type", arg_hls, result)]);
+                    }
                     if segments.as_slice() == ["simple_call"] {
                         if arg_hls.is_empty() {
                             return Err(TyperError::message(
@@ -5770,6 +5780,30 @@ mod tests {
             host, &mymod_entry.host_object,
             "must not resolve to the colliding-leaf sibling"
         );
+    }
+
+    #[test]
+    fn translate_op_call_type_lowers_to_type_spaceop() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_fixture");
+        let vars = mint_vars(&mut graph, 4);
+        let operand = Variable::new();
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(operand.clone()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::function_path(["type"]),
+                args: crate::model::call_args(vec![vars[1].clone()]),
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("FunctionPath [type] must lower to the type op");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "type");
+        assert_eq!(translated[0].args.len(), 1);
+        assert!(matches!(&translated[0].args[0], Hlvalue::Variable(v) if *v == operand));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2144,17 +2144,20 @@ pub fn translate_op(
                             return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                         }
                     }
-                    // `__cast_pointer/<Root>` marker (`front::mir`
-                    // `cast_pointer_marker_op`) — pyre's carrier for the
+                    // `__cast_pointer` marker (`front::mir`
+                    // `cast_pointer_call`) — pyre's carrier for the
                     // upstream `cast_pointer(PTRTYPE, ptr)` downcast
-                    // (lltype.py).  Rebuild the 2-arg upstream shape
-                    // with the target class as the constant first
-                    // argument.  The class is interned by
-                    // qualname so every cast site shares one `HostObject`
-                    // Arc (`getdesc` dedups on Arc identity — fresh Arcs
-                    // would mint one ClassDesc per cast site).
-                    if segments.len() == 2 && segments[0] == "__cast_pointer" && arg_hls.len() == 1
-                    {
+                    // (lltype.py).  The root is a trailing ByteStr
+                    // Constant; intern it by qualname so every cast
+                    // site shares one `HostObject` Arc (`getdesc`
+                    // dedups on Arc identity).
+                    if segments.as_slice() == ["__cast_pointer"] {
+                        if arg_hls.len() != 2 {
+                            return Err(TyperError::message(format!(
+                                "__cast_pointer requires (operand, constant_root), got {}",
+                                arg_hls.len()
+                            )));
+                        }
                         let callable_host = HOST_ENV
                             .import_module("rpython.rtyper.lltypesystem.lltype")
                             .and_then(|m| m.module_get("cast_pointer"))
@@ -2163,17 +2166,29 @@ pub fn translate_op(
                                     "HOST_ENV lltype module must expose cast_pointer".to_string(),
                                 )
                             })?;
+                        let root = match &arg_hls[1] {
+                            Hlvalue::Constant(c) => c.value.as_pystr().ok_or_else(|| {
+                                TyperError::message(
+                                    "__cast_pointer root must be a constant string".to_string(),
+                                )
+                            })?,
+                            _ => {
+                                return Err(TyperError::message(
+                                    "__cast_pointer root must be a Constant".to_string(),
+                                ));
+                            }
+                        };
                         let class_host = call_registry
                             .bookkeeper()
-                            .intern_class_by_qualname(&segments[1]);
-                        let mut call_args = Vec::with_capacity(arg_hls.len() + 2);
+                            .intern_class_by_qualname(root);
+                        let mut call_args = Vec::with_capacity(3);
                         call_args.push(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
                             callable_host,
                         ))));
                         call_args.push(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
                             class_host,
                         ))));
-                        call_args.extend(arg_hls);
+                        call_args.push(arg_hls[0].clone());
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
                     // `__cast_instance_intrinsic` — front-end pointer-downcast
@@ -5998,11 +6013,11 @@ mod tests {
 
     #[test]
     fn translate_op_cast_pointer_marker_rebuilds_two_arg_upstream_call() {
-        // `__cast_pointer/<Root>` marker (front::mir
-        // `cast_pointer_marker_op`) reconstructs the upstream 2-arg
+        // `__cast_pointer` marker reconstructs the upstream 2-arg
         // `cast_pointer(PTRTYPE, ptr)` shape (lltype.py):
-        // constant callable + constant interned target class, then the
-        // pointer operand.
+        // constant callable + interned target class, then the
+        // pointer operand.  The frontend carries the root as a
+        // trailing ByteStr Constant.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 10);
@@ -6011,13 +6026,7 @@ mod tests {
         value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
         let op = SpaceOperation {
             result: Some(vars[2].clone()),
-            kind: OpKind::Call {
-                target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["__cast_pointer".into(), "W_CastTarget".into()],
-                },
-                args: crate::model::call_args(vec![vars[1].clone()]),
-                result_ty: ValueType::Ref(Some("W_CastTarget".into())),
-            },
+            kind: crate::model::cast_pointer_call("W_CastTarget", vars[1].clone()),
         };
         let registry = empty_call_registry();
         let translated = translate_op(&op, &value_map, &registry)

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2178,9 +2178,7 @@ pub fn translate_op(
                                 ));
                             }
                         };
-                        let class_host = call_registry
-                            .bookkeeper()
-                            .intern_class_by_qualname(root);
+                        let class_host = call_registry.bookkeeper().intern_class_by_qualname(root);
                         let mut call_args = Vec::with_capacity(3);
                         call_args.push(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
                             callable_host,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2177,23 +2177,18 @@ pub fn translate_op(
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
                     // `__cast_instance_intrinsic` — front-end pointer-downcast
-                    // narrow (#298).  `front::mir` emits a synthetic
-                    // `Call(["__cast_instance_intrinsic", <root>], [operand])`
-                    // for `obj as *const RegisteredStruct`, stashing the
-                    // target struct root in `segments[1]`.
-                    // Reconstruct it here as `simple_call(callable,
-                    // operand, Constant(root))`: the analyzer reads the
-                    // trailing `ByteStr` root to type the result
+                    // narrow (#298).  `front::mir` emits
+                    // `Call(["__cast_instance_intrinsic"], [operand, const(root)])`
+                    // for `obj as *const RegisteredStruct`.  The analyzer
+                    // reads the trailing `ByteStr` root to type the result
                     // `SomeInstance(root)`, and the typer lowers the call
                     // to a `cast_pointer`.  The callable resolves through
                     // the `__cast_instance_intrinsic` HOST_ENV singleton so its
                     // Arc identity matches the `BUILTIN_TYPER` key.
-                    if segments.len() == 2
-                        && segments[0] == crate::runtime_names::shims::CAST_INSTANCE
-                    {
-                        if arg_hls.len() != 1 {
+                    if segments.as_slice() == [crate::runtime_names::shims::CAST_INSTANCE] {
+                        if arg_hls.len() != 2 {
                             return Err(TyperError::message(format!(
-                                "__cast_instance_intrinsic requires exactly one operand, got {}",
+                                "__cast_instance_intrinsic requires (operand, constant_root), got {}",
                                 arg_hls.len()
                             )));
                         }
@@ -2207,12 +2202,9 @@ pub fn translate_op(
                             })?;
                         let callable =
                             Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host)));
-                        let mut call_args = Vec::with_capacity(arg_hls.len() + 2);
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
                         call_args.push(callable);
                         call_args.extend(arg_hls);
-                        call_args.push(Hlvalue::Constant(Constant::new(ConstValue::byte_str(
-                            &segments[1],
-                        ))));
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
                     // `__cast_address_intrinsic` — the erasing twin of the narrow
@@ -6058,6 +6050,46 @@ mod tests {
             .intern_class_by_qualname("W_CastTarget");
         assert_eq!(class_host, &interned);
         assert!(matches!(lowered.args[2], Hlvalue::Variable(ref v) if *v == operand));
+    }
+
+    #[test]
+    fn translate_op_cast_instance_uses_trailing_root_constant() {
+        // `cast_instance_call` puts the target root at args[1] as a
+        // ByteStr Constant.  The adapter prepends the HOST_ENV
+        // callable and leaves that mixed list intact.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_fixture");
+        let vars = mint_vars(&mut graph, 10);
+        let operand = Variable::new();
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(operand.clone()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: crate::model::cast_instance_call("W_CastTarget", vars[1].clone()),
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("cast_instance_call must lower to simple_call");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "simple_call");
+        assert_eq!(translated[0].args.len(), 3);
+        let Hlvalue::Constant(ref callable) = translated[0].args[0] else {
+            panic!("simple_call callable must be a Constant");
+        };
+        let ConstValue::HostObject(ref host) = callable.value else {
+            panic!("callable must be HostObject");
+        };
+        let expected = HOST_ENV
+            .lookup_builtin(crate::runtime_names::shims::CAST_INSTANCE)
+            .expect("HOST_ENV must register __cast_instance_intrinsic");
+        assert_eq!(host, &expected);
+        assert!(
+            matches!(&translated[0].args[1], Hlvalue::Variable(v) if *v == operand),
+            "operand stays args[1] of simple_call"
+        );
+        let Hlvalue::Constant(ref root) = translated[0].args[2] else {
+            panic!("root must stay a trailing Constant");
+        };
+        assert_eq!(root.value.as_pystr(), Some("W_CastTarget"));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -471,6 +471,21 @@ fn lookup_operand(
         })
 }
 
+/// RPython `SpaceOperation.args` is a mixed `Variable | Constant` list
+/// (`flowspace/model.py`).  `LinkArg::Const` is already the flowspace
+/// Constant — lift it as `Hlvalue::Constant` with no SSA lookup.
+fn lookup_link_arg(
+    value_map: &HashMap<Variable, Hlvalue>,
+    operand: &LinkArg,
+    op: &SpaceOperation,
+    arg_role: &str,
+) -> Result<Hlvalue, TyperError> {
+    match operand {
+        LinkArg::Value(var) => lookup_operand(value_map, var, op, arg_role),
+        LinkArg::Const(c) => Ok(Hlvalue::Constant(c.clone())),
+    }
+}
+
 /// Resolve the `Hlvalue` result slot for a legacy op. When the op has
 /// no result (`Option::None`), allocate a fresh anonymous Variable per
 /// RPython convention (every `SpaceOperation.result` slot is non-None
@@ -1896,7 +1911,7 @@ pub fn translate_op(
                 .enumerate()
                 .map(|(i, v)| {
                     let role = format!("args[{i}]");
-                    lookup_operand(value_map, v, op, &role)
+                    lookup_link_arg(value_map, v, op, &role)
                 })
                 .collect();
             let arg_hls = arg_hls?;
@@ -1910,6 +1925,24 @@ pub fn translate_op(
                 // by the registry) and routes through
                 // `FunctionRepr::call(hop)` (`rpbc.py`).
                 CallTarget::FunctionPath { segments } => {
+                    // RPython `SimpleCall.opname = 'simple_call'`
+                    // (`flowspace/operation.py`); `SimpleCall.eval`
+                    // reads `w_callable, args_w = self.args[0],
+                    // self.args[1:]`.  `front::exc_from_raise` emits
+                    // that mixed list directly (`const(exc_class)` at
+                    // args[0]).  The path names the op, not a second
+                    // callable — do not wrap it again.
+                    if segments.as_slice() == ["simple_call"] {
+                        if arg_hls.is_empty() {
+                            return Err(TyperError::message(
+                                "translate_op: FunctionPath [\"simple_call\"] \
+                                 requires args[0] as the callable \
+                                 (flowspace/operation.py SimpleCall.eval)"
+                                    .to_string(),
+                            ));
+                        }
+                        return Ok(vec![FlowspaceOp::new("simple_call", arg_hls, result)]);
+                    }
                     // RPython `VirtualizableInstanceRepr.hook_access_field`
                     // inserts the `jit_force_virtualizable` LLOp during
                     // rtyping; it never asks the annotator to traverse a
@@ -2114,11 +2147,9 @@ pub fn translate_op(
                     // `__cast_pointer/<Root>` marker (`front::mir`
                     // `cast_pointer_marker_op`) — pyre's carrier for the
                     // upstream `cast_pointer(PTRTYPE, ptr)` downcast
-                    // (lltype.py:964-968).  Same path-encoded-constant
-                    // reconstruction as the `simple_call(<exc class>)`
-                    // raise marker (Branch 3c below): rebuild the 2-arg
-                    // upstream shape with the target class as the
-                    // constant first argument.  The class is interned by
+                    // (lltype.py).  Rebuild the 2-arg upstream shape
+                    // with the target class as the constant first
+                    // argument.  The class is interned by
                     // qualname so every cast site shares one `HostObject`
                     // Arc (`getdesc` dedups on Arc identity — fresh Arcs
                     // would mint one ClassDesc per cast site).
@@ -2149,10 +2180,7 @@ pub fn translate_op(
                     // narrow (#298).  `front::mir` emits a synthetic
                     // `Call(["__cast_instance_intrinsic", <root>], [operand])`
                     // for `obj as *const RegisteredStruct`, stashing the
-                    // target struct root in `segments[1]` because the
-                    // `Vec<Variable>` arg carrier cannot hold a `Constant`
-                    // (same carrier limitation as the Branch-3c
-                    // `simple_call(<exc class>)` reconstruction below).
+                    // target struct root in `segments[1]`.
                     // Reconstruct it here as `simple_call(callable,
                     // operand, Constant(root))`: the analyzer reads the
                     // trailing `ByteStr` root to type the result
@@ -2745,48 +2773,13 @@ pub fn translate_op(
                         // the PRE-EXISTING-ADAPTATION is item `3b.` of this
                         // arm's Layer 3 resolution-order list.
                         attr
-                    } else if segments.len() == 2
-                        && segments[0] == "simple_call"
-                        && let Some(exc_class) = HOST_ENV.lookup_builtin(&segments[1])
-                    {
-                        // Branch 3c — PRE-EXISTING-ADAPTATION closure
-                        // for `front::exc_from_raise::lower_exc_from_raise`
-                        // (~`exc_from_raise.rs`).  Upstream RPython
-                        // `flowcontext.py:614/623` emits
-                        // `op.simple_call(const(exc_class), *args)`
-                        // with the class as `args[0]`; pyre stashes
-                        // the class name in `path[1]` of the
-                        // `FunctionPath` because its `Vec<Variable>`
-                        // arg carrier cannot hold a
-                        // `Constant(HostObject(class))` alongside
-                        // `Variable`s — holding it would require a
-                        // `Vec<Variable>` → `Vec<LinkArg>` carrier (see the
-                        // "TODO: `Constant` SSA carrier shape" section of
-                        // `front/exc_from_raise.rs`'s module preamble for
-                        // the three attempts that failed).  The downstream
-                        // reconstruction is documented at
-                        // `exc_from_raise.rs`:
-                        // > any downstream reader can reconstruct
-                        // > `(op, const_class, args…)` from
-                        // > `(path[0], path[1], op.args)`
-                        // This branch is exactly that
-                        // reconstruction: resolve `path[1]`
-                        // (the exception class name) as a builtin
-                        // HostObject and use it as the simple_call
-                        // callable, leaving `op.args` as the
-                        // trailing message arguments.  No longer
-                        // needed once the arg carrier can hold a
-                        // `Constant` directly.
-                        exc_class
                     } else if let Some(entry) = call_registry.lookup_with_leaf_match(&key) {
                         // Fuzzy leaf-match is the last registry fallback.
-                        // Exact registry entries, HOST_ENV
-                        // module paths, and the `simple_call(<exc class>)`
-                        // raise reconstruction must win first so external
+                        // Exact registry entries and HOST_ENV
+                        // module paths must win first so external
                         // stubs such as `BigInt::from`, `Vec::new`, and
-                        // `Box::new` — and exception classes sharing a leaf —
-                        // cannot be captured by an unrelated user function
-                        // with the same leaf.
+                        // `Box::new` cannot be captured by an unrelated
+                        // user function with the same leaf.
                         //
                         // This is the resting point for the former
                         // caller-scoped `use`-import resolution: MIR callsites
@@ -5427,7 +5420,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["a".into(), "b".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -5466,7 +5459,7 @@ mod tests {
                         "jit_force_virtualizable".into(),
                     ],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Void,
             },
         };
@@ -5511,7 +5504,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__array_repeat".into()],
                 },
-                args: vec![vars[1].clone(), vars[2].clone()],
+                args: crate::model::call_args(vec![vars[1].clone(), vars[2].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -5545,7 +5538,7 @@ mod tests {
                         "try_pyobject_vec_with_capacity".into(),
                     ],
                 },
-                args: vec![vars[0].clone()],
+                args: crate::model::call_args(vec![vars[0].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -5626,7 +5619,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__getslice_minusone".into()],
                 },
-                args: vec![vars[0].clone()],
+                args: crate::model::call_args(vec![vars[0].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -5663,7 +5656,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__getslice_rangeto".into()],
                 },
-                args: vec![vars[0].clone(), vars[1].clone()],
+                args: crate::model::call_args(vec![vars[0].clone(), vars[1].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -5697,7 +5690,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__getslice_rangefrom".into()],
                 },
-                args: vec![vars[0].clone(), vars[1].clone()],
+                args: crate::model::call_args(vec![vars[0].clone(), vars[1].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -5750,7 +5743,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["othermod".into(), "shared_leaf".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -5775,14 +5768,12 @@ mod tests {
     }
 
     #[test]
-    fn translate_op_call_function_path_simple_call_exc_class_beats_leaf_match() {
-        // Branch 3c (`simple_call(<exc class>)` raise reconstruction)
-        // must win over the leaf-match registry fallback so an exception
-        // class sharing a leaf with a registered user function still
-        // resolves to the builtin class HostObject, not the user fn.
-        // Without the ordering, `["simple_call", "ValueError"]` would be
-        // captured by a registered `[mymod, ValueError]` free fn through
-        // `lookup_with_leaf_match`.
+    fn translate_op_call_simple_call_uses_const_callable_at_args_0() {
+        // RPython `flowcontext.py exc_from_raise` emits
+        // `op.simple_call(const(exc_class), *args)`.  The frontend
+        // now carries that Constant at `Call.args[0]`; FunctionPath
+        // `["simple_call"]` is the op name, not a second callable.
+        // A colliding registry leaf must not be prepended.
         use crate::flowspace::argument::Signature;
         use crate::translator::rtyper::call_registry::FunctionPathKey;
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
@@ -5791,52 +5782,44 @@ mod tests {
         value_map.insert(vars[1].clone(), Hlvalue::Variable(Variable::new()));
         value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
         let registry = empty_call_registry();
-        // Free-fn-shaped (snake_case module) candidate whose leaf
-        // `ValueError` collides with the exception class name.
         registry.get_or_register(
-            FunctionPathKey::from_segments(["mymod", "ValueError"]),
+            FunctionPathKey::from_segments(["mymod", "simple_call"]),
             Signature::new(vec!["msg".into()], None, None),
         );
-        // Sanity: leaf-match alone would resolve the colliding user fn.
-        let leaf_hit = registry
-            .lookup_with_leaf_match(&FunctionPathKey::from_segments([
-                "simple_call",
-                "ValueError",
-            ]))
-            .expect("leaf-match must find the colliding user fn");
-        assert!(
-            leaf_hit.host_object.is_user_function(),
-            "leaf-match fallback resolves the registered user fn"
-        );
+        let expected = HOST_ENV
+            .lookup_builtin("ValueError")
+            .expect("bootstrap_builtin_exceptions must register ValueError");
         let op = SpaceOperation {
             result: Some(vars[2].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["simple_call".into(), "ValueError".into()],
+                    segments: vec!["simple_call".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: vec![
+                    LinkArg::from(ConstValue::HostObject(expected.clone())),
+                    LinkArg::from(vars[1].clone()),
+                ],
                 result_ty: ValueType::Ref(None),
             },
         };
         let translated =
-            translate_op(&op, &value_map, &registry).expect("simple_call(<exc class>) must lower");
+            translate_op(&op, &value_map, &registry).expect("simple_call(const(class)) must lower");
         assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "simple_call");
+        assert_eq!(translated[0].args.len(), 2);
         let Hlvalue::Constant(ref callable) = translated[0].args[0] else {
             panic!("simple_call callable must be a Constant");
         };
         let ConstValue::HostObject(ref host) = callable.value else {
             panic!("callable must be ConstValue::HostObject");
         };
-        assert!(
-            !host.is_user_function(),
-            "exc_class branch must resolve the builtin class, not the leaf-match user fn"
-        );
-        let expected = HOST_ENV
-            .lookup_builtin("ValueError")
-            .expect("bootstrap_builtin_exceptions must register ValueError");
         assert_eq!(
             host, &expected,
-            "callable must be the builtin ValueError class HostObject"
+            "callable must be the args[0] class Constant, not a wrapped path"
+        );
+        assert!(
+            matches!(&translated[0].args[1], Hlvalue::Variable(_)),
+            "message arg must stay a Variable"
         );
     }
 
@@ -5861,7 +5844,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["int".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -5913,7 +5896,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__builtin__".into(), "float".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Float,
             },
         };
@@ -5962,7 +5945,7 @@ mod tests {
                         "cast_ptr_to_int".into(),
                     ],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -6008,7 +5991,7 @@ mod tests {
                         "path".into(),
                     ],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Int,
             },
         };
@@ -6040,7 +6023,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__cast_pointer".into(), "W_CastTarget".into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Ref(Some("W_CastTarget".into())),
             },
         };
@@ -6092,7 +6075,7 @@ mod tests {
             result: Some(vars[2].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::synthetic_transparent_ctor("Point"),
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -6132,7 +6115,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec![crate::runtime_names::shims::STRINGBUILDER_NEW.into()],
                 },
-                args: vec![],
+                args: crate::model::call_args(vec![]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -6163,7 +6146,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec!["__majit_stringbuilder_new".into()],
                 },
-                args: vec![vars[2].clone()],
+                args: crate::model::call_args(vec![vars[2].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -6195,7 +6178,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec![crate::runtime_names::shims::STRINGBUILDER_APPEND.into()],
                 },
-                args: vec![vars[1].clone(), vars[2].clone()],
+                args: crate::model::call_args(vec![vars[1].clone(), vars[2].clone()]),
                 result_ty: ValueType::Void,
             },
         };
@@ -6238,7 +6221,7 @@ mod tests {
                 target: crate::model::CallTarget::FunctionPath {
                     segments: vec![crate::runtime_names::shims::STRINGBUILDER_BUILD.into()],
                 },
-                args: vec![vars[1].clone()],
+                args: crate::model::call_args(vec![vars[1].clone()]),
                 result_ty: ValueType::Ref(None),
             },
         };
@@ -6339,7 +6322,7 @@ mod tests {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: segments.clone(),
                     },
-                    args: vars[..arity].to_vec(),
+                    args: crate::model::call_args(vars[..arity].iter().cloned()),
                     result_ty: ValueType::Bool,
                 },
             };
@@ -6407,7 +6390,7 @@ mod tests {
             result: Some(vars[3].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::method("push", Some("Vec".into())),
-                args: vec![vars[1].clone(), vars[2].clone()],
+                args: crate::model::call_args(vec![vars[1].clone(), vars[2].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -6463,7 +6446,7 @@ mod tests {
                     trait_root: "MyTrait".into(),
                     method_name: "do_it".into(),
                 },
-                args: vec![vars[1].clone(), vars[2].clone()],
+                args: crate::model::call_args(vec![vars[1].clone(), vars[2].clone()]),
                 result_ty: ValueType::Int,
             },
         };
@@ -6815,7 +6798,7 @@ mod tests {
             target: crate::model::CallTarget::FunctionPath {
                 segments: segs.iter().map(|s| s.to_string()).collect(),
             },
-            args: (0..argc).map(|_| Variable::new()).collect(),
+            args: crate::model::call_args((0..argc).map(|_| Variable::new())),
             result_ty: ValueType::Int,
         };
         assert!(!op_canraise(&core_call(
@@ -7062,7 +7045,7 @@ mod tests {
                     result: Some(vars[4].clone()),
                     kind: OpKind::Call {
                         target: crate::model::CallTarget::synthetic_transparent_ctor("Array"),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("Array".to_string())),
                     },
                 },
@@ -7409,7 +7392,7 @@ mod tests {
                 result: Some(vars[2].clone()),
                 kind: OpKind::Call {
                     target: crate::model::CallTarget::UnsupportedExpr,
-                    args: vec![arg_var],
+                    args: crate::model::call_args(vec![arg_var]),
                     result_ty: ValueType::Int,
                 },
             }],

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -448,7 +448,7 @@ fn kind_char_to_value_type(kind: char) -> ValueType {
 
 fn infer_call_result_type(
     target: &crate::model::CallTarget,
-    _args: &[crate::flowspace::model::Variable],
+    _args: &[crate::model::LinkArg],
 ) -> ValueType {
     if crate::call::is_int_arithmetic_target(target) {
         return ValueType::Int;
@@ -548,7 +548,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::function_path(["w_int_add"]),
-                    args: vec![a_var.clone(), b_var.clone()],
+                    args: crate::model::call_args(vec![a_var.clone(), b_var.clone()]),
                     result_ty: ValueType::Unknown,
                 },
                 true,
@@ -573,7 +573,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::function_path(["crate", "math", "w_int_add"]),
-                    args: vec![a_var, b_var],
+                    args: crate::model::call_args(vec![a_var, b_var]),
                     result_ty: ValueType::Unknown,
                 },
                 true,

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
@@ -184,8 +184,10 @@ pub fn _cast_whatever() -> Result<(), TyperError> {
     Err(deferred("_cast_whatever"))
 }
 
-pub fn _castdepth() -> Result<(), TyperError> {
-    Err(deferred("_castdepth"))
+/// RPython `lltype._castdepth(outside, inside)` — signed parent-chain
+/// distance used by `jtransform.py Transformer._is_rclass_instance`.
+pub fn _castdepth(outside: &Struct, inside: &Struct) -> i32 {
+    castdepth(outside, inside)
 }
 
 pub fn ann_cast_pointer() -> Result<(), TyperError> {
@@ -7587,6 +7589,9 @@ mod tests {
         let (name, child) = outer._first_struct().expect("leading gc struct expected");
         assert_eq!(name, "head");
         assert_eq!(child._name, "Inner");
+        assert_eq!(_castdepth(&outer, &inner), 1);
+        assert_eq!(_castdepth(&outer, &outer), 0);
+        assert_eq!(_castdepth(&inner, &outer), -1);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -5022,13 +5022,9 @@ mod tests {
         hop.args_s.borrow_mut().push(SomeValue::Instance(
             crate::annotator::model::SomeInstance::new(None, false, Default::default()),
         ));
-        hop.args_r
-            .borrow_mut()
-            .push(Some(inst as Arc<dyn Repr>));
+        hop.args_r.borrow_mut().push(Some(inst as Arc<dyn Repr>));
         assert_eq!(
-            hop.args_r.borrow()[0]
-                .as_ref()
-                .map(|r| r.repr_class_id()),
+            hop.args_r.borrow()[0].as_ref().map(|r| r.repr_class_id()),
             Some(ReprClassId::InstanceRepr)
         );
 
@@ -5036,9 +5032,7 @@ mod tests {
             .unwrap()
             .expect("swap still emits cast_ptr_to_int");
         assert_eq!(
-            hop.args_r.borrow()[0]
-                .as_ref()
-                .map(|r| r.repr_class_id()),
+            hop.args_r.borrow()[0].as_ref().map(|r| r.repr_class_id()),
             Some(ReprClassId::PtrRepr),
             "the fallback relabels InstanceRepr to PtrRepr"
         );

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -4953,4 +4953,98 @@ mod tests {
         reset_swap_fallback_hits();
         assert_eq!(swap_fallback_hits(), 0);
     }
+
+    fn objectptr_type() -> crate::translator::rtyper::lltypesystem::lltype::Ptr {
+        match crate::translator::rtyper::rclass::OBJECTPTR.clone() {
+            LowLevelType::Ptr(p) => *p,
+            other => panic!("OBJECTPTR must be Ptr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rtype_cast_ptr_to_int_with_ptrrepr_does_not_swap() {
+        use crate::annotator::model::SomePtr;
+        use crate::flowspace::model::{Hlvalue, Variable};
+        use crate::translator::rtyper::rmodel::PtrRepr;
+        use std::rc::Rc;
+
+        let hop = dummy_hop();
+        let ptr = objectptr_type();
+        let var = Variable::named("p");
+        var.set_concretetype(Some(LowLevelType::Ptr(Box::new(ptr.clone()))));
+        var.annotation
+            .replace(Some(Rc::new(SomeValue::Ptr(SomePtr::new(ptr.clone())))));
+        hop.args_v.borrow_mut().push(Hlvalue::Variable(var));
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Ptr(SomePtr::new(ptr.clone())));
+        let ptr_repr: Arc<dyn Repr> = Arc::new(PtrRepr::new(ptr));
+        let args_r_before = Arc::as_ptr(&ptr_repr);
+        hop.args_r.borrow_mut().push(Some(ptr_repr));
+
+        let result = rtype_cast_ptr_to_int(&hop, &HashMap::new())
+            .unwrap()
+            .expect("cast_ptr_to_int returns a Signed variable");
+        let args_r_after = hop.args_r.borrow()[0].as_ref().map(Arc::as_ptr);
+        assert_eq!(
+            args_r_after,
+            Some(args_r_before),
+            "orthodox PtrRepr must not be replaced by the InstanceRepr swap"
+        );
+        let llops = hop.llops.borrow();
+        let last = llops.ops.last().expect("the llop is emitted");
+        assert_eq!(result, last.result);
+        assert_eq!(last.opname, "cast_ptr_to_int");
+        match &last.result {
+            Hlvalue::Variable(v) => assert_eq!(v.concretetype(), Some(LowLevelType::Signed)),
+            other => panic!("expected Signed result, got {other:?}"),
+        }
+        assert!(
+            llops._called_exception_is_here_or_cannot_occur,
+            "rbuiltin.py rtype_cast_ptr_to_int calls exception_cannot_occur"
+        );
+    }
+
+    #[test]
+    fn rtype_cast_ptr_to_int_swaps_instancerepr_with_ptr_concretetype() {
+        use crate::flowspace::model::{Hlvalue, Variable};
+        use crate::translator::rtyper::rclass::{Flavor, getinstancerepr};
+
+        let hop = dummy_hop();
+        hop.rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata");
+        let inst = getinstancerepr(&hop.rtyper, None, Flavor::Gc).expect("root InstanceRepr");
+        let ptr = objectptr_type();
+        let var = Variable::named("inst");
+        var.set_concretetype(Some(LowLevelType::Ptr(Box::new(ptr))));
+        hop.args_v.borrow_mut().push(Hlvalue::Variable(var));
+        hop.args_s.borrow_mut().push(SomeValue::Instance(
+            crate::annotator::model::SomeInstance::new(None, false, Default::default()),
+        ));
+        hop.args_r
+            .borrow_mut()
+            .push(Some(inst as Arc<dyn Repr>));
+        assert_eq!(
+            hop.args_r.borrow()[0]
+                .as_ref()
+                .map(|r| r.repr_class_id()),
+            Some(ReprClassId::InstanceRepr)
+        );
+
+        let result = rtype_cast_ptr_to_int(&hop, &HashMap::new())
+            .unwrap()
+            .expect("swap still emits cast_ptr_to_int");
+        assert_eq!(
+            hop.args_r.borrow()[0]
+                .as_ref()
+                .map(|r| r.repr_class_id()),
+            Some(ReprClassId::PtrRepr),
+            "the fallback relabels InstanceRepr to PtrRepr"
+        );
+        let llops = hop.llops.borrow();
+        let last = llops.ops.last().expect("the llop is emitted");
+        assert_eq!(result, last.result);
+        assert_eq!(last.opname, "cast_ptr_to_int");
+    }
 }

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -441,7 +441,7 @@ pub fn lower_indirect_calls(graph: &mut JitFunctionGraph, call_control: &CallCon
             graph,
             block_id,
             oi,
-            receiver_var,
+            receiver_var.into_variable(),
             trait_root.clone(),
             method_name.clone(),
         );
@@ -473,7 +473,7 @@ pub fn lower_indirect_calls(graph: &mut JitFunctionGraph, call_control: &CallCon
             result,
             kind: OpKind::IndirectCall {
                 funcptr: funcptr_var,
-                args,
+                args: crate::model::call_arg_vars(&args),
                 graphs,
                 family_key: None,
                 result_ty,
@@ -838,7 +838,7 @@ pub(crate) mod tests {
             graph.startblock,
             OpKind::Call {
                 target: crate::model::CallTarget::indirect("Handler", "run"),
-                args: vec![receiver_var],
+                args: crate::model::call_args(vec![receiver_var]),
                 result_ty: ValueType::Void,
             },
             true,
@@ -1032,7 +1032,7 @@ pub(crate) mod tests {
                 graph.startblock,
                 OpKind::Call {
                     target: CallTarget::indirect("Storage", "pop"),
-                    args: vec![receiver],
+                    args: crate::model::call_args(vec![receiver]),
                     result_ty: ValueType::Ref(None),
                 },
                 true,
@@ -1094,7 +1094,7 @@ pub(crate) mod tests {
             graph.startblock,
             OpKind::Call {
                 target: CallTarget::method("bar", Some("Foo".to_string())),
-                args: vec![receiver_var],
+                args: crate::model::call_args(vec![receiver_var]),
                 result_ty: ValueType::Void,
             },
             true,

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -649,6 +649,25 @@ impl RPythonTyper {
         })
     }
 
+    /// RPython `RPythonTyper.lltype_to_classdef_mapping` (`rtyper.py`).
+    ///
+    /// ```python
+    /// def lltype_to_classdef_mapping(self):
+    ///     result = {}
+    ///     for (classdef, _), repr in self.instance_reprs.iteritems():
+    ///         result[repr.lowleveltype] = classdef
+    ///     return result
+    /// ```
+    pub fn lltype_to_classdef_mapping(
+        &self,
+    ) -> HashMap<LowLevelType, Option<Rc<RefCell<crate::annotator::classdesc::ClassDef>>>> {
+        let mut result = HashMap::new();
+        for repr in self.instance_reprs.borrow().values() {
+            result.insert(repr.lowleveltype().clone(), repr.classdef());
+        }
+        result
+    }
+
     /// RPython `ExceptionData.finish(rtyper)`
     /// (`rpython/rtyper/exceptiondata.py:28-32`):
     ///
@@ -2987,6 +3006,14 @@ impl LowLevelFunction {
             result,
             graph: Some(graph),
         }
+    }
+
+    /// Graph identity used as `args[0].value._obj.graph` when comparing
+    /// a `direct_call` funcptr to `exceptiondata.fn_exception_match`.
+    pub fn graph_key(&self) -> Option<usize> {
+        self.graph
+            .as_ref()
+            .map(|g| crate::flowspace::model::GraphKey::of(&g.graph).as_usize())
     }
 }
 
@@ -6202,6 +6229,12 @@ mod tests {
         assert_eq!(inst.gcflavor(), Flavor::Gc);
         assert_eq!(inst.object_type(), &OBJECT.clone());
         drop(cache);
+
+        let mapping = rtyper.lltype_to_classdef_mapping();
+        assert!(
+            mapping.get(&OBJECTPTR.clone()).is_some_and(Option::is_none),
+            "root InstanceRepr maps OBJECTPTR to classdef=None"
+        );
 
         // rtyper.py:71 / exceptiondata.py — ExceptionData fields.
         let ed = rtyper.exceptiondata().expect("exceptiondata");

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -270,7 +270,7 @@ fn jit_merge_point_receiver(op: &SpaceOperation) -> Option<&Variable> {
     let receiver_root = target.receiver_root()?;
     let driver_roots = [receiver_root.to_string()];
     (jit_marker_key_from_target(target, &driver_roots) == Some(JitMarkerKey::JitMergePoint))
-        .then(|| args.first())
+        .then(|| args.first().and_then(|a| a.as_variable()))
         .flatten()
 }
 
@@ -463,7 +463,7 @@ pub(crate) fn split_block(
         ExitSwitch::LastException => ExitSwitch::LastException,
         ExitSwitch::Fused { opname, args } => ExitSwitch::Fused {
             opname,
-            args: args
+            args: crate::model::call_args(args)
                 .iter()
                 .map(|var| {
                     get_new_name(
@@ -760,7 +760,7 @@ mod tests {
                 result: Some(result.clone()),
                 kind: OpKind::Call {
                     target: crate::model::CallTarget::function_path(["consume_void"]),
-                    args: vec![omitted_void],
+                    args: crate::model::call_args(vec![omitted_void]),
                     result_ty: ValueType::Void,
                 },
             }],
@@ -797,7 +797,7 @@ mod tests {
                 "jit_merge_point",
                 Some("PyPyJitDriver".into()),
             ),
-            args: vec![receiver.clone()],
+            args: crate::model::call_args(vec![receiver.clone()]),
             result_ty: ValueType::Void,
         };
         let mut graph = graph_with_ops(
@@ -841,7 +841,7 @@ mod tests {
     fn split_with_forcelink_rematerializes_nullary_marker_receiver() {
         assert_split_rematerializes_marker_receiver(OpKind::Call {
             target: crate::model::CallTarget::function_path(["pyre_jit", "eval", "pypyjitdriver"]),
-            args: vec![],
+            args: crate::model::call_args(vec![]),
             result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
         });
     }
@@ -867,7 +867,7 @@ mod tests {
                             "eval",
                             "pypyjitdriver",
                         ]),
-                        args: vec![],
+                        args: crate::model::call_args(vec![]),
                         result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
                     },
                 },
@@ -882,7 +882,7 @@ mod tests {
                             "jit_merge_point",
                             Some("PyPyJitDriver".into()),
                         ),
-                        args: vec![receiver],
+                        args: crate::model::call_args(vec![receiver]),
                         result_ty: ValueType::Void,
                     },
                 },

--- a/majit/majit-translate/tests/test_mir_atomic_load.rs
+++ b/majit/majit-translate/tests/test_mir_atomic_load.rs
@@ -99,17 +99,22 @@ fn atomic_load_real_acquire_readers_preserve_the_diagnostic() {
         "/../../build/llbc/pyre-object.ullbc"
     ))
     .expect("load fresh pyre-object corpus");
-    // get_instantiate publishes the cached W_TypeObject to allocators, whereas
-    // the version tag publishes class mutations. Neither load may become a
-    // scalar field read just because its enclosing caller can be traced.
-    // In particular, a missing instantiate descriptor is not permission to
+    // The version tag publishes class mutations across threads: its Acquire
+    // load may not become a scalar field read just because its enclosing
+    // caller can be traced. A missing descriptor is not permission to
     // recover the old ordering-erasing lowering to satisfy a layout test.
-    for reader in ["w_type_get_version_tag", "get_instantiate"] {
-        let result = lower_function(&llbc, reader);
-        assert!(
-            matches!(result, Err(LowerError::Unsupported(ref message))
-                if message.contains("atomic load ordering Acquire")),
-            "{reader}: the real Acquire reader must not become a plain field value: {result:?}"
-        );
-    }
+    let result = lower_function(&llbc, "w_type_get_version_tag");
+    assert!(
+        matches!(result, Err(LowerError::Unsupported(ref message))
+            if message.contains("atomic load ordering Acquire")),
+        "w_type_get_version_tag: the real Acquire reader must not become a plain field value: {result:?}"
+    );
+    // get_instantiate publishes the cached W_TypeObject to allocators. Its
+    // readers and late writers are all GIL-serialized, so the source spells a
+    // Relaxed load — the one ordering the frontend lowers to a plain read.
+    let result = lower_function(&llbc, "get_instantiate");
+    assert!(
+        result.is_ok(),
+        "get_instantiate: the Relaxed reader must keep lowering: {result:?}"
+    );
 }

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -848,11 +848,8 @@ fn header_read_narrows_to_a_typed_field_read() {
                 OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
                     ..
-                } if segments.as_slice()
-                    == [
-                        "__cast_instance_intrinsic".to_string(),
-                        "ObjectHeader".to_string(),
-                    ] =>
+                } if majit_translate::model::cast_instance_root(&op.kind)
+                    == Some("ObjectHeader") =>
                 {
                     narrows += 1
                 }
@@ -1044,17 +1041,17 @@ fn boxing_cluster_fuses_from_the_host_supplied_class_address() {
     for b in &add_graph.blocks {
         for op in &b.operations {
             let OpKind::Call {
-                target: CallTarget::FunctionPath { segments },
                 args,
                 result_ty,
+                ..
             } = &op.kind
             else {
                 continue;
             };
-            if segments.first().map(String::as_str) != Some("__cast_instance_intrinsic") {
+            let Some(root) = majit_translate::model::cast_instance_root(&op.kind) else {
                 continue;
-            }
-            let root = segments.get(1).cloned().unwrap_or_default();
+            };
+            let root = root.to_string();
             *narrow_roots.entry(root.clone()).or_insert(0usize) += 1;
             assert_eq!(
                 result_ty,

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -1068,7 +1068,7 @@ fn boxing_cluster_fuses_from_the_host_supplied_class_address() {
                 .iter()
                 .flat_map(|b| &b.operations)
                 .any(|p| {
-                    p.result.as_ref() == args.first()
+                    p.result.as_ref() == args.first().and_then(majit_translate::model::LinkArg::as_variable)
                         && matches!(p.kind, OpKind::ConstRefAddr(a) if a == CLASS_ADDR)
                 });
             if narrows_class_addr {

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -1041,9 +1041,7 @@ fn boxing_cluster_fuses_from_the_host_supplied_class_address() {
     for b in &add_graph.blocks {
         for op in &b.operations {
             let OpKind::Call {
-                args,
-                result_ty,
-                ..
+                args, result_ty, ..
             } = &op.kind
             else {
                 continue;
@@ -1065,7 +1063,10 @@ fn boxing_cluster_fuses_from_the_host_supplied_class_address() {
                 .iter()
                 .flat_map(|b| &b.operations)
                 .any(|p| {
-                    p.result.as_ref() == args.first().and_then(majit_translate::model::LinkArg::as_variable)
+                    p.result.as_ref()
+                        == args
+                            .first()
+                            .and_then(majit_translate::model::LinkArg::as_variable)
                         && matches!(p.kind, OpKind::ConstRefAddr(a) if a == CLASS_ADDR)
                 });
             if narrows_class_addr {

--- a/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
+++ b/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
@@ -161,7 +161,7 @@ fn build_indirect_caller_graph(name: &str, trait_root: &str, method_name: &str) 
             result: Some(result_var.clone()),
             kind: OpKind::Call {
                 target: CallTarget::indirect(trait_root, method_name),
-                args: vec![receiver],
+                args: majit_translate::model::call_args(vec![receiver]),
                 result_ty: ValueType::Int,
             },
         });

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -137,7 +137,7 @@ fn vable_array_len_lowers_to_arraylen_not_a_call() {
                     target: CallTarget::FunctionPath { segments },
                     args,
                     ..
-                } if segments == &["__len".to_string()] && args.contains(&array_var) => {
+                } if segments == &["__len".to_string()] && args.iter().any(|a| a == &array_var) => {
                     panic!(
                         "the virtualizable array reaches a `__len` call as an argument, \
                          which trips `_check_no_vable_array` via `handle_residual_call`"
@@ -432,7 +432,7 @@ fn report_vable_array_shape_of_frame_locals_proxy_snapshot() {
                     }
                     for o in &b.operations {
                         if let OpKind::Call { args, .. } = &o.kind
-                            && args.contains(result)
+                            && args.iter().any(|a| a == result)
                         {
                             escapes.push(format!("{:?}: call argument in block {bi}", graph.name));
                         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8091,7 +8091,8 @@ pub(crate) fn type_del_annotations(obj: PyObjectRef) -> PyResult {
 
 /// PyPy `typeobject.py descr__doc` with Python 3.14's `type`
 /// docstring. Heap types read and descriptor-bind only their own `__doc__`;
-/// builtin types expose the doc stored in their native type namespace.
+/// builtin types return `W_TypeObject.w_doc` when TypeCache has published
+/// it, otherwise the namespace `__doc__` entry.
 pub(crate) fn type_get_doc(obj: PyObjectRef) -> PyResult {
     unsafe {
         if std::ptr::eq(obj, crate::typedef::w_type()) {
@@ -8114,6 +8115,13 @@ pub(crate) fn type_get_doc(obj: PyObjectRef) -> PyResult {
             crate::typedef::gettypeobject(&pyre_object::function::METHOD_TYPE),
         ) {
             return Ok(w_str_new(crate::typedef::METHOD_DOC));
+        }
+        if !w_type_is_cpython_heaptype(obj) {
+            // typeobject.py descr__doc: `if not w_type.is_heaptype(): return w_type.w_doc`.
+            let w_doc = w_type_get_w_doc(obj);
+            if !w_doc.is_null() {
+                return Ok(w_doc);
+            }
         }
         let Some(value) = crate::type_dict_lookup(obj, "__doc__") else {
             return Ok(w_none());

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -758,6 +758,7 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                 forward(&mut t.ob_header.w_class);
                 forward(&mut t.w_name);
                 forward(&mut t.w_qualname);
+                forward(&mut t.w_doc);
                 // Heap and builtin types both hold a managed W_DictObject.
                 // Forward the field itself; the dict's custom trace walks its
                 // keys and values during a major collection. During a minor,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -6371,15 +6371,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 "expected a 'posix.ScandirIterator' object",
             ))
         });
-        // `W_ScandirIterator.next_w` exhausts through `fail` → `_close`.
-        // `_finalize_` is then a no-op (`if not self.dirp: return`).  The
-        // prompt-finalization census treats a still-registered finalizer as
-        // a reason to collect the whole heap on `gen.close()`, so the
-        // exhausted iterator needs the same `may_ignore_finalizer` as
-        // `scandir_iter_mark_closed`.
-        if matches!(&result, Err(e) if e.matches_stop_iteration()) {
-            crate::executioncontext::may_ignore_finalizer(self_obj);
-        }
         result
     }
 

--- a/pyre/pyre-interpreter/src/objspace/std/classdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/classdict.rs
@@ -142,6 +142,9 @@ impl ClassDictMethods {
     }
 
     unsafe fn setitem_wtf8(&self, w_dict: PyObjectRef, key: &Wtf8, w_value: PyObjectRef) {
+        // `setitem_str` additionally catches the TypeError and stores raw
+        // into `dict_w` when `w_type.is_cpytype()`; pyre has no cpytype
+        // concept, so the refusal propagates unconditionally.
         if let Err(err) = type_setdictvalue_wtf8(unerase(w_dict), key, w_value) {
             crate::call::set_call_error(err);
         }
@@ -251,6 +254,11 @@ unsafe fn type_setdictvalue_wtf8(
             pyre_object::w_type_get_name(w_type),
         )));
     }
+    // Upstream `setdictvalue` first offers the store to `write_cell` and
+    // returns without `mutated` when the existing MutableCell absorbs it.
+    // Pyre's type dicts hold raw values everywhere (cells are module-dict
+    // only; `object_setattr`'s type arm stores raw too), so the read-side
+    // `unwrap_cell` is a no-op and the cell step has nothing to update.
     crate::baseobjspace::mutated(w_type, name.as_str().ok());
     crate::type_dict_store_wtf8(w_type, name, w_value);
     Ok(())

--- a/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
@@ -106,11 +106,20 @@ impl TypeCache {
             crate::typedef::w_type(),
         );
         unsafe {
-            w_type_set_hasdict(w_type, definition.hasdict);
-            w_type_set_weakrefable(w_type, definition.weakrefable);
+            // typeobject.py TypeCache.build: overridetypedef is
+            // `typedef.applevel_subclasses_base.typedef` or `typedef`.
+            let overridetypedef = if definition.applevel_subclasses_base.is_null() {
+                definition as *const TypeDef
+            } else {
+                definition.applevel_subclasses_base
+            };
+            let override_def = &*overridetypedef;
+            // setup_builtin_type reads hasdict/weakrefable/heaptype off
+            // instancetypedef (the override), not the derived declaration.
+            w_type_set_hasdict(w_type, override_def.hasdict);
+            w_type_set_weakrefable(w_type, override_def.weakrefable);
             w_type_set_flag_sequence_bug_compat(w_type, definition.flag_sequence_bug_compat);
-            // typeobject.py TypeCache.build: `is_heaptype=overridetypedef.heaptype`.
-            w_type_set_heaptype(w_type, definition.heaptype);
+            w_type_set_heaptype(w_type, override_def.heaptype);
             w_type_set_acceptable_as_base_class(w_type, definition.acceptable_as_base_class());
             crate::baseobjspace::compute_and_set_mro(w_type).map_err(CacheError::Build)?;
             let best = crate::call::find_best_base(gc_roots::shadow_stack_get(bases_slot))
@@ -120,18 +129,19 @@ impl TypeCache {
             } else {
                 w_type_get_layout_ptr(best)
             };
-            let layout =
-                if !parent_layout.is_null() && std::ptr::eq((*parent_layout).typedef, definition) {
-                    parent_layout
-                } else {
-                    typeobject::leak_layout(typeobject::Layout {
-                        typedef: definition,
-                        nslots: 0,
-                        newslotnames: vec![],
-                        base_layout: parent_layout,
-                        dict_data_slot: typeobject::DICT_DATA_SLOT_UNRESOLVED,
-                    })
-                };
+            let layout = if !parent_layout.is_null()
+                && std::ptr::eq((*parent_layout).typedef, overridetypedef)
+            {
+                parent_layout
+            } else {
+                typeobject::leak_layout(typeobject::Layout {
+                    typedef: overridetypedef,
+                    nslots: 0,
+                    newslotnames: vec![],
+                    base_layout: parent_layout,
+                    dict_data_slot: typeobject::DICT_DATA_SLOT_UNRESOLVED,
+                })
+            };
             w_type_set_layout(w_type, layout);
             crate::typedef::stamp_new_descr_self(gc_roots::shadow_stack_get(ns_slot), w_type);
         }
@@ -261,6 +271,26 @@ mod tests {
             let heap = ObjSpace::new().gettypeobject(heap).unwrap();
             assert!(w_type_is_heaptype(heap));
             assert!(w_type_get_acceptable_as_base_class(heap));
+        }
+    }
+
+    #[test]
+    fn typecache_build_reuses_applevel_subclasses_base_layout() {
+        crate::typedef::init_typeobjects();
+        unsafe {
+            let space = ObjSpace::new();
+            let base_def = TypeDef::from_rawdict("IOBase", vec![], IndexMap::new(), &INSTANCE_TYPE);
+            let base = space.gettypeobject(base_def).unwrap();
+            let derived_def =
+                TypeDef::from_rawdict("RawIO", vec![base_def], IndexMap::new(), &INSTANCE_TYPE)
+                    as *mut TypeDef;
+            (*derived_def).applevel_subclasses_base = base_def;
+            let derived = space.gettypeobject(derived_def).unwrap();
+            assert!(std::ptr::eq(
+                w_type_get_layout_ptr(derived),
+                w_type_get_layout_ptr(base)
+            ));
+            assert_eq!((*w_type_get_layout_ptr(derived)).typedef, base_def);
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
@@ -120,7 +120,15 @@ impl TypeCache {
             w_type_set_weakrefable(w_type, override_def.weakrefable);
             w_type_set_flag_sequence_bug_compat(w_type, definition.flag_sequence_bug_compat);
             w_type_set_heaptype(w_type, override_def.heaptype);
-            w_type_set_acceptable_as_base_class(w_type, definition.acceptable_as_base_class());
+            if let Some(signature) = &override_def.text_signature {
+                // setup_builtin_type: `w_self.text_signature =
+                // instancetypedef.text_signature`.
+                w_type_set_text_signature(w_type, signature);
+            }
+            // `W_TypeObject.acceptable_as_base_class` reads
+            // `self.layout.typedef.acceptable_as_base_class` — the override
+            // declaration, not the derived one.
+            w_type_set_acceptable_as_base_class(w_type, override_def.acceptable_as_base_class());
             crate::baseobjspace::compute_and_set_mro(w_type).map_err(CacheError::Build)?;
             let best = crate::call::find_best_base(gc_roots::shadow_stack_get(bases_slot))
                 .map_err(CacheError::Build)?;
@@ -143,7 +151,23 @@ impl TypeCache {
                 })
             };
             w_type_set_layout(w_type, layout);
-            crate::typedef::stamp_new_descr_self(gc_roots::shadow_stack_get(ns_slot), w_type);
+            if std::ptr::eq(definition as *const TypeDef, overridetypedef) {
+                // TypeCache.build's else arm: qualify member functions.
+                crate::typedef::stamp_new_descr_self(gc_roots::shadow_stack_get(ns_slot), w_type);
+            } else {
+                // `typedef is not overridetypedef`: the qualname/objclass pass
+                // is skipped; only `ensure_static_new` (from
+                // `ensure_common_attributes`) still runs.  Upstream re-derives
+                // `w_type.w_doc = newtext_or_none(typedef.doc)` here; pyre's
+                // builtin doc observable is the namespace `__doc__` entry,
+                // which already holds `definition.doc` (rawdict) or the
+                // ensure-common None — the same value — so no store is needed.
+                // Divergence: upstream's dict additionally keeps the override
+                // declaration's doc via `dict_w.setdefault('__doc__', w_doc)`
+                // for instance-level lookup; a single storage cannot carry
+                // both values, and pyre keeps the type-level one.
+                crate::typedef::ensure_static_new(gc_roots::shadow_stack_get(ns_slot), w_type);
+            }
         }
         Ok(w_type)
     }
@@ -454,6 +478,52 @@ mod tests {
                 crate::function::fget_func_objclass(function).unwrap(),
                 w_type
             );
+        }
+    }
+
+    #[test]
+    fn derived_declaration_skips_the_qualname_pass_and_reads_override_flags() {
+        crate::typedef::init_typeobjects();
+        let code = crate::compile::compile_source("42", crate::compile::Mode::Eval).unwrap();
+        let _roots = gc_roots::push_roots();
+        let code_slot = gc_roots::shadow_stack_len();
+        let _ = gc_roots::pin_root(crate::w_code_new(Box::into_raw(Box::new(code)).cast()));
+        let globals = w_module_dict_new();
+        let function = crate::function::function_new_with_fixed_code(
+            gc_roots::shadow_stack_get(code_slot).cast(),
+            "original".into(),
+            globals,
+        );
+        unsafe {
+            let base_def = TypeDef::from_rawdict("FlagBase", vec![], IndexMap::new(), &INSTANCE_TYPE)
+                as *mut TypeDef;
+            (*base_def).set_acceptable_as_base_class(true);
+            (*base_def).text_signature = Some("(x, /)".into());
+            let space = ObjSpace::new();
+            let base = space.gettypeobject(base_def).unwrap();
+            assert!(!base.is_null());
+            let derived_def = TypeDef::from_rawdict(
+                "FlagDerived",
+                vec![base_def],
+                IndexMap::from([("method".into(), TypeDefValue::root(function))]),
+                &INSTANCE_TYPE,
+            ) as *mut TypeDef;
+            (*derived_def).applevel_subclasses_base = base_def;
+            let w_type = space.gettypeobject(derived_def).unwrap();
+            // `typedef is not overridetypedef`: the qualname/objclass pass is
+            // skipped, so the function keeps its own name and objclass.
+            let function =
+                w_dict_getitem_str(w_type_get_dict_ptr(w_type).cast(), "method").unwrap();
+            assert_eq!(
+                crate::function::function_get_qualname(function)
+                    .as_str()
+                    .unwrap(),
+                "original"
+            );
+            // `acceptable_as_base_class` and `text_signature` read the
+            // override declaration (`layout.typedef` / `setup_builtin_type`).
+            assert!(w_type_get_acceptable_as_base_class(w_type));
+            assert_eq!(w_type_get_text_signature(w_type), Some("(x, /)"));
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
@@ -5,6 +5,14 @@ use majit_rlib::cache::CacheError;
 use pyre_object::typedef::{TypeDef, TypeDefValue};
 use pyre_object::*;
 
+/// `space.newtext_or_none` (`objspace.py`) for a TypeDef.doc.
+fn newtext_or_none(doc: Option<&str>) -> PyObjectRef {
+    match doc {
+        Some(text) => w_str_new(text),
+        None => w_none(),
+    }
+}
+
 pub struct TypeCache {
     base: SpaceCache<usize, usize, std::sync::Arc<ObjSpace>>,
 }
@@ -74,6 +82,22 @@ impl TypeCache {
         let _ = gc_roots::pin_root(w_tuple_new(bases));
         let ns_slot = gc_roots::shadow_stack_len();
         let _ = gc_roots::pin_root(w_dict_new());
+        // typeobject.py TypeCache.build: overridetypedef is
+        // `typedef.applevel_subclasses_base.typedef` or `typedef`.
+        // Compute it before `ensure_common_attributes` so
+        // `setup_builtin_type` can seed `w_doc` and
+        // `dict_w.setdefault('__doc__', w_doc)` from the override.
+        let overridetypedef = if definition.applevel_subclasses_base.is_null() {
+            definition as *const TypeDef
+        } else {
+            definition.applevel_subclasses_base
+        };
+        let override_def = unsafe { &*overridetypedef };
+        let w_override_doc = newtext_or_none(override_def.doc.as_deref());
+        let _ = gc_roots::pin_root(w_override_doc);
+        unsafe {
+            w_type_set_w_doc(w_type, w_override_doc);
+        }
         for (name, value) in &definition.rawdict {
             let value = match value {
                 TypeDefValue::Text(text) => w_str_new(text),
@@ -106,14 +130,6 @@ impl TypeCache {
             crate::typedef::w_type(),
         );
         unsafe {
-            // typeobject.py TypeCache.build: overridetypedef is
-            // `typedef.applevel_subclasses_base.typedef` or `typedef`.
-            let overridetypedef = if definition.applevel_subclasses_base.is_null() {
-                definition as *const TypeDef
-            } else {
-                definition.applevel_subclasses_base
-            };
-            let override_def = &*overridetypedef;
             // setup_builtin_type reads hasdict/weakrefable/heaptype off
             // instancetypedef (the override), not the derived declaration.
             w_type_set_hasdict(w_type, override_def.hasdict);
@@ -155,17 +171,14 @@ impl TypeCache {
                 // TypeCache.build's else arm: qualify member functions.
                 crate::typedef::stamp_new_descr_self(gc_roots::shadow_stack_get(ns_slot), w_type);
             } else {
-                // `typedef is not overridetypedef`: the qualname/objclass pass
-                // is skipped; only `ensure_static_new` (from
-                // `ensure_common_attributes`) still runs.  Upstream re-derives
-                // `w_type.w_doc = newtext_or_none(typedef.doc)` here; pyre's
-                // builtin doc observable is the namespace `__doc__` entry,
-                // which already holds `definition.doc` (rawdict) or the
-                // ensure-common None — the same value — so no store is needed.
-                // Divergence: upstream's dict additionally keeps the override
-                // declaration's doc via `dict_w.setdefault('__doc__', w_doc)`
-                // for instance-level lookup; a single storage cannot carry
-                // both values, and pyre keeps the type-level one.
+                // `typedef is not overridetypedef`: skip the
+                // qualname/objclass pass.  `setup_builtin_type` already
+                // seeded `w_doc` and `dict_w.setdefault('__doc__', w_doc)`
+                // from the override; overwrite only the type-level slot
+                // (`typeobject.py TypeCache.build`).
+                let w_derived_doc = newtext_or_none(definition.doc.as_deref());
+                let _ = gc_roots::pin_root(w_derived_doc);
+                w_type_set_w_doc(w_type, w_derived_doc);
                 crate::typedef::ensure_static_new(gc_roots::shadow_stack_get(ns_slot), w_type);
             }
         }
@@ -315,6 +328,66 @@ mod tests {
                 w_type_get_layout_ptr(base)
             ));
             assert_eq!((*w_type_get_layout_ptr(derived)).typedef, base_def);
+        }
+    }
+
+    #[test]
+    fn derived_declaration_keeps_override_doc_in_the_namespace() {
+        crate::typedef::init_typeobjects();
+        unsafe {
+            let base_def = TypeDef::from_rawdict(
+                "DocBase",
+                vec![],
+                IndexMap::from([("__doc__".into(), TypeDefValue::Text("override doc".into()))]),
+                &INSTANCE_TYPE,
+            ) as *mut TypeDef;
+            let space = ObjSpace::new();
+            let _base = space.gettypeobject(base_def).unwrap();
+            let derived_def = TypeDef::from_rawdict(
+                "DocDerived",
+                vec![base_def],
+                IndexMap::new(),
+                &INSTANCE_TYPE,
+            ) as *mut TypeDef;
+            (*derived_def).applevel_subclasses_base = base_def;
+            let derived = space.gettypeobject(derived_def).unwrap();
+            // `TypeCache.build`: dict keeps the override via setdefault;
+            // `w_doc` is the derived declaration (absent → None).
+            let ns = w_type_get_dict_ptr(derived) as PyObjectRef;
+            assert_eq!(
+                w_str_get_value(w_dict_getitem_str(ns, "__doc__").unwrap()),
+                "override doc"
+            );
+            assert!(is_none(w_type_get_w_doc(derived)));
+        }
+    }
+
+    #[test]
+    fn derived_declaration_doc_overwrites_only_the_type_slot() {
+        crate::typedef::init_typeobjects();
+        unsafe {
+            let base_def = TypeDef::from_rawdict(
+                "DocBaseOwn",
+                vec![],
+                IndexMap::from([("__doc__".into(), TypeDefValue::Text("override doc".into()))]),
+                &INSTANCE_TYPE,
+            ) as *mut TypeDef;
+            let space = ObjSpace::new();
+            let _base = space.gettypeobject(base_def).unwrap();
+            let derived_def = TypeDef::from_rawdict(
+                "DocDerivedOwn",
+                vec![base_def],
+                IndexMap::from([("__doc__".into(), TypeDefValue::Text("derived doc".into()))]),
+                &INSTANCE_TYPE,
+            ) as *mut TypeDef;
+            (*derived_def).applevel_subclasses_base = base_def;
+            let derived = space.gettypeobject(derived_def).unwrap();
+            let ns = w_type_get_dict_ptr(derived) as PyObjectRef;
+            assert_eq!(
+                w_str_get_value(w_dict_getitem_str(ns, "__doc__").unwrap()),
+                "derived doc"
+            );
+            assert_eq!(w_str_get_value(w_type_get_w_doc(derived)), "derived doc");
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/typeobject.rs
@@ -495,8 +495,9 @@ mod tests {
             globals,
         );
         unsafe {
-            let base_def = TypeDef::from_rawdict("FlagBase", vec![], IndexMap::new(), &INSTANCE_TYPE)
-                as *mut TypeDef;
+            let base_def =
+                TypeDef::from_rawdict("FlagBase", vec![], IndexMap::new(), &INSTANCE_TYPE)
+                    as *mut TypeDef;
             (*base_def).set_acceptable_as_base_class(true);
             (*base_def).text_signature = Some("(x, /)".into());
             let space = ObjSpace::new();

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2700,9 +2700,11 @@ pub(crate) unsafe fn stamp_builtin_owner(func: PyObjectRef, type_name: &str) {
 ///
 /// # Safety
 /// `ns` must be a valid, live `W_DictObject`; `type_obj` a valid type.
-pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
+/// `typeobject.py ensure_static_new` — stamp the type onto its `__new__`
+/// carrier. Runs for every built type (`ensure_common_attributes`), including
+/// derived declarations whose function-metadata pass is skipped.
+pub(crate) unsafe fn ensure_static_new(ns: PyObjectRef, type_obj: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
-    let save_point = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::gc_roots::pin_root(ns);
     let type_obj = pyre_object::gc_roots::pin_root(type_obj);
     if let Some(w_new) = pyre_object::w_dict_getitem_str(ns, "__new__") {
@@ -2723,6 +2725,14 @@ pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef
             }
         }
     }
+}
+
+pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let save_point = pyre_object::gc_roots::shadow_stack_len();
+    let ns = pyre_object::gc_roots::pin_root(ns);
+    let type_obj = pyre_object::gc_roots::pin_root(type_obj);
+    unsafe { ensure_static_new(ns, type_obj) };
     // TypeCache.build's post-initialization function metadata pass. Getsets
     // have already been copied for the allocated owner before initialization.
     let keys: Vec<String> = pyre_object::w_dict_items(ns)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2936,7 +2936,17 @@ pub(crate) fn init_builtin_typeobject(
     let ns = pyre_object::gc_roots::shadow_stack_get(save_point + 1);
     unsafe {
         if pyre_object::w_dict_getitem_str(ns, "__doc__").is_none() {
-            pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none());
+            // `ensure_common_attributes`: `dict_w.setdefault('__doc__', w_self.w_doc)`.
+            let w_doc = pyre_object::w_type_get_w_doc(type_obj);
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                "__doc__",
+                if w_doc.is_null() {
+                    pyre_object::w_none()
+                } else {
+                    w_doc
+                },
+            );
         }
         let ns = pyre_object::gc_roots::shadow_stack_get(save_point + 1);
         if pyre_object::w_dict_getitem_str(ns, "__eq__").is_some()

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -482,6 +482,7 @@ unsafe fn type_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     f(&mut t.bases as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut t.w_name as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut t.w_qualname as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut t.w_doc as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     // `name` points at a GC-managed leaf storage box (`String`, off-GC storage
     // epic S5) for a mortal heap type; forward the field slot so a major GC greys
     // the box, and the box tid's drop glue reclaims the buffer on sweep. An

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -121,14 +121,17 @@ pub fn set_instantiate(tp: &PyType, w_typeobject: PyObjectRef) {
 /// Returns the W_TypeObject (for `w_class`), or null if not yet initialized
 /// (bootstrap phase before `init_typeobjects()`).
 ///
-/// `rclass.py` OBJECT_VTABLE marks every field immutable; `instantiate`
-/// is a pointer slot written once by `set_instantiate` before any
-/// bytecode runs. A plain word load is the getfield the translator
-/// already emits for that slot — `AtomicPtr::load(Acquire)` would stay
-/// a residual and keep `is_plain_int1` off IntegerListStrategy.
+/// `rclass.py` OBJECT_VTABLE marks every field immutable; upstream fills
+/// `instantiate` at translation time.  Pyre also writes it from module
+/// initializers (`set_instantiate` in mmap/_cffi_backend/posix), which run
+/// under the GIL like every reader, so the GIL is the synchronizer and a
+/// Relaxed load suffices.  Relaxed keeps the read a plain word load in the
+/// generated jitcode — `Acquire` would make the frontend decline the graph
+/// and leave every caller with a residual call, keeping `is_plain_int1`
+/// off IntegerListStrategy.
 #[inline]
 pub fn get_instantiate(tp: &PyType) -> PyObjectRef {
-    unsafe { *(&tp.instantiate as *const AtomicPtr<PyObject> as *const PyObjectRef) }
+    tp.instantiate.load(Ordering::Relaxed)
 }
 
 /// True when `obj`'s Python class is exactly the builtin type for its

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -63,6 +63,10 @@ pub struct TypeDef {
     /// TypeCache.build. IndexMap preserves Python dict insertion order.
     pub rawdict: indexmap::IndexMap<String, TypeDefValue>,
     pub doc: Option<String>,
+    /// TypeDef.__init__: `self.text_signature = _text_signature_`. Applied to
+    /// the W_TypeObject by TypeCache.build from the override declaration
+    /// (`setup_builtin_type`).
+    pub text_signature: Option<String>,
     pub weakrefable: bool,
     /// Existing allocation-vtable representation of the interpreter class;
     /// replace with the canonical class metadata when rpy_cls is connected.
@@ -97,6 +101,7 @@ impl TypeDef {
             bases: Vec::new(),
             rawdict: indexmap::IndexMap::new(),
             doc: None,
+            text_signature: None,
             weakrefable: false,
             instance_type,
             acceptable_as_base_class: std::sync::atomic::AtomicBool::new(acceptable_as_base_class),

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -78,6 +78,10 @@ pub struct TypeDef {
     /// TypeDef.__init__: `self.heaptype = False`. TypeCache.build passes
     /// `is_heaptype=overridetypedef.heaptype` into W_TypeObject.__init__.
     pub heaptype: bool,
+    /// TypeDef.__init__: `self.applevel_subclasses_base = None`. TypeCache.build
+    /// uses `applevel_subclasses_base.typedef` as `overridetypedef` so the
+    /// derived declaration reuses that base's Layout.
+    pub applevel_subclasses_base: *const TypeDef,
 }
 
 impl TypeDef {
@@ -100,6 +104,7 @@ impl TypeDef {
             method_descriptor: false,
             flag_sequence_bug_compat: false,
             heaptype: false,
+            applevel_subclasses_base: std::ptr::null(),
         }
     }
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -215,6 +215,12 @@ pub struct W_TypeObject {
     /// App-level `__qualname__` object, with the same lazy/identity semantics
     /// as `w_name`.
     pub w_qualname: PyObjectRef,
+    /// typeobject.py:212 `w_doc` — type-level `__doc__` for non-heap types
+    /// (`descr__doc`). Distinct from `dict_w['__doc__']`:
+    /// `setup_builtin_type` seeds both from the override TypeDef, then
+    /// `TypeCache.build` overwrites only this slot with the derived
+    /// declaration's doc when `typedef is not overridetypedef`.
+    pub w_doc: PyObjectRef,
     /// typeobject.py:213 `text_signature` — an optional interpreter-level
     /// string supplied by the builtin TypeDef.  This is not a Python object
     /// and therefore is not a GC edge.
@@ -578,6 +584,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         w_name: PY_NULL,
         qualname,
         w_qualname: PY_NULL,
+        w_doc: PY_NULL,
         text_signature: std::ptr::null_mut(),
         bases,
         dict: dict_ptr,
@@ -718,6 +725,7 @@ pub fn w_type_alloc_builtin() -> PyObjectRef {
         w_name: PY_NULL,
         qualname: std::ptr::null_mut(),
         w_qualname: PY_NULL,
+        w_doc: PY_NULL,
         text_signature: std::ptr::null_mut(),
         bases: PY_NULL,
         dict: std::ptr::null_mut(),
@@ -1436,6 +1444,26 @@ pub unsafe fn w_type_set_text_signature(obj: PyObjectRef, signature: &str) {
     let type_obj = &mut *(obj as *mut W_TypeObject);
     debug_assert!(type_obj.text_signature.is_null());
     type_obj.text_signature = crate::lltype::malloc_raw(signature.to_owned());
+}
+
+/// typeobject.py `W_TypeObject.w_doc`.
+///
+/// # Safety
+/// `obj` must be a live `W_TypeObject`.
+pub unsafe fn w_type_get_w_doc(obj: PyObjectRef) -> PyObjectRef {
+    (*(obj as *const W_TypeObject)).w_doc
+}
+
+/// typeobject.py `W_TypeObject.w_doc = …`.
+///
+/// # Safety
+/// `obj` must be a live `W_TypeObject`. `w_doc` must be a live object
+/// (`w_None` or a unicode).
+pub unsafe fn w_type_set_w_doc(obj: PyObjectRef, w_doc: PyObjectRef) {
+    let t = &mut *(obj as *mut W_TypeObject);
+    t.w_doc = w_doc;
+    crate::gc_roots::mark_prebuilt_roots_dirty();
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 /// Get the bases tuple.

--- a/scripts/check-rpython-module-parity.py
+++ b/scripts/check-rpython-module-parity.py
@@ -1397,7 +1397,7 @@ INTENTIONAL_SYMBOL_MISSING: dict[tuple[str, str], dict[str, dict[str, str]]] = {
             "VirtualizableArrayField": "represented by Transformer.vable_array_vars metadata plus assertion diagnostics rather than a standalone exception payload",
         },
         "functions": {
-            "constant_fold_ll_issubclass": "Pyre has no cpu.rtyper.exceptiondata ll_issubclass direct-call shape in this transform pass; exception matching is lowered through typed Rust paths",
+            "constant_fold_ll_issubclass": "ported as constant_fold_ll_issubclass + constant_fold_ll_issubclass_flowgraph; identity is LowLevelFunction graph_key, not the helper name. Matcher is threaded from exceptiondata.fn_exception_match",
             "is_test_calldescr": "Rust tests use typed CallDescriptor values, not upstream's string/_for_tests_only calldescr sentinel",
         },
     },


### PR DESCRIPTION
## Summary

`OpKind::Call.args` is now `Vec<LinkArg>`, matching RPython `SpaceOperation.args` (`Variable | Constant`). That unlocks the exception-class and cast-root Constants that used to live in `FunctionPath` segments.

- `lower_exc_from_raise` puts the `HOST_ENV` class at `args[0]`. The adapter no longer rebuilds `simple_call` from `["simple_call", class]`.
- `__cast_instance_intrinsic` and `__cast_pointer` carry the target root as a trailing `ByteStr` Constant. The adapter prepends the HOST_ENV callable; `cast_pointer` still interns the class through the bookkeeper (`intern_class_by_qualname`).
- Front `BinaryOp` emits `simple_call(lltype.cast_ptr_to_int)` for `lt|le|gt|ge|mod|floordiv|div` over `Ref`.
- `jtransform` folds `ll_issubclass` by `LowLevelFunction` graph key.
- `rtype_cast_ptr_to_int` tests cover `PtrRepr` vs the `InstanceRepr` swap.

Also includes the leftover commits on this branch after #1747 rebased onto `main` (TypeCache override/`qualname`, Relaxed `get_instantiate`, raw-struct fielddescr retirement, AtomicPtr pointee spelling, scandir `may_ignore_finalizer`, classdict notes).

## Follow-ups not in this PR

- Adapter layer 3b (`HOST_ENV.import_module` for FQ paths) is still load-bearing.
- `rtype_cast_ptr_to_int` InstanceRepr→PtrRepr swap stays until production `SWAP_FALLBACK_HITS == 0`.
- `coerce_operand_to_int` remains for Skip / hand-built graphs.
- #346 (generic ADT / foreign lib / residual skip) is a separate epic.

## Test plan

- [x] `cargo check -p majit-translate --tests`
- [x] Targeted `majit-translate --lib` tests for Call.args, `exc_from_raise`, cast_instance, cast_pointer, fold, swap lock
- [ ] `cargo test --all --no-default-features --features dynasm`
- [ ] `python3 pyre/check.py`