### PR TITLE
wasm: do not date residual LABEL RefOp as a home def

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2339,7 +2339,11 @@ impl HomeLiveness {
                     continue;
                 }
                 last_use[a.raw() as usize] = i as i32;
-                if op.opcode == OpCode::Label {
+                // A LABEL arg is a phi def (`consider_label`). A
+                // producerless RefOp is a residual virtualizable slot,
+                // not a phi: dating it here would hide the unwritten
+                // local from the post-collection reload.
+                if op.opcode == OpCode::Label && !matches!(a, OpRef::RefOp(_)) {
                     let d = &mut def_pos[a.raw() as usize];
                     *d = (*d).min(i as i32);
                 }


### PR DESCRIPTION
## Summary

Rebased onto `origin/main` after #1773. That landing already keeps InputArgRef LABEL phis, declines a producerless LABEL `RefOp` when a later operand reads it, and materializes a sibling `GETARRAYITEM` when one exists — the compile-path Codex P1 asked for.

What remains here: `HomeLiveness` still dated every LABEL arg as defined at the header. A residual `RefOp` is not a phi (`consider_label`); dating it hid the unwritten local from the post-collection reload. InputArgRef / int / float phis are unchanged.

## Tests

- `cargo test -p majit-backend-wasm --lib -- import_hole`

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.