### PR TITLE
gc: mint leftover per-call strings as collectable

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7577,7 +7577,7 @@ fn attr_error_wtf8(obj: PyObjectRef, name: &Wtf8) -> PyError {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(obj);
-    let w_name = pyre_object::w_str_from_wtf8(name.to_wtf8_buf());
+    let w_name = pyre_object::w_str_from_wtf8_managed(name.to_wtf8_buf());
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_name);
     let exc = pyre_object::interp_exceptions::w_exception_new_wtf8(
@@ -20755,7 +20755,7 @@ pub(crate) fn async_gen_awaitable_finalize(awaitable: PyObjectRef) {
         qualname_repr,
         " was never awaited"
     );
-    let w_message = w_str_from_wtf8(message);
+    let w_message = w_str_from_wtf8_managed(message);
     if let Err(mut err) = crate::warn::warn_category_w(w_message, "RuntimeWarning", 1) {
         // A filter turned into `error` hands back the only reference to the
         // materialised exception, and it lives in this Rust `PyError`, which
@@ -20826,7 +20826,7 @@ fn warn_unawaited_coroutine(gen_obj: PyObjectRef) {
             unsafe { pyre_object::w_str_get_wtf8(qualname) }.to_wtf8_buf()
         };
         let message = crate::display::wtf8_format!("coroutine '", qualname, "' was never awaited");
-        let w_message = pyre_object::w_str_from_wtf8(message);
+        let w_message = pyre_object::w_str_from_wtf8_managed(message);
         if let Err(mut err) = crate::warn::warn_category_w(w_message, "RuntimeWarning", 1) {
             err.write_unraisable(w_none(), &where_desc, gen_obj);
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8576,7 +8576,7 @@ pub(crate) fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bo
         && unsafe { pyre_object::is_member(obj) }
         && let Some(doc) = unsafe { pyre_object::w_member_get_doc(obj) }
     {
-        return Ok(w_str_new(doc));
+        return Ok(w_str_new_managed(doc));
     }
     // Type objects: look up in type's own dict → base dicts
     // PyPy: typeobject.py lookup_where → MRO search + descriptor unwrap

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4185,7 +4185,7 @@ unsafe fn print_emit_native(obj: PyObjectRef, errors: &str) -> Result<(), crate:
         crate::print_output(s);
         return Ok(());
     }
-    let s_obj = pyre_object::w_str_from_wtf8(w);
+    let s_obj = pyre_object::w_str_from_wtf8_managed(w);
     let bytes = crate::type_methods::encode_object(s_obj, "utf-8", errors)?;
     crate::print_output_bytes(&bytes);
     Ok(())
@@ -4808,7 +4808,8 @@ pub(crate) fn sys_displayhook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
     // `_` is cleared before rendering so a failing repr does not leave a
     // stale binding, then set to the value once the write succeeds.
     set_builtins_underscore(w_none())?;
-    let repr = pyre_object::w_str_from_wtf8(unsafe { crate::display::py_repr_wtf8(value)? });
+    let repr =
+        pyre_object::w_str_from_wtf8_managed(unsafe { crate::display::py_repr_wtf8(value)? });
     // `pypy/module/sys/app.py:252-253` —
     //     print_item_to(repr(obj), sys_stdout())
     //     print_newline_to(sys_stdout())
@@ -4878,8 +4879,8 @@ pub(crate) fn sys_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         // is well-formed WTF-8; a decode failure would mean a byte no writer
         // put there, and the lossy read is the last resort for it.
         let w_text = match rustpython_wtf8::Wtf8::from_bytes(&rendered) {
-            Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
-            None => pyre_object::w_str_new(&String::from_utf8_lossy(&rendered)),
+            Some(text) => pyre_object::w_str_from_wtf8_managed(text.to_wtf8_buf()),
+            None => pyre_object::w_str_new_managed(&String::from_utf8_lossy(&rendered)),
         };
         // Read the stream back after that allocation, not before it.
         let result = crate::baseobjspace::call_method(
@@ -5837,12 +5838,16 @@ fn parse_single_required(
     let mut keyword_names_w: Vec<PyObjectRef> = Vec::new();
     let mut keywords_w: Vec<PyObjectRef> = Vec::new();
     if let Some(dict) = kwargs {
-        for (key, val) in unsafe { pyre_object::w_dict_str_entries_wtf8(dict) } {
-            if key.as_str() == Ok("__pyre_kw__") {
-                continue;
-            }
-            keyword_names_w.push(pyre_object::w_str_from_wtf8(key));
-            keywords_w.push(val);
+        let entries: Vec<_> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+            .into_iter()
+            .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
+            .collect();
+        let values: Vec<PyObjectRef> = entries.iter().map(|(_, val)| *val).collect();
+        let values_base = pyre_object::gc_roots::pin_roots(&values);
+        for (index, (key, _)) in entries.into_iter().enumerate() {
+            let w_name = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(key));
+            keyword_names_w.push(w_name);
+            keywords_w.push(pyre_object::gc_roots::shadow_stack_get(values_base + index));
         }
     }
     let signature = crate::gateway::Signature::new(vec![name], None, None, 0, 0);
@@ -10017,7 +10022,7 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let repr_slot = if is_list_or_tuple {
         None
     } else {
-        let rendered = pyre_object::w_str_from_wtf8(unsafe {
+        let rendered = pyre_object::w_str_from_wtf8_managed(unsafe {
             crate::display::py_repr_wtf8(pyre_object::gc_roots::shadow_stack_get(base + 2))?
         });
         let _ = pyre_object::gc_roots::pin_root(rendered);
@@ -10812,7 +10817,7 @@ pub fn finalization_error(message: Option<&str>) -> crate::PyError {
         );
     };
     let args = match message {
-        Some(message) => vec![cls, pyre_object::w_str_new(message)],
+        Some(message) => vec![cls, pyre_object::w_str_new_managed(message)],
         None => vec![cls],
     };
     match exc_exception_new(&args) {
@@ -12742,7 +12747,7 @@ fn stamp_parser_syntax_metadata(error: &mut crate::PyError, source: &str) {
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(error.to_exc_object());
     let source_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(source));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(source));
     let zero_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(0));
     let zero = pyre_object::gc_roots::shadow_stack_get(zero_slot);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -257,7 +257,7 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(mv_src);
-        let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(fmt));
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -305,7 +305,7 @@ unsafe fn w_memoryview_cast_nd(
         // Build each geometry object and pin it as produced: a later allocation
         // may relocate an earlier one, so the pinned shadow slot (re-read below)
         // is the source of truth, not the stale local.
-        let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(fmt));
         let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
         let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
@@ -371,7 +371,7 @@ unsafe fn w_memoryview_new_plain(
         let _ = pyre_object::gc_roots::pin_root(w_obj);
         // A Raw view keeps its explicit format object; a Simple view derives 'B'.
         if is_array {
-            let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
+            let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(fmt));
         }
         // Root view over an exporter: it owns the backing's buffer export.
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
@@ -10816,11 +10816,12 @@ pub fn finalization_error(message: Option<&str>) -> crate::PyError {
             message.unwrap_or("Operation blocked during Python finalization."),
         );
     };
-    let args = match message {
-        Some(message) => vec![cls, pyre_object::w_str_new_managed(message)],
-        None => vec![cls],
-    };
-    match exc_exception_new(&args) {
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(cls);
+    if let Some(message) = message {
+        args.push(pyre_object::w_str_new_managed(message));
+    }
+    match exc_exception_new(&args.take()) {
         Ok(exc) => unsafe { crate::PyError::from_exc_object(exc) },
         Err(err) => err,
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5835,6 +5835,7 @@ fn parse_single_required(
     if kwargs.is_none() && positional.len() == 1 {
         return Ok(positional[0]);
     }
+    let pos_base = pyre_object::gc_roots::pin_roots(positional);
     let mut keyword_names_w: Vec<PyObjectRef> = Vec::new();
     let mut keywords_w: Vec<PyObjectRef> = Vec::new();
     if let Some(dict) = kwargs {
@@ -5844,14 +5845,26 @@ fn parse_single_required(
             .collect();
         let values: Vec<PyObjectRef> = entries.iter().map(|(_, val)| *val).collect();
         let values_base = pyre_object::gc_roots::pin_roots(&values);
-        for (index, (key, _)) in entries.into_iter().enumerate() {
-            let w_name = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(key));
-            keyword_names_w.push(w_name);
-            keywords_w.push(pyre_object::gc_roots::shadow_stack_get(values_base + index));
+        let mut name_slots = Vec::with_capacity(entries.len());
+        for (key, _) in entries {
+            let name_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(key));
+            name_slots.push(name_slot);
         }
+        keyword_names_w = name_slots
+            .iter()
+            .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+            .collect();
+        keywords_w = (0..name_slots.len())
+            .map(|index| pyre_object::gc_roots::shadow_stack_get(values_base + index))
+            .collect();
     }
+    let refreshed_pos: Vec<PyObjectRef> = (0..positional.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(pos_base + index))
+        .collect();
     let signature = crate::gateway::Signature::new(vec![name], None, None, 0, 0);
-    let arguments = crate::argument::Arguments::with_kw(positional, &keyword_names_w, &keywords_w);
+    let arguments =
+        crate::argument::Arguments::with_kw(&refreshed_pos, &keyword_names_w, &keywords_w);
     let mut scope_w = vec![PY_NULL; signature.scope_length()];
     arguments.parse_into_scope(PY_NULL, &mut scope_w, fn_name, &signature, None, PY_NULL)?;
     Ok(scope_w[0])
@@ -11419,6 +11432,10 @@ pub(crate) fn parse_int_from_str(
     s: &str,
     base: u32,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let _source_roots = pyre_object::gc_roots::push_roots();
+    let source_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_source);
+    let w_source = || pyre_object::gc_roots::shadow_stack_get(source_slot);
     // rarithmetic.py `string_to_int` first handles short, plain
     // decimal strings without constructing a NumberStringParser.
     const OVF_DIGITS: usize = 19; // len(str(sys.maxint)) on pyre's i64 target
@@ -11459,7 +11476,7 @@ pub(crate) fn parse_int_from_str(
         majit_rlib::rbigint::NumberStringParser::new(s, base as i64, true, true, 0, None, 0, true)
             .map_err(|error| match error {
                 majit_rlib::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
-                _ => invalid_int_literal(w_source, base),
+                _ => invalid_int_literal(w_source(), base),
             })?;
 
     // NumberStringParser performs this check immediately after its structural
@@ -11483,7 +11500,7 @@ pub(crate) fn parse_int_from_str(
     loop {
         let digit = parser.next_digit().map_err(|error| match error {
             majit_rlib::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
-            _ => invalid_int_literal(w_source, base),
+            _ => invalid_int_literal(w_source(), base),
         })?;
         if digit < 0 {
             return Ok(w_int_new(machine_value));
@@ -11502,7 +11519,7 @@ pub(crate) fn parse_int_from_str(
     let value = BigInt::_from_numberstring_parser(&mut parser).map_err(|error| match error {
         majit_rlib::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
         majit_rlib::rbigint::RBigIntError::MaxStrDigits => unreachable!("limit checked above"),
-        _ => invalid_int_literal(w_source, base),
+        _ => invalid_int_literal(w_source(), base),
     })?;
     Ok(w_long_new(value))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -789,7 +789,7 @@ fn w_memoryview_new_with_flags_impl(
             let sp = pyre_object::gc_roots::shadow_stack_len();
             let _ = pyre_object::gc_roots::pin_root(w_obj);
             let _ = pyre_object::gc_roots::pin_root(backing_obj);
-            let _ = pyre_object::gc_roots::pin_root(w_str_new(&fmt));
+            let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&fmt));
             let shape_i64 = shape.iter().map(|&dim| dim as i64).collect::<Vec<_>>();
             let mut strides = vec![0i64; shape.len()];
             let mut stride = itemsize as i64;

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3281,10 +3281,13 @@ fn call_with_kwargs_in_ctx_impl(
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
                     let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
-                    let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
-                        .iter()
-                        .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
-                        .collect();
+                    let mut keyword_names_w: Vec<pyre_object::PyObjectRef> =
+                        Vec::with_capacity(kwargs.len());
+                    for (k, _) in kwargs.iter() {
+                        keyword_names_w.push(pyre_object::gc_roots::pin_root(
+                            pyre_object::w_str_from_wtf8_managed(k.clone()),
+                        ));
+                    }
                     let keywords_w: Vec<pyre_object::PyObjectRef> =
                         kwargs.iter().map(|(_, v)| *v).collect();
                     let mut arguments = crate::argument::Arguments::with_kw(
@@ -3387,10 +3390,13 @@ fn call_with_kwargs_in_ctx_impl(
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
                     let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
-                    let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
-                        .iter()
-                        .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
-                        .collect();
+                    let mut keyword_names_w: Vec<pyre_object::PyObjectRef> =
+                        Vec::with_capacity(kwargs.len());
+                    for (k, _) in kwargs.iter() {
+                        keyword_names_w.push(pyre_object::gc_roots::pin_root(
+                            pyre_object::w_str_from_wtf8_managed(k.clone()),
+                        ));
+                    }
                     // `keyword_names_w` allocated a string per keyword, so
                     // everything read before it — the positionals, the keyword
                     // values, and the dict `full_args` carries — may have moved

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3281,17 +3281,22 @@ fn call_with_kwargs_in_ctx_impl(
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
                     let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
-                    let mut keyword_names_w: Vec<pyre_object::PyObjectRef> =
-                        Vec::with_capacity(kwargs.len());
+                    let mut name_slots = Vec::with_capacity(kwargs.len());
                     for (k, _) in kwargs.iter() {
-                        keyword_names_w.push(pyre_object::gc_roots::pin_root(
+                        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                        let _ = pyre_object::gc_roots::pin_root(
                             pyre_object::w_str_from_wtf8_managed(k.clone()),
-                        ));
+                        );
+                        name_slots.push(name_slot);
                     }
                     // Name mints can move the positionals, keyword values, and
                     // the earlier `bound` slice. Reload from the entry bracket
                     // and rebind before the profiled call, as the marker
                     // branch below does.
+                    let keyword_names_w: Vec<pyre_object::PyObjectRef> = name_slots
+                        .iter()
+                        .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+                        .collect();
                     let keywords_w: Vec<pyre_object::PyObjectRef> =
                         (0..kwargs.len()).map(current_kwarg).collect();
                     let refreshed_pos: Vec<pyre_object::PyObjectRef> =
@@ -3310,7 +3315,7 @@ fn call_with_kwargs_in_ctx_impl(
                     );
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
                         unsafe { &mut *frame_anchor.live() },
-                        callable,
+                        current_callable(),
                         &mut arguments,
                         &bound,
                     );
@@ -3403,17 +3408,22 @@ fn call_with_kwargs_in_ctx_impl(
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
                     let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
-                    let mut keyword_names_w: Vec<pyre_object::PyObjectRef> =
-                        Vec::with_capacity(kwargs.len());
+                    let mut name_slots = Vec::with_capacity(kwargs.len());
                     for (k, _) in kwargs.iter() {
-                        keyword_names_w.push(pyre_object::gc_roots::pin_root(
+                        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                        let _ = pyre_object::gc_roots::pin_root(
                             pyre_object::w_str_from_wtf8_managed(k.clone()),
-                        ));
+                        );
+                        name_slots.push(name_slot);
                     }
                     // `keyword_names_w` allocated a string per keyword, so
                     // everything read before it — the positionals, the keyword
                     // values, and the dict `full_args` carries — may have moved
                     // since. Everything below reloads from the roots.
+                    let keyword_names_w: Vec<pyre_object::PyObjectRef> = name_slots
+                        .iter()
+                        .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+                        .collect();
                     let keywords_w: Vec<pyre_object::PyObjectRef> =
                         (0..kwargs.len()).map(current_kwarg).collect();
                     let refreshed_pos: Vec<pyre_object::PyObjectRef> =
@@ -3430,7 +3440,7 @@ fn call_with_kwargs_in_ctx_impl(
                         .collect();
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
                         unsafe { &mut *frame_anchor.live() },
-                        callable,
+                        current_callable(),
                         &mut arguments,
                         &full_args,
                     );

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3288,10 +3288,23 @@ fn call_with_kwargs_in_ctx_impl(
                             pyre_object::w_str_from_wtf8_managed(k.clone()),
                         ));
                     }
+                    // Name mints can move the positionals, keyword values, and
+                    // the earlier `bound` slice. Reload from the entry bracket
+                    // and rebind before the profiled call, as the marker
+                    // branch below does.
                     let keywords_w: Vec<pyre_object::PyObjectRef> =
-                        kwargs.iter().map(|(_, v)| *v).collect();
+                        (0..kwargs.len()).map(current_kwarg).collect();
+                    let refreshed_pos: Vec<pyre_object::PyObjectRef> =
+                        (0..pos_args.len()).map(current_pos_arg).collect();
+                    let refreshed_kwargs: Vec<(Wtf8Buf, PyObjectRef)> = kwargs
+                        .iter()
+                        .enumerate()
+                        .map(|(index, (name, _))| (name.clone(), current_kwarg(index)))
+                        .collect();
+                    let bound =
+                        bind_kwargs_to_signature(sig, &fname, &refreshed_pos, &refreshed_kwargs)?;
                     let mut arguments = crate::argument::Arguments::with_kw(
-                        pos_args,
+                        &refreshed_pos,
                         &keyword_names_w,
                         &keywords_w,
                     );

--- a/pyre/pyre-interpreter/src/cpyext/import_.rs
+++ b/pyre/pyre-interpreter/src/cpyext/import_.rs
@@ -20,7 +20,7 @@ pub(super) fn import_module(name: &str) -> Result<PyObjectRef, crate::PyError> {
     let import_slot = pyre_object::gc_roots::shadow_stack_len();
     let import = roots.pin_root(import);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(name));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(name));
     // `__import__` answers with the top-level package, so the submodule is
     // read back out of `sys.modules` afterwards.
     crate::call::call_function_impl_result(

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -748,10 +748,16 @@ pub(super) fn call_cfunction_in_class(
             fastcall_slots.push(pyobject::make_ref(value_slot(index)));
         }
         if flags.contains(MethFlags::METH_KEYWORDS) && !keywords.is_empty() {
-            let mut names = Vec::with_capacity(keywords.len());
+            let mut name_slots = Vec::with_capacity(keywords.len());
             for (name, _) in keywords.iter() {
-                names.push(roots.pin_root(pyre_object::w_str_new_managed(name)));
+                let name_slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = roots.pin_root(pyre_object::w_str_new_managed(name));
+                name_slots.push(name_slot);
             }
+            let names: Vec<PyObjectRef> = name_slots
+                .iter()
+                .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+                .collect();
             keywords_arg = pyobject::make_ref(pyre_object::tupleobject::w_tuple_new(names));
         }
     } else if !flags.intersects(MethFlags::METH_NOARGS | MethFlags::METH_O) {

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -438,7 +438,7 @@ fn missing_init_error(name: &str, path: &Path) -> crate::PyError {
 fn extension_import_error(message: String, name: &str, path: &Path) -> crate::PyError {
     let roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = roots.pin_root(pyre_object::w_str_new(name));
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(name));
     let path_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
     crate::PyError::import_error_name_path(
@@ -748,10 +748,10 @@ pub(super) fn call_cfunction_in_class(
             fastcall_slots.push(pyobject::make_ref(value_slot(index)));
         }
         if flags.contains(MethFlags::METH_KEYWORDS) && !keywords.is_empty() {
-            let names: Vec<PyObjectRef> = keywords
-                .iter()
-                .map(|(name, _)| pyre_object::w_str_new(name))
-                .collect();
+            let mut names = Vec::with_capacity(keywords.len());
+            for (name, _) in keywords.iter() {
+                names.push(roots.pin_root(pyre_object::w_str_new_managed(name)));
+            }
             keywords_arg = pyobject::make_ref(pyre_object::tupleobject::w_tuple_new(names));
         }
     } else if !flags.intersects(MethFlags::METH_NOARGS | MethFlags::METH_O) {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -1730,11 +1730,17 @@ pub(crate) fn wtf8_display_string(rendered: Wtf8Buf, fallback: &str) -> String {
     if let Ok(s) = rendered.as_str() {
         return s.to_owned();
     }
-    let s_obj = pyre_object::w_str_from_wtf8_managed(rendered);
-    crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
-        .ok()
-        .and_then(|b| String::from_utf8(b).ok())
-        .unwrap_or_else(|| fallback.to_string())
+    let _roots = pyre_object::gc_roots::push_roots();
+    let s_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(rendered));
+    crate::type_methods::encode_object(
+        pyre_object::gc_roots::shadow_stack_get(s_slot),
+        "utf-8",
+        "backslashreplace",
+    )
+    .ok()
+    .and_then(|b| String::from_utf8(b).ok())
+    .unwrap_or_else(|| fallback.to_string())
 }
 
 /// The encoded length of the character a WTF-8 lead byte opens.

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -1730,7 +1730,7 @@ pub(crate) fn wtf8_display_string(rendered: Wtf8Buf, fallback: &str) -> String {
     if let Ok(s) = rendered.as_str() {
         return s.to_owned();
     }
-    let s_obj = pyre_object::w_str_from_wtf8(rendered);
+    let s_obj = pyre_object::w_str_from_wtf8_managed(rendered);
     crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
         .ok()
         .and_then(|b| String::from_utf8(b).ok())

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -923,7 +923,7 @@ impl PyError {
         // becomes `args[1]`.
         let details_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(details);
-        let w_msg = pyre_object::w_str_from_wtf8(message.clone());
+        let w_msg = pyre_object::w_str_from_wtf8_managed(message.clone());
         let msg_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(w_msg);
         unsafe {
@@ -1464,7 +1464,8 @@ impl PyError {
         let errno_slot = exc_slot + 1;
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(errno as i64));
         let strerror_slot = errno_slot + 1;
-        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8(strerror.clone()));
+        let _ =
+            pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(strerror.clone()));
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
             pyre_object::gc_roots::shadow_stack_get(errno_slot),
             pyre_object::gc_roots::shadow_stack_get(strerror_slot),
@@ -1473,7 +1474,7 @@ impl PyError {
             pyre_object::interp_exceptions::w_exception_set_args(exc(), args_list);
             let w_errno = pyre_object::w_int_new(errno as i64);
             pyre_object::interp_exceptions::w_exception_set_errno(exc(), w_errno);
-            let w_strerror = pyre_object::w_str_from_wtf8(strerror.clone());
+            let w_strerror = pyre_object::w_str_from_wtf8_managed(strerror.clone());
             pyre_object::interp_exceptions::w_exception_set_strerror(exc(), w_strerror);
         }
         PyError {
@@ -1542,7 +1543,7 @@ impl PyError {
         let w_msg = if message.is_empty() {
             pyre_object::w_none()
         } else {
-            pyre_object::w_str_from_wtf8(message.clone())
+            pyre_object::w_str_from_wtf8_managed(message.clone())
         };
         // Reload name/path after the message allocation: the pins keep them
         // alive, but a minor collection may have relocated the young objects,
@@ -1652,7 +1653,7 @@ impl PyError {
         let exc = pyre_object::gc_roots::pin_root(exc);
         if !self.message.is_empty() {
             let msg_slot = pyre_object::gc_roots::shadow_stack_len();
-            let msg = pyre_object::w_str_from_wtf8(self.message.clone());
+            let msg = pyre_object::w_str_from_wtf8_managed(self.message.clone());
             let msg = pyre_object::gc_roots::pin_root(msg);
             let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![msg]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
@@ -2059,20 +2060,18 @@ impl PyError {
         // vm.py:19-25 also carries `extra_line`; pyre's hook-args
         // structseq targets the 5-field shape, so only the default printer
         // receives the Rust-side extra line.
-        let hook_args = crate::_structseq::new_instance(
-            unraisable_hook_args_type(),
-            vec![
-                w_type,
-                w_value,
-                w_tb,
-                if first_line.is_empty() {
-                    pyre_object::w_none()
-                } else {
-                    pyre_object::w_str_from_wtf8(first_line.clone())
-                },
-                w_object,
-            ],
-        );
+        let mut hook_fields = pyre_object::gc_roots::RootedItems::new();
+        hook_fields.push(w_type);
+        hook_fields.push(w_value);
+        hook_fields.push(w_tb);
+        hook_fields.push(if first_line.is_empty() {
+            pyre_object::w_none()
+        } else {
+            pyre_object::w_str_from_wtf8_managed(first_line.clone())
+        });
+        hook_fields.push(w_object);
+        let hook_args =
+            crate::_structseq::new_instance(unraisable_hook_args_type(), hook_fields.take());
         if let Some(sys_mod) = crate::importing::get_interpreter_sys_module()
             && let Ok(w_hook) = crate::baseobjspace::getattr_str(sys_mod, "unraisablehook")
             && !w_hook.is_null()
@@ -2153,10 +2152,21 @@ impl PyError {
         // way a filesystem name is read so it keeps its escape instead of
         // folding to U+FFFD, and so this sink and the fd sink agree.
         let w_text = match rustpython_wtf8::Wtf8::from_bytes(buf) {
-            Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
-            None => pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_filename_wtf8(buf)),
+            Some(text) => pyre_object::w_str_from_wtf8_managed(text.to_wtf8_buf()),
+            None => {
+                pyre_object::w_str_from_wtf8_managed(crate::gateway::fsdecode_filename_wtf8(buf))
+            }
         };
-        let result = crate::baseobjspace::call_method(stderr, "write", &[w_text]);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let stream_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(stderr);
+        let _ = pyre_object::gc_roots::pin_root(w_text);
+        let text_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let result = crate::baseobjspace::call_method(
+            pyre_object::gc_roots::shadow_stack_get(stream_slot),
+            "write",
+            &[pyre_object::gc_roots::shadow_stack_get(text_slot)],
+        );
         if result.is_null() {
             let _ = crate::call::take_call_error();
             return false;
@@ -3422,7 +3432,7 @@ fn stdlib_module_name(name: &str) -> bool {
     }
     let names_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(names);
-    let name = pyre_object::w_str_new(name);
+    let name = pyre_object::w_str_new_managed(name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(name);
     let names = pyre_object::gc_roots::shadow_stack_get(names_slot);
@@ -4047,7 +4057,7 @@ pub(crate) fn emit_report_to_sys_stderr(buf: &[u8]) {
     // well-formed WTF-8; the lossy read is the last resort for a byte no writer
     // put there.
     let w_text = match rustpython_wtf8::Wtf8::from_bytes(buf) {
-        Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
+        Some(text) => pyre_object::w_str_from_wtf8_managed(text.to_wtf8_buf()),
         None => pyre_object::w_str_new_managed(&String::from_utf8_lossy(buf)),
     };
     let _ = pyre_object::gc_roots::pin_root(w_text);
@@ -4432,7 +4442,7 @@ fn operation_error_from_class(w_type: PyObjectRef, message: Wtf8Buf) -> Operatio
     let _ = _roots.pin_root(w_type);
     // `w_str_new`'s buffer-taking sibling: same allocation policy, and it is
     // the one that accepts a lone surrogate.
-    let w_message = pyre_object::w_str_from_wtf8(message.clone());
+    let w_message = pyre_object::w_str_from_wtf8_managed(message.clone());
     let _ = _roots.pin_root(w_message);
     let (w_type, w_message) = (_roots.get(base), _roots.get(base + 1));
     operation_error_from_instance(
@@ -4814,7 +4824,7 @@ pub fn new_exception_class(
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = _roots.pin_root(w_dict.unwrap_or_else(pyre_object::w_dict_new));
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = _roots.pin_root(pyre_object::w_str_new(name));
+    let _ = _roots.pin_root(pyre_object::w_str_new_managed(name));
     let args = [
         _roots.get(name_slot),
         _roots.get(bases_slot),
@@ -4839,7 +4849,7 @@ pub fn new_exception_class(
         // Pinned like every other operand here: `setattr_str` allocates, and a
         // collection rewrites the root SLOT rather than this frame's copy.
         let module_slot = pyre_object::gc_roots::shadow_stack_len();
-        let _ = _roots.pin_root(pyre_object::w_str_new(module));
+        let _ = _roots.pin_root(pyre_object::w_str_new_managed(module));
         // `space.setattr` propagates its failure through the same bare-return
         // channel as the class call above.
         if let Err(err) = crate::baseobjspace::setattr_str(
@@ -4972,8 +4982,11 @@ pub fn wrap_oserror(
     // from its slot afterwards.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
-    let _ = _roots.pin_root(pyre_object::w_str_new(filename));
-    let w_filename2 = filename2.map(pyre_object::w_str_new);
+    let _ = _roots.pin_root(pyre_object::w_str_new_managed(filename));
+    let w_filename2 = filename2.map(|name| {
+        let _ = _roots.pin_root(pyre_object::w_str_new_managed(name));
+        _roots.get(base + 1)
+    });
     wrap_oserror2(
         space,
         error,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2064,14 +2064,19 @@ impl PyError {
         hook_fields.push(w_type);
         hook_fields.push(w_value);
         hook_fields.push(w_tb);
+        // Pin the object before the managed first-line mint; the structseq
+        // field order is type, value, traceback, line, object.
+        hook_fields.push(w_object);
         hook_fields.push(if first_line.is_empty() {
             pyre_object::w_none()
         } else {
             pyre_object::w_str_from_wtf8_managed(first_line.clone())
         });
-        hook_fields.push(w_object);
-        let hook_args =
-            crate::_structseq::new_instance(unraisable_hook_args_type(), hook_fields.take());
+        let live = hook_fields.take();
+        let hook_args = crate::_structseq::new_instance(
+            unraisable_hook_args_type(),
+            vec![live[0], live[1], live[2], live[4], live[3]],
+        );
         if let Some(sys_mod) = crate::importing::get_interpreter_sys_module()
             && let Ok(w_hook) = crate::baseobjspace::getattr_str(sys_mod, "unraisablehook")
             && !w_hook.is_null()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4748,7 +4748,7 @@ impl OpcodeStepExecutor for PyFrame {
                 let mut qualname =
                     unsafe { crate::function::function_get_qualname(roots.get(func_slot)) };
                 qualname.push_str(".__annotate__");
-                let w_qualname = pyre_object::w_str_from_wtf8(qualname);
+                let w_qualname = pyre_object::w_str_from_wtf8_managed(qualname);
                 unsafe {
                     crate::function::function_set_qualname(roots.get(attr_slot), w_qualname);
                     crate::function::function_set_annotate_unchecked(

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1317,7 +1317,7 @@ pub unsafe fn descr_builtin_function_reduce(obj: PyObjectRef) -> crate::PyResult
         result.push(args);
         return Ok(pyre_object::w_tuple_new(result.take()));
     }
-    Ok(pyre_object::w_str_from_wtf8(unsafe {
+    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
         function_get_qualname(obj)
     }))
 }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -2073,7 +2073,7 @@ pub fn fsdecode_os_str(name: &std::ffi::OsStr) -> pyre_object::PyObjectRef {
     {
         use std::os::windows::ffi::OsStrExt;
         let units: Vec<u16> = name.encode_wide().collect();
-        pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(&units))
+        pyre_object::w_str_from_wtf8_managed(rustpython_wtf8::Wtf8Buf::from_wide(&units))
     }
     #[cfg(not(windows))]
     {

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1598,7 +1598,7 @@ pub unsafe fn builtin_code_call_name(obj: PyObjectRef, receiver: Option<PyObject
 pub unsafe fn builtin_code_get_docstring(obj: PyObjectRef) -> PyObjectRef {
     let func_obj = obj as *const BuiltinCode;
     match unsafe { (*func_obj).docstring } {
-        Some(s) => pyre_object::w_str_new(s),
+        Some(s) => pyre_object::w_str_new_managed(s),
         None => pyre_object::w_none(),
     }
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -929,11 +929,13 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
                         // set still open holds the slots the outer one claims.
                         let entry = {
                             let mut fields = pyre_object::gc_roots::RootedItems::new();
-                            fields.push(pyre_object::w_str_from_wtf8(literal));
-                            fields.push(pyre_object::w_str_from_wtf8(field_name));
-                            fields.push(pyre_object::w_str_from_wtf8(format_spec));
+                            fields.push(pyre_object::w_str_from_wtf8_managed(literal));
+                            fields.push(pyre_object::w_str_from_wtf8_managed(field_name));
+                            fields.push(pyre_object::w_str_from_wtf8_managed(format_spec));
                             fields.push(match conversion_spec {
-                                Some(c) => pyre_object::w_str_new(&c.to_char_lossy().to_string()),
+                                Some(c) => {
+                                    pyre_object::w_str_new_managed(&c.to_char_lossy().to_string())
+                                }
                                 None => pyre_object::w_none(),
                             });
                             pyre_object::w_tuple_new(fields.take())
@@ -945,7 +947,7 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
             if let Some(text) = pending {
                 let entry = {
                     let mut fields = pyre_object::gc_roots::RootedItems::new();
-                    fields.push(pyre_object::w_str_from_wtf8(text));
+                    fields.push(pyre_object::w_str_from_wtf8_managed(text));
                     fields.push(pyre_object::w_none());
                     fields.push(pyre_object::w_none());
                     fields.push(pyre_object::w_none());
@@ -970,11 +972,10 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
             let first = match field_type {
                 FieldType::Auto => pyre_object::w_str_new(""),
                 FieldType::Index(n) => pyre_object::w_int_new(n as i64),
-                FieldType::Keyword(s) => pyre_object::w_str_from_wtf8(s),
+                FieldType::Keyword(s) => pyre_object::w_str_from_wtf8_managed(s),
             };
-            // A `str` and an `int` never move, so `first` is never read back,
-            // but nothing else refers to it while the parts below allocate:
-            // one liveness pin covers it to the end of the call.
+            // `first` is a young managed str or int; pin it across the parts
+            // below, which allocate.
             let roots = pyre_object::gc_roots::push_roots();
             let first = roots.pin_root(first);
             let mut rest = pyre_object::gc_roots::RootedItems::new();
@@ -984,7 +985,7 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
                     match part {
                         FieldNamePart::Attribute(s) => {
                             fields.push(pyre_object::w_bool_from(true));
-                            fields.push(pyre_object::w_str_from_wtf8(s));
+                            fields.push(pyre_object::w_str_from_wtf8_managed(s));
                         }
                         FieldNamePart::Index(n) => {
                             fields.push(pyre_object::w_bool_from(false));
@@ -992,7 +993,7 @@ fn init_string_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
                         }
                         FieldNamePart::StringIndex(s) => {
                             fields.push(pyre_object::w_bool_from(false));
-                            fields.push(pyre_object::w_str_from_wtf8(s));
+                            fields.push(pyre_object::w_str_from_wtf8_managed(s));
                         }
                     }
                     pyre_object::w_tuple_new(fields.take())
@@ -1305,9 +1306,9 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
     );
 
     let base_prefix = sysconfigdata_base_prefix();
-    let base_prefix_str = pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_os_str_wtf8(
-        base_prefix.as_os_str(),
-    ));
+    let base_prefix_str = pyre_object::w_str_from_wtf8_managed(
+        crate::gateway::fsdecode_os_str_wtf8(base_prefix.as_os_str()),
+    );
     // `include/{implementation_lower}{py_version_short}{abi_thread}`, the
     // directory the posix_prefix scheme resolves `get_paths()['include']` to.
     // An interpreter that publishes no base prefix has nowhere to name.
@@ -1458,7 +1459,7 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
     // Python 3.14's relocation check reads these from the generated data.
     unsafe {
         for key in ["prefix", "exec_prefix", "srcdir"] {
-            let w_key = pyre_object::w_str_new(key);
+            let w_key = pyre_object::w_str_new_managed(key);
             pyre_object::w_dict_store(
                 pyre_object::gc_roots::shadow_stack_get(vars_slot),
                 w_key,
@@ -1501,7 +1502,7 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
             let key_slot = pyre_object::gc_roots::shadow_stack_len();
             let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new("TZPATH"));
             let w_value =
-                pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_os_str_wtf8(&joined));
+                pyre_object::w_str_from_wtf8_managed(crate::gateway::fsdecode_os_str_wtf8(&joined));
             pyre_object::w_dict_store(
                 pyre_object::gc_roots::shadow_stack_get(vars_slot),
                 pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -1992,11 +1993,11 @@ fn fix_up_source_module_spec(
     let _ = pin_root(w_name);
     let ext_slot = shadow_stack_len();
     let _ = pin_root(ext);
-    let w_path = pyre_object::w_str_from_wtf8(pathname.to_wtf8_buf());
+    let w_path = pyre_object::w_str_from_wtf8_managed(pathname.to_wtf8_buf());
     let path_slot = shadow_stack_len();
     let _ = pin_root(w_path);
     let w_cpath = match cpathname {
-        Some(c) => pyre_object::w_str_new(c),
+        Some(c) => pyre_object::w_str_new_managed(c),
         None => pyre_object::w_none(),
     };
     let cpath_slot = shadow_stack_len();
@@ -3012,7 +3013,7 @@ pub fn add_sys_path(dir: &Path) {
     // path is allocation-free until the pinned entry reaches `w_list_append`.
     let _roots = push_roots();
     let slot = shadow_stack_len();
-    let _ = pin_root(pyre_object::w_str_from_wtf8(entry.clone()));
+    let _ = pin_root(pyre_object::w_str_from_wtf8_managed(entry.clone()));
     let Some(sys_mod) = get_interpreter_sys_module() else {
         return;
     };
@@ -3168,14 +3169,14 @@ pub(crate) fn sys_modules_registry_get(name: &str) -> Option<PyObjectRef> {
 /// report it — `None` is not a module it can hand back, so it falls through
 /// to the search — hence the separate lookup.
 fn sys_modules_blocks(name: &str) -> bool {
-    sys_modules_blocks_key(pyre_object::w_str_new(name))
+    sys_modules_blocks_key(pyre_object::w_str_new_managed(name))
 }
 
 /// [`sys_modules_blocks`] for a name with no `&str` spelling.  A module name
 /// is WTF-8 and may carry a lone surrogate, and `sys.modules` is free to hold
 /// such a name as a key, so the block is asked for as an object.
 fn sys_modules_blocks_wtf8(name: &Wtf8) -> bool {
-    sys_modules_blocks_key(pyre_object::w_str_from_wtf8(name.to_owned()))
+    sys_modules_blocks_key(pyre_object::w_str_from_wtf8_managed(name.to_owned()))
 }
 
 fn sys_modules_blocks_key(key: PyObjectRef) -> bool {
@@ -4219,7 +4220,7 @@ fn exec_code_module(
     // `write_paths=False` shape (REPL, builtin bootstrap).
     if let Some(p) = pathname {
         // importing.py:284 setitem('__file__', w_pathname).
-        let w_pathname = pyre_object::w_str_from_wtf8(p.to_wtf8_buf());
+        let w_pathname = pyre_object::w_str_from_wtf8_managed(p.to_wtf8_buf());
         unsafe {
             pyre_object::w_dict_setitem_str(w_globals, "__file__", w_pathname);
         }
@@ -4228,7 +4229,7 @@ fn exec_code_module(
         // import was not satisfied from a `.pyc`.  Pyre has no .pyc
         // path today so reachable callers still hit the None arm.
         let w_cpathname = match cpathname {
-            Some(c) => pyre_object::w_str_new(c),
+            Some(c) => pyre_object::w_str_new_managed(c),
             None => pyre_object::w_none(),
         };
         unsafe {
@@ -4341,7 +4342,11 @@ pub fn appleveldef_install_seeded(
     // seen under a different name -- the public spelling of an accelerator it
     // backs -- rebinds `__name__` itself, and that assignment runs later.
     unsafe {
-        pyre_object::w_dict_setitem_str(w_app_globals, "__name__", pyre_object::w_str_new(modname))
+        pyre_object::w_dict_setitem_str(
+            w_app_globals,
+            "__name__",
+            pyre_object::w_str_new_managed(modname),
+        )
     };
     for &(name, value) in seed {
         unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
@@ -4475,7 +4480,7 @@ fn load_source_module(
     } else {
         modulename
     };
-    let package_name = pyre_object::w_str_new(pkg);
+    let package_name = pyre_object::w_str_new_managed(pkg);
     unsafe {
         pyre_object::w_dict_setitem_str(roots.get(globals_slot), "__package__", package_name);
     }
@@ -4515,7 +4520,7 @@ fn load_source_module(
     };
     if let Some(frozen) = frozen_exec_name {
         unsafe {
-            let frozen_name = pyre_object::w_str_new(frozen);
+            let frozen_name = pyre_object::w_str_new_managed(frozen);
             pyre_object::w_dict_setitem_str(roots.get(globals_slot), "__name__", frozen_name);
         }
     }
@@ -4543,7 +4548,7 @@ fn load_source_module(
     // `__module__`; `module.__name__` resolves from this dict entry.
     if frozen_exec_name.is_some() {
         unsafe {
-            let public_name = pyre_object::w_str_new(modulename);
+            let public_name = pyre_object::w_str_new_managed(modulename);
             pyre_object::w_dict_setitem_str(roots.get(globals_slot), "__name__", public_name);
         }
     }
@@ -4809,7 +4814,7 @@ fn set_frozen_alias_metadata(
     crate::baseobjspace::setattr_str(
         shadow_stack_get(module_slot),
         "__origname__",
-        pyre_object::w_str_new(origname),
+        pyre_object::w_str_new_managed(origname),
     )?;
     Ok(())
 }
@@ -4849,7 +4854,7 @@ fn load_namespace_package(
     let roots = pyre_object::gc_roots::push_roots();
     let globals_slot = roots.base();
     let _ = roots.pin_root(w_globals);
-    let package_name = pyre_object::w_str_new(modulename);
+    let package_name = pyre_object::w_str_new_managed(modulename);
     unsafe {
         pyre_object::w_dict_setitem_str(roots.get(globals_slot), "__package__", package_name);
     }
@@ -5299,7 +5304,7 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
         let lock_unlock_slot = shadow_stack_len();
         let _ = pin_root(w_lock_unlock);
         let name_slot = shadow_stack_len();
-        let _ = pin_root(pyre_object::w_str_new(name));
+        let _ = pin_root(pyre_object::w_str_new_managed(name));
         crate::call::call_function_impl_result(
             shadow_stack_get(lock_unlock_slot),
             &[shadow_stack_get(name_slot)],
@@ -5590,7 +5595,7 @@ pub fn dunder_import(
                     level,
                 );
             }
-            let w_name = pyre_object::w_str_new(name);
+            let w_name = pyre_object::w_str_new_managed(name);
             return call_bootstrap_import(
                 shadow_stack_get(import_slot),
                 w_name,
@@ -5672,7 +5677,7 @@ pub fn call_dunder_import_name_only(
     // Minted before the slot is read back: the allocation can move what the
     // slot holds, and an argument read ahead of it would be a stale address.
     let name_slot = shadow_stack_len();
-    let _ = pin_root(pyre_object::w_str_new(name));
+    let _ = pin_root(pyre_object::w_str_new_managed(name));
     crate::call::call_function_impl_result(
         shadow_stack_get(import_slot),
         &[shadow_stack_get(name_slot)],
@@ -5722,7 +5727,7 @@ pub fn call_dunder_import(
     let _ = pin_root(dunder_import_binding(execution_context)?);
     // Minted before any slot is read back: the allocation can move what the
     // slots hold, and an argument read ahead of it would be a stale address.
-    let w_name = pyre_object::w_str_new(name);
+    let w_name = pyre_object::w_str_new_managed(name);
     call_bootstrap_import(
         shadow_stack_get(import_slot),
         w_name,
@@ -5875,7 +5880,7 @@ fn relative_import_head(
         w_globals
     });
     let name_slot = shadow_stack_len();
-    let _ = pin_root(pyre_object::w_str_new(name));
+    let _ = pin_root(pyre_object::w_str_new_managed(name));
     let level_slot = shadow_stack_len();
     let _ = pin_root(pyre_object::w_int_new(level));
 
@@ -5942,7 +5947,7 @@ fn relative_import_head(
         .unwrap_or(abs_name.as_str());
 
     let head_slot = shadow_stack_len();
-    let _ = pin_root(pyre_object::w_str_new(head));
+    let _ = pin_root(pyre_object::w_str_new_managed(head));
     // The raw `sys.modules` entry, `None` sentinel included: only a *missing*
     // key is the KeyError.
     let w_modules = sys_modules_dict();
@@ -6228,7 +6233,7 @@ fn handle_fromlist(
             message.push_str("'");
             return Err(crate::PyError::module_not_found_with_name_obj(
                 message,
-                pyre_object::w_str_from_wtf8(from_name),
+                pyre_object::w_str_from_wtf8_managed(from_name),
             ));
         }
         let Ok(child) = from_name.as_str() else {
@@ -6481,7 +6486,7 @@ pub(crate) fn is_spec_uninitialized_submodule(
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(false),
         Err(e) => return Err(e),
     };
-    crate::baseobjspace::contains(w_value, pyre_object::w_str_new(name))
+    crate::baseobjspace::contains(w_value, pyre_object::w_str_new_managed(name))
 }
 
 /// `_PyModuleSpec_GetFileOrigin` — the spec's file origin: its `origin` string
@@ -6624,7 +6629,10 @@ pub fn import_from(module: PyObjectRef, name: &str) -> Result<PyObjectRef, crate
     let pkgname_slot = pyre_object::gc_roots::shadow_stack_len();
     let (w_pkgname, named) = match crate::baseobjspace::getattr_str(module, "__name__") {
         Ok(v) if unsafe { pyre_object::is_str(v) } => (v, true),
-        _ => (pyre_object::w_str_new("<unknown module name>"), false),
+        _ => (
+            pyre_object::w_str_new_managed("<unknown module name>"),
+            false,
+        ),
     };
     // Pinned for the whole function: every lookup below can run a descriptor
     // or `__getattr__` and so collect, and this name is young and movable.
@@ -6640,7 +6648,7 @@ pub fn import_from(module: PyObjectRef, name: &str) -> Result<PyObjectRef, crate
         });
         fullname.push_str(".");
         fullname.push_str(name);
-        if let Some(submod) = check_sys_modules_w(pyre_object::w_str_from_wtf8(fullname)) {
+        if let Some(submod) = check_sys_modules_w(pyre_object::w_str_from_wtf8_managed(fullname)) {
             return Ok(submod);
         }
     }
@@ -6658,9 +6666,9 @@ pub fn import_from(module: PyObjectRef, name: &str) -> Result<PyObjectRef, crate
     // (including None) reports the location as unknown.
     let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
         Ok(v) if unsafe { pyre_object::is_str(v) } => v,
-        Ok(_) => pyre_object::w_str_new("unknown location"),
+        Ok(_) => pyre_object::w_str_new_managed("unknown location"),
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-            pyre_object::w_str_new("unknown location")
+            pyre_object::w_str_new_managed("unknown location")
         }
         Err(e) => return Err(e),
     };
@@ -6732,7 +6740,7 @@ pub fn import_from(module: PyObjectRef, name: &str) -> Result<PyObjectRef, crate
     // built before the three reads below because the allocation can move the
     // pinned package name and path.
     let name_from_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(name));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
     let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
     let w_pkgpath = pyre_object::gc_roots::shadow_stack_get(pkgpath_slot);
     let w_name_from = pyre_object::gc_roots::shadow_stack_get(name_from_slot);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -6897,12 +6897,14 @@ pub fn import_all_from_w(
 ) -> Result<(), crate::PyError> {
     import_all_from_each(module, |name, value| {
         let _name_roots = pyre_object::gc_roots::push_roots();
+        let locals_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(into_locals);
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(value);
         crate::baseobjspace::setitem(
-            into_locals,
+            pyre_object::gc_roots::shadow_stack_get(locals_slot),
             pyre_object::gc_roots::shadow_stack_get(name_slot),
             pyre_object::gc_roots::shadow_stack_get(value_slot),
         )?;

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1306,9 +1306,6 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
     );
 
     let base_prefix = sysconfigdata_base_prefix();
-    let base_prefix_str = pyre_object::w_str_from_wtf8_managed(
-        crate::gateway::fsdecode_os_str_wtf8(base_prefix.as_os_str()),
-    );
     // `include/{implementation_lower}{py_version_short}{abi_thread}`, the
     // directory the posix_prefix scheme resolves `get_paths()['include']` to.
     // An interpreter that publishes no base prefix has nowhere to name.
@@ -1332,6 +1329,10 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let vars_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    let prefix_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(
+        crate::gateway::fsdecode_os_str_wtf8(base_prefix.as_os_str()),
+    ));
     // `_init_non_posix` derives the same `t` from `Py_GIL_DISABLED` below.
     // The lower-case `abiflags` that forms the include and site-packages
     // directory names is a separate variable, read from `sys.abiflags`
@@ -1459,11 +1460,12 @@ fn init_sysconfigdata(ns: PyObjectRef) -> Result<(), crate::PyError> {
     // Python 3.14's relocation check reads these from the generated data.
     unsafe {
         for key in ["prefix", "exec_prefix", "srcdir"] {
-            let w_key = pyre_object::w_str_new_managed(key);
+            let key_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(key));
             pyre_object::w_dict_store(
                 pyre_object::gc_roots::shadow_stack_get(vars_slot),
-                w_key,
-                base_prefix_str,
+                pyre_object::gc_roots::shadow_stack_get(key_slot),
+                pyre_object::gc_roots::shadow_stack_get(prefix_slot),
             );
         }
     }
@@ -6486,7 +6488,15 @@ pub(crate) fn is_spec_uninitialized_submodule(
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(false),
         Err(e) => return Err(e),
     };
-    crate::baseobjspace::contains(w_value, pyre_object::w_str_new_managed(name))
+    let _roots = pyre_object::gc_roots::push_roots();
+    let list_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_value);
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(name));
+    crate::baseobjspace::contains(
+        pyre_object::gc_roots::shadow_stack_get(list_slot),
+        pyre_object::gc_roots::shadow_stack_get(name_slot),
+    )
 }
 
 /// `_PyModuleSpec_GetFileOrigin` — the spec's file origin: its `origin` string

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -4334,7 +4334,8 @@ pub fn appleveldef_install_seeded(
     }
     let w_app_globals = unsafe { (*ctx).fresh_module_globals() };
     let _root = pyre_object::gc_roots::push_roots();
-    let w_app_globals = pyre_object::gc_roots::pin_root(w_app_globals);
+    let globals_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_app_globals);
     // `gateway.py build_applevel_dict` binds the owning module's name into the
     // namespace before the source runs, so a `def` or a `class` in it answers
     // `__module__` with the module it belongs to rather than `None` for a
@@ -4343,15 +4344,23 @@ pub fn appleveldef_install_seeded(
     // name, or `"<parent>.<child>"` for a submodule.  A source that must be
     // seen under a different name -- the public spelling of an accelerator it
     // backs -- rebinds `__name__` itself, and that assignment runs later.
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(modname));
     unsafe {
         pyre_object::w_dict_setitem_str(
-            w_app_globals,
+            pyre_object::gc_roots::shadow_stack_get(globals_slot),
             "__name__",
-            pyre_object::w_str_new_managed(modname),
+            pyre_object::gc_roots::shadow_stack_get(name_slot),
         )
     };
     for &(name, value) in seed {
-        unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
+        unsafe {
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(globals_slot),
+                name,
+                value,
+            )
+        };
     }
     // `gateway.py ApplevelClass.hidden_applevel = True`, which
     // `build_applevel_dict` passes to `space.exec_` and the compiler carries as
@@ -4363,6 +4372,7 @@ pub fn appleveldef_install_seeded(
     // built in, and what it holds is an extension module on CPython — so none
     // of these frames are the running program's.
     let w_code = crate::pycode::box_code_object_with_hidden_applevel(code, true);
+    let w_app_globals = pyre_object::gc_roots::shadow_stack_get(globals_slot);
     let mut frame = crate::pyframe::createframe_obj(w_code as *const (), w_app_globals, ctx, None)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: createframe — {e:?}"));
     // The source is a module body, so what it raises is the program's to see:
@@ -4372,7 +4382,12 @@ pub fn appleveldef_install_seeded(
     // name the file never binds -- stay panics.
     frame.run_with_jit()?;
     for &name in names {
-        match unsafe { pyre_object::w_dict_getitem_str(w_app_globals, name) } {
+        match unsafe {
+            pyre_object::w_dict_getitem_str(
+                pyre_object::gc_roots::shadow_stack_get(globals_slot),
+                name,
+            )
+        } {
             Some(val) => ns.store(name, val),
             None => panic!("appleveldef `{filename}`: name `{name}` not bound by source"),
         }

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -839,7 +839,7 @@ impl PywrapKind for &str {
 impl PywrapKind for String {
     #[inline]
     fn into_py(self) -> ::pyre_object::PyObjectRef {
-        ::pyre_object::w_str_new(&self)
+        ::pyre_object::w_str_new_managed(&self)
     }
 }
 impl PywrapKind for ::pyre_object::PyObjectRef {

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -2815,11 +2815,11 @@ impl Converter<'_> {
     }
 
     fn string(&self, value: &str) -> Rooted {
-        self.pin(pyre_object::w_str_new(value))
+        self.pin(pyre_object::w_str_new_managed(value))
     }
 
     fn wtf8(&self, value: Wtf8Buf) -> Rooted {
-        self.pin(pyre_object::w_str_from_wtf8(value))
+        self.pin(pyre_object::w_str_from_wtf8_managed(value))
     }
 
     fn none(&self) -> Rooted {

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -293,7 +293,7 @@ fn ast_repr(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn ast_warn(message: rustpython_wtf8::Wtf8Buf) -> Result<(), crate::PyError> {
     crate::warn::warn_category_w(
-        pyre_object::w_str_from_wtf8(message),
+        pyre_object::w_str_from_wtf8_managed(message),
         "DeprecationWarning",
         2,
     )

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeptr.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ctypeptr.rs
@@ -522,7 +522,7 @@ fn unpack_wide_string(item: &W_CType, ptr: *mut u8, length: i64) -> Result<PyObj
             super::wchar_helper::utf8_from_char32(ptr, length)?
         }
     };
-    Ok(pyre_object::w_str_from_wtf8(out))
+    Ok(pyre_object::w_str_from_wtf8_managed(out))
 }
 
 /// `W_CTypePtrOrArray.ctitem`, which every pointer and array has.

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
@@ -91,10 +91,10 @@ pub(crate) fn ffi_arg(w_ffi: PyObjectRef) -> Result<&'static mut W_FFIObject, Py
 pub(crate) fn ffi_error(message: impl Into<String>) -> PyError {
     let message = message.into();
     let mut error = PyError::runtime_error(message.clone());
-    if let Ok(w_exc) = crate::builtins::exc_exception_new(&[
-        newtype::ffi_error(),
-        pyre_object::w_str_new_managed(&message),
-    ]) {
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(newtype::ffi_error());
+    args.push(pyre_object::w_str_new_managed(&message));
+    if let Ok(w_exc) = crate::builtins::exc_exception_new(&args.take()) {
         error.exc_object = w_exc;
     }
     error

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
@@ -468,11 +468,8 @@ pub fn address_of_func_or_global_var(
     let lib_slot = roots.base();
     let _ = roots.pin_root(w_lib);
     let value_slot = lib_slot + 1;
-    let _ = roots.pin_root(get_attr(
-        roots.get(lib_slot),
-        pyre_object::w_str_new(varname),
-        false,
-    )?);
+    let w_name = roots.pin_root(pyre_object::w_str_new_managed(varname));
+    let _ = roots.pin_root(get_attr(roots.get(lib_slot), w_name, false)?);
     let value = roots.get(value_slot);
     if cglob::W_GlobSupport::from_obj(value).is_some() {
         return cglob::address(value);

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
@@ -467,9 +467,10 @@ pub fn address_of_func_or_global_var(
     let roots = pyre_object::gc_roots::push_roots();
     let lib_slot = roots.base();
     let _ = roots.pin_root(w_lib);
-    let value_slot = lib_slot + 1;
-    let w_name = roots.pin_root(pyre_object::w_str_new_managed(varname));
-    let _ = roots.pin_root(get_attr(roots.get(lib_slot), w_name, false)?);
+    let name_slot = lib_slot + 1;
+    let _ = roots.pin_root(pyre_object::w_str_new_managed(varname));
+    let value_slot = lib_slot + 2;
+    let _ = roots.pin_root(get_attr(roots.get(lib_slot), roots.get(name_slot), false)?);
     let value = roots.get(value_slot);
     if cglob::W_GlobSupport::from_obj(value).is_some() {
         return cglob::address(value);

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/newtype.rs
@@ -519,12 +519,12 @@ pub fn detect_custom_layout(
         let mut err = PyError::value_error(format!(
             "{name}: {msg} (cdef says {cdef_value}, but C compiler says {compiler_value}). fix it or use \"...;\" as the last field in the cdef for {name} to make it flexible"
         ));
-        err.exc_object = crate::builtins::exc_exception_new(&[
-            ffi_error(),
-            pyre_object::w_str_new_managed(&format!(
-                "{name}: {msg} (cdef says {cdef_value}, but C compiler says {compiler_value}). fix it or use \"...;\" as the last field in the cdef for {name} to make it flexible"
-            )),
-        ])?;
+        let mut args = pyre_object::gc_roots::RootedItems::new();
+        args.push(ffi_error());
+        args.push(pyre_object::w_str_new_managed(&format!(
+            "{name}: {msg} (cdef says {cdef_value}, but C compiler says {compiler_value}). fix it or use \"...;\" as the last field in the cdef for {name} to make it flexible"
+        )));
+        err.exc_object = crate::builtins::exc_exception_new(&args.take())?;
         return Err(err);
     }
     ct.flags |= ctypeobj::CTypeFlags::CUSTOM_FIELD_POS.bits();

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/realize_c_type.rs
@@ -141,10 +141,10 @@ pub fn with_realize_lock<T>(f: impl FnOnce() -> Result<T, PyError>) -> Result<T,
 fn ffi_error(message: impl Into<String>) -> PyError {
     let message = message.into();
     let mut error = PyError::new(PyErrorKind::RuntimeError, message.clone());
-    if let Ok(w_exc) = crate::builtins::exc_exception_new(&[
-        newtype::ffi_error(),
-        pyre_object::w_str_new_managed(&message),
-    ]) {
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(newtype::ffi_error());
+    args.push(pyre_object::w_str_new_managed(&message));
+    if let Ok(w_exc) = crate::builtins::exc_exception_new(&args.take()) {
         error.exc_object = w_exc;
     }
     error

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -441,10 +441,11 @@ fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             }
             let mut replacement = Wtf8Buf::new();
             replacement.push(CodePoint::from_u32(code).unwrap());
-            Ok(codec_result(
-                w_str_from_wtf8_managed(replacement),
-                w_int_new((exc.start + byte_len) as i64),
-            ))
+            let _roots = gc_roots::push_roots();
+            let repl_slot = gc_roots::shadow_stack_len();
+            let _ = gc_roots::pin_root(w_str_from_wtf8_managed(replacement));
+            let pos = w_int_new((exc.start + byte_len) as i64);
+            Ok(codec_result(gc_roots::shadow_stack_get(repl_slot), pos))
         }
         _ => Err(crate::PyError::type_error(
             "don't know how to handle exception in error callback",
@@ -486,10 +487,11 @@ fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             if consumed == 0 {
                 return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
             }
-            Ok(codec_result(
-                w_str_from_wtf8_managed(replacement),
-                w_int_new((exc.start + consumed) as i64),
-            ))
+            let _roots = gc_roots::push_roots();
+            let repl_slot = gc_roots::shadow_stack_len();
+            let _ = gc_roots::pin_root(w_str_from_wtf8_managed(replacement));
+            let pos = w_int_new((exc.start + consumed) as i64);
+            Ok(codec_result(gc_roots::shadow_stack_get(repl_slot), pos))
         }
         _ => Err(crate::PyError::type_error(
             "don't know how to handle exception in error callback",

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -442,7 +442,7 @@ fn surrogatepass_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             let mut replacement = Wtf8Buf::new();
             replacement.push(CodePoint::from_u32(code).unwrap());
             Ok(codec_result(
-                w_str_from_wtf8(replacement),
+                w_str_from_wtf8_managed(replacement),
                 w_int_new((exc.start + byte_len) as i64),
             ))
         }
@@ -487,7 +487,7 @@ fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
             }
             Ok(codec_result(
-                w_str_from_wtf8(replacement),
+                w_str_from_wtf8_managed(replacement),
                 w_int_new((exc.start + consumed) as i64),
             ))
         }
@@ -1389,7 +1389,7 @@ fn charmap_decode_impl(
             chars.get(b as usize).copied().map(|cp| {
                 let mut one = rustpython_wtf8::Wtf8Buf::new();
                 one.push(cp);
-                w_str_from_wtf8(one)
+                w_str_from_wtf8_managed(one)
             })
         } else {
             charmap_decode_lookup(pyre_object::gc_roots::shadow_stack_get(sp), b)?

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -882,7 +882,8 @@ fn codec_encode_or_decode(
     let sp = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_obj);
     let encoding = crate::baseobjspace::str_utf8_w(w_encoding)?.to_string();
-    let w_codec_info = lookup_codec(&[w_str_new(&encoding)])?;
+    let w_encoding = pyre_object::gc_roots::pin_root(w_str_new_managed(&encoding));
+    let w_codec_info = lookup_codec(&[w_encoding])?;
     let w_coder = unsafe {
         pyre_object::w_tuple_getitem(w_codec_info, i64::from(!encode)).unwrap_or_else(w_none)
     };

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -801,10 +801,20 @@ fn call_codec(
     errors: Option<&str>,
 ) -> Result<PyObjectRef, crate::PyError> {
     // PyPy `interp_codecs.py _call_codec`.
+    let roots = pyre_object::gc_roots::push_roots();
+    let coder_slot = roots.base();
+    let _ = roots.pin_root(w_coder);
+    let obj_slot = coder_slot + 1;
+    let _ = roots.pin_root(w_obj);
     let call = if let Some(errors) = errors {
-        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new_managed(errors)])
+        let err_slot = coder_slot + 2;
+        let _ = roots.pin_root(w_str_new_managed(errors));
+        crate::call::call_function_impl_result(
+            roots.get(coder_slot),
+            &[roots.get(obj_slot), roots.get(err_slot)],
+        )
     } else {
-        crate::call::call_function_impl_result(w_coder, &[w_obj])
+        crate::call::call_function_impl_result(roots.get(coder_slot), &[roots.get(obj_slot)])
     };
     // A codec that raises gets one line of context naming the operation and
     // the encoding, and is re-raised otherwise unchanged:

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -541,7 +541,9 @@ pub(crate) fn validate_encoding(encoding: &str) -> Result<(), crate::PyError> {
     if with_codec_state(|state| state.codec_need_encodings) {
         return Ok(());
     }
-    lookup_codec(&[w_str_new(encoding)]).map(|_| ())
+    let _roots = pyre_object::gc_roots::push_roots();
+    let w_encoding = pyre_object::gc_roots::pin_root(w_str_new_managed(encoding));
+    lookup_codec(&[w_encoding]).map(|_| ())
 }
 
 /// `interp_codecs.py lookup_error`.  The direct codec loops implement
@@ -772,7 +774,9 @@ pub(crate) fn lookup_text_codec(
     action: &str,
     encoding: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let w_codec_info = lookup_codec(&[w_str_new(encoding)])?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let w_encoding = pyre_object::gc_roots::pin_root(w_str_new_managed(encoding));
+    let w_codec_info = lookup_codec(&[w_encoding])?;
     match crate::baseobjspace::getattr_str(w_codec_info, "_is_text_encoding") {
         Ok(w_flag) if !crate::baseobjspace::is_true(w_flag)? => {
             return Err(crate::PyError::new(
@@ -798,7 +802,7 @@ fn call_codec(
 ) -> Result<PyObjectRef, crate::PyError> {
     // PyPy `interp_codecs.py _call_codec`.
     let call = if let Some(errors) = errors {
-        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new(errors)])
+        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new_managed(errors)])
     } else {
         crate::call::call_function_impl_result(w_coder, &[w_obj])
     };
@@ -985,10 +989,11 @@ fn encode_with_name(
     // PyPy `make_encoder_wrapper`: convert to unicode, call unicodehelper
     // encoder, return `(bytes, unicode_length)`.
     let encode_method = crate::baseobjspace::getattr_str(w_obj, "encode")?;
-    let encoded = crate::call::call_function_impl_result(
-        encode_method,
-        &[w_str_new(encoding), w_str_new(&errors)],
-    )?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let encode_method = pyre_object::gc_roots::pin_root(encode_method);
+    let w_encoding = pyre_object::gc_roots::pin_root(w_str_new_managed(encoding));
+    let w_errors = pyre_object::gc_roots::pin_root(w_str_new_managed(&errors));
+    let encoded = crate::call::call_function_impl_result(encode_method, &[w_encoding, w_errors])?;
     Ok(rooted_tuple()
         .arg(encoded)
         .arg(w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64))
@@ -1013,10 +1018,10 @@ fn decode_with_name(
     let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&data));
     let decode_method =
         crate::baseobjspace::getattr_str(pyre_object::gc_roots::shadow_stack_get(sp), "decode")?;
-    let decoded = crate::call::call_function_impl_result(
-        decode_method,
-        &[w_str_new(encoding), w_str_new(&errors)],
-    )?;
+    let decode_method = pyre_object::gc_roots::pin_root(decode_method);
+    let w_encoding = pyre_object::gc_roots::pin_root(w_str_new_managed(encoding));
+    let w_errors = pyre_object::gc_roots::pin_root(w_str_new_managed(&errors));
+    let decoded = crate::call::call_function_impl_result(decode_method, &[w_encoding, w_errors])?;
     Ok(rooted_tuple()
         .arg(decoded)
         .arg(w_int_new(consumed as i64))

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -62,7 +62,7 @@ fn csv_error(msg: impl Into<rustpython_wtf8::Wtf8Buf>) -> PyError {
     let msg = msg.into();
     let mut err = PyError::runtime_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class("_csv.Error") {
-        let args = [cls, pyre_object::w_str_from_wtf8(msg)];
+        let args = [cls, pyre_object::w_str_from_wtf8_managed(msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }
@@ -1079,7 +1079,7 @@ fn writer_writerow_impl(
     rec.push_str(&cfg.lineterminator);
     crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(write_slot),
-        &[pyre_object::w_str_from_wtf8(rec)],
+        &[pyre_object::w_str_from_wtf8_managed(rec)],
     )
 }
 

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -1077,9 +1077,11 @@ fn writer_writerow_impl(
     }
 
     rec.push_str(&cfg.lineterminator);
+    let rec_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(rec));
     crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(write_slot),
-        &[pyre_object::w_str_from_wtf8_managed(rec)],
+        &[pyre_object::gc_roots::shadow_stack_get(rec_slot)],
     )
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1719,7 +1719,7 @@ pub(super) fn bstr_to_pyobject(bytes: &[u8]) -> PyObjectRef {
             windows_sys::Win32::Foundation::SysStringLen(addr as *const u16) as usize,
         )
     };
-    pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(units))
+    pyre_object::w_str_from_wtf8_managed(rustpython_wtf8::Wtf8Buf::from_wide(units))
 }
 
 /// The Python value the bytes of a slot of type code `tc` hold.

--- a/pyre/pyre-interpreter/src/module/_ctypes/com.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/com.rs
@@ -206,7 +206,7 @@ fn prog_id(guid: &[u8; 16]) -> PyObjectRef {
     while unsafe { *progid.add(len) } != 0 {
         len += 1;
     }
-    let value = pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
+    let value = pyre_object::w_str_from_wtf8_managed(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
         std::slice::from_raw_parts(progid, len)
     }));
     unsafe { CoTaskMemFree(progid as *const _) };

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -1902,7 +1902,7 @@ fn internal_wstring_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     // `PyUnicode_FromWideChar` copies nothing for a zero size, so the address
     // is never dereferenced and need not be readable at all.
     if size == 0 {
-        return Ok(pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::new()));
+        return Ok(pyre_object::w_str_new(""));
     }
     // A negative size other than `-1` reaches `find_maxchar_surrogates` as the
     // range `[ptr, ptr + size)`, whose end precedes its start, so nothing is
@@ -1926,7 +1926,7 @@ fn internal_wstring_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             return Err(crate::PyError::overflow_error("size too large"));
         }
     };
-    Ok(pyre_object::w_str_from_wtf8(value))
+    Ok(pyre_object::w_str_from_wtf8_managed(value))
 }
 
 fn internal_memoryview_at(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -992,7 +992,7 @@ pub(super) fn carg_type() -> pyre_object::PyObjectRef {
                     let value = unsafe { pyre_object::w_dict_getitem_str(d, "_obj") }
                         .unwrap_or_else(pyre_object::w_none);
                     let rendered = unsafe { crate::display::py_repr_wtf8(value) }?;
-                    Ok(pyre_object::w_str_from_wtf8(crate::display::wtf8_format!("<cparam ", rendered, ">")))
+                    Ok(pyre_object::w_str_from_wtf8_managed(crate::display::wtf8_format!("<cparam ", rendered, ">")))
                 }),
             );
         });

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1946,8 +1946,8 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
         pyre_object::w_dict_setitem_str(ns_roots.get(ns_slot), "_type_", elem);
         pyre_object::w_dict_setitem_str(ns_roots.get(ns_slot), "_length_", w_length);
     }
-    let bases = pyre_object::w_tuple_new(vec![array_type()]);
-    let w_name = pyre_object::w_str_new(&name);
+    let bases = ns_roots.pin_root(pyre_object::w_tuple_new(vec![array_type()]));
+    let w_name = ns_roots.pin_root(pyre_object::w_str_new_managed(&name));
     let new_cls = crate::call::type_call_instantiate(
         pycarraytype_type(),
         &[w_name, bases, ns_roots.get(ns_slot)],

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -159,7 +159,7 @@ pub(crate) fn unsupported(message: &str) -> crate::PyError {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(w_str_new(message));
+    let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(message));
     match crate::call::call_function_impl_result(
         w_type,
         &[pyre_object::gc_roots::shadow_stack_get(sp)],

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -171,7 +171,7 @@ fn scanner_scan_once(
                 machinery::scan_string(&value[byte_index + 1..], char_index + 1, strict)
                     .map_err(|err| json_decode_error(err.msg, doc, err.pos))?;
             Ok((
-                pyre_object::w_str_from_wtf8(decoded),
+                pyre_object::w_str_from_wtf8_managed(decoded),
                 next_char,
                 byte_index + 1 + bytes_used,
             ))
@@ -361,7 +361,7 @@ fn scanner_parse_object(
 
             let iteration_roots = gc_roots::push_roots();
             let item_slot = gc_roots::shadow_stack_len();
-            let candidate = pyre_object::w_str_from_wtf8(decoded);
+            let candidate = pyre_object::w_str_from_wtf8_managed(decoded);
             let _ = gc_roots::pin_root(candidate);
             let memo = gc_roots::shadow_stack_get(slot + 1);
             let key =

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -118,8 +118,10 @@ fn locale_error(message: &str) -> crate::PyError {
     let cls = crate::builtins::lookup_exc_class("locale.Error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
         .expect("Exception must be installed");
-    let args = vec![cls, pyre_object::w_str_new_managed(message)];
-    let exc = crate::builtins::exc_exception_new(&args)
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(cls);
+    args.push(pyre_object::w_str_new_managed(message));
+    let exc = crate::builtins::exc_exception_new(&args.take())
         .expect("exc_exception_new is infallible for str args");
     let mut err = crate::PyError::value_error(message);
     err.exc_object = exc;

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -178,7 +178,7 @@ pub(crate) fn call_meth(
 fn pickle_exc(class_name: &str, msg: rustpython_wtf8::Wtf8Buf) -> PyError {
     let mut err = PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class(class_name) {
-        let args = [cls, pyre_object::w_str_from_wtf8(msg)];
+        let args = [cls, pyre_object::w_str_from_wtf8_managed(msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -178,7 +178,15 @@ pub(crate) fn call_meth(
 fn pickle_exc(class_name: &str, msg: rustpython_wtf8::Wtf8Buf) -> PyError {
     let mut err = PyError::value_error(msg.clone());
     if let Some(cls) = crate::builtins::lookup_exc_class(class_name) {
-        let args = [cls, pyre_object::w_str_from_wtf8_managed(msg)];
+        let _roots = pyre_object::gc_roots::push_roots();
+        let cls_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(cls);
+        let msg_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(msg));
+        let args = [
+            pyre_object::gc_roots::shadow_stack_get(cls_slot),
+            pyre_object::gc_roots::shadow_stack_get(msg_slot),
+        ];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             err.exc_object = exc;
         }

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -602,7 +602,7 @@ pub(crate) fn parse_int_text(s: &str) -> Result<PyObjectRef, PyError> {
     // interp_pickle.py:2201 calls the ordinary `int` constructor.  Reuse its
     // NumberStringParser consumer so the digit limit, MemoryError edge, and
     // literal diagnostics do not diverge for protocol-0 INT/LONG opcodes.
-    crate::builtins::parse_int_from_str(pyre_object::w_str_new(s), s, 10)
+    crate::builtins::parse_int_from_str(pyre_object::w_str_new_managed(s), s, 10)
 }
 
 pub(crate) fn read_int_le(data: &[u8]) -> i64 {

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -274,7 +274,7 @@ fn add_pickle_object_note(
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     if let Ok(type_name) = pickle_type_name(pyre_object::gc_roots::shadow_stack_get(obj_slot)) {
-        let w_note = pyre_object::w_str_from_wtf8(crate::display::wtf8_format!(
+        let w_note = pyre_object::w_str_from_wtf8_managed(crate::display::wtf8_format!(
             format!("when serializing {type_name} "),
             role
         ));

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3189,7 +3189,7 @@ fn windows_if_nameindex() -> Result<pyre_object::PyObjectRef, crate::PyError> {
             let entry = {
                 let mut fields = pyre_object::gc_roots::RootedItems::new();
                 fields.push(pyre_object::w_int_new(i64::from(row.InterfaceIndex)));
-                fields.push(pyre_object::w_str_from_wtf8(
+                fields.push(pyre_object::w_str_from_wtf8_managed(
                     rustpython_wtf8::Wtf8Buf::from_wide(&name[..end]),
                 ));
                 pyre_object::w_tuple_new(fields.take())

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -213,7 +213,7 @@ fn ssl_error_str(args: &[PyObjectRef]) -> crate::PyResult {
         };
         crate::builtins::builtin_str(&[message])
     } else {
-        Ok(pyre_object::w_str_from_wtf8(unsafe {
+        Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
             crate::display::base_exception_str_wtf8(args[0])?
         }))
     }

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -753,10 +753,10 @@ fn positioned_syntax_error(
         let _ = crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(exc_slot), name, value);
     }
     for (name, value) in [("msg", message), ("filename", "<string>")] {
-        let value = w_str_new(value);
+        let value = w_str_new_managed(value);
         let _ = crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(exc_slot), name, value);
     }
-    let text_value = text.map(w_str_new).unwrap_or_else(w_none);
+    let text_value = text.map(w_str_new_managed).unwrap_or_else(w_none);
     let _ =
         crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(exc_slot), "text", text_value);
     unsafe { crate::PyError::from_exc_object(gc_roots::shadow_stack_get(exc_slot)) }

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -737,7 +737,7 @@ fn positioned_syntax_error(
     };
     let _roots = gc_roots::push_roots();
     let _ = gc_roots::pin_root(class);
-    let _ = gc_roots::pin_root(w_str_new(message));
+    let _ = gc_roots::pin_root(w_str_new_managed(message));
     let base = gc_roots::shadow_stack_len() - 2;
     let exc = match crate::builtins::call_and_check(
         gc_roots::shadow_stack_get(base),

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -494,9 +494,10 @@ pub(crate) fn show_warning(
         && let Ok(write) = crate::baseobjspace::getattr_str(stderr, "write")
     {
         let write_slot = pin_root_slot(write);
+        let line_slot = pin_root_slot(pyre_object::w_str_from_wtf8_managed(line));
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(write_slot),
-            &[pyre_object::w_str_from_wtf8_managed(line)],
+            &[pyre_object::gc_roots::shadow_stack_get(line_slot)],
         )?;
         let source_line = pyre_object::gc_roots::shadow_stack_get(source_line_slot);
         let source_line = if source_line.is_null() || unsafe { is_none(source_line) } {

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -496,7 +496,7 @@ pub(crate) fn show_warning(
         let write_slot = pin_root_slot(write);
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(write_slot),
-            &[pyre_object::w_str_from_wtf8(line)],
+            &[pyre_object::w_str_from_wtf8_managed(line)],
         )?;
         let source_line = pyre_object::gc_roots::shadow_stack_get(source_line_slot);
         let source_line = if source_line.is_null() || unsafe { is_none(source_line) } {
@@ -705,7 +705,7 @@ pub(crate) fn do_warn_explicit(
                 filename_bytes[..filename_bytes.len() - 3].to_vec(),
             )
             .expect("removing an ASCII suffix preserves WTF-8");
-            w_str_from_wtf8(stem)
+            w_str_from_wtf8_managed(stem)
         } else {
             filename
         }

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -103,7 +103,7 @@ pub(super) fn wide_units(w_text: PyObjectRef) -> Vec<u16> {
 
 /// Wide characters back as a `str`.
 fn w_wide(units: &[u16]) -> PyObjectRef {
-    pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(units))
+    pyre_object::w_str_from_wtf8_managed(rustpython_wtf8::Wtf8Buf::from_wide(units))
 }
 
 /// A `DWORD` argument `None` leaves alone.

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -205,7 +205,7 @@ mod process {
         }
         buffer[MAX_PATH - 1] = 0;
         let filename = &buffer[..buffer.iter().position(|&u| u == 0).unwrap_or(MAX_PATH)];
-        Ok(pyre_object::w_str_from_wtf8(
+        Ok(pyre_object::w_str_from_wtf8_managed(
             rustpython_wtf8::Wtf8Buf::from_wide(filename),
         ))
     }

--- a/pyre/pyre-interpreter/src/module/_wmi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_wmi/mod.rs
@@ -676,7 +676,7 @@ fn exec_query(args: &[PyObjectRef]) -> crate::PyResult {
     }
 
     let result = execute_query(std::mem::take(&mut wide))?;
-    Ok(pyre_object::w_str_from_wtf8(
+    Ok(pyre_object::w_str_from_wtf8_managed(
         rustpython_wtf8::Wtf8Buf::from_wide(&result),
     ))
 }

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1340,7 +1340,7 @@ fn write_typeids_sidecar(
     let data_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(match payload {
         TypeidsPayload::Binary(bytes) => w_bytes_from_bytes(bytes),
-        TypeidsPayload::Text(text) => w_str_new(text),
+        TypeidsPayload::Text(text) => w_str_new_managed(text),
     });
     let written = gc_call_method(
         pyre_object::gc_roots::shadow_stack_get(opened_slot),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1287,7 +1287,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     any(target_os = "macos", target_os = "linux")
                 ))]
                 {
-                    Ok(pyre_object::w_list_new(vec![pyre_object::w_str_new(
+                    Ok(pyre_object::w_list_new(vec![pyre_object::w_str_new_managed(
                         crate::cpyext::extension_suffix(),
                     )]))
                 }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1287,9 +1287,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                     any(target_os = "macos", target_os = "linux")
                 ))]
                 {
-                    Ok(pyre_object::w_list_new(vec![pyre_object::w_str_new_managed(
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let suffix_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(
                         crate::cpyext::extension_suffix(),
-                    )]))
+                    ));
+                    Ok(pyre_object::w_list_new(vec![
+                        pyre_object::gc_roots::shadow_stack_get(suffix_slot),
+                    ]))
                 }
                 #[cfg(not(all(
                     feature = "cpyext",

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -465,7 +465,7 @@ fn frozen_name(
 fn frozen_error(message: String, name: &Wtf8) -> crate::PyError {
     crate::PyError::import_error_name_path(
         message,
-        pyre_object::w_str_from_wtf8(name.to_owned()),
+        pyre_object::w_str_from_wtf8_managed(name.to_owned()),
         pyre_object::w_none(),
     )
 }

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -819,7 +819,7 @@ impl wire::MarshalBag for PyreMarshalBag {
     }
 
     fn make_str(&self, value: &Wtf8) -> Rooted {
-        Rooted::new(w_str_from_wtf8(value.to_owned()))
+        Rooted::new(w_str_from_wtf8_managed(value.to_owned()))
     }
 
     fn make_interned_str(&self, value: &Wtf8) -> Rooted {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1187,7 +1187,7 @@ mod win_nt {
         if as_bytes {
             pyre_object::w_bytes_from_bytes(&crate::gateway::fs_result_bytes(text.as_bytes()))
         } else {
-            pyre_object::w_str_from_wtf8(text)
+            pyre_object::w_str_from_wtf8_managed(text)
         }
     }
 
@@ -1232,7 +1232,7 @@ mod win_nt {
             // argument was: `os__findfirstfile_impl` reports `cFileName`
             // through `PyUnicode_FromWideChar` and asks no codec for a
             // `bytes` spelling of it.
-            Ok(name) => Ok(pyre_object::w_str_from_wtf8(
+            Ok(name) => Ok(pyre_object::w_str_from_wtf8_managed(
                 crate::gateway::fsdecode_os_str_wtf8(&name),
             )),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
@@ -9163,10 +9163,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::_structseq::new_instance_with_extra(
                 statvfs_result_seq_type(),
                 fields.take(),
-                vec![(
-                    "f_fsid",
-                    pyre_object::gc_roots::shadow_stack_get(fsid_slot),
-                )],
+                vec![("f_fsid", pyre_object::gc_roots::shadow_stack_get(fsid_slot))],
             )
         }
         #[cfg(not(target_os = "redox"))]

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -27,7 +27,10 @@ fn struct_error(msg: impl Into<String>) -> crate::PyError {
     let cls = crate::builtins::lookup_exc_class("struct.error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
         .expect("Exception must be installed before _struct is used");
-    let exc = crate::builtins::exc_exception_new(&[cls, w_str_new_managed(&msg)])
+    let mut args = pyre_object::gc_roots::RootedItems::new();
+    args.push(cls);
+    args.push(w_str_new_managed(&msg));
+    let exc = crate::builtins::exc_exception_new(&args.take())
         .expect("exc_exception_new is infallible for str args");
     let mut err = crate::PyError::new(crate::PyErrorKind::ValueError, msg);
     err.exc_object = exc;
@@ -1581,7 +1584,9 @@ crate::py_module! {
         "iter_unpack" / 2 = |args| {
             let fmt = format_to_string(args[0])?;
             let size = parse_format(&fmt)?.calcsize()?;
-            make_unpack_iter(w_str_new(&fmt), size, args[1])
+            let _roots = pyre_object::gc_roots::push_roots();
+            let w_fmt = pyre_object::gc_roots::pin_root(w_str_new_managed(&fmt));
+            make_unpack_iter(w_fmt, size, args[1])
         },
     },
     extra_init: |ns| {

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1582,11 +1582,20 @@ crate::py_module! {
     functions: {
         // `iter_unpack(fmt, buffer)` — an iterator over the records.
         "iter_unpack" / 2 = |args| {
-            let fmt = format_to_string(args[0])?;
-            let size = parse_format(&fmt)?.calcsize()?;
             let _roots = pyre_object::gc_roots::push_roots();
-            let w_fmt = pyre_object::gc_roots::pin_root(w_str_new_managed(&fmt));
-            make_unpack_iter(w_fmt, size, args[1])
+            let fmt_obj_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(args[0]);
+            let buf_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(args[1]);
+            let fmt = format_to_string(pyre_object::gc_roots::shadow_stack_get(fmt_obj_slot))?;
+            let size = parse_format(&fmt)?.calcsize()?;
+            let fmt_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(&fmt));
+            make_unpack_iter(
+                pyre_object::gc_roots::shadow_stack_get(fmt_slot),
+                size,
+                pyre_object::gc_roots::shadow_stack_get(buf_slot),
+            )
         },
     },
     extra_init: |ns| {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3933,7 +3933,7 @@ fn sys_audit(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     let event = crate::baseobjspace::str_utf8_w(w_event)?.to_string();
     let _roots = pyre_object::gc_roots::push_roots();
     let args_slot = pyre_object::gc_roots::pin_roots(&positional[1..]);
-    let w_text = w_str_new(&event);
+    let w_text = pyre_object::gc_roots::pin_root(w_str_new_managed(&event));
     let args_w: Vec<pyre_object::PyObjectRef> = (0..positional.len() - 1)
         .map(|i| pyre_object::gc_roots::shadow_stack_get(args_slot + i))
         .collect();

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -2424,7 +2424,7 @@ fn thread_excepthook_file(
         let rendered = unsafe {
             crate::display::py_str_wtf8(pyre_object::gc_roots::shadow_stack_get(name_slot))?
         };
-        thread_excepthook_write(file_slot, w_str_from_wtf8(rendered))?;
+        thread_excepthook_write(file_slot, w_str_from_wtf8_managed(rendered))?;
     } else {
         thread_excepthook_write(file_slot, w_str_new_managed(&current_ident().to_string()))?;
     }
@@ -2442,7 +2442,7 @@ fn thread_excepthook_file(
     .map_err(|err| crate::PyError::runtime_error(format!("failed to display exception: {err}")))?;
     let rendered = rustpython_wtf8::Wtf8Buf::from_bytes(rendered)
         .map_err(|_| crate::PyError::runtime_error("invalid WTF-8 exception display"))?;
-    thread_excepthook_write(file_slot, pyre_object::w_str_from_wtf8(rendered))?;
+    thread_excepthook_write(file_slot, pyre_object::w_str_from_wtf8_managed(rendered))?;
 
     // `_PyFile_Flush(file)`.
     call_method_result(
@@ -2577,7 +2577,7 @@ fn current_thread_name() -> Result<PyObjectRef, crate::PyError> {
             len += 1;
         }
     }
-    let name = pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
+    let name = pyre_object::w_str_from_wtf8_managed(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
         std::slice::from_raw_parts(raw, len)
     }));
     unsafe { LocalFree(raw.cast()) };

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -467,11 +467,16 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         "thread_time" => ("clock_gettime(CLOCK_THREAD_CPUTIME_ID)", true, false),
         _ => return Err(crate::PyError::value_error("unknown clock")),
     };
-    crate::baseobjspace::setattr_str(info, "implementation", w_str_new_managed(implementation))?;
-    crate::baseobjspace::setattr_str(info, "monotonic", w_bool_from(monotonic))?;
-    crate::baseobjspace::setattr_str(info, "adjustable", w_bool_from(adjustable))?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let info_slot = roots.base();
+    let _ = roots.pin_root(info);
+    let impl_slot = info_slot + 1;
+    let _ = roots.pin_root(w_str_new_managed(implementation));
+    crate::baseobjspace::setattr_str(roots.get(info_slot), "implementation", roots.get(impl_slot))?;
+    crate::baseobjspace::setattr_str(roots.get(info_slot), "monotonic", w_bool_from(monotonic))?;
+    crate::baseobjspace::setattr_str(roots.get(info_slot), "adjustable", w_bool_from(adjustable))?;
     crate::baseobjspace::setattr_str(
-        info,
+        roots.get(info_slot),
         "resolution",
         floatobject::w_float_new(get_clock_info_resolution(name_str)),
     )?;

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -467,7 +467,7 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         "thread_time" => ("clock_gettime(CLOCK_THREAD_CPUTIME_ID)", true, false),
         _ => return Err(crate::PyError::value_error("unknown clock")),
     };
-    crate::baseobjspace::setattr_str(info, "implementation", w_str_new(implementation))?;
+    crate::baseobjspace::setattr_str(info, "implementation", w_str_new_managed(implementation))?;
     crate::baseobjspace::setattr_str(info, "monotonic", w_bool_from(monotonic))?;
     crate::baseobjspace::setattr_str(info, "adjustable", w_bool_from(adjustable))?;
     crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -511,7 +511,7 @@ mod imp {
             host_reg::REG_SZ | host_reg::REG_EXPAND_SZ => {
                 let units = utf16_units(data);
                 let end = units.iter().position(|&c| c == 0).unwrap_or(units.len());
-                w_str_from_wtf8(Wtf8Buf::from_wide(&units[..end]))
+                w_str_from_wtf8_managed(Wtf8Buf::from_wide(&units[..end]))
             }
             host_reg::REG_MULTI_SZ => {
                 // `countStrings`/`fixupMultiSZ` — one trailing terminator ends
@@ -524,17 +524,19 @@ mod imp {
                     Some(&0) => units.len() - 1,
                     Some(_) => units.len(),
                 };
-                let mut items = Vec::new();
+                let mut items = pyre_object::gc_roots::RootedItems::new();
                 let mut start = 0;
                 while start < end {
                     let mut stop = start;
                     while stop < end && units[stop] != 0 {
                         stop += 1;
                     }
-                    items.push(w_str_from_wtf8(Wtf8Buf::from_wide(&units[start..stop])));
+                    items.push(w_str_from_wtf8_managed(Wtf8Buf::from_wide(
+                        &units[start..stop],
+                    )));
                     start = stop + 1;
                 }
-                w_list_new(items)
+                w_list_new(items.take())
             }
             _ => {
                 if data.is_empty() {
@@ -843,7 +845,9 @@ mod imp {
         let pos = exact_args(args, "QueryValue", 2)?;
         let key = as_hkey(pos[0], false)?;
         let wide_sub = wide_or_empty(opt_text(pos[1], "QueryValue", "2")?)?;
-        Ok(w_str_from_wtf8(query_default_value(key, &wide_sub)?))
+        Ok(w_str_from_wtf8_managed(query_default_value(
+            key, &wide_sub,
+        )?))
     }
 
     fn query_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -872,7 +876,9 @@ mod imp {
         if rc != 0 {
             return Err(win_err(rc));
         }
-        Ok(w_str_from_wtf8(Wtf8Buf::from_wide(&buffer[..len as usize])))
+        Ok(w_str_from_wtf8_managed(Wtf8Buf::from_wide(
+            &buffer[..len as usize],
+        )))
     }
 
     fn enum_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -1097,7 +1103,7 @@ mod imp {
             "",
         )?;
         match expand_environment_strings_wide(&wide(input)?) {
-            Some(value) => Ok(w_str_from_wtf8(value)),
+            Some(value) => Ok(w_str_from_wtf8_managed(value)),
             None => Err(win_err(
                 std::io::Error::last_os_error().raw_os_error().unwrap_or(0) as u32,
             )),

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -394,9 +394,10 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
                     let Some(dict_slot) = dict else {
                         return Err(PyError::type_error("format requires a mapping"));
                     };
+                    let w_key = pyre_object::gc_roots::pin_root(w_str_from_wtf8_managed(key));
                     let w_value = crate::baseobjspace::getitem(
                         pyre_object::gc_roots::shadow_stack_get(dict_slot),
-                        w_str_from_wtf8_managed(key),
+                        w_key,
                     )?;
                     // A keyed spec still consumes a positional slot when one
                     // is available (`%(k)s %s` leaves nothing for the `%s`).

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -396,7 +396,7 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
                     };
                     let w_value = crate::baseobjspace::getitem(
                         pyre_object::gc_roots::shadow_stack_get(dict_slot),
-                        w_str_from_wtf8(key),
+                        w_str_from_wtf8_managed(key),
                     )?;
                     // A keyed spec still consumes a positional slot when one
                     // is available (`%(k)s %s` leaves nothing for the `%s`).

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -394,10 +394,11 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
                     let Some(dict_slot) = dict else {
                         return Err(PyError::type_error("format requires a mapping"));
                     };
-                    let w_key = pyre_object::gc_roots::pin_root(w_str_from_wtf8_managed(key));
+                    let key_slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = pyre_object::gc_roots::pin_root(w_str_from_wtf8_managed(key));
                     let w_value = crate::baseobjspace::getitem(
                         pyre_object::gc_roots::shadow_stack_get(dict_slot),
-                        w_key,
+                        pyre_object::gc_roots::shadow_stack_get(key_slot),
                     )?;
                     // A keyed spec still consumes a positional slot when one
                     // is available (`%(k)s %s` leaves nothing for the `%s`).

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3963,9 +3963,9 @@ unsafe fn terminator_read_checked<O: MapdictObject>(
             let backing = crate::type_methods::resolve_dict_backing(w_dict);
             unsafe { pyre_object::dictmultiobject::w_dict_getitem_wtf8_checked(backing, name) }
                 .map_err(|_| {
-                    crate::baseobjspace::take_pending_dict_key_error(pyre_object::w_str_from_wtf8(
-                        name.to_wtf8_buf(),
-                    ))
+                    crate::baseobjspace::take_pending_dict_key_error(
+                        pyre_object::w_str_from_wtf8_managed(name.to_wtf8_buf()),
+                    )
                 })
         }
         // Terminator / DictTerminator / NoDictTerminator read nothing.
@@ -4178,7 +4178,7 @@ unsafe fn node_delete<O: MapdictObject>(
                     pyre_object::gc_roots::pin_roots(&[crate::type_methods::resolve_dict_backing(
                         w_dict,
                     )]);
-                let w_key = pyre_object::w_str_from_wtf8(name.to_owned());
+                let w_key = pyre_object::w_str_from_wtf8_managed(name.to_owned());
                 unsafe {
                     pyre_object::w_dict_delitem(
                         pyre_object::gc_roots::shadow_stack_get(backing_slot),

--- a/pyre/pyre-interpreter/src/syntax_warnings.rs
+++ b/pyre/pyre-interpreter/src/syntax_warnings.rs
@@ -402,7 +402,7 @@ fn warn_invalid_escape_sequence(
     let _ =
         pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(&warning_message(escape)));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(filename));
 
     crate::module::_warnings::do_warn_explicit(
         pyre_object::gc_roots::shadow_stack_get(category_slot),
@@ -449,9 +449,9 @@ fn warn_codegen_syntax(
     let category_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(category);
     let message_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(message));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(message));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(filename));
 
     crate::module::_warnings::do_warn_explicit(
         pyre_object::gc_roots::shadow_stack_get(category_slot),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3234,8 +3234,20 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, c
     if let Some(meth) = unsafe { crate::baseobjspace::lookup(val, "__format__") }
         && (unsafe { is_instance(val) } || !unsafe { is_shared_builtin_format(val, meth) })
     {
-        let spec_obj = pyre_object::w_str_from_wtf8_managed(spec.to_wtf8_buf());
-        return call_format_dispatch(val, meth, spec_obj);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let val_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(val);
+        let meth_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(meth);
+        let spec_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(
+            spec.to_wtf8_buf(),
+        ));
+        return call_format_dispatch(
+            pyre_object::gc_roots::shadow_stack_get(val_slot),
+            pyre_object::gc_roots::shadow_stack_get(meth_slot),
+            pyre_object::gc_roots::shadow_stack_get(spec_slot),
+        );
     }
     if spec.is_empty() {
         // Empty spec collapses to `str(value)`, preserved in WTF-8 so a

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2012,7 +2012,7 @@ fn format_render(
             let spec_obj = if resolved_spec.is_empty() {
                 pyre_object::PY_NULL
             } else {
-                pyre_object::w_str_from_wtf8(resolved_spec)
+                pyre_object::w_str_from_wtf8_managed(resolved_spec)
             };
             return Ok(TemplateRender::Object(format_w(
                 inner.get(converted_slot),
@@ -3234,7 +3234,7 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, c
     if let Some(meth) = unsafe { crate::baseobjspace::lookup(val, "__format__") }
         && (unsafe { is_instance(val) } || !unsafe { is_shared_builtin_format(val, meth) })
     {
-        let spec_obj = pyre_object::w_str_from_wtf8(spec.to_wtf8_buf());
+        let spec_obj = pyre_object::w_str_from_wtf8_managed(spec.to_wtf8_buf());
         return call_format_dispatch(val, meth, spec_obj);
     }
     if spec.is_empty() {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3076,11 +3076,18 @@ fn new_typeobject_with_metatype_and_layout(
     if named.is_none()
         && let Some((module, _)) = name.rsplit_once('.')
     {
-        // Allocate the value first: reading `ns` before `w_str_new` would hand
+        // Allocate the value first: reading `ns` before the mint would hand
         // the store an address the allocation is free to move.
-        let w_module = w_str_new(module);
+        let module_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_str_new_managed(module));
         let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
-        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__module__", w_module) };
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                "__module__",
+                pyre_object::gc_roots::shadow_stack_get(module_slot),
+            )
+        };
     }
     // The namespace is complete, so every method descriptor in it can be
     // bound to the type that defines it before the type goes live.
@@ -16198,7 +16205,7 @@ fn descr_reduce(descr: PyObjectRef) -> crate::PyResult {
     let owner = unsafe { crate::function::fget_func_objclass(descr)? };
     let mut args = pyre_object::gc_roots::RootedItems::new();
     args.push(owner);
-    args.push(pyre_object::w_str_new(unsafe {
+    args.push(pyre_object::w_str_new_managed(unsafe {
         crate::function::function_get_name(descr)
     }));
     let args = pyre_object::w_tuple_new(args.take());
@@ -17620,7 +17627,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     let owner = unsafe { pyre_object::w_member_get_cls(member) };
                     let mut args = pyre_object::gc_roots::RootedItems::new();
                     args.push(owner);
-                    args.push(pyre_object::w_str_new(unsafe {
+                    args.push(pyre_object::w_str_new_managed(unsafe {
                         pyre_object::w_member_get_name(member)
                     }));
                     let args = pyre_object::w_tuple_new(args.take());

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13257,7 +13257,7 @@ fn init_type_type(ns: PyObjectRef) {
         |args| unsafe {
             let w_type = args[1];
             if let Some(signature) = pyre_object::w_type_get_text_signature(w_type) {
-                return Ok(pyre_object::w_str_new(signature));
+                return Ok(pyre_object::w_str_new_managed(signature));
             }
             // typeobject.py `extract_txtsig`.
             let w_doc = crate::baseobjspace::getattr_str(w_type, "__doc__")?;
@@ -16112,15 +16112,17 @@ fn init_builtin_code_type(ns: PyObjectRef) {
     let varnames_getter = make_builtin_function_with_arity(
         "co_varnames",
         |args| {
-            let names = code_sig(args)
-                .map(|s| {
-                    s.getallvarnames()
-                        .iter()
-                        .map(|n| pyre_object::w_str_new(n))
-                        .collect()
-                })
-                .unwrap_or_default();
-            Ok(pyre_object::w_tuple_new(names))
+            let names = match code_sig(args) {
+                Some(s) => {
+                    let mut names = pyre_object::gc_roots::RootedItems::new();
+                    for n in s.getallvarnames() {
+                        names.push(pyre_object::w_str_new_managed(n));
+                    }
+                    pyre_object::w_tuple_new(names.take())
+                }
+                None => pyre_object::w_tuple_new(vec![]),
+            };
+            Ok(names)
         },
         2,
     );
@@ -17539,7 +17541,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 return Ok(pyre_object::w_none());
             }
             match unsafe { pyre_object::w_member_get_doc(member) } {
-                Some(doc) => Ok(pyre_object::w_str_new(doc)),
+                Some(doc) => Ok(pyre_object::w_str_new_managed(doc)),
                 None => Ok(pyre_object::w_none()),
             }
         },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6035,8 +6035,8 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // of which the collector rewrites, and each keyword name allocated below
     // can move a `list` or `dict` still waiting in them.  Both columns are
     // published before the first of those allocations and read back where the
-    // `Arguments` copy is taken; a keyword name is a `str` and never moves, so
-    // its pin is liveness only.
+    // `Arguments` copy is taken. Managed keyword names move, so each mint
+    // is pinned before the next allocation.
     let _roots = pyre_object::gc_roots::push_roots();
     let positional_base = pyre_object::gc_roots::pin_roots(positional);
     let (keyword_names_w, keyword_values_base) = match kwargs {
@@ -6049,7 +6049,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             let base = pyre_object::gc_roots::pin_roots(&values);
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
-                let w_name = pyre_object::w_str_from_wtf8(key);
+                let w_name = pyre_object::w_str_from_wtf8_managed(key);
                 let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }
@@ -6741,7 +6741,7 @@ fn init_str_type(ns: PyObjectRef) {
                     {
                         Ok(obj)
                     } else {
-                        Ok(pyre_object::w_str_from_wtf8(
+                        Ok(pyre_object::w_str_from_wtf8_managed(
                             unsafe { pyre_object::w_str_get_wtf8(obj) }.to_wtf8_buf(),
                         ))
                     }
@@ -8559,7 +8559,7 @@ fn init_dict_view_common_slots(
                     if args.is_empty() {
                         return Ok(pyre_object::w_str_new(""));
                     }
-                    Ok(pyre_object::w_str_from_wtf8(unsafe {
+                    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
                         crate::display::py_repr_wtf8(args[0])?
                     }))
                 },
@@ -13276,7 +13276,7 @@ fn init_type_type(ns: PyObjectRef) {
                 if let Some(end) = raw_doc.find(MARKER.as_ref())
                     && end > 0
                 {
-                    return Ok(pyre_object::w_str_from_wtf8(
+                    return Ok(pyre_object::w_str_from_wtf8_managed(
                         raw_doc[name.len()..end + 1].to_wtf8_buf(),
                     ));
                 }
@@ -15586,7 +15586,7 @@ fn builtin_function_qualname(obj: PyObjectRef) -> crate::PyResult {
         // (`stamp_method_owners`), which is also what `bool.from_bytes`
         // reporting `int.from_bytes` requires.
         if unsafe { pyre_object::is_type(instance) } {
-            return Ok(pyre_object::w_str_from_wtf8(unsafe {
+            return Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
                 crate::function::function_get_qualname(descr)
             }));
         }
@@ -15602,13 +15602,11 @@ fn builtin_function_qualname(obj: PyObjectRef) -> crate::PyResult {
         // qualname, which is a `str` the read has to keep rather than reject.
         let type_qualname = unsafe { pyre_object::w_str_get_wtf8(type_qualname) };
         let name = unsafe { crate::function::function_get_name(descr) };
-        Ok(pyre_object::w_str_from_wtf8(crate::display::wtf8_format!(
-            type_qualname,
-            ".",
-            name,
-        )))
+        Ok(pyre_object::w_str_from_wtf8_managed(
+            crate::display::wtf8_format!(type_qualname, ".", name,),
+        ))
     } else {
-        Ok(pyre_object::w_str_from_wtf8(unsafe {
+        Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
             crate::function::function_get_qualname(obj)
         }))
     }
@@ -25275,7 +25273,7 @@ pub(crate) fn utf8_strict_w(text: Wtf8Buf) -> Result<String, crate::PyError> {
         .unwrap_or(0);
     Err(unicode_encode_error(
         "utf-8",
-        pyre_object::w_str_from_wtf8(text),
+        pyre_object::w_str_from_wtf8_managed(text),
         position as i64,
         (position + 1) as i64,
         "surrogates not allowed",
@@ -31041,8 +31039,8 @@ fn itertools_constructor_scope_kwonly(
     // rewrites, and the names and defaults dict allocated below can move a
     // `list` or `dict` waiting in either.  Both columns are published before
     // the first of those allocations and read back where the `Arguments` copy
-    // is taken; a keyword name is a `str` and never moves, so its pin is
-    // liveness only.
+    // is taken. Managed keyword names move, so each mint is pinned before
+    // the next allocation.
     let positional_base = pyre_object::gc_roots::pin_roots(positional);
     let (keyword_names_w, keyword_values_base) = match kwargs {
         Some(dict) => {
@@ -31054,7 +31052,7 @@ fn itertools_constructor_scope_kwonly(
             let base = pyre_object::gc_roots::pin_roots(&values);
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
-                let w_name = pyre_object::w_str_from_wtf8(key);
+                let w_name = pyre_object::w_str_from_wtf8_managed(key);
                 let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }
@@ -31178,7 +31176,7 @@ fn count_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let step = unsafe { crate::display::py_repr_wtf8(w_step)? };
         crate::display::wtf8_format!(cls_name, "(", c, ", ", step, ")")
     };
-    Ok(w_str_from_wtf8(text))
+    Ok(w_str_from_wtf8_managed(text))
 }
 
 /// [3.14-spec] CPython `count_slots` publishes `Py_tp_getattro`, while PyPy's
@@ -31314,7 +31312,7 @@ fn repeat_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     } else {
         crate::display::wtf8_format!(cls_name, "(", objrepr, ")")
     };
-    Ok(w_str_from_wtf8(text))
+    Ok(w_str_from_wtf8_managed(text))
 }
 
 /// [3.14-spec] CPython `repeat_slots` publishes `Py_tp_getattro`, while PyPy's
@@ -31899,8 +31897,8 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // collector rewrites, and every allocation between here and the parse can
     // move a value sitting in it.  The value column is published as one root
     // set before the first of those allocations and read back where the
-    // `Arguments` copy is taken; a keyword name is a `str` and never moves, so
-    // its pin is liveness only.
+    // `Arguments` copy is taken. Managed keyword names move, so each mint
+    // is pinned before the next allocation.
     let (keyword_names_w, keyword_values_base) = match kwargs {
         Some(dict) => {
             let entries: Vec<_> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
@@ -31911,7 +31909,7 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             let base = pyre_object::gc_roots::pin_roots(&values);
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
-                let w_name = pyre_object::w_str_from_wtf8(key);
+                let w_name = pyre_object::w_str_from_wtf8_managed(key);
                 let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13450,11 +13450,10 @@ fn init_type_type(ns: PyObjectRef) {
             }
             // Builtin-name dot split fallback (`typeobject.py:619-624`).
             let name = unsafe { pyre_object::w_type_get_name(cls) };
-            let mod_name = match name.rfind('.') {
-                Some(dot) => name[..dot].to_string(),
-                None => "builtins".to_string(),
-            };
-            Ok(pyre_object::w_str_new(&mod_name))
+            Ok(match name.rfind('.') {
+                Some(dot) => pyre_object::w_str_new_managed(&name[..dot]),
+                None => pyre_object::w_str_new("builtins"),
+            })
         },
         2,
     );
@@ -26476,7 +26475,7 @@ fn bytearray_reduce_impl(
         // unicode string plus the explicit codec name.
         let latin1: String = data.iter().map(|&b| char::from(b)).collect();
         let mut fields = pyre_object::gc_roots::RootedItems::new();
-        fields.push(w_str_new(&latin1));
+        fields.push(w_str_new_managed(&latin1));
         fields.push(w_str_new("latin-1"));
         w_tuple_new(fields.take())
     };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1744,7 +1744,7 @@ use pyre_object::lowlevel_string::{
     LOWLEVEL_STR_BASE_SIZE, LOWLEVEL_UNICODE_BASE_SIZE, bh_alloc_lowlevel_string,
     bh_read_lowlevel_string, bh_write_lowlevel_char,
 };
-use pyre_object::{w_bool_from, w_int_new, w_none, w_str_new, w_tuple_new};
+use pyre_object::{w_bool_from, w_int_new, w_none, w_str_new_managed, w_tuple_new};
 
 // rlib/jit.py PARAMETERS default: loop hot-count threshold. Read from
 // the parameter table rather than restated — upstream a jitdriver that does
@@ -6702,13 +6702,13 @@ pub fn get_location(
             }
         };
     let _ = opcode;
-    w_tuple_new(vec![
-        w_str_new(&filename),
-        w_int_new(line as i64),
-        w_str_new(&name),
-        w_int_new(next_instr as i64),
-        w_str_new(&opcode),
-    ])
+    let mut fields = gc_roots::RootedItems::new();
+    fields.push(w_str_new_managed(&filename));
+    fields.push(w_int_new(line as i64));
+    fields.push(w_str_new_managed(&name));
+    fields.push(w_int_new(next_instr as i64));
+    fields.push(w_str_new_managed(&opcode));
+    w_tuple_new(fields.take())
 }
 
 /// RPython interp_jit.py helper: should_unroll_one_iteration.

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -36,7 +36,7 @@
 //! * `i64` / `i32` / `u32` / `usize` — `w_int_new`.
 //! * `f64` — `w_float_new`.
 //! * `bool` — `w_bool_from`.
-//! * `String` — `w_str_new`.
+//! * `String` — `w_str_new_managed`.
 //! * `pyre_object::PyObjectRef` — passthrough.
 //! * `Result<T, crate::PyError>` — `?`-propagated, then `T` wrapped.
 //! * `()` — `w_none()`.
@@ -934,11 +934,11 @@ fn wrap_value_expr(
             }
             "f64" => return Ok(quote! { ::pyre_object::w_float_new(#value) }),
             "bool" => return Ok(quote! { ::pyre_object::w_bool_from(#value) }),
-            "String" => return Ok(quote! { ::pyre_object::w_str_new(&#value) }),
+            "String" => return Ok(quote! { ::pyre_object::w_str_new_managed(&#value) }),
             // A method whose text may hold a lone surrogate — a `__repr__`
             // naming a filename, say — returns the WTF-8 buffer itself
             // rather than a `String` it cannot spell.
-            "Wtf8Buf" => return Ok(quote! { ::pyre_object::w_str_from_wtf8(#value) }),
+            "Wtf8Buf" => return Ok(quote! { ::pyre_object::w_str_from_wtf8_managed(#value) }),
             _ => {}
         }
         // `Vec<T>` — bytes / list-of-X.

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -271,7 +271,11 @@ impl crate::rordereddict::Equivalent<ObjectKey> for StrLookupKey<'_> {
                 // `dict_keys_equal` does.  The materialized str is the rare-path
                 // cost (a str-subclass dict key); the common exact-str arm
                 // above allocates nothing.
-                dict_keys_equal(k.obj, crate::w_str_new(self.key))
+                {
+                    let _roots = crate::gc_roots::push_roots();
+                    let w_key = crate::gc_roots::pin_root(crate::w_str_new_managed(self.key));
+                    dict_keys_equal(k.obj, w_key)
+                }
             } else {
                 // ObjectDictStrategy uses the ordinary object equality hook
                 // for every hash collision.  A non-str key is allowed to
@@ -281,7 +285,9 @@ impl crate::rordereddict::Equivalent<ObjectKey> for StrLookupKey<'_> {
                 // on this rare collision path, matching
                 // `object_key_for(w_str_new(key))`.  Pass the stored key first,
                 // the order `keyeq(checkingkey, key)` uses (`rordereddict.py:1055`).
-                dict_keys_equal(k.obj, crate::w_str_new(self.key))
+                let _roots = crate::gc_roots::push_roots();
+                let w_key = crate::gc_roots::pin_root(crate::w_str_new_managed(self.key));
+                dict_keys_equal(k.obj, w_key)
             }
         }
     }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3985,9 +3985,13 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         }
         _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
-    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     let _roots = crate::gc_roots::push_roots();
+    let obj_slot = crate::gc_roots::shadow_stack_len();
+    let _ = crate::gc_roots::pin_root(obj);
     let w_key = crate::gc_roots::pin_root(crate::w_str_from_wtf8_managed(key.to_wtf8_buf()));
+    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let dict = &mut *(obj as *mut W_DictObject);
+    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     let removed = entries.remove(&object_key_for(w_key)).is_some();
     if removed {
         dict.keys_version = dict.keys_version.wrapping_add(1);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3837,7 +3837,7 @@ pub unsafe fn wtf8_key_as_str_unchecked(key: &rustpython_wtf8::Wtf8) -> &str {
 /// `Wtf8Buf`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn wtf8_surrogate_key_str_object(key: &rustpython_wtf8::Wtf8) -> PyObjectRef {
-    crate::w_str_from_wtf8(key.to_wtf8_buf())
+    crate::w_str_from_wtf8_managed(key.to_wtf8_buf())
 }
 
 pub unsafe fn w_dict_getitem_wtf8(
@@ -3847,7 +3847,9 @@ pub unsafe fn w_dict_getitem_wtf8(
     if wtf8_key_is_utf8(key) {
         w_dict_getitem_str(obj, wtf8_key_as_str_unchecked(key))
     } else {
-        w_dict_lookup(obj, wtf8_surrogate_key_str_object(key))
+        let _roots = crate::gc_roots::push_roots();
+        let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
+        w_dict_lookup(obj, w_key)
     }
 }
 
@@ -3884,7 +3886,9 @@ pub unsafe fn w_dict_getitem_wtf8_checked(
     if wtf8_key_is_utf8(key) {
         w_dict_getitem_str_checked(obj, wtf8_key_as_str_unchecked(key))
     } else {
-        w_dict_lookup_checked(obj, wtf8_surrogate_key_str_object(key))
+        let _roots = crate::gc_roots::push_roots();
+        let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
+        w_dict_lookup_checked(obj, w_key)
     }
 }
 
@@ -3904,7 +3908,9 @@ pub unsafe fn w_dict_setitem_wtf8(
     if wtf8_key_is_utf8(key) {
         w_dict_setitem_str(obj, wtf8_key_as_str_unchecked(key), value);
     } else {
-        w_dict_store(obj, wtf8_surrogate_key_str_object(key), value);
+        let _roots = crate::gc_roots::push_roots();
+        let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
+        w_dict_store(obj, w_key, value);
     }
 }
 
@@ -3935,7 +3941,8 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         }
         let obj = _dict_guard.root(0);
         let entries = w_module_dict_object_storage_mut(obj);
-        let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
+        let _roots = crate::gc_roots::push_roots();
+        let w_key = crate::gc_roots::pin_root(crate::w_str_from_wtf8_managed(key.to_wtf8_buf()));
         let removed = entries.remove(&object_key_for(w_key)).is_some();
         if removed {
             w_dict_bump_keys_version(obj);
@@ -3952,13 +3959,16 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         StrategyKind::Empty => return false,
         StrategyKind::Object => {}
         StrategyKind::Map | StrategyKind::Class => {
-            let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
+            let _roots = crate::gc_roots::push_roots();
+            let w_key =
+                crate::gc_roots::pin_root(crate::w_str_from_wtf8_managed(key.to_wtf8_buf()));
             return dict.dstrategy.delitem(obj, w_key);
         }
         _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
     let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
-    let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
+    let _roots = crate::gc_roots::push_roots();
+    let w_key = crate::gc_roots::pin_root(crate::w_str_from_wtf8_managed(key.to_wtf8_buf()));
     let removed = entries.remove(&object_key_for(w_key)).is_some();
     if removed {
         dict.keys_version = dict.keys_version.wrapping_add(1);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3854,8 +3854,10 @@ pub unsafe fn w_dict_getitem_wtf8(
         w_dict_getitem_str(obj, wtf8_key_as_str_unchecked(key))
     } else {
         let _roots = crate::gc_roots::push_roots();
+        let obj_slot = crate::gc_roots::shadow_stack_len();
+        let _ = crate::gc_roots::pin_root(obj);
         let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
-        w_dict_lookup(obj, w_key)
+        w_dict_lookup(crate::gc_roots::shadow_stack_get(obj_slot), w_key)
     }
 }
 
@@ -3893,8 +3895,10 @@ pub unsafe fn w_dict_getitem_wtf8_checked(
         w_dict_getitem_str_checked(obj, wtf8_key_as_str_unchecked(key))
     } else {
         let _roots = crate::gc_roots::push_roots();
+        let obj_slot = crate::gc_roots::shadow_stack_len();
+        let _ = crate::gc_roots::pin_root(obj);
         let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
-        w_dict_lookup_checked(obj, w_key)
+        w_dict_lookup_checked(crate::gc_roots::shadow_stack_get(obj_slot), w_key)
     }
 }
 
@@ -3915,8 +3919,13 @@ pub unsafe fn w_dict_setitem_wtf8(
         w_dict_setitem_str(obj, wtf8_key_as_str_unchecked(key), value);
     } else {
         let _roots = crate::gc_roots::push_roots();
+        let obj_slot = crate::gc_roots::pin_roots(&[obj, value]);
         let w_key = crate::gc_roots::pin_root(wtf8_surrogate_key_str_object(key));
-        w_dict_store(obj, w_key, value);
+        w_dict_store(
+            crate::gc_roots::shadow_stack_get(obj_slot),
+            w_key,
+            crate::gc_roots::shadow_stack_get(obj_slot + 1),
+        );
     }
 }
 
@@ -3966,8 +3975,12 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         StrategyKind::Object => {}
         StrategyKind::Map | StrategyKind::Class => {
             let _roots = crate::gc_roots::push_roots();
+            let obj_slot = crate::gc_roots::shadow_stack_len();
+            let _ = crate::gc_roots::pin_root(obj);
             let w_key =
                 crate::gc_roots::pin_root(crate::w_str_from_wtf8_managed(key.to_wtf8_buf()));
+            let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+            let dict = &mut *(obj as *mut W_DictObject);
             return dict.dstrategy.delitem(obj, w_key);
         }
         _ => dict.dstrategy.switch_to_object_strategy(obj),

--- a/pyre/pyre-object/src/interp_array.rs
+++ b/pyre/pyre-object/src/interp_array.rs
@@ -321,7 +321,7 @@ fn unpack_exact(typecode: u8, buf: &[u8]) -> Option<PyObjectRef> {
         b'u' | b'w' => {
             let cp = u32::from_ne_bytes(buf.try_into().ok()?);
             match char::from_u32(cp) {
-                Some(c) => crate::unicodeobject::w_str_new(&c.to_string()),
+                Some(c) => crate::unicodeobject::w_str_new_managed(&c.to_string()),
                 None => {
                     // Lone surrogate / out-of-range Py_UCS4 — represent via
                     // WTF-8 (an out-of-range value yields the empty string).
@@ -329,7 +329,7 @@ fn unpack_exact(typecode: u8, buf: &[u8]) -> Option<PyObjectRef> {
                     if let Some(point) = CodePoint::from_u32(cp) {
                         wb.push(point);
                     }
-                    crate::unicodeobject::w_str_from_wtf8(wb)
+                    crate::unicodeobject::w_str_from_wtf8_managed(wb)
                 }
             }
         }

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -643,7 +643,7 @@ pub fn w_exception_new(kind: ExcKind, message: &str) -> PyObjectRef {
         // exception before `w_exception_set_args` writes through it.
         let _roots = crate::gc_roots::push_roots();
         let exc = crate::gc_roots::pin_root(exc);
-        let arg = crate::unicodeobject::w_str_new(message);
+        let arg = crate::gc_roots::pin_root(crate::unicodeobject::w_str_new_managed(message));
         unsafe { w_exception_set_args(exc, w_exception_args_new(vec![arg])) };
     }
     exc
@@ -657,7 +657,9 @@ pub fn w_exception_new_wtf8(kind: ExcKind, message: &Wtf8) -> PyObjectRef {
         // See `w_exception_new`: pin `exc` across the allocating arg build.
         let _roots = crate::gc_roots::push_roots();
         let exc = crate::gc_roots::pin_root(exc);
-        let arg = crate::unicodeobject::w_str_from_wtf8(message.to_wtf8_buf());
+        let arg = crate::gc_roots::pin_root(crate::unicodeobject::w_str_from_wtf8_managed(
+            message.to_wtf8_buf(),
+        ));
         unsafe { w_exception_set_args(exc, w_exception_args_new(vec![arg])) };
     }
     exc

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -1021,7 +1021,7 @@ fn run_python_impl(source: &str) -> String {
         let _ = pyre_object::gc_roots::pin_root(canonical);
         let key_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new("__file__"));
-        let w_path = pyre_object::w_str_new(path);
+        let w_path = pyre_object::w_str_new_managed(path);
         let _ = pyre_interpreter::baseobjspace::setitem(
             pyre_object::gc_roots::shadow_stack_get(globals_slot),
             pyre_object::gc_roots::shadow_stack_get(key_slot),

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1351,7 +1351,7 @@ pub(crate) fn seed_main_loader(
                 ty,
                 &[
                     pyre_object::w_str_new("__main__"),
-                    pyre_object::w_str_new(path),
+                    pyre_object::w_str_new_managed(path),
                 ],
             )
             .ok()

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -2234,13 +2234,12 @@ fn runpy_run_module_as_main(
 ) -> Result<(), pyre_interpreter::PyError> {
     let runpy = importing::importhook("runpy", canonical, pyre_object::PY_NULL, 0, ec_ptr)?;
     let func = pyre_interpreter::getattr(runpy, pyre_object::w_str_new("_run_module_as_main"))?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let w_module = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(module));
     let args = if alter_argv {
-        vec![pyre_object::w_str_new(module)]
+        vec![w_module]
     } else {
-        vec![
-            pyre_object::w_str_new(module),
-            pyre_object::w_bool_from(false),
-        ]
+        vec![w_module, pyre_object::w_bool_from(false)]
     };
     let res = pyre_interpreter::call_function(func, &args);
     if res.is_null() {

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -518,9 +518,9 @@ pub(crate) fn register_interactive_code(
     let register_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Each `w_str_new` can collect, so the earlier string is rooted before
     // the next one is built rather than left in a temporary.
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(source));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(source));
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new_managed(filename));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     pyre_interpreter::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(register_slot),


### PR DESCRIPTION
## Summary

Follow-up to #1781. Remaining per-call immortal `w_str_new` / `w_str_from_wtf8` sites that leak for the process lifetime.

- Convert leftover format/repr/qualname/keyword-name/exception-message and native-module return sites to `w_str_new_managed` / `w_str_from_wtf8_managed`.
- Pin those mints across later allocations (`RootedItems` / `pin_root`).
- Same rule for `wrap_return` `String`/`Wtf8Buf`, `PywrapKind for String`, BuiltinCode `co_varnames`, JIT `get_location`, audit event rewrap, and encode/unpack format strings.

Clinic defaults, interned names, startup paths (`sys.executable`, version), `_io` encoding-field identity, and JIT ConstPtr exception messages stay on the immortal constructors.

Local compile: `cargo check -p pyre-interpreter --features dynasm`, `cargo check -p pyre-jit --features dynasm`, `cargo check -p pyrex --features dynasm`. LLBC re-extracted for interpreter/object/jit.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stability when creating and handling strings across imports, exceptions, formatting, codecs, and built-in modules.
  * Prevented intermittent reference and memory-management issues during operations that allocate or execute Python code.
  * Strengthened handling of Unicode, WTF-8 text, keyword arguments, filesystem paths, and platform-specific values.
  * Preserved existing behavior and public APIs while improving reliability across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->