### PR TITLE
jit-trace: hash ullbc without spans in the prepass key

### DIFF
--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -14,6 +14,8 @@ mod codegen_cache;
 mod llbc_fingerprint;
 #[path = "../src/pypyjit_driver_layout.rs"]
 mod pypyjit_driver_layout;
+#[path = "../src/ullbc_semantic.rs"]
+mod ullbc_semantic;
 #[path = "../src/virtualizable_spec.rs"]
 mod virtualizable_spec;
 
@@ -29,7 +31,7 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 /// Bump whenever the bytes of a cached output change shape. `bincode` is not
 /// self-describing, so a record written by an older generation is not detected
 /// as stale -- it decodes, into the wrong fields.
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v19";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v20";
 /// Retained cache entries, per version. An entry measures ~36 MB -- 32 MB of
 /// it is `jit_metadata.json` -- so eight covers the configurations one checkout
 /// switches between (native/wasm × release/dev) inside 300 MB.
@@ -2444,19 +2446,18 @@ fn rustc_version_string() -> String {
 }
 
 fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &std::path::Path) {
-    // Hash the LLBC by content, not by (len, mtime) signature. The
-    // analysis (`analyze_multiple_pipeline_with_modules`) derives every
-    // generated artefact from these graph bodies, so a content change that
-    // happens to preserve size and mtime — `git checkout`, a cache restore
-    // that keeps timestamps, an in-place rewrite of equal length — must
-    // still rekey the cache. A signature would let `restore_codegen_cache`
-    // serve stale output and skip re-analysis. The `.ullbc` set is ~660 MB
-    // (89 % of it `fun_decls`), so the read costs under a second — still
-    // negligible next to the tens of seconds of analysis it gates.
+    // Hash the LLBC by a single forward pass that drops span line/col,
+    // `files[].contents`, and `dest_file`. Those move when a comment is
+    // edited or the checkout path changes, and hashing the raw JSON
+    // re-ran the prepass over an unchanged translation. `source_text`
+    // stays in the feed (the translator reads `static mut` off it).
+    // Extract does not run this pass: it must not rescan the artefact.
+    // The `.ullbc` set is ~660 MB; the read plus this walk is still
+    // seconds, next to the tens of seconds of analysis it gates.
     if let Some(paths) = std::env::var_os("MAJIT_MIR_FRONTEND_LLBC") {
         for path in std::env::split_paths(&paths) {
             if !path.as_os_str().is_empty() {
-                hash_file_content(h, repo_root, &path);
+                hash_ullbc_file(h, repo_root, &path);
             }
         }
         return;
@@ -2464,7 +2465,7 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &std::path::Path) {
     // Same single source of truth as `emit_rerun_directives`: a crate missing
     // from this hash keys the codegen cache on a stale snapshot of it.
     for crate_name in LLBC_CRATES {
-        hash_file_content(
+        hash_ullbc_file(
             h,
             repo_root,
             &repo_root
@@ -2480,12 +2481,22 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &std::path::Path) {
     // `restore_codegen_cache` would serve the descrs built from the old
     // offsets.  Empty on a native build.
     for sidecar in llbc_layout_sidecars() {
-        hash_file_content(
+        hash_ullbc_file(
             h,
             repo_root,
             &repo_root.join("build").join("llbc").join(&sidecar),
         );
     }
+}
+
+fn hash_ullbc_file(h: &mut CacheHasher, repo_root: &std::path::Path, path: &std::path::Path) {
+    h.write_str(&codegen_cache::repo_relative(repo_root, path));
+    let Ok(bytes) = std::fs::read(path) else {
+        h.write_str("missing");
+        return;
+    };
+    h.write_str("semantic");
+    ullbc_semantic::feed_semantic_ullbc(&bytes, &mut |chunk| h.write_bytes(chunk));
 }
 
 fn hash_rs_dir_content(h: &mut CacheHasher, repo_root: &std::path::Path, dir: &std::path::Path) {

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -144,6 +144,8 @@ pub mod runtime_fnaddr_patch;
 pub mod state;
 pub mod super_inst_expand;
 mod trace_opcode;
+#[cfg(test)]
+mod ullbc_semantic;
 pub mod unpack_state;
 pub use pyjitcode::{PyJitCode, PyJitCodeMetadata};
 pub mod trace;

--- a/pyre/pyre-jit-trace/src/ullbc_semantic.rs
+++ b/pyre/pyre-jit-trace/src/ullbc_semantic.rs
@@ -1,0 +1,296 @@
+//! Semantic identity of a Charon ULLBC artefact for the prepass cache key.
+//!
+//! One forward pass. The previous extract-time digest called `find` from
+//! each span and hung CI for hours on `pyre-jit.ullbc`. This walk only
+//! advances `index`.
+//!
+//! Dropped from the feed: `files[].contents` (source dump, comments
+//! included), span `beg`/`end` line/col, and `dest_file` (absolute
+//! checkout path). `source_text` stays — the translator reads `static mut`
+//! off it. Graph bodies stay.
+
+/// Emit `data` with source dumps, dest_file, and span locs removed.
+///
+/// Every call advances `index`. Callers must not rescan the file per span.
+pub fn feed_semantic_ullbc(data: &[u8], emit: &mut dyn FnMut(&[u8])) {
+    const CONTENTS: &[u8] = br#""contents":"#;
+    const DEST_FILE: &[u8] = br#""dest_file":"#;
+    const BEG: &[u8] = br#""beg":"#;
+    const END: &[u8] = br#""end":"#;
+
+    let mut index = 0;
+    let mut emit_from = 0;
+    while index < data.len() {
+        // Jump to the next quote. A byte-at-a-time walk of the 882 MB
+        // interpreter artefact is ~14 s unoptimized; skipping to `"`
+        // keeps the prepass key in the same budget as the raw read.
+        match data[index..].iter().position(|&byte| byte == b'"') {
+            Some(rel) => index += rel,
+            None => break,
+        }
+        if let Some(after) = strip_prefix_at(data, index, CONTENTS) {
+            emit(&data[emit_from..index]);
+            emit(CONTENTS);
+            emit(br#""""#);
+            index = skip_json_value(data, after);
+            emit_from = index;
+        } else if let Some(after) = strip_prefix_at(data, index, DEST_FILE) {
+            emit(&data[emit_from..index]);
+            emit(DEST_FILE);
+            emit(br#""""#);
+            index = skip_json_value(data, after);
+            emit_from = index;
+        } else if let Some(after) = strip_prefix_at(data, index, BEG) {
+            if let Some(obj_end) = span_loc_end(data, after) {
+                emit(&data[emit_from..index]);
+                emit(BEG);
+                emit(br#"{"line":0,"col":0}"#);
+                index = obj_end;
+                emit_from = index;
+            } else {
+                index += 1;
+            }
+        } else if let Some(after) = strip_prefix_at(data, index, END) {
+            if let Some(obj_end) = span_loc_end(data, after) {
+                emit(&data[emit_from..index]);
+                emit(END);
+                emit(br#"{"line":0,"col":0}"#);
+                index = obj_end;
+                emit_from = index;
+            } else {
+                index += 1;
+            }
+        } else {
+            index += 1;
+        }
+    }
+    if emit_from < data.len() {
+        emit(&data[emit_from..]);
+    }
+}
+
+fn strip_prefix_at<'a>(data: &'a [u8], index: usize, prefix: &[u8]) -> Option<usize> {
+    let rest = data.get(index..)?;
+    rest.starts_with(prefix).then_some(index + prefix.len())
+}
+
+fn span_loc_end(data: &[u8], after_key: usize) -> Option<usize> {
+    let start = skip_ws(data, after_key);
+    if start >= data.len() || data[start] != b'{' {
+        return None;
+    }
+    let end = skip_json_value(data, start);
+    is_span_loc(&data[start..end]).then_some(end)
+}
+
+fn skip_ws(data: &[u8], mut index: usize) -> usize {
+    while index < data.len() && matches!(data[index], b' ' | b'\t' | b'\n' | b'\r') {
+        index += 1;
+    }
+    index
+}
+
+fn skip_json_string(data: &[u8], mut index: usize) -> usize {
+    index += 1;
+    while index < data.len() {
+        match data[index] {
+            b'\\' => index = index.saturating_add(2),
+            b'"' => return index + 1,
+            _ => index += 1,
+        }
+    }
+    data.len()
+}
+
+fn skip_json_container(data: &[u8], mut index: usize) -> usize {
+    let mut depth = 0;
+    while index < data.len() {
+        match data[index] {
+            b'"' => index = skip_json_string(data, index),
+            b'{' | b'[' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' | b']' => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return index;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    data.len()
+}
+
+fn skip_json_value(data: &[u8], mut index: usize) -> usize {
+    index = skip_ws(data, index);
+    if index >= data.len() {
+        return index;
+    }
+    match data[index] {
+        b'"' => skip_json_string(data, index),
+        b'{' | b'[' => skip_json_container(data, index),
+        b'n' if data[index..].starts_with(b"null") => index + 4,
+        b't' if data[index..].starts_with(b"true") => index + 4,
+        b'f' if data[index..].starts_with(b"false") => index + 5,
+        b'-' | b'0'..=b'9' => {
+            if data[index] == b'-' {
+                index += 1;
+            }
+            while index < data.len() && data[index].is_ascii_digit() {
+                index += 1;
+            }
+            if index < data.len() && data[index] == b'.' {
+                index += 1;
+                while index < data.len() && data[index].is_ascii_digit() {
+                    index += 1;
+                }
+            }
+            if index < data.len() && matches!(data[index], b'e' | b'E') {
+                index += 1;
+                if index < data.len() && matches!(data[index], b'+' | b'-') {
+                    index += 1;
+                }
+                while index < data.len() && data[index].is_ascii_digit() {
+                    index += 1;
+                }
+            }
+            index
+        }
+        _ => index,
+    }
+}
+
+fn is_span_loc(obj: &[u8]) -> bool {
+    let mut index = 0;
+    if index >= obj.len() || obj[index] != b'{' {
+        return false;
+    }
+    index += 1;
+    index = skip_ws(obj, index);
+    if !obj[index..].starts_with(br#""line""#) {
+        return false;
+    }
+    index += 6;
+    index = skip_ws(obj, index);
+    if index >= obj.len() || obj[index] != b':' {
+        return false;
+    }
+    index = skip_ws(obj, index + 1);
+    if index >= obj.len() || !obj[index].is_ascii_digit() {
+        return false;
+    }
+    while index < obj.len() && obj[index].is_ascii_digit() {
+        index += 1;
+    }
+    index = skip_ws(obj, index);
+    if index >= obj.len() || obj[index] != b',' {
+        return false;
+    }
+    index = skip_ws(obj, index + 1);
+    if !obj[index..].starts_with(br#""col""#) {
+        return false;
+    }
+    index += 5;
+    index = skip_ws(obj, index);
+    if index >= obj.len() || obj[index] != b':' {
+        return false;
+    }
+    index = skip_ws(obj, index + 1);
+    if index >= obj.len() || !obj[index].is_ascii_digit() {
+        return false;
+    }
+    while index < obj.len() && obj[index].is_ascii_digit() {
+        index += 1;
+    }
+    index = skip_ws(obj, index);
+    index < obj.len() && obj[index] == b'}' && skip_ws(obj, index + 1) == obj.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+    use std::time::Instant;
+
+    fn digest(data: &[u8]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        feed_semantic_ullbc(data, &mut |chunk| hasher.write(chunk));
+        hasher.finish()
+    }
+
+    const BASE: &[u8] = br#"{"charon_version":"t","options":{"dest_file":"/abs/a.ullbc"},"translated":{"files":[{"id":0,"name":{"Local":"a.rs"},"contents":"fn a() {\n  // c1\n}"}],"fun_decls":[{"item_meta":{"source_text":"fn a() {}","span":{"data":{"file_id":0,"beg":{"line":10,"col":4},"end":{"line":12,"col":1}}}}}]}}"#;
+
+    #[test]
+    fn span_line_col_move_keeps_the_digest() {
+        let replaced = std::str::from_utf8(BASE)
+            .unwrap()
+            .replace("\"line\":10", "\"line\":99")
+            .replace("\"line\":12", "\"line\":101");
+        assert_eq!(digest(BASE), digest(replaced.as_bytes()));
+    }
+
+    #[test]
+    fn contents_and_dest_file_move_keep_the_digest() {
+        let contents = std::str::from_utf8(BASE).unwrap().replace("// c1", "// c2");
+        let dest = std::str::from_utf8(BASE)
+            .unwrap()
+            .replace("/abs/a.ullbc", "/other/b.ullbc");
+        assert_eq!(digest(BASE), digest(contents.as_bytes()));
+        assert_eq!(digest(BASE), digest(dest.as_bytes()));
+    }
+
+    #[test]
+    fn source_text_or_fun_decls_move_changes_the_digest() {
+        let source_text = std::str::from_utf8(BASE)
+            .unwrap()
+            .replace("fn a() {}", "static mut X: u8 = 0;");
+        let body = std::str::from_utf8(BASE)
+            .unwrap()
+            .replace("\"fun_decls\":[", "\"fun_decls\":[{\"changed\":true},");
+        assert_ne!(digest(BASE), digest(source_text.as_bytes()));
+        assert_ne!(digest(BASE), digest(body.as_bytes()));
+    }
+
+    #[test]
+    fn non_span_end_is_not_zeroed() {
+        let a = br#"{"end":{"Unsigned":["U64","0"]},"beg":{"line":1,"col":2}}"#;
+        let b = br#"{"end":{"Unsigned":["U64","1"]},"beg":{"line":1,"col":2}}"#;
+        let c = br#"{"end":{"Unsigned":["U64","0"]},"beg":{"line":9,"col":8}}"#;
+        assert_ne!(digest(a), digest(b));
+        assert_eq!(digest(a), digest(c));
+    }
+
+    #[test]
+    fn eighty_thousand_spans_finish_in_a_second() {
+        // The rejected extract digest called find() from each span. 80k
+        // copies of this object is enough that a quadratic walk misses
+        // this bound on a laptop; a single pass stays well under it.
+        let span = br#"{"span":{"data":{"file_id":0,"beg":{"line":10,"col":1},"end":{"line":11,"col":2}}}}"#;
+        let mut data = Vec::with_capacity(span.len() * 80_000);
+        for _ in 0..80_000 {
+            data.extend_from_slice(span);
+        }
+        let start = Instant::now();
+        let mut emitted = 0usize;
+        feed_semantic_ullbc(&data, &mut |chunk| emitted += chunk.len());
+        assert!(
+            start.elapsed().as_millis() < 1_000,
+            "semantic feed took {:?} over {} bytes",
+            start.elapsed(),
+            data.len()
+        );
+        assert!(emitted > 0);
+        let needle = br#""line":10"#;
+        let at = data
+            .windows(needle.len())
+            .position(|window| window == needle)
+            .expect("fixture contains a span line");
+        let mut shifted = data.clone();
+        shifted[at + 8] = b'9';
+        assert_eq!(digest(&data), digest(&shifted));
+    }
+}


### PR DESCRIPTION
## Summary

Replacement for the closed #1793. That patch hashed the artefact **during extract** with `bytes.find` per span, which is quadratic and hung ubuntu Extract for 168 minutes (cargo finished in 3m 38s, then silence until exit 143).

This one does **not** touch `extract-llbc.py`. The prepass cache key already reads the `.ullbc` set; it now runs one forward pass that drops:

- `files[].contents` (source dump, comments included)
- span `beg`/`end` line/col
- `dest_file` (absolute checkout path)

`source_text` stays — the translator uses it to tell `static mut` from `static`. Graph bodies stay. Cache generation is `codegen-cache-v20`.

A comment in a file-table crate still re-extracts (no rustc oracle). The prepass after that no longer misses.

## PyPy parity

Cache invalidation only. No interpreter or JIT semantics change.

## Verification

- `rustc --test pyre/pyre-jit-trace/src/ullbc_semantic.rs`: 5 passed, including 80k spans under 1s
- Linear feed at `opt-level=1` (build-override): `pyre-jit.ullbc` 0.36s, `pyre-interpreter.ullbc` 2.3s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code generation cache consistency by basing cache identity on meaningful program content rather than formatting details, source locations, embedded source dumps, or checkout paths.
  - Cache behavior is now consistent across override builds, standard crates, and cross-target artifacts.
  - Changes to source text or function declarations continue to invalidate affected cached results.

- **Performance**
  - Improved processing efficiency for large programs with many source spans.

- **Chores**
  - Updated the code generation cache version to ensure compatibility with the new cache-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->