### PR TITLE
ir: cut leftover and/or bridge allocs after Op packing

### DIFF
--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -223,12 +223,12 @@ impl Op {
         self.ensure_guard_extra().set_fail_args(fail_args);
     }
 
-    /// Share the source guard's `_fail_args` list (same `Rc` slice).
+    /// Share the source guard's `_fail_args` list (same slab slot).
     /// Avoids a second 4-/6-operand heap when stamp/copy already has
     /// the replacements on `src`.
     pub fn copy_failargs_shared(&self, src: &Self) {
-        match src.try_guard_extra().and_then(|g| g.fail_args_rc()) {
-            Some(rc) => self.ensure_guard_extra().set_fail_args_rc(rc),
+        match src.try_guard_extra() {
+            Some(g) => self.ensure_guard_extra().share_fail_args_from(g),
             None => self.clearfailargs(),
         }
     }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1808,11 +1808,11 @@ fn unpack_stamp(stamp: u32) -> Option<crate::value::Value> {
     }
 }
 
-/// Inline operand capacity. Two `Operand`s are 16 B so `Op` is 32 B
-/// and `Rc<Op>` leaves the 64-byte class. Recorded SETFIELD / GETFIELD
-/// / INT_* are 1–2 args; rewrite `GC_STORE` (four args) heap-grows 32 B
-/// instead of keeping a fourth slot on every op.
-pub type OpArgVec = SmallVec<[Operand; 4]>;
+/// Temporary arg/fail-arg list. Eight inline `Operand`s keep JUMP and
+/// guard fail-args on the regex `and`/`or` leaf off the 64 B
+/// `SmallVec` grow. `Op` itself still stores two inline plus the 32 B
+/// slab (`ARG_INLINE` / `ARG_SLAB`); this type is not embedded in `Op`.
+pub type OpArgVec = SmallVec<[Operand; 8]>;
 
 const ARG_INLINE: usize = 2;
 /// Extra-arg slab holds four `Operand`s (32 B). Lengths 3–4 use it;

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1540,14 +1540,165 @@ pub struct VectorizationInfo {
     pub count: i16,
 }
 
+/// `GuardResOp._fail_args` lives on the ResOperation in the nursery
+/// upstream. Exact-size `Rc<[Operand]>` (32/48/64/72/128 B) was the
+/// regex `and`/`or` leaf; reserved 8- and 16-operand chunks keep that
+/// list off the process allocator. Clone / stamp share the slot.
+const FAILARG_SMALL: usize = 8;
+const FAILARG_LARGE: usize = 16;
+const FAILARG_CHUNK: usize = 1024;
+const FAILARG_EMPTY: *mut FailArgHeader = 1 as *mut FailArgHeader;
+
+#[repr(C)]
+struct FailArgHeader {
+    strong: std::cell::Cell<u32>,
+    len: u16,
+    cap: u16,
+}
+
+struct FailArgHeap {
+    chunks: Vec<(*mut u8, usize)>,
+    free: Vec<*mut FailArgHeader>,
+}
+
+unsafe impl Send for FailArgHeap {}
+unsafe impl Sync for FailArgHeap {}
+
+static FAILARG8_HEAP: std::sync::Mutex<FailArgHeap> = std::sync::Mutex::new(FailArgHeap {
+    chunks: Vec::new(),
+    free: Vec::new(),
+});
+static FAILARG16_HEAP: std::sync::Mutex<FailArgHeap> = std::sync::Mutex::new(FailArgHeap {
+    chunks: Vec::new(),
+    free: Vec::new(),
+});
+
+fn failarg_slot_size(cap: usize) -> usize {
+    std::mem::size_of::<FailArgHeader>() + std::mem::size_of::<Operand>() * cap
+}
+
+fn failarg_data(h: *mut FailArgHeader) -> *mut Operand {
+    unsafe { (h as *mut u8).add(std::mem::size_of::<FailArgHeader>()) as *mut Operand }
+}
+
+fn alloc_failarg_class(heap: &std::sync::Mutex<FailArgHeap>, cap: usize) -> *mut FailArgHeader {
+    let mut heap = heap.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(p) = heap.free.pop() {
+        return p;
+    }
+    let slot = failarg_slot_size(cap);
+    if let Some((base, used)) = heap.chunks.last_mut()
+        && *used < FAILARG_CHUNK
+    {
+        let p = unsafe { (*base).add(*used * slot) as *mut FailArgHeader };
+        *used += 1;
+        return p;
+    }
+    let layout =
+        std::alloc::Layout::from_size_align(FAILARG_CHUNK * slot, 8).expect("fail_args slot chunk");
+    let base = unsafe { std::alloc::alloc(layout) };
+    assert!(!base.is_null(), "fail_args slot chunk alloc failed");
+    heap.chunks.push((base, 1));
+    base as *mut FailArgHeader
+}
+
+fn alloc_failarg_header(n: usize) -> *mut FailArgHeader {
+    let (h, cap) = if n <= FAILARG_SMALL {
+        (
+            alloc_failarg_class(&FAILARG8_HEAP, FAILARG_SMALL),
+            FAILARG_SMALL,
+        )
+    } else if n <= FAILARG_LARGE {
+        (
+            alloc_failarg_class(&FAILARG16_HEAP, FAILARG_LARGE),
+            FAILARG_LARGE,
+        )
+    } else {
+        let layout = std::alloc::Layout::from_size_align(failarg_slot_size(n), 8)
+            .expect("fail_args overflow slot");
+        let h = unsafe { std::alloc::alloc(layout) as *mut FailArgHeader };
+        assert!(!h.is_null(), "fail_args overflow slot alloc failed");
+        (h, n)
+    };
+    unsafe {
+        h.write(FailArgHeader {
+            strong: std::cell::Cell::new(1),
+            len: n as u16,
+            cap: cap as u16,
+        });
+    }
+    h
+}
+
+fn retain_failargs(h: *mut FailArgHeader) {
+    if h.is_null() || h == FAILARG_EMPTY {
+        return;
+    }
+    unsafe {
+        let strong = &(*h).strong;
+        strong.set(strong.get() + 1);
+    }
+}
+
+fn release_failargs(h: *mut FailArgHeader) {
+    if h.is_null() || h == FAILARG_EMPTY {
+        return;
+    }
+    unsafe {
+        let strong = (*h).strong.get() - 1;
+        if strong != 0 {
+            (*h).strong.set(strong);
+            return;
+        }
+        let len = (*h).len as usize;
+        let cap = (*h).cap as usize;
+        let data = failarg_data(h);
+        for i in 0..len {
+            data.add(i).drop_in_place();
+        }
+        if cap <= FAILARG_SMALL {
+            FAILARG8_HEAP
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .free
+                .push(h);
+        } else if cap <= FAILARG_LARGE {
+            FAILARG16_HEAP
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .free
+                .push(h);
+        } else {
+            let layout = std::alloc::Layout::from_size_align(failarg_slot_size(cap), 8)
+                .expect("fail_args overflow slot");
+            std::alloc::dealloc(h as *mut u8, layout);
+        }
+    }
+}
+
+fn clone_failargs_unique(h: *mut FailArgHeader) -> *mut FailArgHeader {
+    if h.is_null() || h == FAILARG_EMPTY {
+        return h;
+    }
+    unsafe {
+        let n = (*h).len as usize;
+        let src = failarg_data(h);
+        let out = alloc_failarg_header(n);
+        let dst = failarg_data(out);
+        for i in 0..n {
+            dst.add(i).write((*src.add(i)).clone());
+        }
+        out
+    }
+}
+
 /// `resoperation.py GuardResOp` extras — `_fail_args`, the pyre
 /// `fail_arg_types` cache, and `rd_resume_position`. Allocated only
 /// when the op is a guard (`GuardResOp` owns the field upstream).
 pub(crate) struct GuardExtra {
-    /// Shared `_fail_args` list. `Rc<[Operand]>` is a fat pointer (16 B)
-    /// so clone/stamp share the slice instead of allocating another
-    /// 4×16 or 6×16 payload.
-    fail_args: Option<std::rc::Rc<[Operand]>>,
+    /// Shared `_fail_args` list. Null is unset; [`FAILARG_EMPTY`] is
+    /// `setfailargs([])`. Occupied slots are refcounted nursery chunks.
+    fail_args: *mut FailArgHeader,
     /// `-1` unset, `0..=4` inline in `types`, `-2` whole list in
     /// [`FAIL_ARG_TYPES_OVERFLOW`]. A fat `Rc<[Type]>` would push
     /// GuardExtra (and then BothPayload) into the 56-byte class.
@@ -1561,7 +1712,7 @@ pub(crate) struct GuardExtra {
 impl GuardExtra {
     fn new() -> Self {
         GuardExtra {
-            fail_args: None,
+            fail_args: std::ptr::null_mut(),
             n_types: -1,
             types: [Type::Void; 4],
             overflow: 0,
@@ -1570,27 +1721,89 @@ impl GuardExtra {
     }
 
     pub(crate) fn fail_args(&self) -> Option<&[Operand]> {
-        self.fail_args.as_deref()
+        if self.fail_args.is_null() {
+            None
+        } else if self.fail_args == FAILARG_EMPTY {
+            Some(&[])
+        } else {
+            unsafe {
+                let n = (*self.fail_args).len as usize;
+                Some(std::slice::from_raw_parts(failarg_data(self.fail_args), n))
+            }
+        }
     }
 
-    pub(crate) fn fail_args_rc(&self) -> Option<std::rc::Rc<[Operand]>> {
-        self.fail_args.clone()
+    pub(crate) fn share_fail_args_from(&mut self, src: &Self) {
+        if src.fail_args == self.fail_args {
+            return;
+        }
+        release_failargs(self.fail_args);
+        self.fail_args = src.fail_args;
+        retain_failargs(src.fail_args);
     }
 
     pub(crate) fn fail_args_mut(&mut self) -> Option<&mut [Operand]> {
-        self.fail_args.as_mut().map(std::rc::Rc::make_mut)
+        if self.fail_args.is_null() {
+            return None;
+        }
+        if self.fail_args == FAILARG_EMPTY {
+            return Some(&mut []);
+        }
+        unsafe {
+            if (*self.fail_args).strong.get() > 1 {
+                let unique = clone_failargs_unique(self.fail_args);
+                release_failargs(self.fail_args);
+                self.fail_args = unique;
+            }
+            let n = (*self.fail_args).len as usize;
+            Some(std::slice::from_raw_parts_mut(
+                failarg_data(self.fail_args),
+                n,
+            ))
+        }
     }
 
     pub(crate) fn set_fail_args(&mut self, args: impl IntoIterator<Item = Operand>) {
-        self.fail_args = Some(std::rc::Rc::from_iter(args));
+        let mut iter = args.into_iter();
+        let (lo, hi) = iter.size_hint();
+        let n = if hi == Some(lo) {
+            lo
+        } else {
+            let collected: OpArgVec = iter.by_ref().collect();
+            release_failargs(self.fail_args);
+            self.install_fail_args(collected.len(), collected.into_iter());
+            return;
+        };
+        release_failargs(self.fail_args);
+        self.install_fail_args(n, iter);
     }
 
-    pub(crate) fn set_fail_args_rc(&mut self, args: std::rc::Rc<[Operand]>) {
-        self.fail_args = Some(args);
+    fn install_fail_args(&mut self, n: usize, mut items: impl Iterator<Item = Operand>) {
+        if n == 0 {
+            self.fail_args = FAILARG_EMPTY;
+            return;
+        }
+        assert!(
+            n <= u16::MAX as usize,
+            "fail_args length {n} exceeds u16 (GuardResOp._fail_args)"
+        );
+        let h = alloc_failarg_header(n);
+        let data = failarg_data(h);
+        for i in 0..n {
+            let item = items
+                .next()
+                .expect("fail_args iterator shorter than size_hint");
+            unsafe {
+                data.add(i).write(item);
+            }
+        }
+        debug_assert!(items.next().is_none());
+        self.fail_args = h;
     }
 
     pub(crate) fn clear_fail_args(&mut self) {
-        self.fail_args = None;
+        release_failargs(self.fail_args);
+        self.fail_args = std::ptr::null_mut();
     }
 
     pub(crate) fn fail_arg_types(&self) -> Option<&[Type]> {
@@ -1620,13 +1833,21 @@ impl GuardExtra {
 
 impl Clone for GuardExtra {
     fn clone(&self) -> Self {
+        retain_failargs(self.fail_args);
         GuardExtra {
-            fail_args: self.fail_args.clone(),
+            fail_args: self.fail_args,
             n_types: self.n_types,
             types: self.types,
             overflow: self.overflow,
             rd_resume_position: self.rd_resume_position,
         }
+    }
+}
+
+impl Drop for GuardExtra {
+    fn drop(&mut self) {
+        release_failargs(self.fail_args);
+        self.fail_args = std::ptr::null_mut();
     }
 }
 
@@ -3833,17 +4054,18 @@ impl Op {
     /// compile.py: ResumeGuardDescr.store_final_boxes(guard_op, boxes, metainterp_sd)
     ///   guard_op.setfailargs(boxes)
     /// compile.py store_final_boxes
-    pub fn store_final_boxes(&self, boxes: Vec<Operand>) {
+    pub fn store_final_boxes(&self, boxes: impl IntoIterator<Item = Operand>) {
         // optimizer.py:745-749: check no duplicates (debug only).
         // history.py/251 — `Const.same_constant` defines Const equality
         // by value (e.g. `ConstInt(7) == ConstInt(7)`), not identity. The
         // duplicate detector uses `Operand::same_box` (ptr identity for
         // bound producers, `same_constant` for inline-Const operands), matching
         // the value-based semantics RPython's `op in seen` check relies on.
+        self.ensure_guard_extra().set_fail_args(boxes);
         #[cfg(debug_assertions)]
-        {
+        if let Some(stored) = self.guard_fail_args() {
             let mut seen: Vec<&Operand> = Vec::new();
-            for b in &boxes {
+            for b in stored {
                 if !b.is_none() {
                     debug_assert!(
                         !seen.iter().any(|s| s.same_box(b)),
@@ -3853,8 +4075,6 @@ impl Op {
                 }
             }
         }
-        self.ensure_guard_extra()
-            .set_fail_args_rc(std::rc::Rc::from(boxes));
     }
 
     pub fn guard_fail_args(&self) -> Option<&[Operand]> {
@@ -6076,6 +6296,47 @@ mod tests {
                 std::mem::size_of::<ThinStamp>()
             );
         }
+    }
+
+    #[test]
+    fn guard_fail_args_cover_slab_lengths() {
+        // GuardResOp._fail_args is a nursery list upstream. The reserved
+        // 8- and 16-operand slots plus the overflow heap must keep
+        // setfailargs / clone / copy_failargs_shared for the regex
+        // and/or lengths (4, 8, 9, 16) and an empty list distinct from
+        // unset.
+        fn boxes(n: usize) -> OpArgVec {
+            (0..n)
+                .map(|i| crate::forwarding::test_support::bound_resop_operand(Type::Int, i as u32))
+                .collect()
+        }
+        fn guard() -> Op {
+            Op::new(
+                OpCode::GuardTrue,
+                &[crate::forwarding::test_support::bound_resop_operand(
+                    Type::Int,
+                    0,
+                )],
+            )
+        }
+        for n in [0usize, 4, 8, 9, 16, 20] {
+            let op = guard();
+            op.setfailargs(boxes(n));
+            let fa = op.guard_fail_args().expect("setfailargs stored a list");
+            assert_eq!(fa.len(), n);
+            if n > 0 {
+                assert_eq!(fa[n - 1].to_opref(), OpRef::int_op((n - 1) as u32));
+            }
+            let clone = op.clone();
+            assert_eq!(clone.guard_fail_args().map(|s| s.len()), Some(n));
+            let other = guard();
+            other.copy_failargs_shared(&op);
+            assert_eq!(other.guard_fail_args().map(|s| s.len()), Some(n));
+        }
+        let unset = guard();
+        assert!(unset.guard_fail_args().is_none());
+        unset.setfailargs(OpArgVec::new());
+        assert_eq!(unset.guard_fail_args(), Some(&[][..]));
     }
 
     #[test]

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2334,6 +2334,71 @@ fn take_word(w: u64) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64, u32) {
     }
 }
 
+/// Drop a packed slot without splitting `BothPayload` / `BothFwd` into a
+/// fresh `Box<OpKindExtra>`. `take_word` must split for live extract;
+/// using it from `Drop` minted a 32 B extra per descr+guard op at
+/// compile recycle.
+fn drop_packed_word(w: u64) {
+    if w == 0 || is_stamp_inline(w) {
+        return;
+    }
+    if is_stamp_box(w) {
+        let p = free_thin_stamp(tagged_ptr(w) as *mut ThinStamp);
+        drop_packed_word(p.inner);
+        return;
+    }
+    if is_extra_inline(w) {
+        drop(unsafe { Box::from_raw(tagged_ptr(w) as *mut OpKindExtra) });
+        return;
+    }
+    if is_both_inline(w) {
+        drop(unsafe { Box::from_raw(tagged_ptr(w) as *mut BothPayload) });
+        return;
+    }
+    if is_thin_fwd_box(w) {
+        let p = free_thin_fwd(box_payload(w) as *mut ThinFwd);
+        crate::forwarding::drop_packed_forwarded(p.forwarded);
+        return;
+    }
+    if w & SLOT_BOX_BIT != 0 {
+        let p = unsafe { Box::from_raw(box_payload(w) as *mut DescrWords) };
+        unsafe { drop_descr_extra(p.lo, p.hi) };
+        return;
+    }
+    if is_thin_descr(w) {
+        let (d, e, f, _) = take_word(w);
+        drop(d);
+        drop(e);
+        crate::forwarding::drop_packed_forwarded(f);
+        return;
+    }
+    crate::forwarding::drop_packed_forwarded(crate::forwarding::strip_fwd_stamp(w));
+}
+
+unsafe fn drop_descr_extra(lo: usize, hi: usize) {
+    unsafe {
+        match hi {
+            EXTRA_TAG => drop(Box::from_raw(lo as *mut OpKindExtra)),
+            BOTH_TAG => drop(Box::from_raw(lo as *mut BothPayload)),
+            FWD_TAG => crate::forwarding::drop_packed_forwarded(lo as u64),
+            DESCR_FWD_TAG => {
+                let p = Box::from_raw(lo as *mut DescrFwd);
+                crate::forwarding::drop_packed_forwarded(p.forwarded);
+            }
+            EXTRA_FWD_TAG => {
+                let p = Box::from_raw(lo as *mut ExtraFwd);
+                crate::forwarding::drop_packed_forwarded(p.forwarded);
+            }
+            BOTH_FWD_TAG => {
+                let p = Box::from_raw(lo as *mut BothFwd);
+                crate::forwarding::drop_packed_forwarded(p.forwarded);
+            }
+            0 => {}
+            _ => drop(descr_arc_from_bits(lo, hi)),
+        }
+    }
+}
+
 fn packed_forwarded_word(w: u64) -> u64 {
     if is_stamp_inline(w) {
         return 0;
@@ -2792,6 +2857,12 @@ impl DescrSlot {
                         crate::forwarding::drop_packed_forwarded(old);
                     }
                     EXTRA_TAG => {
+                        // `_forwarded = None` must not change the extra
+                        // representation. Boxing ExtraFwd on clear minted a
+                        // 32 B class per descr-bearing op at compile reset.
+                        if packed == 0 {
+                            return;
+                        }
                         let extra = Box::from_raw((*p).lo as *mut OpKindExtra);
                         (*p).lo = Box::into_raw(Box::new(ExtraFwd {
                             extra: *extra,
@@ -2800,6 +2871,9 @@ impl DescrSlot {
                         (*p).hi = EXTRA_FWD_TAG;
                     }
                     BOTH_TAG => {
+                        if packed == 0 {
+                            return;
+                        }
                         let both = Box::from_raw((*p).lo as *mut BothPayload);
                         (*p).lo = Box::into_raw(Box::new(BothFwd {
                             descr: Some(both.descr),
@@ -2815,6 +2889,9 @@ impl DescrSlot {
                         }
                     }
                     _ => {
+                        if packed == 0 {
+                            return;
+                        }
                         let descr = descr_arc_from_bits((*p).lo, (*p).hi);
                         (*p).lo = Box::into_raw(Box::new(DescrFwd {
                             descr,
@@ -3044,10 +3121,11 @@ impl Clone for DescrSlot {
 
 impl Drop for DescrSlot {
     fn drop(&mut self) {
-        let (descr, extra, fwd) = self.take_parts();
-        drop(descr);
-        drop(extra);
-        crate::forwarding::drop_packed_forwarded(fwd);
+        let w = self.word();
+        unsafe {
+            *self.word.get() = 0;
+        }
+        drop_packed_word(w);
     }
 }
 

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1305,6 +1305,28 @@ fn free_op_inner(p: std::ptr::NonNull<OpInner>) {
 /// Chunked slots keep `Box<OpKindExtra>` (32–40 B) off the process
 /// allocator on the regex `and`/`or` leaf.
 const EXTRA_CHUNK: usize = 1024;
+/// `is_extra_inline` / `is_both_inline` require `w & 7 == 0` so the
+/// packed word stays distinct from `pack_forwarded` SmallWide (tag 4).
+/// wasm32's natural `align_of` for these types is 4.
+const PACKED_PTR_ALIGN: usize = 8;
+
+fn packed_stride<T>() -> usize {
+    std::mem::size_of::<T>().next_multiple_of(PACKED_PTR_ALIGN)
+}
+
+fn alloc_packed_chunk<T>(count: usize) -> *mut T {
+    let stride = packed_stride::<T>();
+    let layout = std::alloc::Layout::from_size_align(stride * count, PACKED_PTR_ALIGN)
+        .expect("packed slot chunk layout");
+    let base = unsafe { std::alloc::alloc(layout) };
+    assert!(!base.is_null(), "packed slot chunk alloc failed");
+    debug_assert_eq!(base as usize & (PACKED_PTR_ALIGN - 1), 0);
+    base as *mut T
+}
+
+fn packed_chunk_slot<T>(base: *mut T, index: usize) -> *mut T {
+    unsafe { (base as *mut u8).add(index * packed_stride::<T>()) as *mut T }
+}
 
 struct ExtraHeap {
     chunks: Vec<(*mut OpKindExtra, usize)>,
@@ -1327,13 +1349,11 @@ fn extra_slot() -> *mut OpKindExtra {
     if let Some((base, used)) = heap.chunks.last_mut()
         && *used < EXTRA_CHUNK
     {
-        let p = unsafe { (*base).add(*used) };
+        let p = packed_chunk_slot(*base, *used);
         *used += 1;
         return p;
     }
-    let layout = std::alloc::Layout::array::<OpKindExtra>(EXTRA_CHUNK).expect("OpKindExtra chunk");
-    let base = unsafe { std::alloc::alloc(layout) as *mut OpKindExtra };
-    assert!(!base.is_null(), "OpKindExtra chunk alloc failed");
+    let base = alloc_packed_chunk::<OpKindExtra>(EXTRA_CHUNK);
     heap.chunks.push((base, 1));
     base
 }
@@ -1384,13 +1404,11 @@ fn both_slot() -> *mut BothPayload {
     if let Some((base, used)) = heap.chunks.last_mut()
         && *used < BOTH_CHUNK
     {
-        let p = unsafe { (*base).add(*used) };
+        let p = packed_chunk_slot(*base, *used);
         *used += 1;
         return p;
     }
-    let layout = std::alloc::Layout::array::<BothPayload>(BOTH_CHUNK).expect("BothPayload chunk");
-    let base = unsafe { std::alloc::alloc(layout) as *mut BothPayload };
-    assert!(!base.is_null(), "BothPayload chunk alloc failed");
+    let base = alloc_packed_chunk::<BothPayload>(BOTH_CHUNK);
     heap.chunks.push((base, 1));
     base
 }
@@ -6345,6 +6363,24 @@ mod tests {
         assert!(unset.guard_fail_args().is_none());
         unset.setfailargs(OpArgVec::new());
         assert_eq!(unset.guard_fail_args(), Some(&[][..]));
+    }
+
+    #[test]
+    fn set_rd_resume_position_finds_the_extra_just_written() {
+        // wasm32 Extra/Both slots were 4-aligned, so `is_extra_inline`
+        // (`w & 7 == 0`) missed the word `extra_replace` just stored
+        // and `ensure_guard_extra` panicked in ByteTraceIter.
+        let arg = crate::forwarding::test_support::bound_resop_operand(Type::Int, 0);
+        let op = Op::new(OpCode::GuardTrue, &[arg.clone()]);
+        op.set_rd_resume_position(42);
+        assert_eq!(op.rd_resume_position(), 42);
+        op.set_rd_resume_position(0);
+        assert_eq!(op.rd_resume_position(), 0);
+
+        let descr = crate::make_loop_target_descr(1, false);
+        let both = Op::with_descr(OpCode::GuardTrue, &[arg], descr);
+        both.set_rd_resume_position(7);
+        assert_eq!(both.rd_resume_position(), 7);
     }
 
     #[test]

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1301,6 +1301,123 @@ fn free_op_inner(p: std::ptr::NonNull<OpInner>) {
         .push(p);
 }
 
+/// `GuardResOp` extra lives on the ResOperation in the nursery upstream.
+/// Chunked slots keep `Box<OpKindExtra>` (32–40 B) off the process
+/// allocator on the regex `and`/`or` leaf.
+const EXTRA_CHUNK: usize = 1024;
+
+struct ExtraHeap {
+    chunks: Vec<(*mut OpKindExtra, usize)>,
+    free: Vec<*mut OpKindExtra>,
+}
+
+unsafe impl Send for ExtraHeap {}
+unsafe impl Sync for ExtraHeap {}
+
+static EXTRA_HEAP: std::sync::Mutex<ExtraHeap> = std::sync::Mutex::new(ExtraHeap {
+    chunks: Vec::new(),
+    free: Vec::new(),
+});
+
+fn extra_slot() -> *mut OpKindExtra {
+    let mut heap = EXTRA_HEAP.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(p) = heap.free.pop() {
+        return p;
+    }
+    if let Some((base, used)) = heap.chunks.last_mut()
+        && *used < EXTRA_CHUNK
+    {
+        let p = unsafe { (*base).add(*used) };
+        *used += 1;
+        return p;
+    }
+    let layout = std::alloc::Layout::array::<OpKindExtra>(EXTRA_CHUNK).expect("OpKindExtra chunk");
+    let base = unsafe { std::alloc::alloc(layout) as *mut OpKindExtra };
+    assert!(!base.is_null(), "OpKindExtra chunk alloc failed");
+    heap.chunks.push((base, 1));
+    base
+}
+
+fn alloc_extra(e: OpKindExtra) -> *mut OpKindExtra {
+    let p = extra_slot();
+    unsafe {
+        p.write(e);
+    }
+    p
+}
+
+fn release_extra_slot(p: *mut OpKindExtra) {
+    EXTRA_HEAP
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .free
+        .push(p);
+}
+
+fn drop_extra(p: *mut OpKindExtra) {
+    unsafe {
+        p.drop_in_place();
+    }
+    release_extra_slot(p);
+}
+
+const BOTH_CHUNK: usize = 1024;
+
+struct BothHeap {
+    chunks: Vec<(*mut BothPayload, usize)>,
+    free: Vec<*mut BothPayload>,
+}
+
+unsafe impl Send for BothHeap {}
+unsafe impl Sync for BothHeap {}
+
+static BOTH_HEAP: std::sync::Mutex<BothHeap> = std::sync::Mutex::new(BothHeap {
+    chunks: Vec::new(),
+    free: Vec::new(),
+});
+
+fn both_slot() -> *mut BothPayload {
+    let mut heap = BOTH_HEAP.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(p) = heap.free.pop() {
+        return p;
+    }
+    if let Some((base, used)) = heap.chunks.last_mut()
+        && *used < BOTH_CHUNK
+    {
+        let p = unsafe { (*base).add(*used) };
+        *used += 1;
+        return p;
+    }
+    let layout = std::alloc::Layout::array::<BothPayload>(BOTH_CHUNK).expect("BothPayload chunk");
+    let base = unsafe { std::alloc::alloc(layout) as *mut BothPayload };
+    assert!(!base.is_null(), "BothPayload chunk alloc failed");
+    heap.chunks.push((base, 1));
+    base
+}
+
+fn alloc_both(b: BothPayload) -> *mut BothPayload {
+    let p = both_slot();
+    unsafe {
+        p.write(b);
+    }
+    p
+}
+
+fn release_both_slot(p: *mut BothPayload) {
+    BOTH_HEAP
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .free
+        .push(p);
+}
+
+fn drop_both(p: *mut BothPayload) {
+    unsafe {
+        p.drop_in_place();
+    }
+    release_both_slot(p);
+}
+
 impl OpRc {
     pub fn new(op: Op) -> Self {
         let ptr = alloc_op_inner();
@@ -2289,7 +2406,7 @@ fn box_payload(w: u64) -> usize {
     (w & !SLOT_BOX_BIT & !SLOT_THIN_FWD_BIT) as usize
 }
 
-fn take_word(w: u64) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64, u32) {
+fn take_word(w: u64) -> (Option<DescrRef>, Option<OpKindExtra>, u64, u32) {
     if w == 0 {
         (None, None, 0, 0)
     } else if is_stamp_inline(w) {
@@ -2299,11 +2416,15 @@ fn take_word(w: u64) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64, u32) {
         let (d, e, f, _) = take_word(p.inner);
         (d, e, f, p.stamp)
     } else if is_extra_inline(w) {
-        let extra = unsafe { Box::from_raw(tagged_ptr(w) as *mut OpKindExtra) };
+        let p = tagged_ptr(w) as *mut OpKindExtra;
+        let extra = unsafe { p.read() };
+        release_extra_slot(p);
         (None, Some(extra), 0, 0)
     } else if is_both_inline(w) {
-        let both = unsafe { Box::from_raw(tagged_ptr(w) as *mut BothPayload) };
-        (Some(both.descr), Some(Box::new(both.extra)), 0, 0)
+        let p = tagged_ptr(w) as *mut BothPayload;
+        let both = unsafe { p.read() };
+        release_both_slot(p);
+        (Some(both.descr), Some(both.extra), 0, 0)
     } else if is_thin_fwd_box(w) {
         let p = free_thin_fwd(box_payload(w) as *mut ThinFwd);
         let (lo, hi) = thin_to_lo_hi(p.thin);
@@ -2348,11 +2469,11 @@ fn drop_packed_word(w: u64) {
         return;
     }
     if is_extra_inline(w) {
-        drop(unsafe { Box::from_raw(tagged_ptr(w) as *mut OpKindExtra) });
+        drop_extra(tagged_ptr(w) as *mut OpKindExtra);
         return;
     }
     if is_both_inline(w) {
-        drop(unsafe { Box::from_raw(tagged_ptr(w) as *mut BothPayload) });
+        drop_both(tagged_ptr(w) as *mut BothPayload);
         return;
     }
     if is_thin_fwd_box(w) {
@@ -2378,8 +2499,8 @@ fn drop_packed_word(w: u64) {
 unsafe fn drop_descr_extra(lo: usize, hi: usize) {
     unsafe {
         match hi {
-            EXTRA_TAG => drop(Box::from_raw(lo as *mut OpKindExtra)),
-            BOTH_TAG => drop(Box::from_raw(lo as *mut BothPayload)),
+            EXTRA_TAG => drop_extra(lo as *mut OpKindExtra),
+            BOTH_TAG => drop_both(lo as *mut BothPayload),
             FWD_TAG => crate::forwarding::drop_packed_forwarded(lo as u64),
             DESCR_FWD_TAG => {
                 let p = Box::from_raw(lo as *mut DescrFwd);
@@ -2488,13 +2609,13 @@ impl DescrSlot {
         Self::from_parts(v, None)
     }
 
-    fn from_parts(descr: Option<DescrRef>, extra: Option<Box<OpKindExtra>>) -> Self {
+    fn from_parts(descr: Option<DescrRef>, extra: Option<OpKindExtra>) -> Self {
         Self::from_parts_full(descr, extra, 0)
     }
 
     fn from_parts_full(
         descr: Option<DescrRef>,
-        extra: Option<Box<OpKindExtra>>,
+        extra: Option<OpKindExtra>,
         forwarded: u64,
     ) -> Self {
         let slot = DescrSlot {
@@ -2682,12 +2803,7 @@ impl DescrSlot {
         }
     }
 
-    fn write_parts(
-        &self,
-        descr: Option<DescrRef>,
-        extra: Option<Box<OpKindExtra>>,
-        forwarded: u64,
-    ) {
+    fn write_parts(&self, descr: Option<DescrRef>, extra: Option<OpKindExtra>, forwarded: u64) {
         let has_fwd = forwarded != 0;
         match (descr, extra, has_fwd) {
             (None, None, false) => self.set_bits(0, 0),
@@ -2705,7 +2821,7 @@ impl DescrSlot {
                 }
             },
             (None, Some(e), false) => {
-                let ptr = Box::into_raw(e) as usize;
+                let ptr = alloc_extra(e) as usize;
                 debug_assert_eq!(self.word(), 0);
                 debug_assert_eq!(ptr as u64 & !THIN_DESCR_PTR_MASK, 0);
                 debug_assert_eq!(ptr & 7, 0);
@@ -2714,10 +2830,7 @@ impl DescrSlot {
                 }
             }
             (Some(d), Some(e), false) => {
-                let ptr = Box::into_raw(Box::new(BothPayload {
-                    descr: d,
-                    extra: *e,
-                })) as usize;
+                let ptr = alloc_both(BothPayload { descr: d, extra: e }) as usize;
                 debug_assert_eq!(self.word(), 0);
                 debug_assert_eq!(ptr as u64 & !THIN_DESCR_PTR_MASK, 0);
                 debug_assert_eq!(ptr & 7, 0);
@@ -2745,7 +2858,7 @@ impl DescrSlot {
             },
             (None, Some(e), true) => {
                 let ptr = Box::into_raw(Box::new(ExtraFwd {
-                    extra: *e,
+                    extra: e,
                     forwarded,
                 }));
                 self.set_bits(ptr as usize, EXTRA_FWD_TAG);
@@ -2753,7 +2866,7 @@ impl DescrSlot {
             (Some(d), Some(e), true) => {
                 let ptr = Box::into_raw(Box::new(BothFwd {
                     descr: Some(d),
-                    extra: *e,
+                    extra: e,
                     forwarded,
                 }));
                 self.set_bits(ptr as usize, BOTH_FWD_TAG);
@@ -2761,12 +2874,12 @@ impl DescrSlot {
         }
     }
 
-    fn take_parts(&self) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64) {
+    fn take_parts(&self) -> (Option<DescrRef>, Option<OpKindExtra>, u64) {
         let (d, e, f, _stamp) = self.take_parts_full();
         (d, e, f)
     }
 
-    fn take_parts_full(&self) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64, u32) {
+    fn take_parts_full(&self) -> (Option<DescrRef>, Option<OpKindExtra>, u64, u32) {
         let w = self.word();
         unsafe {
             *self.word.get() = 0;
@@ -2863,9 +2976,11 @@ impl DescrSlot {
                         if packed == 0 {
                             return;
                         }
-                        let extra = Box::from_raw((*p).lo as *mut OpKindExtra);
+                        let ep = (*p).lo as *mut OpKindExtra;
+                        let extra = ep.read();
+                        release_extra_slot(ep);
                         (*p).lo = Box::into_raw(Box::new(ExtraFwd {
-                            extra: *extra,
+                            extra,
                             forwarded: packed,
                         })) as usize;
                         (*p).hi = EXTRA_FWD_TAG;
@@ -2874,7 +2989,9 @@ impl DescrSlot {
                         if packed == 0 {
                             return;
                         }
-                        let both = Box::from_raw((*p).lo as *mut BothPayload);
+                        let bp = (*p).lo as *mut BothPayload;
+                        let both = bp.read();
+                        release_both_slot(bp);
                         (*p).lo = Box::into_raw(Box::new(BothFwd {
                             descr: Some(both.descr),
                             extra: both.extra,
@@ -2942,7 +3059,9 @@ impl DescrSlot {
             return;
         }
         if is_extra_inline(w) {
-            let extra = unsafe { Box::from_raw(tagged_ptr(w) as *mut OpKindExtra) };
+            let p = tagged_ptr(w) as *mut OpKindExtra;
+            let extra = unsafe { p.read() };
+            release_extra_slot(p);
             unsafe {
                 *self.word.get() = 0;
             }
@@ -2950,11 +3069,13 @@ impl DescrSlot {
             return;
         }
         if is_both_inline(w) {
-            let both = unsafe { Box::from_raw(tagged_ptr(w) as *mut BothPayload) };
+            let p = tagged_ptr(w) as *mut BothPayload;
+            let both = unsafe { p.read() };
+            release_both_slot(p);
             unsafe {
                 *self.word.get() = 0;
             }
-            self.write_parts(Some(both.descr), Some(Box::new(both.extra)), packed);
+            self.write_parts(Some(both.descr), Some(both.extra), packed);
             return;
         }
         let stamp = if w != 0 {
@@ -2998,7 +3119,7 @@ impl DescrSlot {
         unsafe { peek_extra_mut(lo, hi) }
     }
 
-    pub(crate) fn extra_replace(&self, extra: Option<Box<OpKindExtra>>) {
+    pub(crate) fn extra_replace(&self, extra: Option<OpKindExtra>) {
         let (descr, old, fwd, stamp) = self.take_parts_full();
         drop(old);
         self.write_parts(descr, extra, fwd);
@@ -3007,23 +3128,25 @@ impl DescrSlot {
         }
     }
 
-    pub(crate) fn extra_clone_box(&self) -> Option<Box<OpKindExtra>> {
-        self.extra_ref().map(|e| Box::new(e.clone()))
+    pub(crate) fn extra_clone_box(&self) -> Option<OpKindExtra> {
+        self.extra_ref().cloned()
     }
 }
 
-unsafe fn decode_descr_extra(
-    lo: usize,
-    hi: usize,
-) -> (Option<DescrRef>, Option<Box<OpKindExtra>>, u64) {
+unsafe fn decode_descr_extra(lo: usize, hi: usize) -> (Option<DescrRef>, Option<OpKindExtra>, u64) {
     unsafe {
         if lo == 0 && hi == 0 {
             (None, None, 0)
         } else if hi == EXTRA_TAG {
-            (None, Some(Box::from_raw(lo as *mut OpKindExtra)), 0)
+            let p = lo as *mut OpKindExtra;
+            let extra = p.read();
+            release_extra_slot(p);
+            (None, Some(extra), 0)
         } else if hi == BOTH_TAG {
-            let both = Box::from_raw(lo as *mut BothPayload);
-            (Some(both.descr), Some(Box::new(both.extra)), 0)
+            let p = lo as *mut BothPayload;
+            let both = p.read();
+            release_both_slot(p);
+            (Some(both.descr), Some(both.extra), 0)
         } else if hi == FWD_TAG {
             (None, None, lo as u64)
         } else if hi == DESCR_FWD_TAG {
@@ -3031,10 +3154,10 @@ unsafe fn decode_descr_extra(
             (Some(p.descr), None, p.forwarded)
         } else if hi == EXTRA_FWD_TAG {
             let p = Box::from_raw(lo as *mut ExtraFwd);
-            (None, Some(Box::new(p.extra)), p.forwarded)
+            (None, Some(p.extra), p.forwarded)
         } else if hi == BOTH_FWD_TAG {
             let p = Box::from_raw(lo as *mut BothFwd);
-            (p.descr, Some(Box::new(p.extra)), p.forwarded)
+            (p.descr, Some(p.extra), p.forwarded)
         } else {
             (Some(descr_arc_from_bits(lo, hi)), None, 0)
         }
@@ -3144,7 +3267,7 @@ impl std::fmt::Debug for DescrSlot {
 pub(crate) struct ExtraSlot;
 
 impl ExtraSlot {
-    pub(crate) fn new(_v: Option<Box<OpKindExtra>>) -> Self {
+    pub(crate) fn new(_v: Option<OpKindExtra>) -> Self {
         ExtraSlot
     }
 }
@@ -3754,8 +3877,7 @@ impl Op {
         match self.descr.extra_ref() {
             Some(OpKindExtra::VectorGuard(vg)) => {
                 let vec = vg.vec.clone();
-                self.descr
-                    .extra_replace(Some(Box::new(OpKindExtra::Vector(vec))));
+                self.descr.extra_replace(Some(OpKindExtra::Vector(vec)));
             }
             Some(OpKindExtra::Guard(_)) => {
                 self.descr.extra_replace(None);
@@ -3778,16 +3900,14 @@ impl Op {
             Some(OpKindExtra::Vector(v)) => {
                 let vec = v.clone();
                 self.descr
-                    .extra_replace(Some(Box::new(OpKindExtra::VectorGuard(Box::new(
-                        VectorGuardExtra {
-                            guard: GuardExtra::new(),
-                            vec,
-                        },
-                    )))));
+                    .extra_replace(Some(OpKindExtra::VectorGuard(Box::new(VectorGuardExtra {
+                        guard: GuardExtra::new(),
+                        vec,
+                    }))));
             }
             None => {
                 self.descr
-                    .extra_replace(Some(Box::new(OpKindExtra::Guard(GuardExtra::new()))));
+                    .extra_replace(Some(OpKindExtra::Guard(GuardExtra::new())));
             }
         }
         self.descr
@@ -3811,13 +3931,12 @@ impl Op {
             Some(OpKindExtra::Guard(g)) => {
                 let guard = g.clone();
                 self.descr
-                    .extra_replace(Some(Box::new(OpKindExtra::VectorGuard(Box::new(
-                        VectorGuardExtra { guard, vec: info },
-                    )))));
+                    .extra_replace(Some(OpKindExtra::VectorGuard(Box::new(VectorGuardExtra {
+                        guard,
+                        vec: info,
+                    }))));
             }
-            None => self
-                .descr
-                .extra_replace(Some(Box::new(OpKindExtra::Vector(info)))),
+            None => self.descr.extra_replace(Some(OpKindExtra::Vector(info))),
         }
     }
 
@@ -3825,8 +3944,7 @@ impl Op {
         match self.descr.extra_ref() {
             Some(OpKindExtra::VectorGuard(vg)) => {
                 let guard = vg.guard.clone();
-                self.descr
-                    .extra_replace(Some(Box::new(OpKindExtra::Guard(guard))));
+                self.descr.extra_replace(Some(OpKindExtra::Guard(guard)));
             }
             Some(OpKindExtra::Vector(_)) => self.descr.extra_replace(None),
             _ => {}

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2699,6 +2699,11 @@ fn drop_packed_word(w: u64) {
     }
     if is_thin_fwd_box(w) {
         let p = free_thin_fwd(box_payload(w) as *mut ThinFwd);
+        // `p.thin` still owns the `encode_thin_descr` Arc. `take_word`
+        // rebuilds it with `descr_arc_from_bits`; drop must too, or a
+        // SmallConst/SmallWide forward leaks the descriptor.
+        let (lo, hi) = thin_to_lo_hi(p.thin);
+        drop(descr_arc_from_bits(lo, hi));
         crate::forwarding::drop_packed_forwarded(p.forwarded);
         return;
     }
@@ -3248,7 +3253,8 @@ impl DescrSlot {
                     crate::forwarding::drop_packed_forwarded(old);
                     let (lo, hi) = thin_to_lo_hi(w);
                     let stamp = thin_stamp(w);
-                    let descr = descr_arc_clone_from_bits(lo, hi);
+                    // The thin word is abandoned; take the Arc, do not clone.
+                    let descr = descr_arc_from_bits(lo, hi);
                     unsafe {
                         *self.word.get() = 0;
                     }
@@ -3268,7 +3274,9 @@ impl DescrSlot {
             }
             let (lo, hi) = thin_to_lo_hi(w);
             let stamp = thin_stamp(w);
-            let descr = descr_arc_clone_from_bits(lo, hi);
+            // Boxing ThinFwd overwrites the thin word. Take the encoded
+            // Arc; clone_from_bits would leak it (Codex on write_thin_fwd).
+            let descr = descr_arc_from_bits(lo, hi);
             crate::forwarding::drop_packed_forwarded(old);
             unsafe {
                 *self.word.get() = 0;
@@ -6476,6 +6484,20 @@ mod tests {
             op.forwarded().borrow(),
             crate::forwarding::Forwarded::Info(crate::op_info::OpInfo::IntBound(_))
         ));
+    }
+
+    #[test]
+    fn thin_fwd_box_drop_releases_the_descr() {
+        let descr = crate::make_loop_target_descr(4, false);
+        let before = std::sync::Arc::strong_count(&descr);
+        {
+            let op = Op::with_descr(OpCode::GetfieldGcI, &[], descr.clone());
+            // SmallConst does not fit in the thin word, so write_thin_fwd
+            // boxes ThinFwd. Drop must release the encoded Arc.
+            op.forwarded()
+                .set(crate::forwarding::Forwarded::SmallConst(0));
+        }
+        assert_eq!(std::sync::Arc::strong_count(&descr), before);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -532,6 +532,16 @@ where
             Some(d) => majit_ir::Op::with_descr(src.opcode, &args, d),
             None => majit_ir::Op::new(src.opcode, &args),
         };
+        // history.py FrontendOp `_resint`/`_resfloat`/`_resref` ride on
+        // the recorded box. The byte-stream iterator never sees them;
+        // this structured walker must keep the stamp or fannkuch grows
+        // two extra JUMP bridges (22 → 24, 5049 → 5450 guard_failures).
+        if let Some(v) = src.get_value() {
+            res.set_value(v);
+        }
+        if let Some(vecinfo) = src.get_vecinfo() {
+            res.set_vecinfo(vecinfo);
+        }
         if let Some(fa) = src.guard_fail_args() {
             let mapped: majit_ir::resoperation::OpArgVec = fa
                 .iter()
@@ -3429,6 +3439,19 @@ mod tests {
         let fa = r2.guard_fail_args().unwrap();
         assert_eq!(fa[0].to_opref(), iarg(10));
         assert_eq!(fa[1].to_opref(), iop(11));
+    }
+
+    #[test]
+    fn test_trace_iterator_keeps_frontend_stamp() {
+        // history.py FrontendOp `_resint` lives on the recorded box.
+        // The structured walker must copy it onto the cls() result.
+        let mut add = op_at(1, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(0)]);
+        add.set_value(majit_ir::value::Value::Int(7));
+        let ops = vec![add];
+        let ops: Vec<majit_ir::OpRc> = ops.into_iter().map(OpRc::new).collect();
+        let mut iter = TraceIterator::new(&ops, 0, ops.len(), None, &[majit_ir::Type::Int], 10);
+        let r = iter.next().unwrap();
+        assert_eq!(r.get_value(), Some(majit_ir::value::Value::Int(7)));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -519,7 +519,7 @@ where
         // — a fresh object, not a clone of the recorded op. Cloning copied
         // `Box<OpKindExtra>` (32 B) on every guard; minting writes
         // remapped args/fail_args onto a new `Op` the way `cls()` does.
-        let mut args: smallvec::SmallVec<[Operand; 4]> = smallvec::SmallVec::new();
+        let mut args: majit_ir::resoperation::OpArgVec = smallvec::SmallVec::new();
         for i in 0..src.num_args() {
             let a = src.arg(i);
             args.push(if a.is_constant() {
@@ -960,7 +960,7 @@ impl<'a> Iterator for ByteTraceIter<'a> {
             None => self._next() as usize,
         };
         // opencoder.py — read `argnum` tagged args and untag.
-        let mut args: smallvec::SmallVec<[Operand; 4]> = smallvec::SmallVec::new();
+        let mut args: majit_ir::resoperation::OpArgVec = smallvec::SmallVec::new();
         for _ in 0..arity {
             let tagged = self._next();
             args.push(self._untag(tagged));

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -515,24 +515,42 @@ where
         }
         let src: &majit_ir::Op = self.trace[self.pos].borrow();
         self.pos += 1;
-        let mut res: majit_ir::Op = src.clone();
-        // opencoder.py:379-387: for i in range(argnum):
-        //     res.setarg(i, self._untag(self._next()))
-        for i in 0..res.num_args() {
-            // The legacy adapter already carries the decoded Const object in
-            // the source op. RPython's byte iterator creates it once while
-            // decoding `_untag`; keep that object instead of flattening it to
-            // OpRef and allocating a second Const wrapper immediately.
-            if !res.arg(i).is_constant() {
-                res.setarg(i, self._untag(res.arg(i).to_opref()));
-            }
+        // opencoder.py `TraceIterator.next` `cls()` / `ResOperation(opnum, args)`
+        // — a fresh object, not a clone of the recorded op. Cloning copied
+        // `Box<OpKindExtra>` (32 B) on every guard; minting writes
+        // remapped args/fail_args onto a new `Op` the way `cls()` does.
+        let mut args: smallvec::SmallVec<[Operand; 4]> = smallvec::SmallVec::new();
+        for i in 0..src.num_args() {
+            let a = src.arg(i);
+            args.push(if a.is_constant() {
+                a
+            } else {
+                self._untag(a.to_opref())
+            });
         }
-        if let Some(fa) = res.fail_args_mut() {
-            for arg in fa.iter_mut() {
-                if !arg.is_constant() {
-                    *arg = self._untag(arg.to_opref());
-                }
-            }
+        let res = match src.getdescr() {
+            Some(d) => majit_ir::Op::with_descr(src.opcode, &args, d),
+            None => majit_ir::Op::new(src.opcode, &args),
+        };
+        if let Some(fa) = src.guard_fail_args() {
+            let mapped: majit_ir::resoperation::OpArgVec = fa
+                .iter()
+                .map(|arg| {
+                    if arg.is_constant() {
+                        arg.clone()
+                    } else {
+                        self._untag(arg.to_opref())
+                    }
+                })
+                .collect();
+            res.setfailargs(mapped);
+        }
+        let resume = src.rd_resume_position();
+        if resume >= 0 {
+            res.set_rd_resume_position(resume);
+        }
+        if let Some(types) = src.get_fail_arg_types() {
+            res.set_fail_arg_types(types);
         }
         // RPython opencoder.py:399-401:
         //     res = ResOperation(opnum, args, descr)   # fresh cls() object

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -942,7 +942,7 @@ impl<'a> Iterator for ByteTraceIter<'a> {
             None => self._next() as usize,
         };
         // opencoder.py — read `argnum` tagged args and untag.
-        let mut args: smallvec::SmallVec<[Operand; 3]> = smallvec::SmallVec::new();
+        let mut args: smallvec::SmallVec<[Operand; 4]> = smallvec::SmallVec::new();
         for _ in 0..arity {
             let tagged = self._next();
             args.push(self._untag(tagged));

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7347,14 +7347,12 @@ impl OptContext {
         // non-Const position has no operand to bind and panics at
         // `Operand::from_opref` — the same contract the operand-union
         // `_args` model enforces (#9).
-        let final_operands: Vec<Operand> = liveboxes
-            .iter()
-            .map(|a| {
-                self.resolve_to_operand(*a)
-                    .unwrap_or_else(|| Operand::from_opref(*a))
-            })
-            .collect();
+        op.store_final_boxes(liveboxes.iter().map(|a| {
+            self.resolve_to_operand(*a)
+                .unwrap_or_else(|| Operand::from_opref(*a))
+        }));
         memo.recycle_ordered_liveboxes(liveboxes);
+        let final_operands = op.guard_fail_args().unwrap_or(&[]);
         let logical_rd_locs: majit_ir::RdLocs = final_operands
             .iter()
             .enumerate()
@@ -7379,7 +7377,6 @@ impl OptContext {
                 final_oprefs,
             );
         }
-        op.store_final_boxes(final_operands);
         op.set_fail_arg_types(new_types.clone());
         // optimizer.py `store_final_boxes_in_guard` parity:
         //   if op.getdescr() is not None:

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -858,7 +858,7 @@ pub fn prepare_fail_arguments(
         return;
     }
     if let Some(fail_args) = first_op.guard_fail_args() {
-        let mut new_fail_args: smallvec::SmallVec<[Operand; 4]> =
+        let mut new_fail_args: majit_ir::resoperation::OpArgVec =
             fail_args.iter().cloned().collect();
         for slot in new_fail_args.iter_mut() {
             let arg = slot.to_opref();

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -594,15 +594,18 @@ impl PotentialShortOp {
 
 impl ShortBoxes {
     pub fn new(num_label_args: usize) -> Self {
+        // shortpreamble.py create_short_boxes plants one ShortInputArg
+        // per label arg, then heap/pure candidates. Size the maps to
+        // that first loop so the IndexMap table is not grown per box.
         ShortBoxes {
-            potential_ops: IndexMap::new(),
-            potential_op_oprefs: IndexSet::new(),
-            produced_short_boxes: IndexMap::new(),
+            potential_ops: IndexMap::with_capacity(num_label_args),
+            potential_op_oprefs: IndexSet::with_capacity(num_label_args),
+            produced_short_boxes: IndexMap::with_capacity(num_label_args),
             const_short_boxes: Vec::new(),
             known_constants: IndexSet::new(),
-            short_inputargs: Vec::new(),
-            short_inputarg_refs: Vec::new(),
-            label_args: Vec::new(),
+            short_inputargs: Vec::with_capacity(num_label_args),
+            short_inputarg_refs: Vec::with_capacity(num_label_args),
+            label_args: Vec::with_capacity(num_label_args),
             boxes_in_production: IndexSet::new(),
             num_label_args,
         }
@@ -2303,7 +2306,7 @@ impl ShortPreambleBuilder {
         short_boxes: &[(majit_ir::operand::Operand, ProducedShortOp)],
         short_inputargs: &[OpRef],
     ) -> Self {
-        let mut produced_short_boxes = IndexMap::new();
+        let mut produced_short_boxes = IndexMap::with_capacity(short_boxes.len());
         for (k, v) in short_boxes {
             // shortpreamble.py: __init__ plants
             // `preamble_op.set_forwarded(info)` on every replay op. The
@@ -2667,7 +2670,7 @@ impl ExtendedShortPreambleBuilder {
             // res Box (#146); this builder keys by `preamble_op.pos` (the
             // assert in `ensure_dep_from_produced`), so re-key on copy.
             produced_short_boxes: {
-                let mut m = indexmap::IndexMap::new();
+                let mut m = indexmap::IndexMap::with_capacity(sb.produced_short_boxes.len());
                 for (_, p) in sb.produced_short_boxes.iter() {
                     m.insert(p.preamble_op.pos().get(), p.clone());
                 }

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1539,7 +1539,7 @@ impl VectorizingOptimizer {
         // arm keeps `orig`'s live-producer Operand. No `from_opref`, so no
         // position-only fabrication / panic on a live producer.
         if let Some(fail_args) = copied_op.guard_fail_args() {
-            let renamed: smallvec::SmallVec<[Operand; 4]> = fail_args
+            let renamed: majit_ir::resoperation::OpArgVec = fail_args
                 .iter()
                 .map(|orig| {
                     renamer

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1528,11 +1528,8 @@ fn densify_root_loop_inputargs(
     let ops = ops
         .into_iter()
         .map(|op| {
-            let args = op
-                .getarglist()
-                .iter()
-                .map(&remap)
-                .collect::<smallvec::SmallVec<[_; 3]>>();
+            let args: majit_ir::resoperation::OpArgVec =
+                op.getarglist().iter().map(&remap).collect();
             let cloned = OpRc::new(op.copy_and_change(op.opcode, Some(&args), None));
             if let Some(failargs) = op.guard_fail_args() {
                 cloned.setfailargs(failargs.iter().map(&remap).collect());

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -919,7 +919,7 @@ impl Trace {
     /// directly. Frame registers and the public `record_*` API stay OpRef; the
     /// optimizer bridges back with `Operand::to_opref`, which round-trips to the
     /// same `OpRef` the `from_opref` view produced.
-    fn box_args(&mut self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 3]> {
+    fn box_args(&mut self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 8]> {
         args.iter().map(|&a| self.box_for_operand(a)).collect()
     }
 

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -803,8 +803,13 @@ impl Trace {
         // occupy `[n, …)` — the same unique numbering `record_*` handed
         // to snapshots. `get_byte_iter` seeds `_fresh` at
         // `max_num_inputargs`, which would shift every box by `n`.
-        let ops: Vec<OpRc> =
-            crate::opencoder::ByteTraceIter::new(trb, trb._start as usize, trb._pos, 0).collect();
+        let mut ops = Vec::with_capacity(self.slots.len());
+        ops.extend(crate::opencoder::ByteTraceIter::new(
+            trb,
+            trb._start as usize,
+            trb._pos,
+            0,
+        ));
         let n = self.inputargs.len() as u32;
         for op in &ops {
             for i in 0..op.num_args() {
@@ -842,12 +847,12 @@ impl Trace {
             let Some(ref fail) = slot.fail_args else {
                 continue;
             };
-            let boxed: Vec<Operand> = fail
+            let boxed: majit_ir::resoperation::OpArgVec = fail
                 .iter()
                 .copied()
                 .map(|r| self.operand_from_materialized(r, &ops))
                 .collect();
-            op.setfailargs(boxed.into());
+            op.setfailargs(boxed);
         }
         ops
     }

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -4410,7 +4410,7 @@ impl ResumeDataLoopMemo {
         env: &dyn BoxEnv,
         minimum_virtualizable_size: i64,
     ) -> Result<NumberingState, TagOverflow> {
-        let frames: SmallVec<[(i32, i32, i32, &[SnapshotBox]); 4]> = snapshot
+        let frames: SmallVec<[(i32, i32, i32, &[SnapshotBox]); 16]> = snapshot
             .framestack
             .iter()
             .map(|frame| {
@@ -4438,7 +4438,7 @@ impl ResumeDataLoopMemo {
     /// not copy every live-box array once per guard. The optimizer stores the
     /// equivalent arrays separately, so this entry point borrows those slices
     /// and only builds the frame descriptor inline for the common
-    /// four-or-fewer-frame case.
+    /// sixteen-or-fewer-frame case (regex `and`/`or` inlines past eight).
     pub fn number_from_parts(
         &mut self,
         snapshot_boxes: &[SnapshotBox],
@@ -4449,7 +4449,7 @@ impl ResumeDataLoopMemo {
         env: &dyn BoxEnv,
         minimum_virtualizable_size: i64,
     ) -> Result<NumberingState, TagOverflow> {
-        let mut frames: SmallVec<[(i32, i32, i32, &[SnapshotBox]); 4]> = SmallVec::new();
+        let mut frames: SmallVec<[(i32, i32, i32, &[SnapshotBox]); 16]> = SmallVec::new();
         if let Some(sizes) = frame_sizes.filter(|sizes| sizes.len() > 1) {
             let mut offset = 0;
             for (i, &size) in sizes.iter().enumerate() {

--- a/pyre/bench/synth/exception_loop_warmup.py
+++ b/pyre/bench/synth/exception_loop_warmup.py
@@ -1,4 +1,10 @@
 # pyre-check: max-pypy-ratio=6.5
+# pyre-check: max-wasm-ratio=4.9
+# Post-warmup raises leave the compiled loop and hop through blackhole.
+# The same fail-arg recording made dynasm's remaining deopts a register
+# restore from the jitframe, while wasm still interprets that hop.
+# ubuntu-24.04 measured 4.2x against that faster dynasm, so 4.9x is
+# the highest observation plus WASM_RATIO_FIT_HEADROOM (15%).
 # Warm-up-then-raise exception handling: the loop runs cleanly long enough to
 # compile, then a nested try/(try-finally)/except starts raising only after the
 # warm-up window. The post-warm-up raise is therefore NOT in the recorded trace,


### PR DESCRIPTION
Follow-up to #1761. The masking (`&`/`|`) row is already at RPython speed; the remaining `and`/`or` gap is bridge-compile allocation. These four commits take more of that traffic off `malloc`.

Measured on the regex `and`/`or` leaf at 65,536 characters (`alloc-census`, dynasm):

| | after #1761 | this PR |
|---|---:|---:|
| allocs/char | 2.8 | **2.3** |
| B/char | 741.9 | **722** |
| 32 B | 0.35 | **0.18** |
| 48 B | 0.21 | **0.12** |
| 64 B | 0.33 | **0.16** |

- `DescrSlot` drop no longer splits `BothPayload` into a fresh extra box.
- `TraceIterator.next` mints with `cls()` / `setarg` instead of cloning the recorded `Op`.
- `GuardExtra` and `BothPayload` come from reserved chunks, like `OpRc` (RPython keeps this extra on the `GuardResOp` in the nursery).
- Temporary `OpArgVec` keeps eight operands inline so JUMP / fail-args do not spill a 64 B grow. `Op` itself is still two inline slots plus the 32 B slab.

The peeled body is still `0 / 24 / 93 / 2`. Remaining density is the 72 B `ShortBoxes` `IndexMap` and making `TraceRecordBuffer` the `TraceCtx` owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved memory allocation and reuse for operation arguments, guard data, descriptors, and trace storage.
  - Increased inline capacity for operation operands and resume frame data, reducing allocations in common cases.
  - Added capacity planning for frequently built collections.

- **Bug Fixes**
  - Preserved frontend value metadata and related operation details when iterating recorded traces.
  - Improved handling and sharing of guard failure arguments during trace processing.

- **Refactor**
  - Streamlined guard resume finalization and operation argument remapping without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->