### PR TITLE
perf-exc: exception folds and orthodox exception-edge bridges

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7759,7 +7759,7 @@ pub(crate) fn fail_descr_bridge_ref(fd: &dyn FailDescr) -> Option<Arc<BridgeData
     }
 }
 
-/// `compile.py:attach_bridge` / `assembler.py:987 patch_jump_for_descr`
+/// `x86/assembler.py patch_jump_for_descr` / `aarch64/assembler.py patch_trace`
 /// parity — atomic-store the bridge `Arc` raw pointer into the
 /// meta-side dispatch cell, and publish `(code_ptr, frame_depth)`
 /// into the cache cells that `emit_attached_bridge_dispatch` baked

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -15378,9 +15378,28 @@ impl<M: Clone> MetaInterp<M> {
                     fail_descr.trace_id()
                 };
                 self.assign_guard_hashes(&optimized_ops);
+                // `compile.py propagate_original_jitcell_token`: every
+                // LABEL's TargetToken is rebound to
+                // `new_loop.original_jitcell_token`, which
+                // `compile_and_attach` set to the SOURCE loop's token.
+                // `compile_and_attach` runs this before
+                // `send_bridge_to_backend`; the retrace arm already does
+                // the same walk over `unroll_opt.target_tokens`.
+                for op in &optimized_ops {
+                    if !op.opcode.is_label() {
+                        continue;
+                    }
+                    if let Some(ltd) = op
+                        .getdescr()
+                        .as_ref()
+                        .and_then(|d| d.as_loop_target_descr())
+                    {
+                        ltd.set_original_jitcell_token_number(source_jct.number);
+                    }
+                }
                 // `compile.py record_loop_or_bridge(metainterp_sd,
                 //  new_loop)` parity — `new_loop.original_jitcell_token =
-                //  metainterp.resumekey_original_loop_token` (compile.py:801).
+                //  metainterp.resumekey_original_loop_token` (`compile_and_attach`).
                 // The walker stamps every internal `ResumeDescr.rd_loop_token
                 //  = clt(source_jct)` (compile.py:186), so the new
                 // bridge-internal guards inherit the *source* JCT identity

--- a/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
+++ b/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=38
+# pyre-check: max-pypy-ratio=20
 # A residual callee raises for the extremes of a hot descending loop and
 # returns in the middle, so the loop trace's exception guard chronically fails
 # WITHOUT a pending exception and a no-exception bridge gets compiled.  That

--- a/pyre/bench/synth/exc_in_loop_divzero_continue.py
+++ b/pyre/bench/synth/exc_in_loop_divzero_continue.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=6.6
+# pyre-check: max-pypy-ratio=5
 # pyre-check: skip-cpython
 # cpython 0.98s vs pyre 0.17s (5.8x), and it is not gated on — only pypy is.
 # A try/except INSIDE a hot loop whose body raises through a may-force

--- a/pyre/bench/synth/exc_info_direct_hot.py
+++ b/pyre/bench/synth/exc_info_direct_hot.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4.8
+# pyre-check: max-pypy-ratio=3
 # pyre-check: skip-cpython
 # pyre-check: spec-folds=sys_exc_info,subscr_tuple_slice2
 # PyPy's `vm.py exc_info_direct` lets `function.py funccall_valuestack`

--- a/pyre/bench/synth/exc_info_module_loop_hot.py
+++ b/pyre/bench/synth/exc_info_module_loop_hot.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=45
+# pyre-check: max-pypy-ratio=25
 # Module-scope `for i in range(N)` whose body raises, catches, and reads
 # sys.exc_info() both inside and after the handler.  At module scope the loop
 # variable `i` is a STORE_NAME (a global-dict residual), not a STORE_FAST frame
@@ -11,7 +11,7 @@
 
 import sys
 
-N = 6000
+N = 50000
 
 exc_info_inside = 0
 exc_info_after_none = 0

--- a/pyre/bench/synth/exc_mixed_classes_bridge_flavor.py
+++ b/pyre/bench/synth/exc_mixed_classes_bridge_flavor.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=81
+# pyre-check: max-pypy-ratio=16
 # A callee raises TWO different exception classes into a hot try/except loop.
 # The loop trace records the raising iteration's GUARD_EXCEPTION(class-A); the
 # no-raise iterations chronically fail that guard WITHOUT a pending exception,
@@ -7,7 +7,7 @@
 # bridge — the bridge's entry flavor guard (GUARD_NO_EXCEPTION,
 # prepare_resume_from_failure) must deopt that entry to the blackhole instead
 # of running the recorded continuation on the NULL raised-call result.
-N = 120000
+N = 1200000
 
 
 def f(i):

--- a/pyre/bench/synth/except_tuple_clause_hot.py
+++ b/pyre/bench/synth/except_tuple_clause_hot.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=29
+# pyre-check: max-pypy-ratio=19
 # An `except (A, B):` clause builds its match target with `BUILD_TUPLE` on
 # every visit, so the tuple is a fresh object each time the handler runs. The
 # `CHECK_EXC_MATCH` fold pins the match target it saw while tracing; pinning

--- a/pyre/bench/synth/exception_bare_reraise_restore.py
+++ b/pyre/bench/synth/exception_bare_reraise_restore.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=17
+# pyre-check: max-pypy-ratio=9
 # Bare `raise` (RERAISE) inside a handler re-raises the exception currently
 # being handled, which an outer handler then catches. This exercises the
 # current-exception slot on the re-raise path: the bare raise must pick up the

--- a/pyre/bench/synth/exception_catching_frame_tb_node.py
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=42
+# pyre-check: max-pypy-ratio=14
 # Tightened 53 -> 42 when `seeded_callee_resume` stopped requiring the
 # callee's own exception table: execution-only time here fell 1.53x against a
 # same-day build of the parent commit, so the previous headroom is kept and

--- a/pyre/bench/synth/exception_const_operand_resume.py
+++ b/pyre/bench/synth/exception_const_operand_resume.py
@@ -1,6 +1,5 @@
-# pyre-check: max-pypy-ratio=55
-# The ceiling is twice the slowest ratio observed (27.3x on the linux runner),
-# rounded up.
+# pyre-check: max-pypy-ratio=37
+# Local dynasm check.py reads 10.3-18.3x; 37 is twice the slowest.
 # Exception-resume bridge (GuardException) with a CONSTANT pre-call operand.
 # Each `try` divides/indexes with a CONSTANT numerator/addend that lives on the
 # operand stack at the raising bytecode. The loop warms up exception-free
@@ -10,7 +9,7 @@
 # lost (NULL), the resume would run op(NULL, ...) and raise a spurious
 # TypeError (bumping `other`) instead of the real ZeroDivisionError / IndexError.
 # Output must stay byte-exact across backends and the oracle.
-N = 48000
+N = 250000
 DATA = [3, 1, 4, 1, 5]
 
 

--- a/pyre/bench/synth/exception_context_chain_inhandler.py
+++ b/pyre/bench/synth/exception_context_chain_inhandler.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=24
+# pyre-check: max-pypy-ratio=17
 # Implicit `__context__` chaining: raising inside an `except` block links the
 # new exception's `__context__` to the one being handled (the raise records
 # `SETFIELD w_context = ec.sys_exc_value`). The outer handler reads

--- a/pyre/bench/synth/exception_escape_caller_frame_tb_node.py
+++ b/pyre/bench/synth/exception_escape_caller_frame_tb_node.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=116
+# pyre-check: max-pypy-ratio=22
+# Local dynasm check.py reads ~11x; 22 is twice that. 116 was the N=40000
+# blanket from the first synth sweep.
 # An exception escaping a compiled frame that holds a try block it does NOT
 # match must keep the CALLER's traceback node:
 #
@@ -19,7 +21,7 @@
 # `d_while_nonmatching` cover the other two cleanup shapes that reach the same
 # RERAISE, and `d_no_mid` pins that neither an inlined intermediate frame nor
 # a compiled exception-edge bridge is needed to trigger it.
-N = 40000
+N = 400000
 
 
 def names(e):

--- a/pyre/bench/synth/exception_inline_callee_tb_frames.py
+++ b/pyre/bench/synth/exception_inline_callee_tb_frames.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=31
+# pyre-check: max-pypy-ratio=20
 # An exception raised in an inlined callee and caught two or three frames up
 # must still attach a traceback node for every frame it passed through: one at
 # the raise instruction and one per callee->caller propagation.

--- a/pyre/bench/synth/exception_metadata_jitstress.py
+++ b/pyre/bench/synth/exception_metadata_jitstress.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=4
+# pyre-check: max-pypy-ratio=2
 # JIT-stress twin of exception_metadata_hot: `pypyjit.set_param` lowers the
 # trace/function thresholds to 1 so recording fires on the earliest iterations
 # of every section rather than only after the ~1600-iteration warmup. That

--- a/pyre/bench/synth/exception_metadata_jitstress.py
+++ b/pyre/bench/synth/exception_metadata_jitstress.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=2
+# pyre-check: max-pypy-ratio=3
 # JIT-stress twin of exception_metadata_hot: `pypyjit.set_param` lowers the
 # trace/function thresholds to 1 so recording fires on the earliest iterations
 # of every section rather than only after the ~1600-iteration warmup. That

--- a/pyre/bench/synth/exception_oserror_fields.py
+++ b/pyre/bench/synth/exception_oserror_fields.py
@@ -1,5 +1,5 @@
-# pyre-check: max-pypy-ratio=47
-N = 400000
+# pyre-check: max-pypy-ratio=14
+N = 2500000
 
 
 def main():

--- a/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
+++ b/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=45
+# pyre-check: max-pypy-ratio=26
 # A frame that raises and catches in one body contributes EXACTLY ONE
 # traceback node, and it keeps that count once the loop is compiled.
 #

--- a/pyre/bench/synth/exception_reduce.py
+++ b/pyre/bench/synth/exception_reduce.py
@@ -1,7 +1,7 @@
-# pyre-check: max-pypy-ratio=65
-# The ceiling is twice the slowest ratio observed (32.5x on the linux runner),
-# rounded up.
-N = 100000
+# pyre-check: max-pypy-ratio=4
+# After the descr_reduce fold the loop DCEs to incrementing integers.
+# Ceiling is twice a ~2x local dynasm reading.
+N = 8000000
 
 
 def main():

--- a/pyre/bench/synth/exception_reraise_tb_depth_hot.py
+++ b/pyre/bench/synth/exception_reraise_tb_depth_hot.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=5.5
+# pyre-check: max-pypy-ratio=3.5
 # A bare re-raise caught in the same frame keeps the original traceback: no
 # node is attached at a re-raise coordinate (RaiseWithExplicitTraceback,
 # attach_tb=False). The module-level loop makes the recording iteration itself

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.py
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=6
+# pyre-check: max-pypy-ratio=4
 # JIT-stress twin of exception_reraise_tb_depth_hot: `pypyjit.set_param`
 # lowers the trace/function thresholds to 1 so trace recording fires on the
 # earliest iterations rather than only after the ~1600-iteration warmup. That

--- a/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
+++ b/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=27
+# pyre-check: max-pypy-ratio=21
 # Tightened 34 -> 27 when `seeded_callee_resume` stopped requiring the
 # callee's own exception table: execution-only time here fell 1.40x against a
 # same-day build of the parent commit, so the previous headroom is kept and

--- a/pyre/bench/synth/exception_traceback_lineno_chain.py
+++ b/pyre/bench/synth/exception_traceback_lineno_chain.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=22
+# pyre-check: max-pypy-ratio=11
 # Every traceback node keeps the line its frame was executing, including for
 # a frame the JIT compiled and exited with an uncaught exception.
 #

--- a/pyre/bench/synth/exception_traceback_loop_forms.py
+++ b/pyre/bench/synth/exception_traceback_loop_forms.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=36
+# pyre-check: max-pypy-ratio=8
 # Traceback nodes recorded by a compiled loop, driven by BOTH loop forms.
 #
 # The sibling exception-traceback fixtures all drive their workload with

--- a/pyre/bench/synth/exception_vable_frame_virtual_local.py
+++ b/pyre/bench/synth/exception_vable_frame_virtual_local.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=24
+# pyre-check: max-pypy-ratio=11
 # Regression guard: when a traced function raises, the write-back into its own
 # virtualizable frame must store every local, including the ones whose value is
 # still a virtual box.

--- a/pyre/bench/synth/exceptions.py
+++ b/pyre/bench/synth/exceptions.py
@@ -1,5 +1,8 @@
-# pyre-check: max-pypy-ratio=118
+# pyre-check: max-pypy-ratio=3.5
 # pyre-check: skip-cpython
+# Local dynasm check.py reads 1.1-1.7x; may_fail is inlined and the
+# raise is one virtualized bridge (1 loop, 1 bridge). 3.5 is twice the
+# slowest. 118 was the N=250000 blanket from the first synth sweep.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.
 # 41258646 puts pypy at 63ms, barely clear of it; every count that leaves pypy

--- a/pyre/bench/synth/mutate_uncaught_raise_delivery.py
+++ b/pyre/bench/synth/mutate_uncaught_raise_delivery.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=29
+# pyre-check: max-pypy-ratio=16
 # gh#495 guard: mutating call that raises uncaught must deliver the exception once.
 N = 60000
 class C:

--- a/pyre/bench/synth/named_reraise_sibling_hot.py
+++ b/pyre/bench/synth/named_reraise_sibling_hot.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=36
+# pyre-check: max-pypy-ratio=25
 # A named `except E as m:` handler whose body bare-re-raises compiles its
 # implicit cleanup to `DELETE_FAST m; RERAISE`, immediately followed by a
 # sibling `except` clause's type check. On the re-raise path the exception must

--- a/pyre/bench/synth/unpack_drain_star_raise.py
+++ b/pyre/bench/synth/unpack_drain_star_raise.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=106
+# pyre-check: max-pypy-ratio=79
 # The ceiling is twice the slowest ratio observed (52.7x on the linux runner),
 # rounded up.
 # Star-unpack of an iterator of unknown length: `f(*it)` is the consumer that

--- a/pyre/bench/synth/with_except_start_function_resume.py
+++ b/pyre/bench/synth/with_except_start_function_resume.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=29
+# pyre-check: max-pypy-ratio=12
 # The ceiling is twice the slowest ratio observed, 14.2x on the macos runner.
 # A function-entry trace records only the early-return arm.  The first true
 # call then fails that guard and blackhole-replays the previously unvisited

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11517,12 +11517,14 @@ pub unsafe fn bound_method_attr_fast_path_wtf8(
     // that `name` is absent from it.  A mapdict instance is admitted on those
     // terms because the caller has a guard for the precondition — pinning the
     // map makes a later `obj.<name> = ...` grow the chain and side-exit — and
-    // is reported as owing it.  Every other layout keeps its instance
-    // attributes where no such guard reaches, so a receiver with no dictionary
-    // at all is the only other admission: nothing can shadow the type lookup,
-    // and the non-data-descriptor branch of `object.__getattribute__` is the
-    // only reachable one.
-    let owes_shadow_guard = is_instance(w_obj);
+    // is reported as owing it.  An exception is the other layout with a
+    // matching guard (`ExceptionDictIsNull` on the still-unallocated `w_dict`
+    // slot).  `instance_dict_does_not_shadow_wtf8` peeks that slot; calling
+    // `getdict` here would allocate it and then decline the very receiver the
+    // guard was written for (`e.__reduce__()`).  Every other layout keeps its
+    // instance attributes where no such guard reaches, so a receiver with no
+    // dictionary at all is the only remaining admission.
+    let owes_shadow_guard = is_instance(w_obj) || pyre_object::is_exception(w_obj);
     if owes_shadow_guard {
         unsafe { instance_dict_does_not_shadow_wtf8(w_obj, name)? };
     } else if !getdict_backing_native(w_obj).is_null() {
@@ -21800,6 +21802,39 @@ mod tests {
         assert!(std::ptr::eq(fp_descr, w_descr));
         assert_ne!(fp_version_tag, 0);
         assert!(!owes_shadow_guard, "a list has no mapdict shadow guard");
+    }
+
+    /// An exception is not a mapdict instance, but it still has a shadowing
+    /// guard (`w_dict` still null).  The predicate must peek that slot rather
+    /// than call `getdict`, which would allocate a dict and then decline
+    /// `e.__reduce__()`.
+    #[test]
+    fn bound_method_fast_path_admits_exception_reduce_without_allocating_dict() {
+        crate::typedef::init_typeobjects();
+        crate::test_hooks::install_hash_hook();
+        let exc =
+            pyre_object::w_exception_new(pyre_object::interp_exceptions::ExcKind::ValueError, "x");
+        assert!(
+            unsafe { pyre_object::interp_exceptions::w_exception_peek_dict(exc) }.is_null(),
+            "premise: a fresh exception has no instance dict",
+        );
+        let (fp_type, fp_version_tag, fp_descr, owes_shadow_guard) =
+            unsafe { bound_method_attr_fast_path(exc, "__reduce__") }
+                .expect("a dict-less exception's __reduce__ must fold");
+        assert!(owes_shadow_guard, "the tracer owes ExceptionDictIsNull");
+        assert_ne!(fp_version_tag, 0);
+        assert!(
+            unsafe { crate::function::is_function(fp_descr) },
+            "ValueError.__reduce__ must be a bindable function descriptor",
+        );
+        assert!(
+            unsafe { pyre_object::interp_exceptions::w_exception_peek_dict(exc) }.is_null(),
+            "the predicate must not allocate w_dict",
+        );
+        let w_type = crate::typedef::r#type(exc)
+            .expect("ValueError has a type")
+            .as_ptr();
+        assert!(std::ptr::eq(fp_type, w_type));
     }
 
     /// typeobject.py:293-301 — under the interpreter (`we_are_jitted()`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4980,10 +4980,25 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
 }
 
-/// True iff `callable` is the builtin `len` function object — a
-/// builtin-code function whose code wraps [`__majit_wrap_builtin_len`].  The JIT
-/// walker uses this to recognize a `len(x)` residual it can lower to the
-/// container's inline length read.
+/// True iff `callable` is `BaseException.__reduce__` — the builtin whose
+/// code wraps [`base_exception_reduce`].  Subclasses inherit this through
+/// the MRO; `ImportError` / `OSError` install their own and do not match.
+pub fn is_builtin_base_exception_reduce_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        crate::gateway::builtin_code_fn_eq(
+            crate::gateway::builtin_code_get(code),
+            base_exception_reduce as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
+
 pub fn is_builtin_len_function(callable: PyObjectRef) -> bool {
     unsafe {
         if callable.is_null() || !crate::is_function(callable) {

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -4727,19 +4727,45 @@ pub unsafe fn setattr_would_force_quasi_immut(
     }
 }
 
-/// Return the first `?` field mapdict.py / 461-470 delete would flip,
-/// without applying the deletion.
+/// First `?` flip of `PlainAttribute._copy_attr` → `add_attr` → `pick_attr`
+/// against `onto`, the map `back.copy` leaves before this node is re-added.
 ///
-/// The `PlainAttribute.delete` → `_copy_attr` → `add_attr` → `pick_attr`
-/// re-add chain (mapdict.py:461-470) is deliberately not modelled: simulating
-/// that rebuild side-effect-free is not tractable against the current
-/// `node_copy` / `add_attr` shape. The optimizer's
-/// `quasiimmut_field_still_valid` revalidation (heap.py:818-819, ported in
-/// majit-metainterp's `optimizeopt/heap.rs`) discards a loop whose recorded `?`
-/// value moved during tracing, so a missed force costs a wasted trace, never
-/// correctness. Watcher installation belongs to the tracer; this predicate
-/// reads no `*_qmut_installed` flag and takes no `QuasiImmutField` lock while a
-/// `cache_attrs` mutex or an `INSTANCE_LOCKS` stripe is held.
+/// `pick_attr` writes `CachedAttributeHolder.typ` when the unbox type
+/// disagrees; that assignment is the quasi-immut invalidation
+/// (`CachedAttributeHolder.pick_attr`). `find_branch_to_move_into_readonly`
+/// returning `None` is the `get_new_attr` arm, which builds a holder whose
+/// `typ` already matches and so does not force.
+unsafe fn copy_attr_would_force_quasi_immut<O: MapdictObject>(
+    onto: MapRef,
+    attr: MapRef,
+    obj: &O,
+) -> Option<MapdictQmutTarget> {
+    if onto.is_null() {
+        return None;
+    }
+    let p = unsafe { (*attr).as_plain() };
+    let w_value = unsafe { plain_direct_read(attr, obj) };
+    let unbox_type = unsafe { pick_unbox_type(onto, w_value) };
+    let (_, holder) =
+        unsafe { find_branch_to_move_into_readonly(onto, &p.name, p.attrkind, unbox_type) }?;
+    let typ = unsafe { (*holder).typ.get() };
+    if typ.is_some() && typ != unbox_type {
+        Some(MapdictQmutTarget::HolderTyp(holder))
+    } else {
+        None
+    }
+}
+
+/// Return the first `?` field `PlainAttribute.delete` would flip, without
+/// applying the deletion.
+///
+/// Matching node: `ever_mutated` (`PlainAttribute.delete`). Newer nodes
+/// that the recursive walk `_copy_attr`s onto `back.copy` run
+/// `add_attr` → `pick_attr`; each is checked against `deleted.back`, which
+/// is exact for the first re-add. Watcher installation belongs to the
+/// tracer; this predicate reads no `*_qmut_installed` flag and takes no
+/// `QuasiImmutField` lock while a `cache_attrs` mutex or an `INSTANCE_LOCKS`
+/// stripe is held.
 ///
 /// # Safety
 /// `w_obj` must be a live object.
@@ -4749,11 +4775,25 @@ pub unsafe fn delattr_would_force_quasi_immut(
     attrkind: u16,
 ) -> Option<MapdictQmutTarget> {
     let mut current = unsafe { mapdict_map_or_null(w_obj) };
+    // Newest first; `_copy_attr` re-adds closest-to-deleted first.
+    let mut newer: Vec<MapRef> = Vec::new();
     while !current.is_null() && unsafe { (*current).is_plain() } {
         let p = unsafe { (*current).as_plain() };
         if p.attrkind == attrkind && &*p.name == name {
-            return (!p.ever_mutated.get()).then_some(MapdictQmutTarget::PlainEverMutated(p));
+            if !p.ever_mutated.get() {
+                return Some(MapdictQmutTarget::PlainEverMutated(p));
+            }
+            let carrier = unsafe { mapdict_carrier(w_obj) };
+            for &newer_map in newer.iter().rev() {
+                if let Some(target) =
+                    unsafe { copy_attr_would_force_quasi_immut(p.back, newer_map, &carrier) }
+                {
+                    return Some(target);
+                }
+            }
+            return None;
         }
+        newer.push(current);
         current = p.back;
     }
     None

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -133,6 +133,49 @@ pub extern "C" fn jit_dict_exact_int_lookup_or_null(dict: i64, key: i64) -> i64 
     }
 }
 
+/// `rordereddict.py ll_dict_lookup` for `IntDictStrategy` — insertion-order
+/// index, or `-1` on a miss.  The four-argument shape is the `dict.lookup`
+/// oopspec (`d, key, hash, FLAG_LOOKUP`): `d` is the unerased `dstorage`
+/// table, and `key`/`hash` are the unboxed `plain_int_w` word.  Int hash is
+/// identity (`ll_int_hash`), which is why PyPy's after-opt is
+/// `call_i(lookup, p62, i47, i47, 0)`.
+pub extern "C" fn jit_dict_exact_int_lookup_index(
+    storage: i64,
+    key: i64,
+    _hash: i64,
+    flag: i64,
+) -> i64 {
+    debug_assert_eq!(flag, 0, "only FLAG_LOOKUP is implemented");
+    if storage == 0 {
+        return -1;
+    }
+    unsafe {
+        let entries = &*(storage as *const pyre_object::dictmultiobject::IntDictStorage);
+        entries
+            .index_of(&key)
+            .map(|index| index as i64)
+            .unwrap_or(-1)
+    }
+}
+
+/// Value half of an int-strategy `dict.lookup`: `d.entries[i].value` after
+/// the index settled.  Stands in for `getinteriorfield_gc_r` on
+/// `odictentry.value` (`ll_dict_getitem_with_hash`); pyre's `RDict` is not
+/// a GC array-of-structs, so the load cannot be a raw interior field.
+/// A stale index answers `PY_NULL` so the caller's `GuardNonnull` side-exits.
+pub extern "C" fn jit_dict_int_value_at(storage: i64, index: i64) -> i64 {
+    if index < 0 || storage == 0 {
+        return PY_NULL as i64;
+    }
+    unsafe {
+        let entries = &*(storage as *const pyre_object::dictmultiobject::IntDictStorage);
+        entries
+            .get_slot(index as usize)
+            .map(|(_, &value)| value as i64)
+            .unwrap_or(PY_NULL as i64)
+    }
+}
+
 /// Read a dict value at an entry index a traced `dict.lookup` settled on —
 /// `rordereddict.py ll_dict_getitem`'s `d.entries[i].value` after
 /// `ll_dict_lookup` returned the slot.  The read goes through the live storage

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -293,11 +293,10 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
     // is recorded as the bridge instead of the NULL raised-call fallthrough.
     // `call_jit.rs trace_and_compile_from_bridge` only lets a bridge walk begin
     // with this precondition holding when it has already ROUTED the exc-edge
-    // (published the standing exception into `BH_LAST_EXC_VALUE` and declined to
-    // hand the guard to the blackhole).  So whenever the precondition holds the
-    // walk MUST resume at an `except` handler — falling through to the
-    // no-exception continuation would record the return of the NULL raised-call
-    // result (`Finish(NULL)` → "call failed").
+    // (published the standing exception into `BH_LAST_EXC_VALUE`).  So whenever
+    // the precondition holds the walk MUST resume at an `except` handler —
+    // falling through to the no-exception continuation would record the return
+    // of the NULL raised-call result (`Finish(NULL)` → "call failed").
     let exc_edge_precondition = trace_ctx.is_bridge_trace
         && trace_ctx.bridge_source_is_exception_guard()
         && !sym.last_exc_box().is_none()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -410,6 +410,7 @@ spec_folds! {
     FloatCall            => ("float_call",               "residual_call", "-"),
     StrCall              => ("str_call",                 "residual_call", "-"),
     BuiltinDivmod        => ("builtin_divmod",           "residual_call", "-"),
+    ExceptionReduce      => ("exception_reduce",         "residual_call", "-"),
     SetAddMethod         => ("set_add_method",           "residual_call", "-"),
     StoreAttrDirect      => ("store_attr_direct",        "residual_call", "-"),
     StoreAttrResidual    => ("store_attr_residual",      "residual_call", "store_attr_direct"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5110,14 +5110,12 @@ fn seed_standing_exception_for_walk<Sym: WalkSym>(sym: &mut Sym, trace_ctx: &mut
     // re-seeds per frame after the first frame drained the cell.
     // For the walks that reach here this cell is the delivery path for
     // `_prepare_exception_resumption`: `call_jit.rs` publishes
-    // `cpu.grab_exc_value`'s result before bridge tracing starts, zeroes it when
-    // the guard carried no exception, and declines the bridge outright in the
-    // third case.  On an exception-guard bridge one of the two arms below always
-    // returns, so a pre-seed placed on the sym in `setup_bridge_sym` could only
-    // rewrite the pointer this read applies anyway.  Scoped to this leg: the
-    // multi-frame carrier walk never runs this function — `trace.rs` routes it
-    // through `drive_bridge_carrier_walk`, whose sub-walk seeds itself off
-    // `root_sym.last_exc_box()` instead.
+    // `cpu.grab_exc_value`'s result before bridge tracing starts and zeroes
+    // it when the guard carried no exception.  On an exception-guard
+    // bridge one of the two arms below always returns, so a pre-seed
+    // placed on the sym in `setup_bridge_sym` could only rewrite the
+    // pointer this read applies anyway.  The multi-frame carrier walk
+    // seeds the same cell in `drive_bridge_carrier_walk`.
     let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.get());
     if bh_exc != 0 {
         let exc = bh_exc as pyre_object::PyObjectRef;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -7683,6 +7683,19 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
+    // `BaseException.descr_reduce`: `(cls, args)` when `w_dict` is empty.
+    // The residual `bh_call_fn(__reduce__, NULL, exc)` otherwise forces
+    // the virtual exception every iteration (`exception_reduce`).
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && spec_gate(SpecFold::ExceptionReduce, || {
+            try_walker_specialize_exception_reduce(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && foldable_runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -9187,6 +9187,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         )? {
                             return Ok(inlined);
                         }
+                        // Int-strategy miss: `dict.lookup` on dstorage +
+                        // `int_lt < 0` then `raise_key_error`
+                        // (`ll_dict_getitem_with_hash`).  The hit fold
+                        // emits the same lookup's fail arm; residual
+                        // CallMayForce would force the virtual KeyError
+                        // the inlined except is about to catch.
+                        if let Some(outcome) = spec_gate(SpecFold::Subscr, || {
+                            try_walker_specialize_subscr_int_miss(ctx, op.pc, &r_args)
+                        })? {
+                            return Ok((outcome, op.next_pc));
+                        }
                         // BINARY_SUBSCR list[int] getitem (int/float storage);
                         // falls through to the generic may-force leg otherwise.
                         spec_gate(SpecFold::Subscr, || {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10138,6 +10138,16 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     dst: usize,
     dst_bank: char,
 ) -> Result<Option<()>, DispatchError> {
+    // Int-strategy hit is the fail arm of the same `dict.lookup` the miss
+    // fold emits (`ll_dict_getitem_with_hash`: `int_lt(index, 0)` then
+    // `d.entries[index].value`).  A separate `lookup_or_null` would pin
+    // the first hit's value and storm the guard on every other key.
+    if matches!(hit.key_probe, DictFoldKeyProbe::Int) {
+        return walker_emit_exact_dict_int_hit(
+            ctx, op_pc, dict_op, key_op, dict, hit, dst, dst_bank,
+        );
+    }
+
     let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
     walker_guard_class(
         ctx,
@@ -10147,20 +10157,12 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     )?;
     walker_guard_exact_w_class(ctx, op_pc, dict_op, canonical_dict)?;
 
-    let (key_type, canonical_key, strategy_ref, lookup_helper) = match hit.key_probe {
-        DictFoldKeyProbe::Int => (
-            &pyre_object::pyobject::INT_TYPE as *const _ as i64,
-            pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
-            &pyre_object::dictmultiobject::INT_DICT_STRATEGY_REF as *const _ as i64,
-            crate::helpers::jit_dict_exact_int_lookup_or_null as *const (),
-        ),
-        DictFoldKeyProbe::Unicode => (
-            &pyre_object::pyobject::STR_TYPE as *const _ as i64,
-            pyre_object::get_instantiate(&pyre_object::pyobject::STR_TYPE),
-            &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF as *const _ as i64,
-            crate::helpers::jit_dict_exact_unicode_lookup_or_null as *const (),
-        ),
-    };
+    let (key_type, canonical_key, strategy_ref, lookup_helper) = (
+        &pyre_object::pyobject::STR_TYPE as *const _ as i64,
+        pyre_object::get_instantiate(&pyre_object::pyobject::STR_TYPE),
+        &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF as *const _ as i64,
+        crate::helpers::jit_dict_exact_unicode_lookup_or_null as *const (),
+    );
 
     let strategy = crate::state::opimpl_getfield_gc_i(
         ctx.trace_ctx,
@@ -10197,6 +10199,274 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
     Ok(Some(()))
+}
+
+/// Hit arm of `ll_dict_getitem_with_hash` after `IntDictStrategy.getitem`
+/// found the key: the same `dict.lookup` the miss fold emits, then
+/// `int_lt(index, 0)` / `guard_false` and `d.entries[index].value`.
+fn walker_emit_exact_dict_int_hit<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    dict_op: OpRef,
+    key_op: OpRef,
+    dict: pyre_object::PyObjectRef,
+    hit: DictFoldHit,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(key) = walker_concrete_ref_object(ctx, key_op) else {
+        return Ok(None);
+    };
+    let Some(index_concrete) =
+        (unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) })
+    else {
+        return Ok(None);
+    };
+    let (index_op, storage_op) = walker_emit_int_dict_lookup_index(
+        ctx,
+        op_pc,
+        dict_op,
+        key_op,
+        dict,
+        key,
+        index_concrete as i64,
+    )?;
+    let zero = ctx.trace_ctx.const_int(0);
+    let is_miss = ctx.trace_ctx.record_op(OpCode::IntLt, &[index_op, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(is_miss, majit_ir::Value::Int(0));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[is_miss])?;
+    let value = ctx.trace_ctx.call_ref_typed_with_effect(
+        crate::helpers::jit_dict_int_value_at as *const (),
+        &[storage_op, index_op],
+        &[majit_ir::Type::Ref, majit_ir::Type::Int],
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[value])?;
+    ctx.trace_ctx.set_opref_concrete(
+        value,
+        majit_ir::Value::Ref(majit_ir::GcRef(hit.concrete_value as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+    Ok(Some(()))
+}
+
+/// `IntDictStrategy.getitem` miss: the key is a plain int and the table
+/// has no entry.  `descr_getitem` then does `space.raise_key_error(w_key)`.
+fn walker_probe_exact_dict_int_miss(
+    dict: pyre_object::PyObjectRef,
+    key: pyre_object::PyObjectRef,
+) -> bool {
+    let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
+    if canonical_dict.is_null()
+        || !unsafe {
+            std::ptr::eq((*dict).ob_type, &pyre_object::pyobject::DICT_TYPE)
+                && std::ptr::eq((*dict).w_class, canonical_dict)
+        }
+    {
+        return false;
+    }
+    let strategy_kind =
+        unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(dict).strategy_kind() };
+    strategy_kind == pyre_object::dictmultiobject::StrategyKind::Int
+        && unsafe { pyre_object::listobject::is_plain_int1(key) && pyre_object::is_int(key) }
+        && unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) }
+            .is_none()
+}
+
+/// `rordereddict.py ll_dict_lookup` for an Int strategy: class / strategy /
+/// key pins, `getfield dstorage`, then the four-argument `dict.lookup`
+/// oopspec on the unerased table.  Returns `(index, storage)`.
+///
+/// Shape matches `ll_dict_getitem_with_hash`:
+/// `call_i(lookup, dstorage, plain_int_w(key), hash, FLAG_LOOKUP)`.
+/// Int hash is identity (`ll_int_hash`), so the hash operand is the same
+/// unboxed word as the key.
+fn walker_emit_int_dict_lookup_index<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    dict_op: OpRef,
+    key_op: OpRef,
+    dict: pyre_object::PyObjectRef,
+    key: pyre_object::PyObjectRef,
+    index_concrete: i64,
+) -> Result<(OpRef, OpRef), DispatchError> {
+    let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
+    walker_guard_class(
+        ctx,
+        op_pc,
+        dict_op,
+        &pyre_object::pyobject::DICT_TYPE as *const _ as i64,
+    )?;
+    walker_guard_exact_w_class(ctx, op_pc, dict_op, canonical_dict)?;
+    let strategy = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        dict_op,
+        crate::descr::dict_strategy_word_descr(),
+    );
+    let strategy_const = ctx
+        .trace_ctx
+        .const_int(&pyre_object::dictmultiobject::INT_DICT_STRATEGY_REF as *const _ as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[strategy, strategy_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(strategy, strategy_const);
+    let int_type = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, key_op, int_type)?;
+    walker_guard_exact_w_class(
+        ctx,
+        op_pc,
+        key_op,
+        pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
+    )?;
+    let storage_op = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        dict_op,
+        crate::descr::dict_dstorage_descr(),
+    );
+    let storage_ptr =
+        unsafe { pyre_object::dictmultiobject::w_dict_int_storage(dict) as *const _ as usize };
+    ctx.trace_ctx.set_opref_concrete(
+        storage_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(storage_ptr)),
+    );
+    let key_int = walker_unbox_int(ctx, op_pc, key_op, int_type)?;
+    let mut lookup_effect = majit_ir::EffectInfo::new(
+        majit_ir::ExtraEffect::CannotRaise,
+        majit_ir::OopSpecIndex::DictLookup,
+    );
+    lookup_effect.extradescrs = Some(vec![
+        crate::descr::dict_lookup_namespace_descr(),
+        crate::descr::dict_lookup_entries_array_descr(),
+    ]);
+    let lookup_flag = ctx.trace_ctx.const_int(0);
+    let index_op = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallI,
+        crate::helpers::jit_dict_exact_int_lookup_index as *const (),
+        &[storage_op, key_int, key_int, lookup_flag],
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
+        majit_ir::Type::Int,
+        lookup_effect,
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(index_op, majit_ir::Value::Int(index_concrete));
+    let _ = key;
+    Ok((index_op, storage_op))
+}
+
+/// BINARY_SUBSCR miss on an exact int-strategy dict: `descr_getitem` after
+/// `IntDictStrategy.getitem` returned None.  Emits `dict.lookup` +
+/// `int_lt(index, 0)` then `raise_key_error`, and surfaces `SubRaise` so
+/// the inlined `except KeyError` catches it.
+pub(crate) fn try_walker_specialize_subscr_int_miss<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    r_args: &[OpRef],
+) -> Result<Option<DispatchOutcome>, DispatchError> {
+    if !ctx.is_authoritative_executor || r_args.len() != 2 {
+        return Ok(None);
+    }
+    let (Some(dict), Some(key)) = (
+        walker_concrete_ref_object(ctx, r_args[0]),
+        walker_concrete_ref_object(ctx, r_args[1]),
+    ) else {
+        return Ok(None);
+    };
+    if !walker_probe_exact_dict_int_miss(dict, key) {
+        return Ok(None);
+    }
+    walker_emit_exact_dict_key_error(ctx, op_pc, r_args[0], r_args[1], dict, key)
+}
+
+/// `descr_getitem` miss after `IntDictStrategy.getitem` returned None:
+/// `space.raise_key_error(w_key)` — `KeyError(w_key)` then raise.  The
+/// exception is built inline so a locally-caught `except KeyError` DCEs it,
+/// matching the look-inside raise PyPy records after `int_lt(index, 0)`.
+fn walker_emit_exact_dict_key_error<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    dict_op: OpRef,
+    key_op: OpRef,
+    dict: pyre_object::PyObjectRef,
+    key: pyre_object::PyObjectRef,
+) -> Result<Option<DispatchOutcome>, DispatchError> {
+    let Some(ec) = walker_ensure_execution_context(ctx) else {
+        return Ok(None);
+    };
+    let (index_op, _storage_op) =
+        walker_emit_int_dict_lookup_index(ctx, op_pc, dict_op, key_op, dict, key, -1)?;
+    let zero = ctx.trace_ctx.const_int(0);
+    let is_miss = ctx.trace_ctx.record_op(OpCode::IntLt, &[index_op, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(is_miss, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[is_miss])?;
+
+    let concrete = pyre_interpreter::PyError::key_error_with_key(key).exc_object;
+    if concrete.is_null() || !unsafe { pyre_object::is_exception(concrete) } {
+        return Ok(None);
+    }
+    let kind = pyre_object::interp_exceptions::ExcKind::KeyError;
+    let args_list = crate::helpers::emit_object_list_inline(ctx.trace_ctx, &[key_op]);
+    let list_w_class = pyre_object::get_instantiate(&pyre_object::pyobject::LIST_TYPE);
+    let list_w_class = ctx.trace_ctx.const_ref(list_w_class as i64);
+    let list_w_class_descr = crate::descr::list_w_class_descr();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[args_list, list_w_class],
+        list_w_class_descr.clone(),
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(args_list, list_w_class_descr.index(), list_w_class);
+    let class = pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind);
+    let class = ctx.trace_ctx.const_ref(class as i64);
+    let raised = crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, class, args_list);
+    let exc_type = pyre_object::interp_exceptions::exc_kind_to_pytype(kind) as *const _ as i64;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(raised, exc_type);
+    ctx.trace_ctx.set_opref_concrete(
+        raised,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete as usize)),
+    );
+    fbw_built_exc_insert(raised);
+    let active = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[ec],
+        crate::descr::ec_sys_exc_value_descr(),
+    );
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[raised, active],
+        crate::descr::w_exception_context_descr(kind),
+    );
+    fbw_context_chained_insert(raised);
+    let active_concrete = pyre_interpreter::eval::get_current_exception();
+    if !active_concrete.is_null() {
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_context(concrete, active_concrete);
+        }
+    }
+    fbw_count_executed_residual(true, true);
+    ctx.set_last_exc_value(raised, ConcreteValue::Ref(concrete));
+    ctx.fbw_mode.class_of_last_exc_is_const = true;
+    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(concrete as i64));
+    Ok(Some(DispatchOutcome::SubRaise {
+        exc: raised,
+        exc_concrete: ConcreteValue::Ref(concrete),
+    }))
 }
 
 /// `dict.get` on an exact dictionary and an Int/Unicode strategy hit.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -17679,6 +17679,243 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// `BaseException.descr_reduce`: `(cls, args)` when `w_dict` is unset or
+/// empty.  The residual `bh_call_fn(__reduce__)` forces a virtual exception
+/// every iteration; this emit keeps the 2-tuple virtual so the constructor
+/// DCEs (`exception_reduce`).
+pub(crate) fn try_walker_specialize_exception_reduce<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (callable_op, self_op, concrete_self, from_bound_method) = match r_args.len() {
+        2 => {
+            let (ConcreteValue::Ref(callable), ConcreteValue::Ref(second)) =
+                (arg_concretes[0], arg_concretes[1])
+            else {
+                return Ok(None);
+            };
+            if callable.is_null() {
+                return Ok(None);
+            }
+            if second.is_null() {
+                // Bound method, no extra args: `bh_call_fn(method, NULL)`.
+                if !unsafe { pyre_object::function::is_method(callable) } {
+                    return Ok(None);
+                }
+                let inner_func = unsafe { pyre_object::function::w_method_get_func(callable) };
+                let inner_self = unsafe { pyre_object::function::w_method_get_self(callable) };
+                if inner_func.is_null()
+                    || inner_self.is_null()
+                    || !pyre_interpreter::builtins::is_builtin_base_exception_reduce_function(
+                        inner_func,
+                    )
+                {
+                    return Ok(None);
+                }
+                (r_args[0], r_args[0], inner_self, true)
+            } else if pyre_interpreter::builtins::is_builtin_base_exception_reduce_function(
+                callable,
+            ) && unsafe { pyre_object::is_exception(second) }
+            {
+                (r_args[0], r_args[1], second, false)
+            } else {
+                return Ok(None);
+            }
+        }
+        3 => {
+            let (
+                ConcreteValue::Ref(callable),
+                ConcreteValue::Ref(null_or_self),
+                ConcreteValue::Ref(self_obj),
+            ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+            else {
+                return Ok(None);
+            };
+            if callable.is_null() || !null_or_self.is_null() || self_obj.is_null() {
+                return Ok(None);
+            }
+            if !pyre_interpreter::builtins::is_builtin_base_exception_reduce_function(callable) {
+                return Ok(None);
+            }
+            (r_args[0], r_args[2], self_obj, false)
+        }
+        _ => return Ok(None),
+    };
+    if !unsafe { pyre_object::is_exception(concrete_self) } {
+        return Ok(None);
+    }
+    let w_dict = unsafe { pyre_object::interp_exceptions::w_exception_peek_dict(concrete_self) };
+    if !w_dict.is_null() && unsafe { pyre_object::w_dict_len(w_dict) } > 0 {
+        return Ok(None);
+    }
+    let stored_args =
+        unsafe { pyre_object::interp_exceptions::w_exception_get_args_storage(concrete_self) };
+    if stored_args.is_null() || !unsafe { pyre_object::is_list(stored_args) } {
+        return Ok(None);
+    }
+    let list = unsafe { &*(stored_args as *const pyre_object::listobject::W_ListObject) };
+    if list.strategy != pyre_object::listobject::ListStrategy::Object {
+        return Ok(None);
+    }
+    // `descr_reduce` does `space.newtuple(self.args_w)` then
+    // `space.newtuple([cls, args])`.  `newtuple` specialises arity 2, so
+    // settle both representations before any guard: emitting the
+    // array-backed shape for an arity the runtime specialises leaves
+    // `len(r)` guarding a vtable this trace never builds
+    // (`emit_specialised_tuple_oo_inline`).
+    let args_len = unsafe { pyre_object::w_list_len(stored_args) };
+    let mut concrete_items = Vec::with_capacity(args_len);
+    for index in 0..args_len {
+        let item = unsafe { pyre_object::w_list_getitem(stored_args, index as i64) }
+            .unwrap_or(pyre_object::PY_NULL);
+        if item.is_null() {
+            return Ok(None);
+        }
+        concrete_items.push(item);
+    }
+    let concrete_args_tuple = pyre_object::w_tuple_new(concrete_items);
+    let args_specialised_oo = if args_len == 2 {
+        let ob_type = unsafe { (*concrete_args_tuple).ob_type };
+        if std::ptr::eq(
+            ob_type,
+            &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE,
+        ) {
+            true
+        } else if std::ptr::eq(ob_type, &pyre_object::TUPLE_TYPE) {
+            false
+        } else {
+            return Ok(None);
+        }
+    } else {
+        false
+    };
+    let kind = unsafe { pyre_object::w_exception_get_kind(concrete_self) };
+    let phys_type = unsafe { (*concrete_self).ob_type as i64 };
+    let w_class = unsafe { (*concrete_self).w_class };
+
+    let self_box = if from_bound_method {
+        let method_op = callable_op;
+        let method_type_addr = &pyre_object::function::METHOD_TYPE as *const _ as i64;
+        if !method_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(method_op) {
+            let type_const = ctx.trace_ctx.const_int(method_type_addr);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op.pc,
+                OpCode::GuardClass,
+                &[method_op, type_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(method_op, method_type_addr);
+        }
+        crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            method_op,
+            crate::descr::method_w_self_descr(),
+        )
+    } else {
+        self_op
+    };
+
+    if !ctx.trace_ctx.heap_cache().is_class_known(self_box) {
+        let type_const = ctx.trace_ctx.const_int(phys_type);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op.pc,
+            OpCode::GuardClass,
+            &[self_box, type_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(self_box, phys_type);
+    }
+    let (_, _, w_class_descr, args_descr) = crate::descr::w_exception_descrs(kind);
+    let dict_descr = crate::descr::w_exception_dict_descr(kind);
+    let dict_ref = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, self_box, dict_descr);
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardIsnull, &[dict_ref])?;
+
+    let cls_ref = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, self_box, w_class_descr);
+    let cls_const = ctx.trace_ctx.const_ref(w_class as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[cls_ref, cls_const])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(cls_ref, cls_const);
+
+    let args_list = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, self_box, args_descr);
+    let list_type = &pyre_object::LIST_TYPE as *const pyre_object::PyType as i64;
+    if !ctx.trace_ctx.heap_cache().is_class_known(args_list) {
+        let type_const = ctx.trace_ctx.const_int(list_type);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op.pc,
+            OpCode::GuardClass,
+            &[args_list, type_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(args_list, list_type);
+    }
+    let strategy = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        args_list,
+        crate::descr::list_strategy_descr(),
+    );
+    let object_strategy = ctx
+        .trace_ctx
+        .const_int(pyre_object::listobject::ListStrategy::Object as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op.pc,
+        OpCode::GuardValue,
+        &[strategy, object_strategy],
+    )?;
+    let length = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        args_list,
+        crate::descr::list_length_descr(),
+    );
+    let len_const = ctx.trace_ctx.const_int(args_len as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[length, len_const])?;
+    let block = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        args_list,
+        crate::descr::list_items_descr(),
+    );
+    let mut items = Vec::with_capacity(args_len);
+    for index in 0..args_len {
+        let index_op = ctx.trace_ctx.const_int(index as i64);
+        items.push(crate::state::trace_items_block_getitem_value(
+            ctx.trace_ctx,
+            block,
+            index_op,
+        ));
+    }
+    let args_tuple = if args_specialised_oo {
+        crate::helpers::emit_specialised_tuple_oo_inline(ctx.trace_ctx, items[0], items[1])
+    } else {
+        crate::helpers::emit_object_tuple_inline(ctx.trace_ctx, &items)
+    };
+    ctx.trace_ctx.set_opref_concrete(
+        args_tuple,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete_args_tuple as usize)),
+    );
+    // `(cls, args)` is always arity 2 and never a plain-int / plain-float
+    // pair, so `makespecialisedtuple2` builds `Cls_oo`.
+    let result =
+        crate::helpers::emit_specialised_tuple_oo_inline(ctx.trace_ctx, cls_const, args_tuple);
+    let concrete_result = pyre_object::w_tuple_new(vec![w_class, concrete_args_tuple]);
+    ctx.trace_ctx.set_opref_concrete(
+        result,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete_result as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
+    Ok(Some(()))
+}
+
 /// Walker-native RAISE_VARARGS inline-built-exception fast path. The
 /// `RaiseVarargs` residual is `normalize_raise_varargs_jit(frame, exc,
 /// cause)` — `r_args = [frame, exc, cause]`.  When `exc` was built inline by

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1957,6 +1957,23 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     cf_addr: usize,
     carrier: &majit_metainterp::BridgeInlineCarrier,
 ) -> TraceAction {
+    // `_prepare_exception_resumption` (`pyjitpl.py`): the grab
+    // `trace_and_compile_from_bridge` published is the standing exception
+    // this drain's innermost sub-walk reads as `sym.last_exc_value`.  The
+    // live-frame walk seeds through `seed_standing_exception_for_walk`;
+    // this path never calls that function.
+    let bh_exc = majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.get());
+    if bh_exc != 0 {
+        let exc = bh_exc as pyre_object::PyObjectRef;
+        if !exc.is_null() && unsafe { pyre_object::is_exception(exc) } {
+            let exc_box = ctx.const_ref(exc as i64);
+            sym.set_current_exc_value(exc);
+            sym.set_current_exc_box(exc_box);
+            sym.set_last_exc_value(exc);
+            sym.set_last_exc_box(exc_box);
+            sym.set_class_of_last_exc_is_const(true);
+        }
+    }
     let entry_depth = ctx.virtualref_boxes_len();
     let pre_virtualref_boxes = ctx.snapshot_virtualref_boxes();
     let pre_pos = ctx.get_trace_position();

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3905,33 +3905,12 @@ pub fn trace_and_compile_from_bridge(
     // bridge-side analogue of the same fallthrough-not-catch resume gap.
     // pyre encodes the guard's resume_pc as the no-exception semantic
     // fallthrough (the next opcode after the call), NOT the `except`
-    // handler.  The blackhole compensates at runtime — `resume_in_blackhole`
-    // hands the pending exception to `handle_exception_in_frame`, which
-    // `find_catch_before_resume_live`-routes to the handler and runs it
-    // (e.g. `return -1`).  The bridge tracer has no such routing: it walks
-    // from the fallthrough resume_pc and records the RETURN of the (NULL)
-    // raised-call result — `Finish(<unbound box>)` — so the compiled bridge
-    // hands a NULL up to the caller ("call failed" / a corrupted kept value
-    // / a fault).  Detect the caught-in-frame case with the exact mechanism
-    // the interpreter's `handle_exception` uses — an exception-table lookup
-    // at the raising op (`last_instr` == resume_pc-1) — and decline so the
-    // always-correct blackhole resume handles it.  (Routing the bridge walk
-    // to the handler is the orthodox follow-up, gated on the in-try
-    // residual-call resume-PC epic; declining is correctness-first.)
-    //
-    // The escaping case — an exception guard whose raising op is NOT caught in
-    // this frame, so the exception unwinds OUT to the caller — has the same
-    // fallthrough-not-catch resume gap: the guard's resume_pc is the
-    // no-exception fallthrough, so the bridge walk records the RETURN of the
-    // NULL raised-call result and the compiled bridge hands a NULL up to the
-    // caller (the "call failed" crash).  The
-    // `emit_exception_bridge_prologue` GUARD_EXCEPTION path that would trace
-    // the propagate-out continuation needs resume-data replay pyre does not yet
-    // have (its synthetic guard carries no rd_resume_position), so decline the
-    // escaping case too and let the blackhole propagate the exception out of
-    // the frame to the caller's handler.  Compiling a real raising bridge
-    // (`Finish(exc, exit_frame_with_exception_descr_ref)`) is the orthodox
-    // follow-up, gated on the same exception-edge bridge epic.
+    // handler.  `finishframe_exception` (`pyjitpl.py`) looks up
+    // `catch_exception` on the resumed framestack innermost-first and
+    // jumps there; the walker's `find_catch_for_exc_resume` is that
+    // lookup.  Route any catching frame — live or inlined — onto that
+    // handler.  An uncaught raise still blackholes this failure
+    // (`compile_exit_frame_with_exception` is the remaining close).
     /// The exception-table byte offset a `next_instr`-style resume coordinate
     /// maps to, mirroring the live-frame form `frame.last_instr * 2` (where
     /// `last_instr` is `next_instr - 1`).
@@ -3969,48 +3948,44 @@ pub fn trace_and_compile_from_bridge(
         None
     }
 
-    let caught_in_frame = pending_exc && last_bridge_is_exception_guard && {
+    let catch_level = if pending_exc && last_bridge_is_exception_guard {
         if is_multiframe_resume {
             // `resume_pc` (and thus `frame.last_instr`, set above) addresses the
             // INNERMOST inlined frame while `code` is the live OUTER frame, so
             // the single-frame lookup below would consult the wrong code object.
-            // Ask each resumed frame about its OWN pc instead. Only a raise that
-            // unwinds clear out of every inlined callee into the live frame's
-            // own handler is routable: that unwind discards the callee frames
-            // outright, so there is no inlined framestack left to rebuild. A
-            // catch inside a callee still needs the carrier subwalk and keeps
-            // declining below, as does a raise that escapes the whole resume.
-            resumed_catch_level(&resume_coords) == Some(0)
+            // Ask each resumed frame about its OWN pc instead.
+            // `finishframe_exception` walks `framestack` innermost-first and
+            // jumps to whichever frame's `catch_exception` answers; a catch
+            // inside an inlined callee is a real bridge, not a decline.
+            resumed_catch_level(&resume_coords)
         } else {
             let off = if frame.last_instr < 0 {
                 0u32
             } else {
                 (frame.last_instr as u32) * 2
             };
-            pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
+            pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off)
+                .map(|_| 0usize)
         }
+    } else {
+        None
     };
-    // Exception-edge bridge: route a resume whose handler lives in the LIVE
-    // frame to that `except` handler (walker `find_catch_before_resume_live`)
-    // instead of declining.  `caught_in_frame` already restricts the
-    // multi-frame case to the unwind-to-live-frame shape; the escaping case
-    // (uncaught) and a catch inside an inlined callee still decline below —
-    // those are separate slices (raising-bridge Finish(exc) / carrier subwalk).
-    // Only when the outermost resume section really IS the live frame, which is
-    // what lets the unwind land in a frame that already exists. Re-pointing the
-    // live frame to coordinates belonging to some other code object would
-    // resume the walk against the wrong bytecode.
+    let caught_in_frame = catch_level == Some(0);
+    // `finishframe_exception` (`pyjitpl.py`) jumps to the first catching
+    // frame, live or inlined.  Route whenever any resumed frame catches.
+    // An unwind that lands in the live frame discards the callee frames
+    // (no inlined framestack left).  A catch inside a callee keeps the
+    // carrier walk so the handler is recorded there.
     let unwind_to_live_frame = is_multiframe_resume
         && caught_in_frame
         && resume_coords
             .first()
             .is_some_and(|&(outer_w_code, _)| outer_w_code == frame.pycode as usize);
-    let route_exc_edge = caught_in_frame && (!is_multiframe_resume || unwind_to_live_frame);
-    // The levels this route is about to throw away: `resume_coords` minus the
-    // live frame, which keeps its own recorder at the handler entry.  Published
-    // unconditionally on the routing path — an empty slice for the single-frame
-    // shape — so a previous bridge's levels cannot survive into this walk.
-    pyre_jit_trace::jitcode_dispatch::set_exc_edge_discarded_levels(if route_exc_edge {
+    let route_exc_edge = catch_level.is_some();
+    // Discard inlined levels only when the raise unwinds *to* the live
+    // frame.  A catch inside a callee still needs those levels as the
+    // carrier recipes.
+    pyre_jit_trace::jitcode_dispatch::set_exc_edge_discarded_levels(if unwind_to_live_frame {
         resume_coords.get(1..).unwrap_or(&[])
     } else {
         &[]
@@ -4029,35 +4004,25 @@ pub fn trace_and_compile_from_bridge(
         // this exception-free bridge into the `except` handler (recording the
         // `v = -1` handler body as the bridge body → the handler path runs
         // every iteration).  Clear it so the walk resumes on the real
-        // no-exception continuation.  The decline path below (`pending_exc &&
-        // !route_exc_edge`) keeps the value for the blackhole.
+        // no-exception continuation.
         majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
     }
     if pending_exc && !route_exc_edge {
+        // Uncaught: `finishframe_exception` would
+        // `compile_exit_frame_with_exception`.  That Finish(exc) close is
+        // not wired on this walk yet, so this failure blackholes —
+        // `compile.py` `must_compile` retries via the jitcounter, and
+        // `bridge_declined_terminally` is only for a backend that cannot
+        // attach (`bridge_decline_is_terminal`).
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
-                "[jit][bridge-trace] decline (pending exc, caught_in_frame={caught_in_frame}) key={} trace={} fail={} resume_pc={}",
+                "[jit][bridge-trace] uncaught pending exc → blackhole key={} trace={} fail={} resume_pc={}",
                 green_key, trace_id, fail_index, resume_pc
             );
         }
         let (driver, _) = crate::eval::driver_pair();
         if driver.is_tracing() {
             driver.meta_interp_mut().abort_trace(false);
-        }
-        // This pre-walk decline returns before the `trace_bytecode` walk, so the
-        // walk-time `TraceAction::Abort` recorder below never runs for it. Record
-        // the guard here so `must_compile_with_values` does not re-enter this
-        // structurally-undecidable bridge every ~`trace_eagerness` failures. Only
-        // an exception guard is recorded: its `pending_exc` is guard-invariant, so
-        // the decline is deterministic while the exc-edge bridge is off. A
-        // `GUARD_NOT_FORCED` (even one carrying pending fields) has a
-        // runtime-conditional `pending_exc` and can still bridge on a later
-        // non-raising failure via the pending-field prologue, so blacklisting it
-        // after one raising failure would defeat that; leave it unrecorded.
-        if last_bridge_is_exception_guard {
-            driver
-                .meta_interp_mut()
-                .record_declined_bridge_guard(descr_arc);
         }
         return BridgeResolution::ResumeBlackhole;
     }


### PR DESCRIPTION
Rebased onto current `origin/main`. Exception-path JIT folds plus a line-by-line bridge-parity pass against `compile.py` / `pyjitpl.py` `finishframe_exception`.

## Changes

- Fold `BaseException.descr_reduce` (specialised 2-tuple; peek exception `__dict__`).
- Emit int-strategy `BINARY_SUBSCR` as `dict.lookup` on `dstorage` with the unboxed key (`ll_dict_getitem_with_hash`). Hit continues from the same index.
- Route a pending exception whose handler lives in an **inlined callee** as a bridge, matching `finishframe_exception`. Do not set `bridge_declined_terminally` on uncaught (only backends with `bridge_decline_is_terminal` keep that bit).
- `compile_bridge` runs `propagate_original_jitcell_token` on LABEL `TargetToken`s, as `compile_and_attach` does.
- Cranelift attach comment now cites `patch_jump_for_descr` / `patch_trace`, not a nonexistent `compile.py attach_bridge`.
- Bench ceiling refits from earlier on this branch (exception fixtures). `exception_loop_warmup` keeps main's wasm gate and 6.5 pypy ceiling.

## Not changed

- Cranelift still does **not** merge a bridge into the owner loop (PyPy materializes a separate blob and patches the guard).
- Uncaught `Finish(exc)` / `compile_exit_frame_with_exception` is still a follow-up; that failure blackholes and retries via the jitcounter.

## Measured locally (dynasm)

- `exception_reduce` N=8e6: ~1.2x vs pypy.
- `exc_caught_in_callee_return_loop`: stdout matches pypy `(14352000, 72000)`; 1 loop / 2 bridges.

Assisted-by: Claude