### PR TITLE
llbc: give Charon its own cargo target dir and cache it

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -184,6 +184,21 @@ jobs:
         retention-days: 1
         include-hidden-files: true
         if-no-files-found: error
+    # Charon's rustc is a different compiler from the stable rust-cache
+    # toolchain. Its rlibs cannot live in `target/` or every extract
+    # rebuilds the graph. `extract-llbc.py` writes them under
+    # `.pyre-build/charon-target` (`CHARON_TARGET_DIR`). Restore before
+    # Extract; save only when Charon actually rewrote a crate, under a
+    # lockfile key so a second extract of the same lock is an exact hit
+    # and does not clone the dir.
+    - name: Restore Charon cargo target
+      id: charon-target-cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pyre-build/charon-target
+        key: charon-target-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          charon-target-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Compute LLBC fingerprints
       id: llbc-fingerprint
       shell: bash
@@ -364,6 +379,19 @@ jobs:
           build/llbc/pyre-jit.ullbc.fingerprint
           build/llbc/pyre-jit.ullbc.readfiles
         key: llbc3-pyre-jit-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_jit }}
+    - name: Save Charon cargo target
+      # The directory is only populated when extract ran Charon. An exact
+      # hit on this key already has the deps; saving again is refused.
+      if: >-
+        steps.charon-target-cache.outputs.cache-hit != 'true' &&
+        (steps.llbc-extract.outputs.majit_rlib_rewrote == '1' ||
+         steps.llbc-extract.outputs.pyre_object_rewrote == '1' ||
+         steps.llbc-extract.outputs.pyre_interpreter_rewrote == '1' ||
+         steps.llbc-extract.outputs.pyre_jit_rewrote == '1')
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pyre-build/charon-target
+        key: charon-target-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ hashFiles('Cargo.lock') }}
     - name: Upload LLBC artifact
       # Hand the ullbc set (freshly extracted, or restored from the cache
       # above) to the downstream jobs as a run-scoped artifact. Unlike

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1436,6 +1436,22 @@ def charon_paths(charon_root: Path) -> tuple[str, Path, Path]:
     return platform_key, charon_dest, charon_dest / charon_exe
 
 
+def charon_cargo_target_dir(root: Path) -> Path:
+    """Cargo target dir for Charon's nightly rustc, not the workspace `target/`.
+
+    Charon's rustc is a different compiler from the stable build. Sharing
+    `target/` with it either rebuilds the whole graph (metadata rustc hash)
+    or, with incremental on, fuses CGUs from the two sessions. A dedicated
+    directory lets CI cache the nightly deps without bloating rust-cache,
+    and lets worktrees share them via `PYRE_SHARED_BUILD`.
+    """
+    if value := os.environ.get("CHARON_TARGET_DIR"):
+        return Path(value)
+    repo_parent = root.parent
+    shared = Path(os.environ.get("PYRE_SHARED_BUILD", repo_parent / ".pyre-build"))
+    return shared / "charon-target"
+
+
 def llbc_dest_path(out_dir: Path, root: Path) -> Path:
     """Where artefacts live, without creating it.
 
@@ -2312,6 +2328,15 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
     unstamped: list[str] = []
     env = os.environ.copy()
     prepend_msvc_link(env)
+    # Dedicated dir so Charon's nightly rlibs are not mixed with the
+    # stable `target/` rust-cache, and so `invalidate_cargo_unit` sees
+    # the same layout `charon cargo` writes. Set on `os.environ` too:
+    # `cargo_unit_location` runs `cargo metadata` without an env dict.
+    charon_target = charon_cargo_target_dir(eng.root)
+    charon_target.mkdir(parents=True, exist_ok=True)
+    env["CARGO_TARGET_DIR"] = str(charon_target)
+    os.environ["CARGO_TARGET_DIR"] = str(charon_target)
+    print(f"charon cargo target: {charon_target}")
 
     crate_attr = "-Zcrate-attr=feature(cfg_select)"
     env["RUSTC_BOOTSTRAP"] = "1"

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -268,6 +268,51 @@ def run_stamp_skip(engine) -> int:
     return failures
 
 
+def run_charon_target_dir(engine) -> int:
+    """Charon's cargo target is not the workspace `target/`."""
+    failures = 0
+
+    def expect(name, condition):
+        nonlocal failures
+        if condition:
+            print(f"ok   {name}")
+        else:
+            failures += 1
+            print(f"FAIL {name}")
+
+    import os
+
+    root = pathlib.Path(tempfile.mkdtemp()).resolve()
+    saved = {
+        key: os.environ.pop(key, None)
+        for key in ("CHARON_TARGET_DIR", "PYRE_SHARED_BUILD")
+    }
+    try:
+        default = engine.charon_cargo_target_dir(root)
+        expect(
+            "default target sits under the shared build dir",
+            default == root.parent / ".pyre-build" / "charon-target",
+        )
+        os.environ["PYRE_SHARED_BUILD"] = str(root / "shared")
+        expect(
+            "PYRE_SHARED_BUILD relocates the target",
+            engine.charon_cargo_target_dir(root) == root / "shared" / "charon-target",
+        )
+        os.environ["CHARON_TARGET_DIR"] = str(root / "explicit")
+        expect(
+            "CHARON_TARGET_DIR wins over the shared dir",
+            engine.charon_cargo_target_dir(root) == root / "explicit",
+        )
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        shutil.rmtree(root, ignore_errors=True)
+    return failures
+
+
 def main() -> None:
     engine = load_engine()
     failures = (
@@ -275,6 +320,7 @@ def main() -> None:
         + run_fingerprint(engine)
         + run_layout_sidecar(engine)
         + run_stamp_skip(engine)
+        + run_charon_target_dir(engine)
     )
     if failures:
         raise SystemExit(f"llbc_extract_selftest: {failures} failed")


### PR DESCRIPTION
## Summary

- Charon's rustc is the pinned nightly, not the stable toolchain rust-cache keys on. Its rlibs in workspace `target/` were either rebuilt from scratch every extract or mixed with the stable session (the reason extract already sets `CARGO_INCREMENTAL=0`).
- Extract now writes that graph under `.pyre-build/charon-target` (`CHARON_TARGET_DIR` / `PYRE_SHARED_BUILD`). Local worktrees can share it the same way they share Charon itself.
- CI restores that directory before Extract and saves it only when Charon actually rewrote a crate, keyed by OS/arch/Charon/Cargo.lock. A second extract of the same lock is an exact hit and does not clone the dir.

`invalidate_cargo_unit` still drops only the crate being extracted, so a warm cache recompiles that unit and reuses dependency rlibs.

## PyPy parity

Cache invalidation only. No interpreter or JIT semantics change.

## Verification

- `python3 scripts/llbc_extract_selftest.py`: all passed, including the new target-dir cases