### PR TITLE
compile_trace: FINISH uses optimize_loop; JUMP descr is the cell

### DIFF
--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -928,6 +928,39 @@ pub fn make_call_may_force_descr(arg_types: &[Type], result_type: Type) -> Descr
     })
 }
 
+/// `pyjitpl.py compile_trace` records `descr=ptoken` on the tentative JUMP.
+/// `unroll.py optimize_bridge` then does `cell_token = jump_op.getdescr()`
+/// and `assert isinstance(cell_token, JitCellToken)`.
+#[derive(Debug)]
+struct JitCellTokenDescr {
+    token: Arc<JitCellToken>,
+}
+
+impl majit_ir::Descr for JitCellTokenDescr {
+    fn as_loop_token_descr(&self) -> Option<&dyn majit_ir::descr::LoopTokenDescr> {
+        Some(self)
+    }
+}
+
+impl majit_ir::descr::LoopTokenDescr for JitCellTokenDescr {
+    fn loop_token_number(&self) -> u64 {
+        self.token.number
+    }
+
+    fn call_virtualizable_index(&self) -> Option<usize> {
+        self.token.virtualizable_arg_index()
+    }
+
+    fn token_handle_any(&self) -> Option<&dyn std::any::Any> {
+        Some(&self.token)
+    }
+}
+
+/// Wrap a live `JitCellToken` as the JUMP descr `compile_trace` records.
+pub fn jit_cell_token_as_descr(token: Arc<JitCellToken>) -> DescrRef {
+    Arc::new(JitCellTokenDescr { token })
+}
+
 /// `compile.py isinstance(descr, JitCellToken)` parity factory.
 ///
 /// Create a `CALL_ASSEMBLER_*` descr that owns the same `Arc<JitCellToken>`
@@ -1009,6 +1042,27 @@ mod set_effect_bitstrings_tests {
             Some(&[0x88u8][..])
         );
         assert_eq!(ei_after.write_descrs_fields.as_deref(), Some(&[0x00u8][..]));
+    }
+
+    #[test]
+    fn jit_cell_token_as_descr_exposes_the_same_arc() {
+        let token = Arc::new(JitCellToken::new(42));
+        let descr = jit_cell_token_as_descr(Arc::clone(&token));
+        let recovered = descr
+            .as_loop_token_descr()
+            .and_then(|ltd| ltd.token_handle_any())
+            .and_then(|any| any.downcast_ref::<Arc<JitCellToken>>())
+            .expect("JUMP descr must be the JitCellToken");
+        assert!(
+            Arc::ptr_eq(recovered, &token),
+            "compile_trace records descr=ptoken, the same Arc the cell holds"
+        );
+        assert_eq!(
+            descr
+                .as_loop_token_descr()
+                .map(|ltd| ltd.loop_token_number()),
+            Some(42)
+        );
     }
 
     /// Default `Descr::set_effect_bitstrings` is a no-op for descrs

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1945,6 +1945,34 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         }
     }
 
+    /// `compile.py emit_op` / `get_box_replacement`: a residual body-LABEL
+    /// `RefOp` is a reminted virtualizable slot that still forwards to the
+    /// expanded inputarg Box. Key the local table by that reminted raw so
+    /// the walk below rewrites it to the GETFIELD/GETARRAYITEM just as
+    /// RPython rewrites a LABEL arg that *is* the forwarded inputarg.
+    fn forward_residual_args_sharing_inputarg(
+        ops: &[majit_ir::OpRc],
+        forwarding: &mut Vec<Option<Operand>>,
+        old_opref: OpRef,
+        target: &Operand,
+    ) {
+        if !old_opref.is_input_arg() {
+            return;
+        }
+        for op in ops {
+            let args = op
+                .getarglist()
+                .into_iter()
+                .chain(op.getfailargs().into_iter().flatten());
+            for arg in args {
+                let via = arg.get_box_replacement(false);
+                if via.to_opref() == old_opref || arg.to_opref() == old_opref {
+                    set_local_forwarded(forwarding, arg.to_opref(), target.clone());
+                }
+            }
+        }
+    }
+
     fn emit_forwarded_patch_op(
         extra_ops: &mut Vec<majit_ir::OpRc>,
         op: &Op,
@@ -2085,7 +2113,9 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         op.pos().set(new_opref);
         op.setdescr(descr);
         let op = OpRc::new(op);
-        set_local_forwarded(&mut forwarding, old_opref, Operand::from_bound_op(&op));
+        let target = Operand::from_bound_op(&op);
+        set_local_forwarded(&mut forwarding, old_opref, target.clone());
+        forward_residual_args_sharing_inputarg(ops, &mut forwarding, old_opref, &target);
         extra_ops.push(op);
         i += 1;
     }
@@ -2234,7 +2264,9 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
             elem_op.pos().set(new_opref);
             elem_op.setdescr(item_descr.clone());
             let elem_op = OpRc::new(elem_op);
-            set_local_forwarded(&mut forwarding, old_opref, Operand::from_bound_op(&elem_op));
+            let target = Operand::from_bound_op(&elem_op);
+            set_local_forwarded(&mut forwarding, old_opref, target.clone());
+            forward_residual_args_sharing_inputarg(ops, &mut forwarding, old_opref, &target);
             extra_ops.push(elem_op);
             i += 1;
         }
@@ -3040,6 +3072,66 @@ mod tests {
                 ops[2].pos().get(),
                 ops[3].pos().get()
             ]
+        );
+    }
+
+    /// Residual body-LABEL `RefOp`s that still forward to an expanded
+    /// inputarg are the same Box as `loop.inputargs[i]`. `emit_op` must
+    /// rewrite them to the GETARRAYITEM, not leave a producerless hole.
+    #[test]
+    fn test_patch_new_loop_rewrites_residual_label_refop_forwarded_to_inputarg() {
+        use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
+
+        let mut vinfo = crate::virtualizable::VirtualizableInfo::new(0);
+        vinfo.add_embedded_array_field(
+            "locals_cells_stack_w",
+            Type::Ref,
+            8,
+            0,
+            8,
+            0,
+            majit_ir::descr::make_array_descr(0, 8, Type::Ref),
+        );
+        vinfo.set_parent_descr(majit_ir::descr::make_size_descr(16));
+
+        let slot = rooted_inputarg_operand(Type::Ref, 1);
+        let reminted = rooted_resop_operand(Type::Ref, 85);
+        reminted.set_forwarded_inputarg(
+            &slot
+                .bound_inputarg()
+                .expect("rooted inputarg must carry its InputArgRc"),
+        );
+
+        let mut ops: Vec<majit_ir::OpRc> = vec![OpRc::new(Op::new(
+            OpCode::Label,
+            &[rooted_inputarg_operand(Type::Ref, 0), reminted],
+        ))];
+        let mut inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::default();
+
+        patch_new_loop_to_load_virtualizable_fields(
+            &mut ops,
+            &mut inputargs,
+            &vinfo,
+            &[1],
+            1,
+            0,
+            &mut constants,
+        );
+
+        assert_eq!(inputargs, vec![InputArg::new_ref(0)]);
+        let label = ops.iter().find(|op| op.opcode == OpCode::Label).unwrap();
+        let getitem = ops
+            .iter()
+            .find(|op| op.opcode == OpCode::GetarrayitemRawR)
+            .unwrap();
+        assert_eq!(
+            label
+                .getarglist()
+                .iter()
+                .map(|a| a.to_opref())
+                .collect::<Vec<_>>(),
+            vec![OpRef::input_arg_ref(0), getitem.pos().get()]
         );
     }
 

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -24,6 +24,7 @@ use majit_backend::{
     Backend, BackendError, CompiledLoopToken, CompiledTraceInfo, ExitFrameLayout,
     ExitRecoveryLayout, FailDescrLayout, JitCellToken, TerminalExitLayout,
 };
+use majit_ir::forwarding::ForwardingHost;
 use majit_ir::operand::Operand;
 use majit_ir::{
     AccumInfo, Const, DescrRef, FailDescr, GcRef, GuardPendingFieldEntry, InputArg, Op, OpCode,
@@ -385,14 +386,12 @@ pub struct DeadFrameArtifacts {
 
 /// `compile.py` `class CompileData(object)`.
 ///
-/// PYRE-ADAPTATION: RPython's `CompileData.optimize_trace()` builds the
-/// optimizer chain, logs, dispatches to the subclass `optimize()`, and clears
-/// forwarded boxes in one Python method. Pyre's optimizer entry points borrow
-/// `MetaInterp`, backend state, constant pools, and snapshot side tables
-/// directly in `pyjitpl.rs`, so that dispatch remains flattened there.
-/// These structs intentionally model the RPython constructor payloads only;
-/// call sites must still pass the same trace/runtime/resume/call-pure/opts
-/// state that RPython would store on the corresponding object.
+/// `optimize_trace` is the compile.py method: run subclass `optimize()`,
+/// then `forget_optimization_info`. Logging / `build_opt_chain` stay at the
+/// flattened call site in `pyjitpl.rs` because the optimizer borrows
+/// `MetaInterp`, backend state, constant pools, and snapshot side tables.
+/// Call sites still pass the same trace/runtime/resume/call-pure/opts state
+/// that RPython would store on the corresponding object.
 pub struct CompileData<'a> {
     pub trace: &'a TreeLoop,
 }
@@ -400,6 +399,22 @@ pub struct CompileData<'a> {
 impl<'a> CompileData<'a> {
     pub fn new(trace: &'a TreeLoop) -> Self {
         Self { trace }
+    }
+
+    /// compile.py `CompileData.forget_optimization_info`:
+    /// `for arg in self.trace.inputargs: arg.set_forwarded(None)`.
+    pub fn forget_optimization_info(&self) {
+        for arg in self.inputargs() {
+            arg.clear_forwarded();
+        }
+    }
+
+    /// compile.py `CompileData.optimize_trace`: run the subclass
+    /// `optimize()` body, then `forget_optimization_info`.
+    pub fn optimize_trace<T, E>(&self, optimize: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
+        let result = optimize();
+        self.forget_optimization_info();
+        result
     }
 
     pub fn inputargs(&self) -> &'a [majit_ir::InputArgRc] {
@@ -465,6 +480,14 @@ impl<'a> SimpleCompileData<'a> {
             enable_opts,
         }
     }
+
+    /// compile.py `CompileData.optimize_trace` + `SimpleCompileData.optimize`.
+    pub fn optimize_trace<T, E>(
+        &self,
+        optimize: impl FnOnce(&Self) -> Result<T, E>,
+    ) -> Result<T, E> {
+        self.base.optimize_trace(|| optimize(self))
+    }
 }
 
 /// `compile.py` `class BridgeCompileData(CompileData)`.
@@ -474,7 +497,9 @@ pub struct BridgeCompileData<'a> {
     pub runtime_boxes: &'a [OpRef],
     #[allow(dead_code)]
     pub resumestorage: Option<&'a ResumeStorage>,
+    #[allow(dead_code)]
     pub call_pure_results: &'a crate::optimizeopt::util::ArgsDict,
+    #[allow(dead_code)]
     pub inline_short_preamble: bool,
     #[allow(dead_code)]
     pub enable_opts: &'a [String],
@@ -497,6 +522,14 @@ impl<'a> BridgeCompileData<'a> {
             inline_short_preamble,
             enable_opts,
         }
+    }
+
+    /// compile.py `CompileData.optimize_trace` + `BridgeCompileData.optimize`.
+    pub fn optimize_trace<T, E>(
+        &self,
+        optimize: impl FnOnce(&Self) -> Result<T, E>,
+    ) -> Result<T, E> {
+        self.base.optimize_trace(|| optimize(self))
     }
 }
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -64,8 +64,9 @@ pub struct TargetToken {
     /// closing onto this LABEL lands one arg short. A virtualizable static
     /// field is reconstructible from the frame at any point, so record the
     /// `(opcode, field descr)` pair and let the close emit the load.
-    /// Non-reconstructible appends record nothing and still reach
-    /// `compile_bridge`'s arity giveup.
+    /// Non-reconstructible appends record nothing; the LABEL/JUMP
+    /// contract is `vable_label_arg_recipes` in
+    /// `OptUnroll::jump_to_existing_trace`.
     pub vable_label_arg_recipes: Vec<(majit_ir::OpCode, majit_ir::DescrRef)>,
     jump_target_descr: Arc<LoopTargetDescr>,
     /// `IncrementalMiniMarkGC.old_objects_pointing_to_young` state for the

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4046,55 +4046,25 @@ impl<S: JitState> JitDriver<S> {
                                 self.bridge_attempt_declined = true;
                             }
                             crate::pyjitpl::BridgeCompileResult::Declined => {
-                                // pyjitpl.py: `compile_trace` returned without raising, so the
-                                // trace is NOT given up — tracing continues.  Latch the decline so the walk
-                                // does not re-run the optimizer over the same key, and re-enter the walk at
-                                // the merge point's own pc (pyjitpl.py `self.pc = saved_pc`).
-                                //
-                                // Only latch what an attempt actually rejected.  A close the gate
-                                // above never evaluated cost no optimizer pass, which is the whole
-                                // reason the latch exists, and the gate's own conditions can be
-                                // false now and true at the next visit of this header.
+                                // pyjitpl.py raise_if_successful does not raise
+                                // on None. The reached greens are the target
+                                // we failed to JUMP into, so the merge-point
+                                // scan below (same-greenkey of this trace)
+                                // must not compile_loop them. Re-enter the
+                                // walk as `reached_loop_header` does after
+                                // appending a merge point. Do not latch: the
+                                // next header visit retries compile_trace
+                                // (`if not self.partial_trace`).
+                                if attempted {
+                                    crate::mc_diag_bump(50); // bridge_declined_close
+                                } else {
+                                    crate::mc_diag_bump(67); // bridge_unattempted_close
+                                }
                                 if let Some(ctx) = self.meta.trace_ctx() {
-                                    if attempted {
-                                        // The two sibling close sites report a declined
-                                        // attempt under the same tally; this one is the
-                                        // third.  Bump it on the same condition the latch
-                                        // uses, so the census counts closes an optimizer
-                                        // pass actually rejected and not headers the gate
-                                        // above skipped.
-                                        crate::mc_diag_bump(50); // bridge_declined_close
-                                        ctx.note_cross_loop_close_declined(target_key);
-                                    } else {
-                                        // The gate above declined to attempt this close, so no
-                                        // optimizer pass ran and slot 50 must not move.  That
-                                        // is a different event from "an attempt was declined",
-                                        // and without its own slot the two are indistinguishable
-                                        // downstream: both render as slot 50 reading zero.
-                                        // `result` is initialized to `Declined` at the top of
-                                        // this block and is only written inside the gate, so
-                                        // this arm is reachable with nothing having been tried
-                                        // — the sibling close sites bind `result` from
-                                        // `close_bridge` directly and have no such path.
-                                        crate::mc_diag_bump(67); // bridge_unattempted_close
-                                    }
-                                    // pyjitpl.py `self.pc = saved_pc` resumes at the
-                                    // merge point that was CONSULTED — the one whose greens
-                                    // `get_procedure_token` read (pyjitpl.py), which is
-                                    // this one. The `continue` below re-runs the walk with
-                                    // the native interpreter's `pc` untouched, i.e. at the
-                                    // position the walk STARTED from, while the symbolic
-                                    // state stands here. Publish the position half before
-                                    // dropping the only record of it, or the re-entered walk
-                                    // replays the instructions between the two against state
-                                    // that belongs to neither.
                                     ctx.resume_walk_after_close();
                                     ctx.close_greens = None;
                                     ctx.close_green_pc = None;
                                 }
-                                // The walk-final handoff staged at the top of this arm describes a trace
-                                // that ENDED; discard it, same as the `take_keep_tracing_after_close` path
-                                // at the bottom of this arm.
                                 self.meta.single_pass_outcome = None;
                                 self.meta.single_pass_scalar_values = None;
                                 self.meta.single_pass_ref_scalar_values = None;
@@ -4121,17 +4091,11 @@ impl<S: JitState> JitDriver<S> {
                     // retrace a second time. Fall straight through to the
                     // merge-point scan, which is the only consumer upstream leaves
                     // for a partial trace.
-                    // pyjitpl.py:3003-3005 has no resumekey test in this gate:
-                    // upstream re-attempts `compile_trace` on every header visit.
-                    // majit keeps its declined-attempt latch here for now, so this
-                    // commit changes no behavior at this site.
+                    // pyjitpl.py `if not self.partial_trace:` is the only
+                    // compile_trace gate. Upstream retries on every header
+                    // visit; do not skip a later visit after a decline.
                     let has_partial_trace = self.meta.partial_trace().is_some();
-                    let attempt_declined = self.bridge_attempt_declined;
-                    if let Some(bridge) = self
-                        .meta
-                        .bridge_info()
-                        .filter(|_| !has_partial_trace && !attempt_declined)
-                    {
+                    if let Some(bridge) = self.meta.bridge_info().filter(|_| !has_partial_trace) {
                         let bridge_key = bridge.green_key;
                         let bridge_trace_id = bridge.trace_id;
                         let bridge_fail_index = bridge.fail_index;
@@ -4482,17 +4446,11 @@ impl<S: JitState> JitDriver<S> {
                     // loop being closed is a RETRACE, and re-entering
                     // `compile_trace` would both bridge into the loop the retrace
                     // exists to respecialize and arm the retrace a second time.
-                    // pyjitpl.py:3003-3005 has no resumekey test in this gate:
-                    // upstream re-attempts `compile_trace` on every header visit.
-                    // majit keeps its declined-attempt latch here for now, so this
-                    // commit changes no behavior at this site.
+                    // pyjitpl.py `if not self.partial_trace:` is the only
+                    // compile_trace gate. Upstream retries on every header
+                    // visit; do not skip a later visit after a decline.
                     let has_partial_trace = self.meta.partial_trace().is_some();
-                    let attempt_declined = self.bridge_attempt_declined;
-                    if let Some(bridge) = self
-                        .meta
-                        .bridge_info()
-                        .filter(|_| !has_partial_trace && !attempt_declined)
-                    {
+                    if let Some(bridge) = self.meta.bridge_info().filter(|_| !has_partial_trace) {
                         let bridge_key = bridge.green_key;
                         let bridge_trace_id = bridge.trace_id;
                         let bridge_fail_index = bridge.fail_index;
@@ -11953,16 +11911,11 @@ mod cross_loop_cut_close_tests {
 
         // pyjitpl.py: `compile_trace` returned without raising, so
         // the trace is NOT given up — the walk keeps recording.
+        // Upstream retries compile_trace on the next header visit
+        // (`if not self.partial_trace`); do not latch the decline.
         assert!(
             driver.is_tracing(),
             "a cut target must not be entered by an entry bridge",
-        );
-        assert!(
-            driver
-                .meta
-                .trace_ctx()
-                .is_some_and(|ctx| ctx.cross_loop_close_declined(inner_key)),
-            "the decline must be latched so the walk does not re-attempt it",
         );
     }
 
@@ -11993,9 +11946,8 @@ mod cross_loop_cut_close_tests {
     /// this lands in the same `Declined` arm a rejected attempt lands in — and
     /// the two must not report as one event.
     ///
-    /// Both assertions are trace-local on purpose: `MC_DIAG` is process-global
-    /// and this suite runs in parallel, so slot 50 is checked through the latch
-    /// it always writes rather than by reading its counter.
+    /// Slot 67 is process-global and this suite runs in parallel, so the
+    /// assertion is a before/after bump rather than an absolute count.
     #[test]
     fn interp_origin_close_into_an_uncompiled_target_is_not_a_declined_attempt() {
         let mut driver = JitDriver::<CutCloseState>::new(2);
@@ -12014,14 +11966,6 @@ mod cross_loop_cut_close_tests {
         assert!(
             crate::mc_diag(67) > before,
             "a close that was never attempted must be counted under its own slot",
-        );
-        assert!(
-            driver
-                .meta
-                .trace_ctx()
-                .is_some_and(|ctx| !ctx.cross_loop_close_declined(never_compiled)),
-            "nothing rejected this close, so there is no decline to latch — \
-             latching it would suppress a retry the gate's own conditions allow",
         );
         assert!(
             driver.is_tracing(),

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1562,8 +1562,8 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// returned true, 6 = start_retrace_from_guard entered, 7 = start_retrace bailed
 /// (source loop evicted: compiled_loops miss), 8 = compile_bridge entered (trace
 /// closed → backend request path), 9 = compile_bridge InvalidLoop discard, 10 =
-/// compile_bridge retrace_requested return, 11 = compile_bridge arity giveup
-/// return (JUMP args != target LABEL args), 12 = start_bridge_tracing entered,
+/// compile_bridge retrace_requested return, 11 = retired (compile.py
+/// compile_trace has no JUMP/LABEL arity giveup), 12 = start_bridge_tracing entered,
 /// 13 = sbt early: descr not FailDescr, 14 = sbt early: no owning jct, 15 = sbt
 /// early: no compiled_meta, 16 = sbt early: !can_trace, 17 = sbt early:
 /// fail_values too short, 18 = compile_and_run_once entered from a back edge,
@@ -1892,8 +1892,7 @@ pub const MC_DIAG_LABELS: &[&str] = &[
     //
     // A crate that never passes `"max_unroll_loops"` to `jit::set_param` takes
     // L from `warmstate::DEFAULT_MAX_UNROLL_LOOPS`, so read that constant before
-    // reading 72. `TraceCtx::declined_cross_loop_closes` draws its own
-    // consequence from the same one.
+    // reading 72.
     "unroll_cancelled_invalid_loop",
     "unroll_free_retry_rescued",
     "unroll_free_retry_failed",

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1639,10 +1639,9 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// rule still cannot become an assert, because the same length test is what
 /// keeps the trace-start seed `TraceCtx::new` plants under the trace's own
 /// green key from matching a loop header's first arrival; 55 =
-/// `register_retrace_merge_point` declined to
-/// register because some jump arg carried no intrinsic type, where
-/// `pyjitpl.py:3059-3060 self.current_merge_points.append((live_arg_boxes,
-/// start))` appends unconditionally; 56 = `close_header_pc` fell back to
+/// `register_retrace_merge_point` used to decline when a jump arg
+/// carried no intrinsic type; it now appends unconditionally
+/// (`pyjitpl.py` `current_merge_points.append`); 56 = `close_header_pc` fell back to
 /// `self.header_pc` because the walk recorded no close greens, where
 /// `pyjitpl.py same_greenkey(original_boxes, live_arg_boxes,
 /// num_green_args)` always compares the actual closing boxes. 55 and 56 are

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4565,10 +4565,38 @@ impl Optimizer {
                     &format!("Retracing ({}/{retrace_limit})", retraced_count + 1),
                 );
             }
-            // unroll.py:231-233: export the bridge's own runtime boxes for retracing.
-            if let Some(ref mut state) = self.exported_loop_state {
-                state.runtime_boxes = runtime_boxes.to_vec();
-            }
+            // unroll.py `exported_state = self.optunroll.export_state(
+            //     info.jump_op.getarglist(), info.inputargs, runtime_boxes)`
+            // after the failed virtual-state match. Reusing a JUMP-time
+            // `exported_loop_state` (or leaving it None) skips that late
+            // export; `retrace_needed` then starts without a state.
+            let renamed_inputargs: Vec<OpRef> = (0..num_inputs)
+                .map(|i| {
+                    let pos = ctx.inputarg_base + i as u32;
+                    OpRef::input_arg_typed(pos, ctx.inputarg_type_at_strict(i))
+                })
+                .collect();
+            let exported_int_bounds = self.collect_exported_int_bounds(&jump_args, &mut ctx);
+            let mut state = crate::optimizeopt::unroll::export_state(
+                &jump_args,
+                &renamed_inputargs,
+                self,
+                &mut ctx,
+                Some(&exported_int_bounds),
+            );
+            state.runtime_boxes = runtime_boxes.to_vec();
+            // unroll.py `exported_state.quasi_immutable_deps =
+            // self.quasi_immutable_deps`
+            crate::optimizeopt::unroll::merge_quasi_immutable_deps(
+                &mut state.quasi_immutable_deps,
+                &self.quasi_immutable_deps,
+            );
+            crate::optimizeopt::unroll::merge_quasi_immutable_deps(
+                &mut state.quasi_immutable_deps,
+                &ctx.quasi_immutable_deps,
+            );
+            state.patchguardop = self.patchguardop.clone();
+            self.exported_loop_state = Some(state);
             // unroll.py:234-236 returns `self._newoperations` whole, so the
             // retrace is built on the flush + end-of-preamble force + failed
             // match guards above, not on the body alone. `retarget_close_jump`
@@ -4578,6 +4606,8 @@ impl Optimizer {
             // heap store the bridge body performed.
             let mut result = optimized_ops;
             result.append(&mut ctx.new_operations);
+            // unroll.py `_clean_optimization_info(self._newoperations)`
+            Self::clean_optimization_info(&result);
             return Ok((result, true));
         }
 
@@ -4700,6 +4730,18 @@ impl Optimizer {
             }
         }
         exported
+    }
+
+    /// optimizer.py `_clean_optimization_info(lst)` — drop `_forwarded`
+    /// on each exported op so the next optimizer (the retrace body) does
+    /// not inherit preamble forwarding.
+    fn clean_optimization_info(ops: &[majit_ir::OpRc]) {
+        use majit_ir::forwarding::ForwardingHost;
+        for op in ops {
+            if !matches!(op.get_forwarded(), majit_ir::forwarding::Forwarded::None) {
+                op.clear_forwarded();
+            }
+        }
     }
 
     /// Send one operation through the pass chain.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4204,6 +4204,50 @@ impl Optimizer {
         Ok(ops)
     }
 
+    /// compile.py `SimpleCompileData.optimize` → `Optimizer.optimize_loop`.
+    ///
+    /// The caller has already done `trace.get_iter()` (`prepare_bridge_trace`).
+    /// `resumestorage` arrives as `pending_bridge_rd` and is deserialized
+    /// inside `optimize_with_constants_and_inputs_at`, matching
+    /// `optimize_loop`'s `if resumestorage: deserialize_optimizer_knowledge`.
+    /// `BasicLoopInfo.final()` is always True, so there is no retrace.
+    pub(crate) fn optimize_loop(
+        &mut self,
+        ops: &[majit_ir::OpRc],
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
+        num_inputs: usize,
+        pending_bridge_rd: Option<PendingBridgeRd>,
+        inputarg_base: u32,
+    ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
+        self.simple_compile = true;
+        self.pending_bridge_rd = pending_bridge_rd;
+        // Bridge ops are a fresh TraceIterator's reminted slots; producer
+        // lookup runs off `resop_refs` after `bind_input_resops`.
+        self.explicit_input_ops_seed = Some(Vec::new());
+        let max_op_pos = ops
+            .iter()
+            .filter_map(|op| {
+                if op.pos().get().is_none() || op.pos().get().is_constant() {
+                    None
+                } else {
+                    Some(op.pos().get().raw())
+                }
+            })
+            .max();
+        let start_next_pos = max_op_pos
+            .map(|p| p + 1)
+            .unwrap_or(inputarg_base + num_inputs as u32)
+            .max(inputarg_base + num_inputs as u32);
+        self.optimize_with_constants_and_inputs_at(
+            ops,
+            constants,
+            num_inputs,
+            inputarg_base,
+            start_next_pos,
+            false,
+        )
+    }
+
     /// unroll.py: optimize_bridge()
     ///
     /// Optimizes a bridge trace and redirects its terminal JUMP to the
@@ -4323,7 +4367,7 @@ impl Optimizer {
         );
         self.building_bridge = building_bridge_saved;
         self.skip_flush = skip_flush_saved;
-        let optimized_ops = optimized_ops?;
+        let mut optimized_ops = optimized_ops?;
 
         // `reached_loop_header` emits the GUARD_FUTURE_CONDITION before both
         // of its closes, so upstream always has a `patchguardop`:
@@ -4359,17 +4403,28 @@ impl Optimizer {
             self.patchguardop = Some((**g).clone());
         }
 
-        // RPython flush=False: JUMP is in terminal_op, not in optimized_ops.
-        let terminal_jump = self.terminal_op.take();
-        let has_jump = terminal_jump
-            .as_ref()
-            .is_some_and(|op| op.opcode == OpCode::Jump);
+        // unroll.py optimize_bridge: `jump_op = info.jump_op`.
+        // `propagate_all_forward(..., flush=False)` parks JUMP on
+        // `info.jump_op`. Pyre's skip_flush=false path instead sends it
+        // through the passes into `new_operations`; pull it back out so
+        // `jump_to_preamble` can rewrite `descr=cell_token.target_tokens[0]`.
+        let mut terminal_jump = self
+            .terminal_op
+            .take()
+            .filter(|op| op.opcode == OpCode::Jump);
+        if terminal_jump.is_none()
+            && let Some(idx) = optimized_ops
+                .iter()
+                .rposition(|op| op.opcode == OpCode::Jump)
+        {
+            terminal_jump = Some((*optimized_ops.remove(idx)).clone());
+        }
 
         if optimized_ops.len() < 120 && crate::smallir_enabled() {
             eprintln!(
                 "@@@SMALLIR BRIDGE total={} has_jump={} front_targets={}",
                 optimized_ops.len(),
-                has_jump as i32,
+                terminal_jump.is_some() as i32,
                 front_target_tokens.len(),
             );
             for (i, op) in optimized_ops.iter().enumerate() {
@@ -4381,11 +4436,13 @@ impl Optimizer {
             }
         }
 
-        if !has_jump {
-            return Ok((optimized_ops, false));
-        }
-
-        let terminal_jump = terminal_jump.unwrap();
+        // A FINISH-only trace belongs on SimpleCompileData.optimize_loop
+        // (`compile.py compile_trace` `ends_with_jump=False`).
+        let Some(terminal_jump) = terminal_jump else {
+            return Err(crate::optimize::InvalidLoop(
+                "optimize_bridge requires a JUMP; FINISH uses optimize_loop",
+            ));
+        };
         let jump_args: Vec<OpRef> = terminal_jump
             .getarglist()
             .iter()
@@ -4421,19 +4478,12 @@ impl Optimizer {
                         .unwrap_or_else(|| vec![majit_ir::Type::Ref; ni]);
                     OptContext::with_inputarg_types(32, &types)
                 });
-                // unroll.py: jump_to_preamble →
-                //   jump_op = jump_op.copy_and_change(rop.JUMP,
-                //                 descr=cell_token.target_tokens[0])
-                //   self.send_extra_operation(jump_op)
-                // `cell_token.target_tokens[0]` is the preamble of the jitcell
-                // the JUMP points to — i.e. terminal_jump's own (recorded)
-                // descr (`is_preamble_target`). Keep both the jump_op's forced
-                // args AND its descr; only re-send it through the pass chain.
-                let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-                self.send_extra_operation(&jump_op, &mut ctx)?;
-                let mut result = optimized_ops;
-                result.append(&mut ctx.new_operations);
-                return Ok((result, false));
+                return self.jump_to_preamble(
+                    &terminal_jump,
+                    front_target_tokens,
+                    optimized_ops,
+                    &mut ctx,
+                );
             }
             return Ok((optimized_ops, false));
         }
@@ -4525,15 +4575,12 @@ impl Optimizer {
             // RPython: self.jump_to_preamble → send_extra_operation
             Err(_) => {
                 if !front_target_tokens.is_empty() {
-                    // unroll.py jump_to_preamble parity: the jump-to
-                    // jitcell is `jump_op.getdescr()` = terminal_jump's own
-                    // recorded descr, the preamble of the loop the trace closed
-                    // into. Keep both jump_op's forced args AND its descr.
-                    let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-                    self.send_extra_operation(&jump_op, &mut ctx)?;
-                    let mut result = optimized_ops;
-                    result.append(&mut ctx.new_operations);
-                    return Ok((result, false));
+                    return self.jump_to_preamble(
+                        &terminal_jump,
+                        front_target_tokens,
+                        optimized_ops,
+                        &mut ctx,
+                    );
                 }
                 let mut result = optimized_ops;
                 result.append(&mut ctx.new_operations);
@@ -4650,23 +4697,41 @@ impl Optimizer {
             );
         }
         if !front_target_tokens.is_empty() {
-            // unroll.py jump_to_preamble parity: keep jump_op's own
-            // (forced) args so send_extra_operation's Virtualize pass forces the
-            // still-virtual ref args, AND keep its recorded descr. That descr is
-            // `cell_token.target_tokens[0]` (cell_token = jump_op.getdescr()) —
-            // the preamble of the jitcell the trace closed into. Redirecting to
-            // a token picked here instead would deliver args to the wrong frame
-            // slots whenever that jitcell's preamble has different arglocs.
-            let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
-            self.send_extra_operation(&jump_op, &mut ctx)?;
-            let mut result = optimized_ops;
-            result.append(&mut ctx.new_operations);
-            Ok((result, false))
+            self.jump_to_preamble(&terminal_jump, front_target_tokens, optimized_ops, &mut ctx)
         } else {
             let mut result = optimized_ops;
             result.append(&mut ctx.new_operations);
             Ok((result, false))
         }
+    }
+
+    /// unroll.py `UnrollOptimizer.jump_to_preamble`:
+    /// `jump_op.copy_and_change(rop.JUMP, descr=cell_token.target_tokens[0])`
+    /// then `send_extra_operation`. The recorded JUMP descr is the
+    /// `JitCellToken`; this rewrites it to the preamble TargetToken.
+    fn jump_to_preamble(
+        &mut self,
+        terminal_jump: &Op,
+        front_target_tokens: &[crate::history::TargetToken],
+        mut optimized_ops: Vec<majit_ir::OpRc>,
+        ctx: &mut OptContext,
+    ) -> Result<(Vec<majit_ir::OpRc>, bool), crate::optimize::InvalidLoop> {
+        // unroll.py: `assert cell_token.target_tokens[0].virtual_state is None`
+        if front_target_tokens
+            .first()
+            .is_some_and(|token| token.virtual_state.is_some())
+        {
+            return Err(crate::optimize::InvalidLoop(
+                "jump_to_preamble: target_tokens[0].virtual_state is not None",
+            ));
+        }
+        let preamble = front_target_tokens
+            .first()
+            .map(|token| token.as_jump_target_descr());
+        let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, Some(preamble));
+        self.send_extra_operation(&jump_op, ctx)?;
+        optimized_ops.append(&mut ctx.new_operations);
+        Ok((optimized_ops, false))
     }
 
     /// Wrapper: call jump_to_existing_trace, catch only InvalidLoop panics.
@@ -7069,6 +7134,35 @@ mod tests {
                 .map(|a| a.to_opref())
                 .collect::<Vec<_>>(),
             vec![OpRef::int_op(2)]
+        );
+    }
+
+    #[test]
+    fn test_optimize_loop_keeps_finish_and_does_not_export() {
+        // compile.py SimpleCompileData.optimize → Optimizer.optimize_loop:
+        // a DoneWithThisFrame FINISH is final (BasicLoopInfo.final is True)
+        // and must stay in the op list. optimize_bridge would park it in
+        // terminal_op / try jump matching.
+        let mut opt = Optimizer::default_pipeline();
+        let mut finish = Op::new(OpCode::Finish, &[rooted_resop_operand(Type::Int, 0)]);
+        finish.pos().set(OpRef::void_op(1));
+        let ops = vec![OpRc::new(finish)];
+        opt.trace_inputargs = OpRef::inputarg_refs(&[Type::Int]);
+        let mut constants = majit_ir::ConstMap::default();
+        let result = opt
+            .optimize_loop(&ops, &mut constants, 1, None, 0)
+            .expect("optimize_loop must accept a FINISH-only trace");
+        assert!(
+            opt.simple_compile,
+            "SimpleCompileData.optimize sets Optimizer.simple_compile"
+        );
+        assert!(
+            opt.exported_loop_state.is_none(),
+            "BasicLoopInfo.final is True; optimize_loop must not export for retrace"
+        );
+        assert!(
+            result.last().is_some_and(|op| op.opcode == OpCode::Finish),
+            "FINISH must remain in the optimized ops, got {result:?}"
         );
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2293,8 +2293,8 @@ impl UnrollOptimizer {
         // vable input layout is `[frame, static scalars.., array items..]`, so
         // an appended static-scalar slot is exactly `GetfieldGc*(frame, descr)`
         // — the load the preamble itself performed before the optimizer folded
-        // it onto the seeded slot. Appends outside that window record nothing
-        // and keep reaching `compile_bridge`'s arity giveup.
+        // it onto the seeded slot. Appends outside that window record nothing;
+        // the LABEL/JUMP contract is `vable_label_arg_recipes`.
         //
         // The list is all-or-nothing: the recipes rebuild a contiguous LABEL
         // tail, so one append with no recipe leaves the close short anyway and

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5676,6 +5676,18 @@ fn assemble_peeled_trace_with_jump_args(
         }
     }
 
+    // compile.py emit_op / get_box_replacement: a residual virtualizable
+    // slot on the body LABEL is the same Box as `loop.inputargs[i]`. A
+    // reminted producerless RefOp loses that identity — recover it when
+    // the arg still forwards to an InputArg so `patch_new_loop` can
+    // rewrite the slot to the GETARRAYITEM it installs on that inputarg.
+    for a in &mut full_label_args {
+        let resolved = ctx.get_replacement_opref(*a);
+        if resolved.is_input_arg() {
+            *a = resolved;
+        }
+    }
+
     // SameAs for every LABEL arg that is a forwarded preamble box, not
     // only extras discovered from a body use-before-def. Base label_args
     // sit in `label_set` from the start, so the scan above never saw them.
@@ -8744,6 +8756,72 @@ mod tests {
             "SameAs must not be sourced from a Phase-2 inputarg absent from the preamble stream"
         );
         assert_eq!(combined[1].opcode, OpCode::Label);
+    }
+
+    #[test]
+    fn test_assemble_peeled_trace_resolves_residual_label_refop_to_inputarg() {
+        // compile.py emit_op / get_box_replacement: a reminted residual
+        // slot on the body LABEL is the same Box as the expanded inputarg.
+        let p1_ops = vec![{
+            let mut op = Op::new(
+                OpCode::IntAdd,
+                &[
+                    rooted_resop_operand(Type::Int, 0),
+                    rooted_resop_operand(Type::Int, 1),
+                ],
+            );
+            op.pos().set(OpRef::int_op(3));
+            op
+        }];
+        let p2_ops = vec![Op::new(
+            OpCode::Jump,
+            &[rooted_resop_operand(Type::Ref, 85)],
+        )];
+        let p1_ops_rc: Vec<majit_ir::OpRc> = p1_ops
+            .iter()
+            .map(|op| majit_ir::OpRc::new(op.clone()))
+            .collect();
+        let p2_ops_rc: Vec<majit_ir::OpRc> = p2_ops
+            .iter()
+            .map(|op| majit_ir::OpRc::new(op.clone()))
+            .collect();
+        let mut ctx = assemble_test_context(&p1_ops, &p2_ops, 1);
+        let reminted = ctx.materialize_operand_at(OpRef::ref_op(85));
+        let input = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.make_equal_to(&reminted, &input);
+
+        let combined = assemble_peeled_trace_with_jump_args(
+            &p1_ops_rc,
+            &p2_ops_rc,
+            &[OpRef::ref_op(85)],
+            &[OpRef::input_arg_ref(0)],
+            &[],
+            &[],
+            1,
+            0,
+            true,
+            &[],
+            &majit_ir::ConstMap::default(),
+            None,
+            None,
+            &[],
+            &mut Vec::new(),
+            &mut ctx,
+        );
+
+        let label = combined
+            .iter()
+            .find(|op| op.opcode == OpCode::Label)
+            .expect("assembled peel has a body LABEL");
+        assert_eq!(
+            label
+                .getarglist()
+                .iter()
+                .map(|a| a.to_opref())
+                .collect::<Vec<_>>(),
+            vec![OpRef::input_arg_ref(0)],
+            "residual LABEL RefOp must recover the forwarded InputArg identity"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8821,21 +8821,17 @@ impl<M: Clone> MetaInterp<M> {
         let Some(ctx) = self.tracing.as_mut() else {
             return;
         };
+        // pyjitpl.py `current_merge_points.append((live_arg_boxes, start))`
+        // is unconditional. A missing type is a bookkeeping bug, not a
+        // reason to skip the append.
+        debug_assert!(
+            jump_args.iter().all(|op| op.ty().is_some()),
+            "retrace merge-point jump_args must carry box.type (history.py)"
+        );
         let green_boxes: Vec<crate::trace_ctx::GreenBox> = jump_args
             .iter()
-            .filter_map(|&op| op.ty().map(|ty| crate::trace_ctx::GreenBox::new(op, ty)))
+            .map(|&op| crate::trace_ctx::GreenBox::new(op, op.ty().unwrap_or(majit_ir::Type::Void)))
             .collect();
-        if green_boxes.len() != jump_args.len() {
-            // `pyjitpl.py:3059-3060 self.current_merge_points.append(
-            // (live_arg_boxes, start))` appends unconditionally. This decline
-            // is a pyre stand-in and it ALSO suppresses the
-            // `keep_tracing_after_close` write below, so the trace is
-            // abandoned without appearing in `loops_aborted`. Slot 55 counts
-            // every firing so a corpus (run with a non-zero `retrace_limit`)
-            // reading 0 can promote it to a `debug_assert!`.
-            crate::mc_diag_bump(55);
-            return;
-        }
         let key = ctx.green_key;
         // pyjitpl.py:3059-3060 `self.current_merge_points.append(
         // (live_arg_boxes, start))` appends the greens the trace is closing
@@ -9819,11 +9815,13 @@ impl<M: Clone> MetaInterp<M> {
 
         let num_combined_ops = combined_ops.len();
         let opcodes_after: Vec<OpCode> = combined_ops.iter().map(|op| op.opcode).collect();
-        let has_guard = combined_ops.iter().any(|op| op.opcode.is_guard());
-        if !has_guard {
-            crate::debug::log_one("jit-abort", "compile_retrace: guardless loop");
-            return false;
-        }
+        // compile.py `compile_retrace` declines only on InvalidLoop.
+        // The optimizer always emits GUARD_NOT_INVALIDATED; a missing
+        // guard is a bug, not a cancel. Same check as `compile_loop`.
+        debug_assert!(
+            combined_ops.iter().any(|op| op.opcode.is_guard()),
+            "optimizer produced guardless retrace — GUARD_NOT_INVALIDATED should always be present"
+        );
 
         // `compile.py` — `resumekey.compile_and_attach(metainterp,
         // loop, inputargs)` dispatches on the resumekey's class:

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -14906,27 +14906,14 @@ impl<M: Clone> MetaInterp<M> {
             prepared_ops,
             Vec::new(),
         );
-        let bridge_resumestorage = pending_bridge_rd
-            .as_ref()
-            .map(|pending| pending.storage.as_ref());
-        let (bridge_inline_short_preamble, bridge_call_pure_results) = {
-            let bridge_data = compile::BridgeCompileData::new(
-                &bridge_trace_data,
-                &prepared_runtime_boxes,
-                bridge_resumestorage,
-                &call_pure_results,
-                inline_short_preamble,
-                self.warm_state.get_enable_opts(),
-            );
-            // The flattened dispatch consumes this slice below rather than
-            // through BridgeCompileData::optimize, but constructing the
-            // payload still validates that both views name the same boxes.
-            debug_assert_eq!(bridge_data.runtime_boxes, prepared_runtime_boxes);
-            (
-                bridge_data.inline_short_preamble,
-                bridge_data.call_pure_results.clone(),
-            )
-        };
+        // `enable_opts` must be owned before `take_optimizer` / compiled_loops
+        // borrows. CompileData.resumestorage is the same payload as
+        // `pending_bridge_rd` (compile.py BridgeCompileData.resumestorage);
+        // the flattened optimize_* call consumes that value, so the
+        // CompileData constructor below cannot also borrow it.
+        let enable_opts = self.warm_state.get_enable_opts().to_vec();
+        let bridge_inline_short_preamble = inline_short_preamble;
+        let bridge_call_pure_results = call_pure_results.clone();
         let bridge_inputarg_types: Vec<majit_ir::OpRef> = prepared_inputargs
             .iter()
             .enumerate()
@@ -15013,28 +15000,49 @@ impl<M: Clone> MetaInterp<M> {
                         .front_target_tokens
                 }
             };
-            optimizer.optimize_bridge(
-                bridge_ops,
-                &mut constants,
-                bridge_inputargs.len(),
-                front_target_tokens,
-                bridge_runtime_boxes,
-                bridge_inline_short_preamble,
-                retraced_count,
-                retrace_limit,
-                pending_bridge_rd,
-                Some(loop_num_inputs),
-                bridge_inputarg_base,
-            )
-        } else {
-            optimizer
-                .optimize_loop(
+            // compile.py BridgeCompileData.optimize → UnrollOptimizer.optimize_bridge
+            let bridge_data = compile::BridgeCompileData::new(
+                &bridge_trace_data,
+                &prepared_runtime_boxes,
+                None,
+                &call_pure_results,
+                inline_short_preamble,
+                &enable_opts,
+            );
+            debug_assert_eq!(bridge_data.runtime_boxes, prepared_runtime_boxes.as_slice());
+            bridge_data.optimize_trace(|_| {
+                optimizer.optimize_bridge(
                     bridge_ops,
                     &mut constants,
                     bridge_inputargs.len(),
+                    front_target_tokens,
+                    bridge_runtime_boxes,
+                    bridge_inline_short_preamble,
+                    retraced_count,
+                    retrace_limit,
                     pending_bridge_rd,
+                    Some(loop_num_inputs),
                     bridge_inputarg_base,
                 )
+            })
+        } else {
+            let simple_data = compile::SimpleCompileData::new(
+                &bridge_trace_data,
+                None,
+                &call_pure_results,
+                &enable_opts,
+            );
+            // compile.py SimpleCompileData.optimize → Optimizer.optimize_loop
+            simple_data
+                .optimize_trace(|_| {
+                    optimizer.optimize_loop(
+                        bridge_ops,
+                        &mut constants,
+                        bridge_inputargs.len(),
+                        pending_bridge_rd,
+                        bridge_inputarg_base,
+                    )
+                })
                 .map(|ops| (ops, false))
         };
         if let Some(tokens) = crossed_target_tokens
@@ -15144,47 +15152,9 @@ impl<M: Clone> MetaInterp<M> {
             &constants,
         );
 
-        // compile.py giveup() parity: a bridge whose terminal JUMP
-        // targets an already-compiled loop must supply exactly as many args
-        // as that loop's LABEL — the backend regalloc asserts
-        // `arglocs.len() == target_arglocs.len()`. The full-body walk can
-        // close a bridge against an outer-loop LABEL that an unroll short
-        // preamble grew beyond the virtualizable layout the bridge close
-        // reconstructs (its loop-invariant `extra` inputargs), so the counts
-        // disagree. Give up on this bridge gracefully (blackhole resume still
-        // produces the correct result) instead of letting the backend panic.
-        // target_arglocs is empty for a not-yet-compiled target (fresh
-        // retrace token); skip the check there, matching the backend's own
-        // `target_arglocs.is_empty()` no-assert branch.
-        if let Some(jump) = optimized_ops
-            .last()
-            .filter(|op| op.opcode == majit_ir::OpCode::Jump)
-        {
-            let target_len = jump.getdescr().and_then(|d| {
-                d.as_loop_target_descr()
-                    .map(|ltd| ltd.target_arglocs().len())
-            });
-            if let Some(target_len) = target_len {
-                let jump_len = jump.getarglist().len();
-                if target_len != 0 && jump_len != target_len {
-                    crate::mc_diag_bump(11); // compile_bridge arity giveup return
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit] compile_bridge giveup: JUMP args {jump_len} != \
-                             target LABEL args {target_len} (key={green_key} guard={fail_index})"
-                        );
-                    }
-                    crate::debug::log_one(
-                        "jit-summary",
-                        &format!(
-                            "bridge giveup: JUMP args {jump_len} != target LABEL args {target_len}"
-                        ),
-                    );
-                    self.return_optimizer(optimizer);
-                    return false;
-                }
-            }
-        }
+        // compile.py compile_trace has no JUMP/LABEL arity giveup. Extra
+        // LABEL slots are rebuilt from `vable_label_arg_recipes` in
+        // `OptUnroll::jump_to_existing_trace` (`unroll.py` send_extra JUMP).
 
         self.backend
             .set_constants_pool(compiled_constants_typed.clone());

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6969,11 +6969,13 @@ impl<M: Clone> MetaInterp<M> {
     /// Pyre's structure matches RPython compile.py:312/320/327 — `inputargs`
     /// (entry contract) and `start_label.args` carry the trace's ROOT
     /// expanded shape ([0..num_inputs)), while the body `LABEL`/`JUMP`
-    /// inside `compiled_ops` use virtualstate-allocated OpRefs that are
-    /// outside the forwarding map. Truncating `inputargs` to `num_red_args`
-    /// and prepending GETFIELD_GC / GETARRAYITEM_GC therefore only rewrites
-    /// the entry contract and `start_label.args`; body LABEL/JUMP arities
-    /// stay independent.
+    /// inside `compiled_ops` use the compact virtualstate arglist
+    /// (`loop_info.label_op`). Truncating `inputargs` to `num_red_args`
+    /// and prepending GETFIELD_GC / GETARRAYITEM_GC rewrites every operand
+    /// that is the same Box as a stripped inputarg — start LABEL, body
+    /// LABEL/JUMP, and residual remints that still forward to that
+    /// inputarg (`compile.py emit_op` / `get_box_replacement`). Arity of
+    /// the compact body LABEL is independent of the entry prefix.
     pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         &self,
         inputargs: &mut Vec<InputArg>,
@@ -7045,15 +7047,13 @@ impl<M: Clone> MetaInterp<M> {
             constants,
         );
         // compile.py `patch_new_loop_to_load_virtualizable_fields`
-        // only touches `loop.inputargs`; it does not rewrite any LABEL/JUMP
-        // arity inside `loop.operations`. The helper's forwarding map is
-        // ROOT inputarg OpRef → fresh GETFIELD result OpRef, so any op that
-        // referenced a removed inputarg slot (start_label, preamble ops, and
-        // any guard fail_args reaching back to it) gets rewritten in place;
-        // body LABEL/JUMP carry virtualstate-allocated OpRefs outside that
-        // map and stay untouched. Both `compile_loop_body` and
-        // `finish_and_compile` invoke this helper, mirroring RPython's
-        // unconditional `send_loop_to_backend` wiring (compile.py).
+        // does not change LABEL/JUMP *arity*. `emit_op` still rewrites
+        // any operand that is the same Box as a stripped inputarg —
+        // start LABEL, body LABEL/JUMP, fail_args, and reminted residual
+        // slots that still forward to that inputarg. Both
+        // `compile_loop_body` and `finish_and_compile` invoke this helper,
+        // mirroring RPython's unconditional `send_loop_to_backend` wiring
+        // (compile.py).
     }
 
     /// compile.py:510 `vable = orig_inpargs[index_of_virtualizable].getref_base()`
@@ -8422,14 +8422,11 @@ impl<M: Clone> MetaInterp<M> {
         // field reload for every loop. Mirrors the FINISH-path call in
         // `finish_and_compile`; see `MetaInterp::patch_new_loop_to_load_virtualizable_fields`
         // for the shared helper. RPython's `loop.inputargs` is independent
-        // from the inner body LABEL/JUMP arity (compile.py:312/320/327 — entry
-        // contract is `start_state.renamed_inputargs`, body LABEL is
-        // `loop_info.label_op`); pyre's `start_label.args` and `inputargs`
-        // are at the trace's ROOT inputarg shape ([0..num_inputs)), and the
-        // body LABEL inside `compiled_ops` carries virtualstate-allocated
-        // OpRefs that the helper's forwarding map does not touch. Truncating
-        // `inputargs` to `num_red_args` and prepending GETFIELD_GC /
-        // GETARRAYITEM_GC therefore leaves body LABEL/JUMP arities intact.
+        // from the inner body LABEL/JUMP *arity* (`compile_loop`
+        // `loop.inputargs` / `start_label` / `loop_info.label_op` —
+        // entry contract is `start_state.renamed_inputargs`, body LABEL is
+        // `loop_info.label_op`). `emit_op` still rewrites residual body
+        // LABEL args that share Box identity with a stripped inputarg.
         self.patch_new_loop_to_load_virtualizable_fields(
             &mut inputargs,
             &mut compiled_ops,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9002,101 +9002,34 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(descr) = finish_descr {
             ctx.finish(finish_args, descr);
         } else {
-            // pyjitpl.py:3005-3007 reads the procedure token once, through
-            // the `warmstate.py:191-196` invalidation filter, and hands that
-            // same object to `compile_trace` — the loop a bridge closes onto
-            // is the loop `has_compiled_targets` admitted. `has_compiled_targets`
-            // here already answers from the token, so taking the
-            // descr from the `compiled_loops` side table made one decision read
-            // two sources: the side table applies no invalidation filter, and
-            // `jitdriver.rs`'s `invalidate_loop` keeps an invalidated loop's
-            // target tokens on
-            // purpose. Reading both halves off the token is what makes the
-            // filter cover the target as well as the gate.
-            //
-            // Resolving to a TargetToken descr here, where `pyjitpl.py:3213-3214`
-            // records the JitCellToken itself, is early binding rather than a
-            // different answer. Upstream's cell-token descr is a placeholder the
-            // optimizer always consumes, in one of two ways: `unroll.py:196-199`
-            // takes `jump_to_preamble` when the target list holds one entry, and
-            // `:238-241` rewrites the descr to `cell_token.target_tokens[0]` —
-            // element zero, unconditionally, exactly what `first_target_token`
-            // answers; otherwise `:320-359` virtual-state matches and rewrites to
-            // the token it picked. Both consumers exist here:
-            // `jump_to_existing_trace_impl` (`unroll.rs`) iterates every
-            // candidate, and its `unroll.py:357-359` arm re-points this JUMP's
-            // descr at whichever token matched. So the ladder is not bypassed by
-            // binding early; only the preamble arm keeps what is recorded here.
-            //
-            // The equivalence needs the list to be unchanged between the two
-            // points, and it is: recording and optimizing are one synchronous
-            // sequence in this function (cut → record → snapshot → optimize) on
-            // the single JIT thread, and `optimize_bridge` mints no target
-            // tokens.
-            let jump_descr = self
-                .warm_state
-                .get_procedure_token(green_key)
-                .and_then(|token| token.first_target_token());
-            let Some(jump_descr) = jump_descr else {
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[jit] compile_trace: no front_target_token for key={}, bridge_origin={:?}",
-                        green_key, bridge_origin
-                    );
-                }
+            // pyjitpl.py compile_trace: `history.record(JUMP, ..., descr=ptoken)`
+            // — the JitCellToken itself, not `target_tokens[0]`.
+            // `unroll.py optimize_bridge` reads `cell_token = jump_op.getdescr()`
+            // and either `jump_to_preamble` (rewrites to `target_tokens[0]`)
+            // or `_jump_to_existing_trace` (scans every token).
+            let Some(ptoken) = self.warm_state.get_procedure_token(green_key) else {
                 if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
-                crate::mc_diag_bump(29); // compile_trace: no front target token
+                crate::mc_diag_bump(29); // compile_trace: no procedure token
                 return CompileOutcome::Cancelled;
             };
-            // `unroll.py jump_to_preamble` reaches this same unconditional
-            // take of the head, and it opens with
-            // `assert cell_token.target_tokens[0].virtual_state is None`.
-            // That assertion is what makes the take sound: a head carrying a
-            // virtual state is a specialized label, and entering one needs the
-            // guards `_jump_to_existing_trace` derives from that state — which
-            // the take, by construction, does not emit. The crate layering
-            // keeps `virtual_state` off the backend's descr list (see the note
-            // below), so read it from the `compiled_loops` projection the head
-            // is mirrored into. Upstream states this as unreachable; declining
-            // costs a bridge where crashing would cost the process.
-            if self
-                .compiled_loops
-                .get(&green_key)
-                .and_then(|compiled| compiled.front_target_tokens.first())
-                .is_some_and(|front| front.virtual_state.is_some())
-            {
+            if !ptoken.has_target_tokens() {
                 if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
-                crate::mc_diag_bump(crate::mc_diag_slot(
-                    "bridge_close_head_target_has_virtual_state",
-                ));
+                crate::mc_diag_bump(29);
                 return CompileOutcome::Cancelled;
             }
-            // The descr list on the token and the value list in
-            // `compiled_loops` are two projections of one thing, written by
-            // separate statements, and nothing else checks that they agree.
-            // Upstream cannot drift because `token.target_tokens` holds the
-            // TargetTokens themselves; the split here is forced by the crate
-            // layering (`JitCellToken` lives in majit-backend, which cannot
-            // name a `VirtualState`). This asserts what that layering costs us
-            // the ability to guarantee: the head the optimizer will see is the
-            // head whose value the ladder reads.
-            debug_assert!(
-                self.compiled_loops
-                    .get(&green_key)
-                    .and_then(|compiled| compiled.front_target_tokens.first())
-                    .is_none_or(
-                        |front| majit_ir::descr_identity(&front.as_jump_target_descr())
-                            == majit_ir::descr_identity(&jump_descr)
-                    ),
-                "compile_trace: token target-descr head disagrees with \
-                 front_target_tokens head for key={green_key}"
+            ctx.recorder.close_loop_with_descr(
+                finish_args,
+                Some(crate::call_descr::jit_cell_token_as_descr(ptoken)),
             );
-            ctx.recorder
-                .close_loop_with_descr(finish_args, Some(jump_descr));
+        }
+        // compile.py compile_trace: `trace.tracing_done()` before optimize.
+        if let Err(reason) = ctx.recorder.tracing_done() {
+            self.pending_abort_reason = Some(reason.as_int());
+            return CompileOutcome::Aborted;
         }
 
         // Keep the recorded operations (including JUMP) alive while the
@@ -9211,24 +9144,6 @@ impl<M: Clone> MetaInterp<M> {
                 // `resumekey.rd_loop_token`; pyre stores it in
                 // `active_trace_session.bridge.green_key`.
                 let origin_key = self.bridge_info().map(|b| b.green_key).unwrap_or(green_key);
-                // Prevent double-compilation: if a bridge was already compiled
-                // and attached to this guard, skip. RPython's
-                // raise_continue_running_normally stops the trace entirely,
-                // so this path is never re-entered; pyre's trace may continue
-                // and re-enter, so guard explicitly.
-                let already = self.bridge_was_compiled(origin_key, trace_id, fail_index);
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[jit] bridge_was_compiled({}, {}, {}) = {}",
-                        origin_key, trace_id, fail_index, already
-                    );
-                }
-                if already {
-                    return CompileOutcome::Compiled {
-                        green_key: 0,
-                        from_retry: false,
-                    };
-                }
                 // `pyjitpl.py` `handle_guard_failure(self,
                 // resumedescr, deadframe)` parity: the source descr Arc
                 // is `self.resumekey` (== the descr
@@ -9275,6 +9190,7 @@ impl<M: Clone> MetaInterp<M> {
                     snapshot_vref_boxes,
                     snapshot_frame_pcs,
                     call_pure_results,
+                    ends_with_jump,
                 );
                 if success {
                     CompileOutcome::Compiled {
@@ -10675,6 +10591,7 @@ impl<M: Clone> MetaInterp<M> {
             &mut snapshot_vref_map,
         ]);
         // compile.py SimpleCompileData.optimize → optimize_loop parity.
+        optimizer.simple_compile = true;
         // Wire snapshot data through to the optimizer so guard
         // store_final_boxes_in_guard (optimizeopt/mod.rs) can properly populate
         // rd_numb / rd_consts via _number_boxes (resume.py).
@@ -14736,6 +14653,9 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_vref_boxes: SnapshotBoxes,
         snapshot_frame_pcs: SnapshotFramePcs,
         call_pure_results: crate::optimizeopt::util::ArgsDict,
+        // compile.py compile_trace: BridgeCompileData when ends_with_jump,
+        // SimpleCompileData (optimize_loop) otherwise.
+        ends_with_jump: bool,
     ) -> bool {
         self.remember_compiled_graph_write();
         self.last_compiled_artifact_token = None;
@@ -15073,12 +14993,16 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             None
         };
-        // compile.py:1077-1078 parity: optimize_bridge may raise InvalidLoop
-        // (e.g. rewrite.py:404-407 GUARD_CLASS proven to always fail).
-        // RPython catches it via the abstract jitexc handler and discards
-        // the bridge. Mirror that here so the trace abort doesn't unwind
+        // compile.py compile_trace: ends_with_jump selects BridgeCompileData
+        // (UnrollOptimizer.optimize_bridge) vs SimpleCompileData
+        // (Optimizer.optimize_loop). A DoneWithThisFrame FINISH has no JUMP
+        // for jump_to_existing_trace; BasicLoopInfo.final() is always True.
+        // compile.py compile_trace: either optimize may raise InvalidLoop
+        // (e.g. rewrite.py GUARD_CLASS proven to always fail). RPython
+        // catches it via the abstract jitexc handler and discards the
+        // bridge. Mirror that here so the trace abort doesn't unwind
         // past compile_bridge.
-        let bridge_optimize_result = {
+        let bridge_optimize_result = if ends_with_jump {
             let front_target_tokens = match crossed_target_tokens.as_mut() {
                 Some(tokens) => tokens,
                 None => {
@@ -15102,6 +15026,16 @@ impl<M: Clone> MetaInterp<M> {
                 Some(loop_num_inputs),
                 bridge_inputarg_base,
             )
+        } else {
+            optimizer
+                .optimize_loop(
+                    bridge_ops,
+                    &mut constants,
+                    bridge_inputargs.len(),
+                    pending_bridge_rd,
+                    bridge_inputarg_base,
+                )
+                .map(|ops| (ops, false))
         };
         if let Some(tokens) = crossed_target_tokens
             && let Some(compiled) = self.compiled_loops.get_mut(&cell_token_key)
@@ -17828,12 +17762,15 @@ impl<M: Clone> MetaInterp<M> {
                     Ok(())
                 }
                 CompileOutcome::Cancelled => {
-                    // Preserve the existing cancelled-compile teardown: it
-                    // does not propagate a SwitchToBlackhole reason, but it is
-                    // not a successful compile either.
+                    // pyjitpl.py compile_done_with_this_frame /
+                    // compile_exit_frame_with_exception:
+                    //   target_token = compile.compile_trace(...)
+                    //   if target_token is not token: compile.giveup()
+                    // compile_trace returns None on InvalidLoop or a
+                    // non-final optimize; None is not the FINISH descr.
                     self.abort_trace_live(false);
-                    self.clear_pending_abort();
-                    Ok(())
+                    crate::mc_diag_bump(49);
+                    Err(SwitchToBlackhole::giveup())
                 }
                 // pyjitpl.py:3220/:3245 `compile.giveup()` per
                 // `rpython/jit/metainterp/compile.py:27` →

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7200,38 +7200,25 @@ where
                             // `get_procedure_token(greenboxes)` reads the greens of the merge point just
                             // reached, not the trace-start header's).
                             //
-                            // A key whose attempt already ran and did not compile keeps today's
-                            // behaviour — decline and keep tracing.  Re-attempting would re-run the
-                            // optimizer over a growing trace-so-far for a deterministic decline; the
-                            // same latch (`TraceCtx::declined_cross_loop_closes`) guards the equivalent
-                            // site in the other frontend.
-                            if ctx.cross_loop_close_declined(inner_key) {
-                                if crate::majit_log_enabled() {
-                                    eprintln!(
-                                        "[jit] merge point pc={pc} already has compiled loop \
-                                             key={inner_key} — declining the cross-loop cut \
-                                             (pyjitpl.py:3005)"
-                                    );
-                                }
-                            } else {
-                                crate::mc_diag_bump(70); // xloop_close_published
-                                ctx.close_greens = Some(mp_greens.clone());
-                                ctx.close_green_pc = Some(pc);
-                                ctx.close_jump_into_key = Some(inner_key);
-                                if capture_walk_reds {
-                                    ctx.walk_final_pc = Some(pc as usize);
-                                    ctx.walk_final_reds = std::mem::take(&mut walk_reds);
-                                }
-                                if crate::majit_log_enabled() {
-                                    eprintln!(
-                                        "[jit] merge point pc={pc} has compiled loop key={inner_key} \
-                                             — compile_trace JUMP (pyjitpl.py:3005)"
-                                    );
-                                }
-                                // GUARD_FUTURE_CONDITION was already emitted unconditionally at the
-                                // reached_loop_header entry above (pyjitpl.py).
-                                return TraceAction::CloseLoop;
+                            // pyjitpl.py compile_trace is retried on every
+                            // header visit (`if not self.partial_trace`).
+                            crate::mc_diag_bump(70); // xloop_close_published
+                            ctx.close_greens = Some(mp_greens.clone());
+                            ctx.close_green_pc = Some(pc);
+                            ctx.close_jump_into_key = Some(inner_key);
+                            if capture_walk_reds {
+                                ctx.walk_final_pc = Some(pc as usize);
+                                ctx.walk_final_reds = std::mem::take(&mut walk_reds);
                             }
+                            if crate::majit_log_enabled() {
+                                eprintln!(
+                                    "[jit] merge point pc={pc} has compiled loop key={inner_key} \
+                                             — compile_trace JUMP (pyjitpl.py compile_trace)"
+                                );
+                            }
+                            // GUARD_FUTURE_CONDITION was already emitted unconditionally at the
+                            // reached_loop_header entry above (pyjitpl.py).
+                            return TraceAction::CloseLoop;
                         } else if ctx.has_merge_point_at(inner_key, header_pc) {
                             if crate::jitdriver::spdiag_enabled() {
                                 eprintln!(

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -388,6 +388,16 @@ impl Trace {
         self.trb.is_some()
     }
 
+    /// opencoder.py `Trace.tracing_done` — `compile.py compile_trace`
+    /// calls this before `optimize_trace`. A tag overflow becomes
+    /// `SwitchToBlackhole(ABORT_TOO_LONG)`.
+    pub fn tracing_done(&mut self) -> Result<(), crate::pyjitpl::AbortReason> {
+        if let Some(trb) = self.trb.as_mut() {
+            return trb.tracing_done();
+        }
+        Ok(())
+    }
+
     pub fn snapshot_offset_count(&self) -> usize {
         self.snapshot_offsets.len()
     }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -419,23 +419,6 @@ pub struct TraceCtx {
     /// namespace-length gate).  Per-trace: a fresh ctx starts `false`, so no
     /// manual reset is needed.
     pub reads_module_global: bool,
-    /// Green keys whose cross-loop close this recording walk already attempted
-    /// and did not get compiled.
-    ///
-    /// `reached_loop_header` (pyjitpl.py) answers a cancelled close by
-    /// `cancel_count += 1` and, once `cancelled_too_many_times()` holds
-    /// (`max_unroll_loops` defaults to 0, `rlib/jit.py:598`), by
-    /// `SwitchToBlackhole(ABORT_BAD_LOOP)` — so upstream re-attempts a close at
-    /// most once per tracing pass. The walker instead keeps tracing when the
-    /// crossed key is not its own root, because closing there would store the
-    /// loop where nothing enters. Without this set it would also re-attempt the
-    /// close on every later crossing of the same header, and each attempt
-    /// re-optimizes the whole trace-so-far: an inner loop crossed N times costs
-    /// N optimizer passes over a trace that keeps growing. A structural decline
-    /// is deterministic — the same key rebuilds the same unsupported bridge —
-    /// which is the reasoning the guard descr's terminal-decline bit records
-    /// for guards. Per-trace, so a fresh walk retries once.
-    pub declined_cross_loop_closes: Vec<u64>,
     /// For a bridge trace (`is_bridge_trace`), the loop-header bytecode pc of
     /// the parent loop the bridge will JUMP into. The bridge closes when it
     /// reaches this pc (a real compiled-loop header), NOT when it transiently
@@ -1868,7 +1851,6 @@ impl TraceCtx {
             compiled_key_for_greens_fn: None,
             is_bridge_trace: false,
             reads_module_global: false,
-            declined_cross_loop_closes: Vec::new(),
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,
@@ -1970,7 +1952,6 @@ impl TraceCtx {
             compiled_key_for_greens_fn: None,
             is_bridge_trace: false,
             reads_module_global: false,
-            declined_cross_loop_closes: Vec::new(),
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,
@@ -2345,20 +2326,6 @@ impl TraceCtx {
     /// to a reached loop header during tracing.
     pub fn root_green_key(&self) -> u64 {
         self.root_green_key
-    }
-
-    /// Whether this walk already tried, and failed, to close across `key`.
-    /// See [`TraceCtx::declined_cross_loop_closes`].
-    pub fn cross_loop_close_declined(&self, key: u64) -> bool {
-        self.declined_cross_loop_closes.contains(&key)
-    }
-
-    /// Record that closing across `key` did not compile, so a later crossing of
-    /// the same header does not re-run the optimizer on the trace-so-far.
-    pub fn note_cross_loop_close_declined(&mut self, key: u64) {
-        if !self.cross_loop_close_declined(key) {
-            self.declined_cross_loop_closes.push(key);
-        }
     }
 
     /// See `TraceCtx::close_jump_into_key`.  Read-and-clear: the answer is only

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -14030,168 +14030,137 @@ fn handle<Sym: WalkSym>(
                     .bridge_info()
                     .map(|b| (b.trace_id, b.fail_index));
                 let has_targets = driver.meta_interp().has_compiled_targets(key);
-                // A close an attempt *rejected* is not retried on a later
-                // crossing of the same header: the attempt runs the optimizer
-                // over the whole trace-so-far, and the decline is deterministic,
-                // so an inner loop crossed N times would pay N optimizer passes
-                // over a growing trace (see
-                // `TraceCtx::declined_cross_loop_closes`).  Which outcomes count
-                // as rejected is the `classify_compile_outcome` match below.
-                let already_declined = ctx.trace_ctx.cross_loop_close_declined(key);
+                // pyjitpl.py `if not self.partial_trace:` is the only
+                // compile_trace gate. Upstream retries on every header visit.
                 if !has_partial && has_targets {
-                    if !already_declined {
-                        // pyjitpl.py reached_loop_header:
-                        //
-                        //     # generate a dummy guard just before the JUMP so
-                        //     # that unroll can use it when it's creating
-                        //     # artificial guards.
-                        //     self.generate_guard(rop.GUARD_FUTURE_CONDITION)
-                        //
-                        // Upstream emits it once at :2993, ahead of BOTH the
-                        // `get_procedure_token` / `compile_trace` pair at
-                        // :3001-3007 that closes into an ALREADY compiled loop
-                        // and the merge-point scan at :3018-3060 that closes a
-                        // loop of the trace's own. pyre splits those two
-                        // outcomes across different returns and had the guard on
-                        // only one of them: the own-loop leg gets it from
-                        // `close_loop_args_at`, which runs off
-                        // `DispatchOutcome::CloseLoop`, while this leg returns
-                        // `CompileTracePending` and never reached it. So every
-                        // bridge arrived at the optimizer carrying no
-                        // GUARD_FUTURE_CONDITION — measured across
-                        // `pyre/bench/synth`: 672 bridge compilations, 0 with
-                        // one. `Optimizer.patchguardop` was left to a stand-in
-                        // synthesized from one of the bridge's own body guards,
-                        // whose resume coordinate is mid-trace where upstream's
-                        // is the merge point's, and a bridge with no such guard
-                        // got none at all.
-                        //
-                        // `_jump_to_existing_trace` dereferences that
-                        // patchguardop for the extra virtual-state guards
-                        // (unroll.py:333-337) and hands it to
-                        // `inline_short_preamble`, which stamps it onto every
-                        // replayed short-preamble guard (unroll.py:409).
-                        //
-                        // Emitted on this leg only, so the own-loop leg is not
-                        // double-guarded. The capture coordinate is the
-                        // `jit_merge_point` op's OWN JitCode pc — the walk is
-                        // standing on the loop header, so "where we are" and
-                        // "where the synthesized JUMP goes" are the same
-                        // program point. `next_instr` is the green Python pc
-                        // (`make_green_key` above); feeding it to a parameter
-                        // read as a JitCode offset resolves an unrelated
-                        // `-live-` marker, and the snapshot then describes a
-                        // program point the walk registers hold nothing for.
-                        ctx.trace_ctx
-                            .record_guard(OpCode::GuardFutureCondition, &[], 0);
-                        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-                        // `JitDriver::merge_point` states the rule the latch runs
-                        // under: only latch what an attempt actually rejected.
-                        // The give-up below returns without calling into
-                        // `compile_trace` at all, so it costs no optimizer pass
-                        // and has nothing to report about this header.
-                        let mut attempted = true;
-                        let outcome = match bridge_origin {
-                            // Guard-origin: existing bridge path.
-                            Some(_) => driver.meta_interp_mut().compile_trace(
-                                key,
-                                &live_args,
-                                bridge_origin,
-                            ),
-                            // pyjitpl.py interp-origin: a
-                            // function-entry trace (ResumeFromInterpDescr)
-                            // closes as an entry bridge jumping into the
-                            // already-compiled hot loop (compile.py);
-                            // a trace rooted at a *loop header* falls back to
-                            // the plain bridge shape.
-                            None => match driver.compile_trace_entry_data() {
-                                Some((original_green_key, mut entry_meta)) => {
-                                    // `compile_trace_entry_data` clones the active
-                                    // trace metadata, whose `namespace_dependent` is
-                                    // only finalized by `finish_trace_namespace_dependency`
-                                    // after the walk returns. An entry bridge is
-                                    // compiled mid-walk, before that finalize, so a
-                                    // trace that has already read a module global
-                                    // would otherwise install the bridge with a stale
-                                    // `namespace_dependent = false` and let it be
-                                    // re-entered after later namespace growth. Fold in
-                                    // the live per-trace flag so the bridge keeps the
-                                    // conservative namespace gate.
-                                    entry_meta.namespace_dependent |=
-                                        ctx.trace_ctx.reads_module_global;
-                                    driver.meta_interp_mut().compile_trace_from_interp(
-                                        key,
-                                        &live_args,
-                                        original_green_key,
-                                        entry_meta,
-                                    )
-                                }
-                                // compile.py:1002-1021 — an interp-origin close is a
-                                // `ResumeFromInterpDescr` entry bridge, and with no
-                                // entry data there is no original green key to attach
-                                // it to. `compile_trace(key, args, None)` cannot serve
-                                // that state: its `None`-origin arm demands the
-                                // entry-bridge payload and answers `Cancelled` for
-                                // every input, after deep-cloning the whole
-                                // trace-so-far and lowering its snapshot pool. Decline
-                                // here instead, so the give-up reads as one.
-                                // `compile_trace_entry_data` reads
-                                // `trace_ctx().root_green_key()` and `trace_meta()`,
-                                // and every `JitDriver` trace start installs both
-                                // halves, so this is unreachable from a jd0 walk; only
-                                // `MetaInterp::force_start_tracing` opens a tracer with
-                                // no session envelope.
-                                None => {
-                                    attempted = false;
-                                    majit_metainterp::CompileOutcome::Cancelled
-                                }
-                            },
-                        };
-                        // pyjitpl.py:2982-2983 `classify_compile_outcome` is
-                        // the shared reading of a close's outcome; the sibling
-                        // close in `JitDriver::merge_point` already goes through it.
-                        // Reading `Compiled` here and treating every other
-                        // outcome as one declined close collapses three states
-                        // the classifier keeps apart, and latches the one that
-                        // is explicitly retryable.
-                        match driver.meta_interp().classify_compile_outcome(outcome) {
-                            majit_metainterp::BridgeCompileResult::Compiled => {
-                                if majit_metainterp::majit_log_enabled() {
-                                    eprintln!(
-                                        "[jit][walker-reached-loop-header] compile_trace success: \
-                                 key={} pc={} bridge={:?}",
-                                        key, next_instr, bridge_origin
-                                    );
-                                }
-                                // pyjitpl.py raise_if_successful() — the
-                                // successful compile_trace ends tracing; surface
-                                // the dedicated outcome so the driver maps it to
-                                // `TraceAction::CompileTrace` (no further compile
-                                // or abort on this session).
-                                driver.note_compile_trace_success();
-                                return Ok((
-                                    DispatchOutcome::CompileTracePending {
-                                        loop_header_pc: next_instr,
-                                    },
-                                    op.next_pc,
-                                ));
-                            }
-                            // pyjitpl.py:3000, `JitDriver::merge_point`: the
-                            // attempt armed `partial_trace`, so the next visit
-                            // of this header takes the `has_partial` arm of the
-                            // gate above and runs no optimizer pass either way.
-                            // Once the retrace lands, the state this close was
-                            // refused against is gone -- latching it would
-                            // refuse the close forever for a reason that has
-                            // already stopped holding.
-                            majit_metainterp::BridgeCompileResult::RetraceNeeded => {}
-                            majit_metainterp::BridgeCompileResult::Declined
-                            | majit_metainterp::BridgeCompileResult::Failed => {
-                                if attempted {
-                                    ctx.trace_ctx.note_cross_loop_close_declined(key);
-                                }
-                            }
+                    // pyjitpl.py reached_loop_header:
+                    //
+                    //     # generate a dummy guard just before the JUMP so
+                    //     # that unroll can use it when it's creating
+                    //     # artificial guards.
+                    //     self.generate_guard(rop.GUARD_FUTURE_CONDITION)
+                    //
+                    // Upstream emits it once in `reached_loop_header`, ahead
+                    // of BOTH the `get_procedure_token` / `compile_trace`
+                    // pair that closes into an ALREADY compiled loop
+                    // and the merge-point scan that closes a
+                    // loop of the trace's own. pyre splits those two
+                    // outcomes across different returns and had the guard on
+                    // only one of them: the own-loop leg gets it from
+                    // `close_loop_args_at`, which runs off
+                    // `DispatchOutcome::CloseLoop`, while this leg returns
+                    // `CompileTracePending` and never reached it. So every
+                    // bridge arrived at the optimizer carrying no
+                    // GUARD_FUTURE_CONDITION — measured across
+                    // `pyre/bench/synth`: 672 bridge compilations, 0 with
+                    // one. `Optimizer.patchguardop` was left to a stand-in
+                    // synthesized from one of the bridge's own body guards,
+                    // whose resume coordinate is mid-trace where upstream's
+                    // is the merge point's, and a bridge with no such guard
+                    // got none at all.
+                    //
+                    // `_jump_to_existing_trace` dereferences that
+                    // patchguardop for the extra virtual-state guards
+                    // (`unroll.py` `_jump_to_existing_trace`) and hands it to
+                    // `inline_short_preamble`, which stamps it onto every
+                    // replayed short-preamble guard.
+                    //
+                    // Emitted on this leg only, so the own-loop leg is not
+                    // double-guarded. The capture coordinate is the
+                    // `jit_merge_point` op's OWN JitCode pc — the walk is
+                    // standing on the loop header, so "where we are" and
+                    // "where the synthesized JUMP goes" are the same
+                    // program point. `next_instr` is the green Python pc
+                    // (`make_green_key` above); feeding it to a parameter
+                    // read as a JitCode offset resolves an unrelated
+                    // `-live-` marker, and the snapshot then describes a
+                    // program point the walk registers hold nothing for.
+                    ctx.trace_ctx
+                        .record_guard(OpCode::GuardFutureCondition, &[], 0);
+                    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+                    let outcome = match bridge_origin {
+                        // Guard-origin: existing bridge path.
+                        Some(_) => {
+                            driver
+                                .meta_interp_mut()
+                                .compile_trace(key, &live_args, bridge_origin)
                         }
+                        // pyjitpl.py interp-origin: a
+                        // function-entry trace (ResumeFromInterpDescr)
+                        // closes as an entry bridge jumping into the
+                        // already-compiled hot loop (compile.py);
+                        // a trace rooted at a *loop header* falls back to
+                        // the plain bridge shape.
+                        None => match driver.compile_trace_entry_data() {
+                            Some((original_green_key, mut entry_meta)) => {
+                                // `compile_trace_entry_data` clones the active
+                                // trace metadata, whose `namespace_dependent` is
+                                // only finalized by `finish_trace_namespace_dependency`
+                                // after the walk returns. An entry bridge is
+                                // compiled mid-walk, before that finalize, so a
+                                // trace that has already read a module global
+                                // would otherwise install the bridge with a stale
+                                // `namespace_dependent = false` and let it be
+                                // re-entered after later namespace growth. Fold in
+                                // the live per-trace flag so the bridge keeps the
+                                // conservative namespace gate.
+                                entry_meta.namespace_dependent |= ctx.trace_ctx.reads_module_global;
+                                driver.meta_interp_mut().compile_trace_from_interp(
+                                    key,
+                                    &live_args,
+                                    original_green_key,
+                                    entry_meta,
+                                )
+                            }
+                            // compile.py compile_trace — an interp-origin close is a
+                            // `ResumeFromInterpDescr` entry bridge, and with no
+                            // entry data there is no original green key to attach
+                            // it to. `compile_trace(key, args, None)` cannot serve
+                            // that state: its `None`-origin arm demands the
+                            // entry-bridge payload and answers `Cancelled` for
+                            // every input, after deep-cloning the whole
+                            // trace-so-far and lowering its snapshot pool. Decline
+                            // here instead, so the give-up reads as one.
+                            // `compile_trace_entry_data` reads
+                            // `trace_ctx().root_green_key()` and `trace_meta()`,
+                            // and every `JitDriver` trace start installs both
+                            // halves, so this is unreachable from a jd0 walk; only
+                            // `MetaInterp::force_start_tracing` opens a tracer with
+                            // no session envelope.
+                            None => majit_metainterp::CompileOutcome::Cancelled,
+                        },
+                    };
+                    // pyjitpl.py `classify_compile_outcome` is the shared
+                    // reading of a close's outcome; the sibling close in
+                    // `JitDriver::merge_point` already goes through it.
+                    match driver.meta_interp().classify_compile_outcome(outcome) {
+                        majit_metainterp::BridgeCompileResult::Compiled => {
+                            if majit_metainterp::majit_log_enabled() {
+                                eprintln!(
+                                    "[jit][walker-reached-loop-header] compile_trace success: \
+                                 key={} pc={} bridge={:?}",
+                                    key, next_instr, bridge_origin
+                                );
+                            }
+                            // pyjitpl.py raise_if_successful() — the
+                            // successful compile_trace ends tracing; surface
+                            // the dedicated outcome so the driver maps it to
+                            // `TraceAction::CompileTrace` (no further compile
+                            // or abort on this session).
+                            driver.note_compile_trace_success();
+                            return Ok((
+                                DispatchOutcome::CompileTracePending {
+                                    loop_header_pc: next_instr,
+                                },
+                                op.next_pc,
+                            ));
+                        }
+                        // pyjitpl.py raise_if_successful does not raise
+                        // on None. Fall through to the merge-point scan;
+                        // the next header visit retries compile_trace.
+                        majit_metainterp::BridgeCompileResult::RetraceNeeded
+                        | majit_metainterp::BridgeCompileResult::Declined
+                        | majit_metainterp::BridgeCompileResult::Failed => {}
                     }
                     // The jump did not take (`compile.compile_trace` returns
                     // None when none of the existing loop tokens match). Fall

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3806,12 +3806,12 @@ pub fn trace_and_compile_from_bridge(
     let env = PyreEnv;
     let mut jit_state = build_jit_state(frame, info);
 
-    // NOTE: guard resume_pc pointing to LOAD_CONST + RETURN_VALUE does NOT
-    // mean the guard is a loop-exit guard. It means the blackhole resume
-    // path leads to function return. RPython handles this correctly via
-    // blackhole resume → interpreter runs remaining code → natural return.
-    // Direct FINISH bridges are WRONG here — they skip the remaining loop
-    // body that the blackhole should execute.
+    // A resume_pc on LOAD_CONST + RETURN_VALUE (or `n<=0` RETURN) is still
+    // a live `handle_guard_failure` walk. RPython's `interpret()` records
+    // through that return and `compile_done_with_this_frame` attaches a
+    // DoneWithThisFrame FINISH bridge (`compile.compile_trace` with
+    // `ends_with_jump=False`). Blackhole-only is the SwitchToBlackhole
+    // fallback, not the success path.
     // RPython rebuild_from_resumedata (pyjitpl.py:2901,3400)
     // restores the complete frame stack before bridge tracing.
     // Bridge tracing sees the full frame layout — no truncation.
@@ -4455,14 +4455,13 @@ fn jit_ca_handle_guard_failure(
     }
     let mut frame_root = FrameRoot::new(unsafe { &mut *(fail0 as *mut PyFrame) });
 
-    // This callback has no channel for the exception value carried by a
-    // failing CALL_ASSEMBLER exception guard.  Compiling from its post-call
-    // resume state would treat the null call result as a normal operand.
-    // Leave exception-guard recovery to the blackhole path, which owns the
-    // callee exception and propagates it through the caller frames.
-    if descr_arc.is_guard_exc() {
-        return false;
-    }
+    // compile.py handle_fail traces exception guards the same as any other
+    // (`must_compile` then `_trace_and_compile_from_bridge`). The exception
+    // lives on the deadframe (`cpu.grab_exc_value`); read it here so
+    // `_prepare_exception_resumption` / `prepare_resume_from_failure` see
+    // the same value the general `handle_fail` path threads as `guard_exc`.
+    let guard_exc = unsafe { (*deadframe).jf_guard_exc as i64 };
+    let _guard_exc_root = majit_metainterp::blackhole::GuardExcRoot::park(guard_exc);
 
     // compile.py must_compile: jitcounter.tick(guard_hash, increment)
     let (must_compile, owning_key) = {
@@ -4513,9 +4512,6 @@ fn jit_ca_handle_guard_failure(
     // with the matching `start_compiling` even on panic.
     let compiled = {
         let _guard = crate::eval::GuardCompilingScope::new(&descr_arc);
-        // CALL_ASSEMBLER guard failures grab their callee exception on the
-        // blackhole leg, not here; pass 0 so the non-exception-guard
-        // deferral keys only off the general guard path's `guard_exc`.
         // `allow_finish_direct_return = false`: this callback returns a bare
         // bool to native code and has no channel for a concrete result; a
         // walk that terminates with a kept finish-concrete stash hands it to
@@ -4541,7 +4537,7 @@ fn jit_ca_handle_guard_failure(
             frame_root.frame(),
             &raw_values,
             &exit_layout,
-            0,
+            guard_exc,
             false,
         ) {
             BridgeResolution::CompiledContinue => true,


### PR DESCRIPTION
## Summary

Align `compile_trace` / guard-failure attach with `compile.py` `compile_trace` and `pyjitpl.py` `compile_done_with_this_frame`.

- **FINISH bridges** (`ends_with_jump=False`) go through `SimpleCompileData` → `Optimizer.optimize_loop`, not `UnrollOptimizer.optimize_bridge`. This is the `DoneWithThisFrame` path (`n<=0` RETURN). A failed FINISH attach is `compile.giveup()`, not a silent `Ok`.
- **JUMP descr** is the `JitCellToken` (`descr=ptoken`). `jump_to_preamble` rewrites it to `cell_token.target_tokens[0]`. `compile_trace` calls `trace.tracing_done()` before optimize.
- **CALL_ASSEMBLER exception guards** trace from `jf_guard_exc` instead of being refused. The old comment that a RETURN resume must blackhole-only was wrong: RPython's `interpret()` records through the return and attaches a FINISH bridge.

Also on this branch (already committed): residual LABEL RefOp identity recovery, and retrace `export_state` after a failed virtual match.

## Test plan

- [x] `cargo test --no-default-features --features dynasm -p majit-metainterp --lib` for `test_optimize_loop_keeps_finish`, `jit_cell_token_as_descr`, `test_hook_on_compile_bridge_fires_through_real_pipeline`, `test_start_retrace_from_guard_*`
- [ ] `cargo test --all --no-default-features --features dynasm`
- [ ] `python3 pyre/check.py` (host backends including wasm)
- [ ] Remeasure `recursion_past_unroll` bridge count vs `pypy3` (expect 4 bridges, including the `n<=0` RETURN FINISH)