### PR TITLE
wasm: cheaper gcmap publish and eager-merge invalidation peels

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2633,11 +2633,16 @@ fn emit_ca_reload_top(sink: &mut PeepSink<'_, '_>, top_addr: u32) {
 /// Publish `build_home_gcmap` on the live frame (`local 0` is the items
 /// base). `ptr == 0` is the test path that never installs a map.
 ///
-/// Ordinary homes and LABEL captures grow independently, so the live map
-/// and this module's map can be incomparable. With a residual type family
-/// the store is their bitwise union (`wasm_jit_union_gcmap`). Without one
-/// (host tests) the store is still monotonic: publish this map only when
-/// it covers every live bit.
+/// assembler.py `push_gcmap` stores this site's map. Ordinary homes and
+/// LABEL captures grow independently, so two live maps can be incomparable
+/// and a later keyed resume must not drop the other region. The host
+/// `wasm_jit_union_gcmap` exists only for that case. A live map that
+/// already covers these bits — the same pointer, or a prior union — is
+/// left in place: a host call here sat on every keyed LABEL resume and
+/// every key-0 re-entry after the first, including the hot out-of-line
+/// loop-closing bridges that #1766 put over the wasm/dynasm ceiling.
+/// Without a residual type family (host tests) the store is still
+/// monotonic: publish this map only when it covers every live bit.
 fn emit_publish_home_gcmap(
     sink: &mut PeepSink<'_, '_>,
     ptr: i64,
@@ -2692,6 +2697,46 @@ fn emit_publish_home_gcmap(
     if let Some(base) = residual_type_base {
         // `(i64, i64) -> i64` at `residual_type_base + 2`.
         let union_fn = crate::wasm_jit_union_gcmap as *const () as usize as i64;
+        let ne_words = |sink: &mut PeepSink<'_, '_>| {
+            if word == 4 {
+                sink.i32_ne();
+            } else {
+                sink.i64_ne();
+            }
+        };
+        sink.block(BlockType::Empty); // $after
+        sink.local_get(old_local);
+        sink.i64_extend_i32_u();
+        sink.i64_const(ptr);
+        sink.i64_eq();
+        sink.br_if(0);
+        sink.block(BlockType::Empty); // $union
+        sink.local_get(old_local);
+        load_usize(sink, 0);
+        if word == 8 {
+            sink.i32_wrap_i64();
+        }
+        sink.i32_const(n_new as i32);
+        sink.i32_lt_u();
+        sink.br_if(0);
+        for (i, &new_word) in new_words.iter().enumerate() {
+            if new_word == 0 {
+                continue;
+            }
+            sink.local_get(old_local);
+            load_usize(sink, (1 + i as u32) as u64 * word as u64);
+            const_usize(sink, new_word);
+            if word == 4 {
+                sink.i32_and();
+            } else {
+                sink.i64_and();
+            }
+            const_usize(sink, new_word);
+            ne_words(sink);
+            sink.br_if(0);
+        }
+        sink.br(1);
+        sink.end(); // $union
         emit_hdr(sink);
         sink.local_get(old_local);
         sink.i64_extend_i32_u();
@@ -2699,6 +2744,7 @@ fn emit_publish_home_gcmap(
         sink.i32_const(union_fn as i32);
         sink.call_indirect(0, base + 2);
         emit_word_store(sink, JF_GCMAP_OFS as u64);
+        sink.end(); // $after
         sink.end();
         return;
     }
@@ -3921,10 +3967,11 @@ pub struct CaParams {
     pub inline: Option<CaInlineParams>,
     /// `build_home_gcmap` pointer published after the fresh-entry home/input
     /// stores, and again on each keyed LABEL resume after those slots are
-    /// already valid or newly marked ones have been nulled. Used only when
-    /// [`Self::compute_home_gcmap`] is false. Zero leaves `jf_gcmap` unset
-    /// in the generated module (tests). assembler.py writes `jf_gcmap` at
-    /// safepoints once those slots are live.
+    /// already valid or newly marked ones have been nulled. A resume whose
+    /// live map already covers this pointer leaves `jf_gcmap` unchanged.
+    /// Used only when [`Self::compute_home_gcmap`] is false. Zero leaves
+    /// `jf_gcmap` unset in the generated module (tests). assembler.py
+    /// writes `jf_gcmap` at safepoints once those slots are live.
     pub home_gcmap_ptr: i64,
     /// When set, leak a map from this module's `RefHomes` and LABEL captures
     /// (raised to the `home_gcmap_min_*` floors) instead of
@@ -6176,7 +6223,11 @@ fn build_function(
             // Keyed resume skipped the key-0 stores. Grown slots were
             // nulled before `br_table`; remaining marked homes already
             // hold the previous module's values. Publish before the
-            // loader stores, matching `push_gcmap` at a live safepoint.
+            // loader stores so a foreign JUMP or a grown re-emission
+            // cannot leave this module's homes unmarked. assembler.py
+            // `push_gcmap` is a safepoint store, not a LABEL op: when
+            // the live map already covers these bits the publish is a
+            // guest compare, not a host union.
             emit_publish_home_gcmap(
                 &mut sink,
                 publish_ptr,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3005,12 +3005,12 @@ fn emit_ca_malloc_cond_varsize_frame(
     sink.i32_shr_u();
     sink.i64_extend_i32_u();
     emit_word_store(sink, JF_FRAME_OFS as u64);
-    // Leave `jf_gcmap` null. The callee key-0 prologue nulls the whole
-    // frozen home region (live homes plus chain padding) and then
-    // publishes the map — the same moment PyPy's assembler writes
-    // `_finish_gcmap` / the live gcmap, once those slots are valid or
-    // null. Filling `ca_frame_bytes` here on every recursive bump is
-    // what made `recursion_past_unroll_bound_from_loop` 4.9x dynasm.
+    // Leave `jf_gcmap` null. The callee key-0 prologue nulls the homes
+    // `build_home_gcmap` marks and then publishes — the same moment
+    // PyPy's assembler writes `_finish_gcmap` / the live gcmap, once
+    // those slots are valid or null. Filling `ca_frame_bytes` here on
+    // every recursive bump is what made
+    // `recursion_past_unroll_bound_from_loop` 4.9x dynasm.
     sink.local_get(alloc_scratch_local);
     sink.i64_const(0);
     emit_word_store(sink, JF_GCMAP_OFS as u64);
@@ -6025,27 +6025,26 @@ fn build_function(
     // prefix and the LABEL-capture tail, not reserved chain-padding.
     // The nursery bump leaves `jf_gcmap` null and does not fill items, so
     // unused marked homes still hold recycled nursery bytes; those must
-    // be null before the map is published. A resume dispatch branches
-    // past this code, preserving captures written when the source loop
-    // first crossed the LABEL, and publishes in the resume loader.
-    // A home the input loop fills below needs no null first: its store follows
-    // immediately and nothing between the two allocates, so no collection can
-    // read the slot while it is stale. Homes no input fills keep their clear
-    // because store-on-def writes them only later.
-    // The loop below fills `entry_inputargs`, not every arg of the merged
-    // stream: an appended region's live-ins are stored by the guard-fail branch
-    // that reaches the region, which is nowhere near this entry. Marking those
-    // homes filled here would skip their clear and leave the collector reading
-    // an uninitialised slot.
-    let mut input_filled_home = vec![false; ref_homes.len()];
-    for ia in entry_inputargs {
-        if let Some(h) = ref_homes.home_id(ia.index) {
-            input_filled_home[h as usize] = true;
-        }
-    }
-    emit_null_home_slots(&mut sink, frame, 0..frame.home_slots as u64, |h| {
-        (h as usize) >= input_filled_home.len() || !input_filled_home[h as usize]
-    });
+    // be null before the map is published. Unmarked reserved padding is
+    // invisible to `jitframe_trace` and must not be cleared on every
+    // CALL_ASSEMBLER — that 128-slot fill is what still bound
+    // `fib_recursive`. A resume dispatch branches past this code,
+    // preserving captures written when the source loop first crossed
+    // the LABEL, and publishes in the resume loader.
+    // Null every slot the map about to be published marks. Skipping
+    // input-filled homes left recycled nursery words in a marked slot
+    // when the later store used a different home than `home_id` named
+    // (`recursive_call_frame_relocation` then copied an invalid
+    // type_id). The extra store per input Ref is lost in the noise
+    // next to the CALL_ASSEMBLER itself.
+    emit_null_home_slots(&mut sink, frame, 0..used_ordinary as u64, |_| true);
+    let label_base = frame.ordinary_home_slots() as u64;
+    emit_null_home_slots(
+        &mut sink,
+        frame,
+        label_base..label_base + used_labels as u64,
+        |_| true,
+    );
 
     // Load inputs from frame into locals, and store Ref inputs to their homes.
     // The input value lives at the frame slot its producer wrote it to: the
@@ -9009,13 +9008,13 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, arg.to_opref());
                     sink.i64_store(mem64(FRAME_SLOT_BASE + arg_index as u64 * SLOT_SIZE));
                 }
-                // Homes are still recycled nursery bytes. Null the *callee*
-                // home range from the dispatch snapshot before installing
-                // that snapshot's gcmap. The caller module's FrameGeometry
-                // can disagree after `redirect_call_assembler`.
-                // No call sits between the input stores and this map, so a
-                // Ref argument cannot be collected while the map is still
-                // null. x86 writes the map at the first safepoint instead.
+                // Homes are still recycled nursery bytes. Null the callee
+                // home range from the dispatch snapshot and publish that
+                // snapshot's gcmap before `call_indirect`. A minor
+                // collection can fire in the callee
+                // (`recursive_call_frame_relocation`) while this frame is
+                // already on the shadow stack. Key-0 still skips unmarked
+                // frozen padding.
                 sink.local_get(ca_target_local);
                 sink.i32_load(mem32(crate::failguard::WASM_CA_TARGET_HOME_SLOTS_OFS));
                 sink.if_(BlockType::Empty);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -5251,21 +5251,6 @@ impl majit_backend::Backend for WasmBackend {
                     if !outside_labels_initialized {
                         diag_bump(48);
                         decline("uninitialized_label");
-                    } else if has_invalidation_guard && outside_loop {
-                        // A quasi-immutable fold's dependencies are registered
-                        // once, against whatever flag the token names when this
-                        // compile returns — the bridge's own, because deferring
-                        // takes the out-of-line path below. The merge cannot
-                        // move a registration that has already happened, so
-                        // merged, the region would read the owner's root flag
-                        // while its dependencies still hold the bridge's: a
-                        // field mutated before the trip would be forgotten, and
-                        // one mutated after would leave the fold in place. The
-                        // eager invalidation arm below has no such window — it
-                        // merges before this compile returns, so the flag it
-                        // records is the one the dependencies then attach to.
-                        diag_bump(56);
-                        decline("defer_invalidation_guard");
                     } else if !has_invalidation_guard {
                         // Eligible, but not yet worth its owner re-emission:
                         // arm the bridge's entry counter and merge when it
@@ -5303,10 +5288,14 @@ impl majit_backend::Backend for WasmBackend {
                         decline("eager_too_large");
                     } else {
                         // Deferral would register this region's dependencies
-                        // against its temporary bridge flag. A header region
-                        // can instead merge before this compile returns, so
-                        // its dependencies attach to the owner's flag from the
-                        // outset. The outside-loop case was declined above.
+                        // against its temporary bridge flag. Merge before this
+                        // compile returns so they attach to the owner's flag
+                        // from the outset — the same moment
+                        // `patch_jump_for_descr` rewrites the guard. A
+                        // preamble / outside-loop region takes this arm too:
+                        // it cannot defer (the flag would be the temporary
+                        // bridge's) and leaving it out of line makes the
+                        // peel the hot crossing.
                         let region = codegen::InlinedBridge {
                             source_fail_index: merged_fail_index,
                             external_jump: region_external.clone(),

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4627,7 +4627,7 @@ impl majit_backend::Backend for WasmBackend {
                     .find(|(target_token, _)| *target_token == token.number)
                     .map(|(_, target)| target.callee_gcmap_ptr)
             })
-            .unwrap_or_else(|| Box::leak(build_callee_gcmap(compiled.frame)).as_ptr() as i64);
+            .unwrap_or(home_gcmap_ptr as i64);
         // The module has now acquired its host-appended shared-table slot and
         // its finish index. Publish those mutable pieces before exposing the
         // immutable geometry metadata: previously compiled CALL_ASSEMBLER

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -133,9 +133,9 @@ fn stat_value(stderr: &str, name: &str) -> u64 {
 
 /// CALL_ASSEMBLER must not refill a frame on the bump path. The inline
 /// bump leaves `jf_gcmap` unset. Expected `memory.fill`s are the entry
-/// home clear, `emit_zero_bytes` New* payload zeros, and the CA caller
-/// nulling the callee home range from the dispatch snapshot before
-/// publishing that snapshot's gcmap.
+/// home clear of marked slots, `emit_zero_bytes` New* payload zeros,
+/// and the CA caller nulling the callee home range from the dispatch
+/// snapshot before publishing that snapshot's gcmap.
 #[track_caller]
 fn assert_no_call_assembler_frame_fill(stderr: &str) {
     let home_base = format!(
@@ -169,7 +169,6 @@ fn assert_no_call_assembler_frame_fill(stderr: &str) {
             && lines[index - 3].starts_with("local.get ")
             && lines[index - 2] == "i32.const 0"
             && lines[index - 1].starts_with("i32.const ");
-        // dest = cfp + target.home_slot_base, size = home_slots * SLOT_SIZE.
         let is_ca_callee_home_null = index >= 8
             && lines[index - 1] == "i32.mul"
             && lines[index - 2] == "i32.const 8"
@@ -2301,9 +2300,9 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
         saw_nursery_free,
         "malloc_cond_varsize_frame must load nursery_free"
     );
-    // The CA arm may memory.fill the callee home range (length is
-    // `home_slots * SLOT_SIZE` at runtime). The bump itself must not
-    // refill `ca_frame_bytes`.
+    // The CA arm no longer memory.fills the frozen home range; the
+    // callee key-0 prologue nulls only marked slots. The bump itself
+    // must not refill `ca_frame_bytes`.
     let frame = codegen::FrameGeometry::fixed();
     assert!(
         !fill_lengths.contains(&(frame.ca_frame_bytes as i32)),
@@ -2311,11 +2310,11 @@ fn call_assembler_inlines_malloc_cond_varsize_frame() {
     );
 }
 
-/// Key-0 nulls the frozen home region before `jf_gcmap` is published.
-/// Recycled nursery bytes in unused padding must not be live when the
-/// map goes up (`invalid type_id` from an oldgen type-3 JitFrame).
+/// Key-0 nulls only the homes `build_home_gcmap` marks. Frozen
+/// chain-padding is unmarked, so a 128-slot fill on every
+/// CALL_ASSEMBLER is wasted work (`fib_recursive`).
 #[test]
-fn entry_prologue_nulls_the_frozen_home_region() {
+fn entry_prologue_does_not_null_unmarked_home_padding() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))])];
     let frame = codegen::FrameGeometry::compact(64, 128, 2);
@@ -2362,8 +2361,8 @@ fn entry_prologue_nulls_the_frozen_home_region() {
         _ => {}
     });
     assert!(
-        fill_lengths.contains(&home_fill_bytes),
-        "key-0 must memory.fill the whole frozen home region ({home_fill_bytes} bytes); fills were {fill_lengths:?}"
+        !fill_lengths.contains(&home_fill_bytes),
+        "key-0 must not memory.fill unmarked frozen padding ({home_fill_bytes} bytes); fills were {fill_lengths:?}"
     );
     assert!(
         !fill_lengths.contains(&(frame.ca_frame_bytes as i32)),

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2977,6 +2977,101 @@ fn home_gcmap_union_call_validates_on_a_reload_only_residual_family() {
     validate_wasm(&bytes);
 }
 
+/// assembler.py `push_gcmap` stores this site's map. The host union is
+/// only for incomparable ordinary/LABEL extents; a live map that already
+/// covers these bits must not `call_indirect` it. The pointer-eq sits in
+/// front of that call so a keyed resume into the same module is a guest
+/// compare.
+#[test]
+fn home_gcmap_publish_pointer_eq_guards_the_union_call() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let ops = vec![
+        Op::new(
+            OpCode::Label,
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(1), OpRef::input_arg_int(0)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(3),
+        ),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(3), const_100],
+            OpRef::int_op(4),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(4)],
+            &[OpRef::int_op(3), OpRef::int_op(2)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
+    ];
+    let mut ca = codegen::CaParams::default();
+    ca.compute_home_gcmap = true;
+    ca.ca_reload_fn_ptr = 1;
+    let frame = codegen::FrameGeometry::compact(64, 128 + 2, 2);
+    let inputs = codegen::ModuleBuildInputs {
+        inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+        ops: ops.iter().cloned().collect(),
+        inlined_bridges: Vec::new(),
+        constants: indexmap::IndexMap::new(),
+        vtable_offset: Some(0),
+        classptr_to_typeid: HashMap::new(),
+        guard_gc_type_info: codegen::GuardGcTypeInfo::default(),
+        alloc: codegen::AllocHelpers::default(),
+        wb: codegen::WriteBarrierHelpers::for_current_gc(0, 0),
+        nursery: None,
+        invalidated_flag_addr: 0,
+        gc_table_base: 0,
+        fail_index_base: 0,
+        bridge_cells_base: 0,
+        bridge_entry_arity: None,
+        bridge_param_dispatch: false,
+        trace_entry_census: None,
+        inline_trip: None,
+        external_jump_slot: 0,
+        external_jump_wide_slot: 0,
+        external_jump_key: 0,
+        frame,
+        ca,
+    };
+    let (bytes, _, _, _) = codegen::build_wasm_module(&inputs)
+        .expect("cover-check publish must still declare the union residual");
+    validate_wasm(&bytes);
+    let mut ptr_eqs = 0usize;
+    let mut union_calls = 0usize;
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            for op in body.get_operators_reader().unwrap() {
+                match op.unwrap() {
+                    wasmparser::Operator::I64Eq => ptr_eqs += 1,
+                    wasmparser::Operator::CallIndirect { .. } => union_calls += 1,
+                    _ => {}
+                }
+            }
+        }
+    }
+    assert!(
+        ptr_eqs > 0,
+        "publish must i64.eq the live jf_gcmap against this map before union"
+    );
+    assert!(
+        union_calls > 0,
+        "incomparable ordinary/LABEL maps still need the union residual"
+    );
+}
+
 /// A re-emission that grew the LABEL-capture tail must still build when
 /// asked to null only the newly marked slots before publishing.
 #[test]


### PR DESCRIPTION
## Summary

Three leftover wasm follow-ups after #1766 / #1805, aimed at the recent wasm SLOWER set (ubuntu job on #1805: `exception_loop_warmup` 6.4x and five other bridge-heavy fixtures over 4x). No `max-wasm-ratio` raises.

* **CALL_ASSEMBLER key-0** nulls only the homes `build_home_gcmap` marks, not the frozen 128-slot padding. The CA caller still fills the snapshot home range and publishes `jf_gcmap` before `call_indirect` so a collecting callee can walk the live frame.
* **`push_gcmap` at keyed resume / key-0 re-entry** no longer `call_indirect`s `wasm_jit_union_gcmap` when the live map already covers this module's bits (pointer equality, then a guest bit check). The host union stays for incomparable ordinary vs LABEL extents.
* **Outside-loop / preamble regions with `GUARD_NOT_INVALIDATED`** take the eager merge arm instead of a permanent decline. Deferral would register quasi-immut dependencies on the temporary bridge flag; `patch_jump_for_descr` rewrites the guard in place so those deps attach to the owner. The decline left `exception_loop_warmup`'s `i >= 2000` peel as a 47M-entry cross-module crossing.

## Local check

`cargo test --all --no-default-features --features dynasm` green.

`python3 pyre/check.py --backend dynasm,wasm`: dynasm 549/549, wasm 539/539. `exception_loop_warmup` 6.4x → 2.6x. No new ratio allowances.